### PR TITLE
Accept delivered deck responses in slides API test

### DIFF
--- a/tests/slides-api.spec.ts
+++ b/tests/slides-api.spec.ts
@@ -183,6 +183,7 @@ test("T3: explicit generate triggers mofa_slides", async () => {
     content.includes("生成") ||
     content.includes("generat") ||
     content.includes(".pptx") ||
+    content.includes("Deck delivered") ||
     content.includes("mofa_slides") ||
     (doneEvent?.has_bg_tasks === true),
   ).toBe(true);


### PR DESCRIPTION
## Summary
- accept the current live slides delivery response wording in T3
- stop treating a delivered deck as a failure when the response says `Deck delivered`

## Validation
- live Windows slides generate path now returns a delivered deck response
- targeted Playwright rerun reached successful deck generation on the host logs