### PR TITLE
refactor(message-store): extract reducers (Phase 1+2)

### DIFF
--- a/docs/OCTOS_WEB_MESSAGE_STORE_REFACTOR_CONTRACT.md
+++ b/docs/OCTOS_WEB_MESSAGE_STORE_REFACTOR_CONTRACT.md
@@ -1,0 +1,59 @@
+# octos-web message-store refactor contract
+
+Status: active. Phase 1 + 2 landed in `refactor/message-store-phases-1-4`.
+
+## Goals
+
+1. Separate pure message-shape logic (reducers) from stateful facade
+   (session/topic maps, React subscriptions, observability counters).
+2. Make each transformation independently testable without spinning up a
+   backend or a browser.
+3. Preserve the runtime fix on `main` that removed `_queued` and the
+   client-side message queue — every user send POSTs immediately; the
+   backend queue modes are authoritative.
+
+## Phase map
+
+| Phase | Branch | Scope |
+| --- | --- | --- |
+| 1 | `refactor/message-store-reducers-phase1` | Reducer scaffold, shared types. |
+| 2 | `refactor/message-store-reducers-phase2` | Pure reducer functions extracted. |
+| 3 | `refactor/message-store-phase-3-4` (PR B) | Route runtime bridges through reducers. |
+| 4 | `refactor/message-store-phase-3-4` (PR B) | Hardening tests (session switching, TTS, deep research). |
+
+## Reducer inventory
+
+Located in `src/store/message-store-reducers/`:
+
+- `shared.ts` — helper functions (`withRuntime`, `pathMatchKeys`, `normalizeMessageText`, runtime status mapping). Shared across reducers.
+- `user-message-reducer.ts` — `reduceCreateUserMessageEvent`, `createLocalMessage`.
+- `assistant-turn-reducer.ts` — `reduceCreateAssistantTurnEvent`, `reduceAppendAssistantTextEvent`, `reduceStopStreamingAssistantEvent`, `reduceEnsureStreamingAssistantEvent`, `mergeAssistantDuplicate`, `isAssistantCompanionForFileMessage`.
+- `background-task-reducer.ts` — `reduceProjectTaskAnchorEvent`, `projectTaskAnchorMessage`, `mergeTaskAnchorMeta`, `sameTaskAnchorMeta`, `findTaskAnchorIndex`, `taskAnchorMessageId`, `taskIdentity`, `runtimeStatusForTask`, `taskMessageStatus`.
+- `file-artifact-reducer.ts` — `reduceAppendFileArtifactEvent`, `parseLegacyFileDeliveries`, `findFileResultTargetIndex`, `findMessageIndexForFilePath`, `mergeFileResultIntoTarget`, `shouldCoalesceFileResult`.
+- `history-replay-reducer.ts` — `reduceConvertHistoryReplayMessageEvent`, `reduceMergeAuthoritativeHistoryMessageEvent`, `findOptimisticMatchIndex`, `mergeAuthoritativeIntoMessage`, `shouldCollapseAuthoritativeDuplicate`, `convertApiMessage`.
+
+A `src/store/message-store-reducer.ts` barrel re-exports the public surface.
+
+## Invariants (do not regress)
+
+- `_queued` does not exist anywhere. User sends POST immediately.
+- `subscribeNew` is only wired after `replaceHistory` has hydrated from the
+  authoritative API so that streamed `session_result` payloads do not land
+  before the replay is applied.
+- Task anchors are keyed by `taskAnchorMessageId(sessionId, taskId)`. Multiple
+  anchors for the same task in the same session are a bug.
+- `historySeq` ordering is authoritative; local-only bubbles without a seq
+  sort after confirmed messages.
+- `Message.role` stays `"user" | "assistant" | "system"`. Task anchors are
+  tagged via `kind: "task_anchor"` (not a new role).
+- Reducers are pure: no `Date.now()`, no `Math.random()`, no global state.
+  Injection via `createId` / `now` callbacks.
+
+## Testing
+
+- `tests/message-store-reducer.spec.ts` — unit-style Playwright specs that run
+  the pure reducers in isolation (no browser navigation).
+- `tests/message-store-live.spec.ts` — live gate guarded by
+  `LIVE_MESSAGE_STORE_GATE=1`. Exercises the full runtime.
+- Existing spec suites (`session-switching`, `background-task-scope`,
+  `tts-runtime-events`) remain the regression fence.

--- a/src/api/types.ts
+++ b/src/api/types.ts
@@ -31,6 +31,34 @@ export interface MessageInfo {
   tool_calls?: { id?: string; name?: string }[];
 }
 
+export interface BackgroundTaskRuntimeDetail {
+  schema?: string;
+  kind?: string;
+  workflow_kind?: string;
+  workflow?: string;
+  node?: string;
+  tool?: string;
+  iteration?: number;
+  current_phase?: string;
+  progress_message?: string;
+  message?: string;
+  progress?: number;
+  lifecycle_state?: string;
+  [key: string]: unknown;
+}
+
+export interface BackgroundTaskProgressEvent {
+  recorded_at: string;
+  kind: string;
+  workflow_kind?: string | null;
+  node?: string | null;
+  tool?: string | null;
+  iteration?: number | null;
+  phase?: string | null;
+  message?: string | null;
+  progress?: number | null;
+}
+
 export interface BackgroundTaskInfo {
   id: string;
   tool_name: string;
@@ -41,6 +69,13 @@ export interface BackgroundTaskInfo {
   output_files?: string[];
   error: string | null;
   session_key?: string;
+  workflow_kind?: string | null;
+  current_phase?: string | null;
+  lifecycle_state?: string | null;
+  runtime_detail?: BackgroundTaskRuntimeDetail | null;
+  progress_message?: string | null;
+  progress?: number | null;
+  progress_events?: BackgroundTaskProgressEvent[];
 }
 
 export interface ServerStatus {

--- a/src/layouts/chat-layout.tsx
+++ b/src/layouts/chat-layout.tsx
@@ -1,4 +1,4 @@
-import { type ReactNode, useState, useEffect, useCallback } from "react";
+import { type ReactNode, useState, useEffect, useCallback, useRef } from "react";
 import { useAuth } from "@/auth/auth-context";
 import { useOctosStatus } from "@/hooks/use-octos-status";
 import { useTheme } from "@/hooks/use-theme";
@@ -46,29 +46,45 @@ export function ChatLayout({ children }: { children: ReactNode }) {
 
   // Notification toast state
   const [toast, setToast] = useState<string | null>(null);
+  const toastTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
   const openPanel = useCallback(() => setMediaPanelOpen(true), []);
+  const clearToastTimer = useCallback(() => {
+    if (toastTimerRef.current) {
+      clearTimeout(toastTimerRef.current);
+      toastTimerRef.current = null;
+    }
+  }, []);
+  const dismissToast = useCallback(() => {
+    clearToastTimer();
+    setToast(null);
+  }, [clearToastTimer]);
 
   // Listen for crew:file to show toast (crew:file_notification is a secondary
   // event dispatched by the file-store itself, so listening to both caused
   // duplicate toasts).
   useEffect(() => {
-    let toastTimer: ReturnType<typeof setTimeout> | null = null;
     function onFile(e: Event) {
       const detail = (e as CustomEvent).detail;
       if (!eventMatchesScope(detail, currentSessionId, historyTopic)) return;
       const filename = detail?.filename || "file";
       const isAudio = /\.(mp3|wav|ogg|m4a|opus|flac|aac)$/i.test(filename);
       setToast(isAudio ? `🎵 Audio ready: ${filename}` : `📄 File ready: ${filename}`);
-      if (toastTimer) clearTimeout(toastTimer);
-      toastTimer = setTimeout(() => setToast(null), 8000);
+      clearToastTimer();
+      toastTimerRef.current = setTimeout(() => {
+        toastTimerRef.current = null;
+        setToast(null);
+      }, 8000);
     }
     window.addEventListener("crew:file", onFile);
     return () => {
       window.removeEventListener("crew:file", onFile);
-      if (toastTimer) clearTimeout(toastTimer);
     };
-  }, [currentSessionId, historyTopic]);
+  }, [clearToastTimer, currentSessionId, historyTopic]);
+
+  useEffect(() => {
+    return dismissToast;
+  }, [currentSessionId, dismissToast, historyTopic]);
 
   return (
     <div className="chat-shell flex h-screen gap-3 p-3">
@@ -191,6 +207,7 @@ export function ChatLayout({ children }: { children: ReactNode }) {
             {/* Inline toast notification */}
             {toast && (
               <button
+                data-testid="file-notification-toast"
                 onClick={openPanel}
                 className="glass-pill absolute bottom-20 left-1/2 z-30 flex -translate-x-1/2 items-center gap-2 rounded-[12px] px-4 py-2.5 text-sm text-text shadow-lg hover:text-text-strong"
               >

--- a/src/store/message-store-reducer.ts
+++ b/src/store/message-store-reducer.ts
@@ -1,0 +1,6 @@
+export * from "./message-store-reducers/shared";
+export * from "./message-store-reducers/user-message-reducer";
+export * from "./message-store-reducers/assistant-turn-reducer";
+export * from "./message-store-reducers/background-task-reducer";
+export * from "./message-store-reducers/file-artifact-reducer";
+export * from "./message-store-reducers/history-replay-reducer";

--- a/src/store/message-store-reducers/assistant-turn-reducer.ts
+++ b/src/store/message-store-reducers/assistant-turn-reducer.ts
@@ -1,0 +1,159 @@
+import type { Message } from "../message-store";
+import type { CreateMessageId, Now } from "./shared";
+import {
+  mergeMessageFiles,
+  normalizeMessageText,
+  withRuntime,
+} from "./shared";
+
+export interface CreateAssistantTurnEvent {
+  type: "create_assistant_turn";
+  message: Omit<Message, "id" | "timestamp"> & { role: "assistant" };
+  createId: CreateMessageId;
+  now?: Now;
+}
+
+export interface AppendAssistantTextEvent {
+  type: "append_assistant_text";
+  message: Message;
+  chunk: string;
+  now?: Now;
+}
+
+export interface StopStreamingAssistantEvent {
+  type: "stop_streaming_assistant";
+  message: Message;
+  fallbackText?: string;
+  now?: Now;
+}
+
+export interface EnsureStreamingAssistantEvent {
+  type: "ensure_streaming_assistant";
+  messages: Message[];
+  text?: string;
+  createId: CreateMessageId;
+  now?: Now;
+}
+
+export interface AssistantTurnListProjection {
+  messageId: string;
+  messages: Message[];
+  changed: boolean;
+}
+
+export function reduceCreateAssistantTurnEvent(event: CreateAssistantTurnEvent): Message {
+  return withRuntime(
+    { ...event.message, id: event.createId(), timestamp: (event.now ?? Date.now)() },
+    {},
+    event.now ?? Date.now,
+  );
+}
+
+export function reduceAppendAssistantTextEvent(event: AppendAssistantTextEvent): Message {
+  return withRuntime(
+    { ...event.message, text: event.message.text + event.chunk },
+    {},
+    event.now ?? Date.now,
+  );
+}
+
+export function reduceStopStreamingAssistantEvent(event: StopStreamingAssistantEvent): Message {
+  if (event.message.status !== "streaming" || event.message.kind === "task_anchor") {
+    return event.message;
+  }
+  return withRuntime(
+    {
+      ...event.message,
+      text: event.message.text.trim()
+        ? event.message.text
+        : (event.fallbackText ?? "Stopped."),
+      status: "stopped",
+    },
+    { status: "stopped" },
+    event.now ?? Date.now,
+  );
+}
+
+export function reduceEnsureStreamingAssistantEvent(
+  event: EnsureStreamingAssistantEvent,
+): AssistantTurnListProjection {
+  const text = event.text ?? "Resuming ongoing work...";
+  const now = event.now ?? Date.now;
+  const existing = [...event.messages]
+    .reverse()
+    .find((message) => message.role === "assistant" && message.status === "streaming");
+
+  if (existing) {
+    if (!existing.text && text) {
+      const index = event.messages.findIndex((message) => message.id === existing.id);
+      if (index !== -1) {
+        const messages = [...event.messages];
+        messages[index] = withRuntime({ ...existing, text }, {}, now);
+        return { messageId: existing.id, messages, changed: true };
+      }
+    }
+    return { messageId: existing.id, messages: event.messages, changed: false };
+  }
+
+  const id = event.createId();
+  return {
+    messageId: id,
+    messages: [
+      ...event.messages,
+      withRuntime({
+        id,
+        role: "assistant",
+        text,
+        files: [],
+        toolCalls: [],
+        status: "streaming",
+        timestamp: now(),
+      }, {}, now),
+    ],
+    changed: true,
+  };
+}
+
+export function mergeAssistantDuplicate(primary: Message, duplicate: Message): Message {
+  return {
+    ...primary,
+    text: primary.text.trim() ? primary.text : duplicate.text,
+    files: mergeMessageFiles(duplicate.files, primary.files),
+    toolCalls:
+      primary.toolCalls.length > 0 ? primary.toolCalls : duplicate.toolCalls,
+    sourceToolCallId: primary.sourceToolCallId ?? duplicate.sourceToolCallId,
+    historySeq:
+      typeof primary.historySeq === "number" && typeof duplicate.historySeq === "number"
+        ? Math.max(primary.historySeq, duplicate.historySeq)
+        : (duplicate.historySeq ?? primary.historySeq),
+  };
+}
+
+export function isAssistantCompanionForFileMessage(
+  candidate: Message,
+  fileMessage: Message,
+): boolean {
+  if (candidate.kind === "task_anchor" || fileMessage.kind === "task_anchor") {
+    return false;
+  }
+  if (candidate.role !== "assistant" || fileMessage.role !== "assistant") {
+    return false;
+  }
+  if (candidate.files.length > 0 || fileMessage.files.length === 0) {
+    return false;
+  }
+  if (
+    normalizeMessageText(candidate.text) !== normalizeMessageText(fileMessage.text)
+  ) {
+    return false;
+  }
+
+  if (
+    typeof candidate.historySeq === "number" &&
+    typeof fileMessage.historySeq === "number"
+  ) {
+    return candidate.historySeq + 1 === fileMessage.historySeq;
+  }
+
+  return Math.abs(candidate.timestamp - fileMessage.timestamp) <= 5 * 60_000;
+}

--- a/src/store/message-store-reducers/background-task-reducer.ts
+++ b/src/store/message-store-reducers/background-task-reducer.ts
@@ -1,0 +1,209 @@
+import type { BackgroundTaskInfo } from "../../api/types";
+import type {
+  Message,
+  MessageRuntime,
+  MessageRuntimeStatus,
+  TaskAnchorMeta,
+} from "../message-store";
+import type { Now } from "./shared";
+import {
+  findMessageIndexById,
+  uniqueStrings,
+  withRuntime,
+} from "./shared";
+
+export interface ProjectTaskAnchorEvent {
+  type: "project_task_anchor";
+  sessionId: string;
+  task: BackgroundTaskInfo;
+  list: Message[];
+  taskAnchor: TaskAnchorMeta;
+  current?: Message;
+  now?: Now;
+}
+
+export function taskAnchorMessageId(sessionId: string, taskId: string): string {
+  return `task:${sessionId}:${taskId}`;
+}
+
+export function taskTimestamp(task: BackgroundTaskInfo, now: Now = Date.now): number {
+  const startedAt = new Date(task.started_at).getTime();
+  return Number.isFinite(startedAt) ? startedAt : now();
+}
+
+export function taskIdentity(task: BackgroundTaskInfo | null | undefined): string | null {
+  const id = typeof task?.id === "string" ? task.id.trim() : "";
+  return id || null;
+}
+
+export function taskAnchorTimelineTimestamp(
+  list: Message[],
+  task: BackgroundTaskInfo,
+  now: Now = Date.now,
+): number {
+  void list;
+  return taskTimestamp(task, now);
+}
+
+function sameStrings(left: string[] | undefined, right: string[] | undefined): boolean {
+  const normalizedLeft = uniqueStrings(left ?? []);
+  const normalizedRight = uniqueStrings(right ?? []);
+  if (normalizedLeft.length !== normalizedRight.length) return false;
+  return normalizedLeft.every((value, index) => value === normalizedRight[index]);
+}
+
+function sameJson(left: unknown, right: unknown): boolean {
+  return JSON.stringify(left ?? null) === JSON.stringify(right ?? null);
+}
+
+export function sameTaskAnchorMeta(
+  left: TaskAnchorMeta | undefined,
+  right: TaskAnchorMeta | undefined,
+): boolean {
+  return (
+    left?.taskId === right?.taskId &&
+    left?.toolCallId === right?.toolCallId &&
+    left?.taskStartedAt === right?.taskStartedAt &&
+    left?.taskStatus === right?.taskStatus &&
+    left?.lifecycleState === right?.lifecycleState &&
+    left?.currentPhase === right?.currentPhase &&
+    left?.progressMessage === right?.progressMessage &&
+    left?.progress === right?.progress &&
+    left?.completedAt === right?.completedAt &&
+    left?.error === right?.error &&
+    left?.workflowKind === right?.workflowKind &&
+    sameStrings(left?.outputFiles, right?.outputFiles) &&
+    sameStrings(left?.toolNames, right?.toolNames) &&
+    sameJson(left?.progressEvents, right?.progressEvents) &&
+    sameJson(left?.runtimeDetail, right?.runtimeDetail)
+  );
+}
+
+export function mergeTaskAnchorMeta(
+  existing: TaskAnchorMeta | undefined,
+  task: BackgroundTaskInfo,
+): TaskAnchorMeta {
+  const normalizedToolName = normalizeToolName(task.tool_name) || task.tool_name;
+  return {
+    taskId: task.id || existing?.taskId,
+    toolCallId: task.tool_call_id ?? existing?.toolCallId,
+    taskStartedAt: task.started_at ?? existing?.taskStartedAt,
+    taskStatus: task.status ?? existing?.taskStatus,
+    lifecycleState: task.lifecycle_state ?? existing?.lifecycleState,
+    currentPhase: task.current_phase ?? existing?.currentPhase,
+    progressMessage: task.progress_message ?? existing?.progressMessage,
+    progress: task.progress ?? existing?.progress,
+    progressEvents: task.progress_events ?? existing?.progressEvents,
+    runtimeDetail: task.runtime_detail ?? existing?.runtimeDetail,
+    completedAt: task.completed_at ?? existing?.completedAt,
+    error: task.error ?? existing?.error,
+    workflowKind: task.workflow_kind ?? existing?.workflowKind,
+    outputFiles: uniqueStrings([...(existing?.outputFiles ?? []), ...(task.output_files ?? [])]),
+    toolNames: uniqueStrings([...(existing?.toolNames ?? []), normalizedToolName]),
+  };
+}
+
+export function normalizeToolName(name: string | undefined): string {
+  if (!name) return "";
+  return name === "Direct TTS" ? "fm_tts" : name;
+}
+
+export function runtimeStatusForTask(task: BackgroundTaskInfo): MessageRuntimeStatus {
+  switch (task.status) {
+    case "spawned":
+    case "running":
+      return "ongoing";
+    case "completed":
+      return "completed";
+    case "failed":
+      return "failed";
+  }
+}
+
+export function isTaskActive(task: BackgroundTaskInfo): boolean {
+  return task.status === "spawned" || task.status === "running";
+}
+
+export function taskMessageStatus(task: BackgroundTaskInfo): Message["status"] {
+  if (task.status === "failed") return "error";
+  if (isTaskActive(task)) return "streaming";
+  return "complete";
+}
+
+export function taskRuntimeOverrides(task: BackgroundTaskInfo): Partial<MessageRuntime> {
+  return {
+    type: "background_task",
+    status: runtimeStatusForTask(task),
+    taskId: task.id,
+    toolCallId: task.tool_call_id,
+    phase: task.current_phase ?? task.lifecycle_state ?? null,
+    detail: task.progress_message ?? task.error ?? null,
+  };
+}
+
+export function projectTaskAnchorMessage(
+  sessionId: string,
+  task: BackgroundTaskInfo,
+  list: Message[],
+  taskAnchor: TaskAnchorMeta,
+  current?: Message,
+  now: Now = Date.now,
+): Message {
+  const taskId = taskIdentity(task) ?? "";
+  const base = current
+    ? {
+        ...current,
+        id: taskAnchorMessageId(sessionId, taskId),
+        role: current.role === "system" ? "assistant" : current.role,
+        kind: "task_anchor" as const,
+        status: taskMessageStatus(task),
+        timestamp: taskAnchorTimelineTimestamp(list, task, now),
+        sourceToolCallId: task.tool_call_id ?? current.sourceToolCallId,
+        taskAnchor,
+      }
+    : {
+        id: taskAnchorMessageId(sessionId, taskId),
+        role: "assistant" as const,
+        kind: "task_anchor" as const,
+        text: "",
+        files: [],
+        toolCalls: [],
+        status: taskMessageStatus(task),
+        timestamp: taskAnchorTimelineTimestamp(list, task, now),
+        sourceToolCallId: task.tool_call_id,
+        taskAnchor,
+      };
+
+  return withRuntime(base, taskRuntimeOverrides(task), now);
+}
+
+export function reduceProjectTaskAnchorEvent(event: ProjectTaskAnchorEvent): Message {
+  return projectTaskAnchorMessage(
+    event.sessionId,
+    event.task,
+    event.list,
+    event.taskAnchor,
+    event.current,
+    event.now,
+  );
+}
+
+export function findTaskAnchorIndex(
+  sessionId: string,
+  taskMessageIds: ReadonlyMap<string, string> | undefined,
+  list: Message[],
+  task: BackgroundTaskInfo,
+): number {
+  const taskId = taskIdentity(task);
+  if (!taskId) return -1;
+  const anchorId = taskAnchorMessageId(sessionId, taskId);
+  const directIndex = findMessageIndexById(list, anchorId);
+  if (directIndex !== -1) return directIndex;
+
+  if (taskMessageIds?.has(taskId)) {
+    const mappedIndex = findMessageIndexById(list, taskMessageIds.get(taskId)!);
+    if (mappedIndex !== -1) return mappedIndex;
+  }
+
+  return -1;
+}

--- a/src/store/message-store-reducers/file-artifact-reducer.ts
+++ b/src/store/message-store-reducers/file-artifact-reducer.ts
@@ -1,0 +1,173 @@
+import type { Message, MessageFile } from "../message-store";
+import { displayFilenameFromPath } from "../../lib/utils";
+import {
+  findMessageIndexById,
+  findMessageIndexByToolCallId,
+  mergeMessageFiles,
+  pathMatchKeys,
+  TASK_COMPLETION_RE,
+} from "./shared";
+
+export interface AppendFileArtifactEvent {
+  type: "append_file_artifact";
+  message: Message;
+  file: MessageFile;
+}
+
+export function addFileToMessage(message: Message, file: MessageFile): Message {
+  if (message.files.some((existing) => existing.path === file.path)) return message;
+  return { ...message, files: [...message.files, file] };
+}
+
+export function reduceAppendFileArtifactEvent(event: AppendFileArtifactEvent): Message {
+  return addFileToMessage(event.message, event.file);
+}
+
+export function parseLegacyFileLine(line: string): MessageFile | null {
+  const match = line.trim().match(/^\[file:([^\]]+)\]\s*(.*)$/u);
+  if (!match) return null;
+
+  const path = match[1]?.trim();
+  if (!path) return null;
+
+  const fallbackName = displayFilenameFromPath(path);
+  const remainder = (match[2] || "").trim();
+  if (!remainder) {
+    return { filename: fallbackName, path, caption: "" };
+  }
+
+  const separator = " — ";
+  const sepIdx = remainder.indexOf(separator);
+  if (sepIdx === -1) {
+    return { filename: remainder || fallbackName, path, caption: "" };
+  }
+
+  const filename = remainder.slice(0, sepIdx).trim() || fallbackName;
+  const caption = remainder.slice(sepIdx + separator.length).trim();
+  return { filename, path, caption };
+}
+
+export function parseLegacyFileDeliveries(content: string): {
+  text: string;
+  files: MessageFile[];
+} {
+  if (!content.includes("[file:")) {
+    return { text: content, files: [] };
+  }
+
+  const files: MessageFile[] = [];
+  const remainingLines: string[] = [];
+  const seenPaths = new Set<string>();
+
+  for (const line of content.split(/\r?\n/u)) {
+    const parsed = parseLegacyFileLine(line);
+    if (!parsed) {
+      remainingLines.push(line);
+      continue;
+    }
+
+    if (seenPaths.has(parsed.path)) continue;
+    seenPaths.add(parsed.path);
+    files.push(parsed);
+  }
+
+  return {
+    text: remainingLines.join("\n").trim(),
+    files,
+  };
+}
+
+export function findMessageIndexForFilePath(
+  outputPathMessageIds: ReadonlyMap<string, string> | undefined,
+  list: Message[],
+  file: MessageFile,
+): number {
+  if (!outputPathMessageIds) return -1;
+
+  for (const pathKey of pathMatchKeys(file.path)) {
+    const messageId = outputPathMessageIds.get(pathKey);
+    if (!messageId) continue;
+    const index = findMessageIndexById(list, messageId);
+    if (index !== -1) return index;
+  }
+  return -1;
+}
+
+export function shouldCoalesceFileResult(message: Message): boolean {
+  if (message.role !== "assistant" || message.files.length === 0) return false;
+  if (message.sourceToolCallId) return true;
+  if (!message.text.trim()) return true;
+  return TASK_COMPLETION_RE.test(message.text.trim());
+}
+
+export function findFileResultTargetIndex(
+  outputPathMessageIds: ReadonlyMap<string, string> | undefined,
+  list: Message[],
+  fileResult: Message,
+): number {
+  if (!shouldCoalesceFileResult(fileResult)) return -1;
+
+  const byToolCall = findMessageIndexByToolCallId(
+    list,
+    fileResult.sourceToolCallId,
+  );
+  if (byToolCall !== -1) return byToolCall;
+
+  for (const file of fileResult.files) {
+    const byPath = findMessageIndexForFilePath(outputPathMessageIds, list, file);
+    if (byPath !== -1) return byPath;
+  }
+
+  const adjacent = findAdjacentFileResultTargetIndex(list, fileResult);
+  if (adjacent !== -1) return adjacent;
+
+  return -1;
+}
+
+export function findAdjacentFileResultTargetIndex(
+  list: Message[],
+  fileResult: Message,
+): number {
+  const fileText = fileResult.text.trim();
+  const isMediaOnly = fileText.length === 0 || TASK_COMPLETION_RE.test(fileText);
+  if (!isMediaOnly) return -1;
+  const fileSeq = fileResult.historySeq;
+
+  for (let index = list.length - 1; index >= 0; index -= 1) {
+    const candidate = list[index];
+    if (candidate.kind === "task_anchor") continue;
+    if (candidate.role === "user" || candidate.role === "system") return -1;
+    if (candidate.role !== "assistant") continue;
+    if (!candidate.text.trim() && candidate.toolCalls.length === 0) continue;
+
+    if (typeof fileSeq === "number" && typeof candidate.historySeq === "number") {
+      return fileSeq === candidate.historySeq + 1 ? index : -1;
+    }
+
+    const delta = fileResult.timestamp - candidate.timestamp;
+    if (delta < 0 || delta > 5 * 60_000) return -1;
+    return index;
+  }
+
+  return -1;
+}
+
+export function mergeFileResultIntoTarget(target: Message, fileResult: Message): Message {
+  const files = fileResult.files.map((file) => ({
+    ...file,
+    caption: file.caption || fileResult.text || "",
+  }));
+
+  return {
+    ...target,
+    text: target.text.trim() ? target.text : fileResult.text,
+    files: mergeMessageFiles(files, target.files),
+    toolCalls:
+      target.toolCalls.length > 0 ? target.toolCalls : fileResult.toolCalls,
+    sourceToolCallId: target.sourceToolCallId ?? fileResult.sourceToolCallId,
+    historySeq:
+      typeof target.historySeq === "number" && typeof fileResult.historySeq === "number"
+        ? Math.max(target.historySeq, fileResult.historySeq)
+        : (fileResult.historySeq ?? target.historySeq),
+  };
+}

--- a/src/store/message-store-reducers/history-replay-reducer.ts
+++ b/src/store/message-store-reducers/history-replay-reducer.ts
@@ -1,0 +1,220 @@
+import type { MessageInfo } from "../../api/types";
+import type { Message, ToolCallInfo } from "../message-store";
+import { displayFilenameFromPath } from "../../lib/utils";
+import type { CreateMessageId, Now } from "./shared";
+import {
+  mergeMessageFiles,
+  normalizeMessageText,
+  TASK_COMPLETION_RE,
+  withRuntime,
+} from "./shared";
+import { parseLegacyFileDeliveries } from "./file-artifact-reducer";
+
+export interface ConvertHistoryReplayMessageEvent {
+  type: "convert_history_replay_message";
+  message: MessageInfo;
+  createId: CreateMessageId;
+  now?: Now;
+}
+
+export interface MergeAuthoritativeHistoryMessageEvent {
+  type: "merge_authoritative_history_message";
+  existing: Message;
+  authoritative: Message;
+  now?: Now;
+}
+
+export function shouldCollapseAuthoritativeDuplicate(
+  candidate: Message,
+  authoritative: Message,
+): boolean {
+  if (candidate.kind === "task_anchor") return false;
+  if (candidate.role !== authoritative.role) return false;
+
+  if (
+    typeof candidate.historySeq === "number" &&
+    typeof authoritative.historySeq === "number" &&
+    candidate.historySeq === authoritative.historySeq
+  ) {
+    return true;
+  }
+
+  if (
+    authoritative.clientMessageId &&
+    candidate.clientMessageId === authoritative.clientMessageId
+  ) {
+    return true;
+  }
+
+  if (
+    authoritative.responseToClientMessageId &&
+    candidate.responseToClientMessageId === authoritative.responseToClientMessageId
+  ) {
+    return true;
+  }
+
+  if (candidate.role !== "assistant") return false;
+
+  const timeDelta = Math.abs(candidate.timestamp - authoritative.timestamp);
+  if (timeDelta > 15 * 60_000) return false;
+
+  if (candidate.status === "streaming") return true;
+
+  const candidateText = normalizeMessageText(candidate.text);
+  const authoritativeText = normalizeMessageText(authoritative.text);
+  return candidateText.length > 0 && candidateText === authoritativeText;
+}
+
+export function findOptimisticMatchIndex(list: Message[], authoritative: Message): number {
+  if (authoritative.clientMessageId) {
+    const directMatchIndex = list.findIndex(
+      (candidate) =>
+        typeof candidate.historySeq !== "number" &&
+        candidate.kind !== "task_anchor" &&
+        candidate.role === authoritative.role &&
+        candidate.clientMessageId === authoritative.clientMessageId,
+    );
+    if (directMatchIndex !== -1) return directMatchIndex;
+  }
+
+  if (authoritative.responseToClientMessageId) {
+    const responseMatchIndex = list.findIndex(
+      (candidate) =>
+        typeof candidate.historySeq !== "number" &&
+        candidate.kind !== "task_anchor" &&
+        candidate.role === authoritative.role &&
+        candidate.responseToClientMessageId === authoritative.responseToClientMessageId,
+    );
+    if (responseMatchIndex !== -1) return responseMatchIndex;
+  }
+
+  if (authoritative.role === "assistant") {
+    for (let index = list.length - 1; index >= 0; index -= 1) {
+      const candidate = list[index];
+      if (typeof candidate.historySeq === "number") continue;
+      if (candidate.kind === "task_anchor") continue;
+      if (candidate.role !== "assistant" || candidate.status !== "streaming") continue;
+
+      const timeDelta = Math.abs(candidate.timestamp - authoritative.timestamp);
+      if (timeDelta > 15 * 60_000) continue;
+
+      // Recovery can replay the committed session_result before the resumed
+      // streaming bubble receives its final `done` payload. In that window the
+      // texts differ ("Resuming..." vs final answer), but they still represent
+      // the same assistant turn and must collapse into one message.
+      return index;
+    }
+  }
+
+  const authoritativeText = normalizeMessageText(authoritative.text);
+  const authoritativeTime = authoritative.timestamp;
+
+  let bestIndex = -1;
+  let bestTimeDelta = Number.MAX_SAFE_INTEGER;
+
+  for (let index = 0; index < list.length; index += 1) {
+    const candidate = list[index];
+    if (typeof candidate.historySeq === "number") continue;
+    if (candidate.kind === "task_anchor") continue;
+    if (candidate.role !== authoritative.role) continue;
+    if (normalizeMessageText(candidate.text) !== authoritativeText) continue;
+    // Don't require file or tool call match — both arrive asynchronously
+    // via SSE and may differ from the API version.
+
+    const timeDelta = Math.abs(candidate.timestamp - authoritativeTime);
+    // Recovery can recreate an optimistic assistant bubble and then replay the
+    // committed session_result much later. Keep a wider assistant merge window
+    // so resumed turns are replaced in place instead of appending a duplicate
+    // assistant bubble after one or more reloads.
+    const optimisticWindowMs =
+      candidate.role === "assistant" ? 15 * 60_000 : 60_000;
+    if (timeDelta > optimisticWindowMs) continue;
+    if (timeDelta >= bestTimeDelta) continue;
+
+    bestIndex = index;
+    bestTimeDelta = timeDelta;
+  }
+
+  return bestIndex;
+}
+
+export function mergeAuthoritativeIntoMessage(
+  existing: Message,
+  authoritative: Message,
+  now: Now = Date.now,
+): Message {
+  const merged: Message = {
+    ...existing,
+    text: authoritative.text,
+    clientMessageId: authoritative.clientMessageId ?? existing.clientMessageId,
+    responseToClientMessageId:
+      authoritative.responseToClientMessageId ?? existing.responseToClientMessageId,
+    files: mergeMessageFiles(authoritative.files, existing.files),
+    toolCalls:
+      authoritative.toolCalls.length > 0 ? authoritative.toolCalls : existing.toolCalls,
+    status: "complete",
+    timestamp: authoritative.timestamp,
+    historySeq: authoritative.historySeq,
+    meta: existing.meta,
+    sourceToolCallId: authoritative.sourceToolCallId ?? existing.sourceToolCallId,
+    kind: existing.kind ?? authoritative.kind,
+    taskAnchor: existing.taskAnchor ?? authoritative.taskAnchor,
+  };
+  return withRuntime(merged, {}, now);
+}
+
+export function reduceMergeAuthoritativeHistoryMessageEvent(
+  event: MergeAuthoritativeHistoryMessageEvent,
+): Message {
+  return mergeAuthoritativeIntoMessage(event.existing, event.authoritative, event.now);
+}
+
+export function convertApiMessage(
+  m: MessageInfo,
+  createId: CreateMessageId,
+  now: Now = Date.now,
+): Message | null {
+  if (m.role === "tool") return null;
+  const role = m.role === "user" ? "user" : m.role === "system" ? "system" : "assistant";
+  const mediaFiles = (m.media ?? []).map((path) => ({
+    filename: displayFilenameFromPath(path),
+    path,
+    caption: "",
+  }));
+  const parsedLegacy = parseLegacyFileDeliveries(m.content);
+  const files = mergeMessageFiles(parsedLegacy.files, mediaFiles);
+  const text = parsedLegacy.text;
+  if (!text.trim() && files.length === 0) return null;
+  // Skip task completion status messages (e.g. "✓ fm_tts completed (file.mp3)")
+  // — the file is already delivered via the media field on a separate message.
+  if (role === "assistant" && files.length === 0 && TASK_COMPLETION_RE.test(text.trim())) {
+    return null;
+  }
+
+  const toolCalls: ToolCallInfo[] =
+    m.tool_calls?.filter((tc) => tc.name).map((tc) => ({
+      id: tc.id || "",
+      name: tc.name || "",
+      status: "complete" as const,
+    })) ?? [];
+
+  return withRuntime({
+    id: createId(),
+    role,
+    text,
+    clientMessageId: m.client_message_id,
+    responseToClientMessageId: m.response_to_client_message_id,
+    files,
+    toolCalls,
+    status: "complete",
+    timestamp: m.timestamp ? new Date(m.timestamp).getTime() : now(),
+    historySeq: typeof m.seq === "number" ? m.seq : undefined,
+    sourceToolCallId: m.tool_call_id,
+  }, {}, now);
+}
+
+export function reduceConvertHistoryReplayMessageEvent(
+  event: ConvertHistoryReplayMessageEvent,
+): Message | null {
+  return convertApiMessage(event.message, event.createId, event.now);
+}

--- a/src/store/message-store-reducers/shared.ts
+++ b/src/store/message-store-reducers/shared.ts
@@ -1,0 +1,201 @@
+import type {
+  Message,
+  MessageRuntime,
+  MessageRuntimeStatus,
+  MessageRuntimeType,
+  MessageFile,
+} from "../message-store";
+import { displayFilenameFromPath } from "../../lib/utils";
+
+export type CreateMessageId = () => string;
+export type Now = () => number;
+
+/** Task completion notifications are status messages, not real responses. */
+export const TASK_COMPLETION_RE = /^[✓✗]\s+\S+\s+(completed|failed)\s*\(/u;
+
+export function compareMessagesForDisplay(a: Message, b: Message): number {
+  const aIsTaskAnchor = a.kind === "task_anchor";
+  const bIsTaskAnchor = b.kind === "task_anchor";
+  if (aIsTaskAnchor || bIsTaskAnchor) {
+    const byTime = a.timestamp - b.timestamp;
+    if (byTime !== 0) return byTime;
+  }
+
+  const aSeq =
+    typeof a.historySeq === "number" ? a.historySeq : Number.MAX_SAFE_INTEGER;
+  const bSeq =
+    typeof b.historySeq === "number" ? b.historySeq : Number.MAX_SAFE_INTEGER;
+  if (aSeq !== bSeq) return aSeq - bSeq;
+  return a.timestamp - b.timestamp;
+}
+
+export function sortedMessagesForDisplay(messages: Message[]): Message[] {
+  return messages
+    .map((message, index) => ({ message, index }))
+    .sort((a, b) => compareMessagesForDisplay(a.message, b.message) || a.index - b.index)
+    .map(({ message }) => message);
+}
+
+export function realignTaskAnchors(messages: Message[]): Message[] {
+  return messages.map((message) => {
+    const startedAt = message.taskAnchor?.taskStartedAt
+      ? new Date(message.taskAnchor.taskStartedAt).getTime()
+      : NaN;
+    if (message.kind !== "task_anchor" || !Number.isFinite(startedAt)) {
+      return message;
+    }
+    const timestamp = startedAt;
+    return timestamp === message.timestamp ? message : { ...message, timestamp };
+  });
+}
+
+export function uniqueStrings(values: Array<string | undefined | null>): string[] {
+  return [
+    ...new Set(
+      values
+        .filter((value): value is string => !!value && !!value.trim())
+        .map((value) => value.trim()),
+    ),
+  ];
+}
+
+export function messageRuntimeType(message: Pick<Message, "role" | "kind">): MessageRuntimeType {
+  if (message.kind === "task_anchor") return "background_task";
+  return message.role;
+}
+
+export function runtimeStatusForMessageStatus(status: Message["status"]): MessageRuntimeStatus {
+  switch (status) {
+    case "streaming":
+      return "ongoing";
+    case "complete":
+      return "completed";
+    case "stopped":
+      return "stopped";
+    case "error":
+      return "failed";
+  }
+}
+
+export function runtimeForMessage(
+  message: Message,
+  overrides: Partial<MessageRuntime> = {},
+  now: Now = Date.now,
+): MessageRuntime {
+  return {
+    ...(message.runtime ?? {
+      type: messageRuntimeType(message),
+      status: runtimeStatusForMessageStatus(message.status),
+      updatedAt: now(),
+    }),
+    type: overrides.type ?? messageRuntimeType(message),
+    status: overrides.status ?? runtimeStatusForMessageStatus(message.status),
+    updatedAt: overrides.updatedAt ?? now(),
+    taskId: overrides.taskId ?? message.taskAnchor?.taskId ?? message.runtime?.taskId,
+    toolCallId:
+      overrides.toolCallId ??
+      message.sourceToolCallId ??
+      message.taskAnchor?.toolCallId ??
+      message.runtime?.toolCallId,
+    phase: overrides.phase ?? message.taskAnchor?.currentPhase ?? message.runtime?.phase,
+    detail:
+      overrides.detail ??
+      message.taskAnchor?.progressMessage ??
+      message.taskAnchor?.error ??
+      message.runtime?.detail,
+  };
+}
+
+export function withRuntime<T extends Message>(
+  message: T,
+  overrides: Partial<MessageRuntime> = {},
+  now: Now = Date.now,
+): T {
+  return {
+    ...message,
+    runtime: runtimeForMessage(message, overrides, now),
+  };
+}
+
+export function pathMatchKeys(path: string): string[] {
+  const keys = new Set<string>();
+  const add = (value: string | undefined) => {
+    const normalized = value?.trim();
+    if (normalized) keys.add(normalized);
+  };
+
+  add(path);
+  try {
+    add(decodeURIComponent(path));
+  } catch {
+    // Keep the original path when decoding fails.
+  }
+  add(displayFilenameFromPath(path));
+  return [...keys];
+}
+
+export function findMessageIndexById(list: Message[], messageId: string): number {
+  return list.findIndex((message) => message.id === messageId);
+}
+
+export function messageBelongsToDifferentTask(message: Message, taskId?: string): boolean {
+  return Boolean(
+    taskId &&
+      message.kind === "task_anchor" &&
+      message.taskAnchor?.taskId &&
+      message.taskAnchor.taskId !== taskId,
+  );
+}
+
+export function findMessageIndexByToolCallId(
+  list: Message[],
+  toolCallId?: string,
+  taskId?: string,
+): number {
+  if (!toolCallId) return -1;
+  return list.findIndex(
+    (message) =>
+      !messageBelongsToDifferentTask(message, taskId) &&
+      (message.toolCalls.some((toolCall) => toolCall.id === toolCallId) ||
+        message.sourceToolCallId === toolCallId),
+  );
+}
+
+export function mergeMessageFiles(primary: MessageFile[], fallback: MessageFile[]): MessageFile[] {
+  const merged = new Map<string, MessageFile>();
+
+  for (const file of primary) {
+    merged.set(file.path, file);
+  }
+
+  for (const file of fallback) {
+    const existing = merged.get(file.path);
+    if (!existing) {
+      merged.set(file.path, file);
+      continue;
+    }
+
+    merged.set(file.path, {
+      ...existing,
+      filename: existing.filename || file.filename,
+      caption: existing.caption || file.caption || "",
+    });
+  }
+
+  return Array.from(merged.values());
+}
+
+export function normalizeMessageText(text: string): string {
+  // Strip tool progress lines, streaming stats, and provider info that
+  // may differ between the SSE-streamed text and the API-stored text.
+  const lines = text.split("\n").filter((line) => {
+    const t = line.trim();
+    if (!t) return false;
+    if (/^[✓✗⚙📄✦]\s*[`[]/u.test(t)) return false; // tool badges
+    if (/^via\s+\S+\s+\(/u.test(t)) return false; // provider info
+    if (/^\d+s(\s*·\s*[\d.]+k?[↑↓].*)?$/u.test(t)) return false; // streaming stats
+    if (t === "Processing") return false;
+    return true;
+  });
+  return lines.join(" ").replace(/\s+/gu, " ").trim();
+}

--- a/src/store/message-store-reducers/user-message-reducer.ts
+++ b/src/store/message-store-reducers/user-message-reducer.ts
@@ -1,0 +1,22 @@
+import type { Message } from "../message-store";
+import type { CreateMessageId, Now } from "./shared";
+import { withRuntime } from "./shared";
+
+export interface CreateUserMessageEvent {
+  type: "create_user_message";
+  message: Omit<Message, "id" | "timestamp"> & { role: "user" };
+  createId: CreateMessageId;
+  now?: Now;
+}
+
+export function createLocalMessage(
+  msg: Omit<Message, "id" | "timestamp">,
+  createId: CreateMessageId,
+  now: Now = Date.now,
+): Message {
+  return withRuntime({ ...msg, id: createId(), timestamp: now() }, {}, now);
+}
+
+export function reduceCreateUserMessageEvent(event: CreateUserMessageEvent): Message {
+  return createLocalMessage(event.message, event.createId, event.now);
+}

--- a/src/store/message-store.ts
+++ b/src/store/message-store.ts
@@ -5,14 +5,50 @@
  * Messages are keyed by sessionId plus optional history topic. History is
  * loaded from the API on first access; streaming updates arrive via the
  * runtime bridges.
+ *
+ * Pure reducer logic lives in ./message-store-reducers/*. This file keeps the
+ * stateful facade — session/topic maps, React subscriptions, and observability
+ * counters — but delegates message-shape transformations to the reducers for
+ * isolated unit testing.
  */
 
 import { useSyncExternalStore } from "react";
 import { getMessages as fetchMessages } from "@/api/sessions";
 import type { BackgroundTaskInfo, MessageInfo } from "@/api/types";
-import { displayFilenameFromPath } from "@/lib/utils";
 import { addFile as addToFileStore } from "@/store/file-store";
 import { recordRuntimeCounter } from "@/runtime/observability";
+import {
+  addFileToMessage,
+  convertApiMessage,
+  createLocalMessage,
+  findFileResultTargetIndex,
+  findMessageIndexById,
+  findMessageIndexByToolCallId,
+  findOptimisticMatchIndex,
+  findTaskAnchorIndex,
+  mergeAuthoritativeIntoMessage,
+  mergeFileResultIntoTarget,
+  mergeMessageFiles,
+  mergeTaskAnchorMeta,
+  normalizeMessageText,
+  pathMatchKeys,
+  projectTaskAnchorMessage,
+  reduceAppendAssistantTextEvent,
+  reduceAppendFileArtifactEvent,
+  reduceCreateAssistantTurnEvent,
+  reduceCreateUserMessageEvent,
+  reduceEnsureStreamingAssistantEvent,
+  reduceStopStreamingAssistantEvent,
+  runtimeStatusForTask,
+  sameTaskAnchorMeta,
+  shouldCollapseAuthoritativeDuplicate,
+  sortedMessagesForDisplay,
+  taskAnchorMessageId,
+  taskIdentity,
+  taskMessageStatus,
+  withRuntime,
+  TASK_COMPLETION_RE,
+} from "@/store/message-store-reducer";
 
 // ---------------------------------------------------------------------------
 // Types
@@ -22,6 +58,7 @@ export interface ToolCallInfo {
   id: string;
   name: string;
   status: "running" | "complete" | "error";
+  detail?: string;
 }
 
 export interface MessageFile {
@@ -37,19 +74,58 @@ export interface MessageMeta {
   duration_s: number;
 }
 
+export type MessageRuntimeType = "user" | "assistant" | "system" | "background_task";
+export type MessageRuntimeStatus =
+  | "queued"
+  | "ongoing"
+  | "completed"
+  | "stopped"
+  | "failed";
+
+export interface MessageRuntime {
+  type: MessageRuntimeType;
+  status: MessageRuntimeStatus;
+  updatedAt: number;
+  taskId?: string;
+  toolCallId?: string;
+  phase?: string | null;
+  detail?: string | null;
+}
+
+export interface TaskAnchorMeta {
+  taskId?: string;
+  toolCallId?: string;
+  taskStartedAt?: string;
+  taskStatus?: BackgroundTaskInfo["status"];
+  lifecycleState?: string | null;
+  currentPhase?: string | null;
+  progressMessage?: string | null;
+  progress?: number | null;
+  progressEvents?: BackgroundTaskInfo["progress_events"];
+  runtimeDetail?: BackgroundTaskInfo["runtime_detail"];
+  completedAt?: string | null;
+  error?: string | null;
+  workflowKind?: string | null;
+  outputFiles?: string[];
+  toolNames?: string[];
+}
+
 export interface Message {
   id: string;
   role: "user" | "assistant" | "system";
   text: string;
+  kind?: "task_anchor";
   clientMessageId?: string;
   responseToClientMessageId?: string;
   files: MessageFile[];
   toolCalls: ToolCallInfo[];
-  status: "streaming" | "complete" | "error";
+  status: "streaming" | "complete" | "error" | "stopped";
+  runtime?: MessageRuntime;
   timestamp: number;
   historySeq?: number;
   meta?: MessageMeta;
   sourceToolCallId?: string;
+  taskAnchor?: TaskAnchorMeta;
 }
 
 // ---------------------------------------------------------------------------
@@ -144,23 +220,6 @@ function taskToolStatus(
   return "complete";
 }
 
-function pathMatchKeys(path: string): string[] {
-  const keys = new Set<string>();
-  const add = (value: string | undefined) => {
-    const normalized = value?.trim();
-    if (normalized) keys.add(normalized);
-  };
-
-  add(path);
-  try {
-    add(decodeURIComponent(path));
-  } catch {
-    // Keep the original path when decoding fails.
-  }
-  add(displayFilenameFromPath(path));
-  return [...keys];
-}
-
 function mapFor(
   root: Map<string, Map<string, string>>,
   key: string,
@@ -202,18 +261,6 @@ function indexTaskForMessage(key: string, task: BackgroundTaskInfo, messageId: s
       outputMap.set(pathKey, messageId);
     }
   }
-}
-
-function findMessageIndexById(list: Message[], messageId: string): number {
-  return list.findIndex((message) => message.id === messageId);
-}
-
-function findMessageIndexByToolCallId(list: Message[], toolCallId?: string): number {
-  if (!toolCallId) return -1;
-  return list.findIndex((message) =>
-    message.toolCalls.some((toolCall) => toolCall.id === toolCallId) ||
-    message.sourceToolCallId === toolCallId,
-  );
 }
 
 function findMessageIndexForFilePath(key: string, list: Message[], file: MessageFile): number {
@@ -291,11 +338,6 @@ function upsertToolCall(
   return { ...message, toolCalls: [...message.toolCalls, toolCall] };
 }
 
-function addFileToMessage(message: Message, file: MessageFile): Message {
-  if (message.files.some((existing) => existing.path === file.path)) return message;
-  return { ...message, files: [...message.files, file] };
-}
-
 function indexFilesForMessage(sessionId: string, message: Message): void {
   for (const file of message.files) {
     addToFileStore({
@@ -305,272 +347,6 @@ function indexFilesForMessage(sessionId: string, message: Message): void {
       caption: file.caption ?? "",
     });
   }
-}
-
-function parseLegacyFileLine(line: string): MessageFile | null {
-  const match = line.trim().match(/^\[file:([^\]]+)\]\s*(.*)$/u);
-  if (!match) return null;
-
-  const path = match[1]?.trim();
-  if (!path) return null;
-
-  const fallbackName = displayFilenameFromPath(path);
-  const remainder = (match[2] || "").trim();
-  if (!remainder) {
-    return { filename: fallbackName, path, caption: "" };
-  }
-
-  const separator = " — ";
-  const sepIdx = remainder.indexOf(separator);
-  if (sepIdx === -1) {
-    return { filename: remainder || fallbackName, path, caption: "" };
-  }
-
-  const filename = remainder.slice(0, sepIdx).trim() || fallbackName;
-  const caption = remainder.slice(sepIdx + separator.length).trim();
-  return { filename, path, caption };
-}
-
-function parseLegacyFileDeliveries(content: string): {
-  text: string;
-  files: MessageFile[];
-} {
-  if (!content.includes("[file:")) {
-    return { text: content, files: [] };
-  }
-
-  const files: MessageFile[] = [];
-  const remainingLines: string[] = [];
-  const seenPaths = new Set<string>();
-
-  for (const line of content.split(/\r?\n/u)) {
-    const parsed = parseLegacyFileLine(line);
-    if (!parsed) {
-      remainingLines.push(line);
-      continue;
-    }
-
-    if (seenPaths.has(parsed.path)) continue;
-    seenPaths.add(parsed.path);
-    files.push(parsed);
-  }
-
-  return {
-    text: remainingLines.join("\n").trim(),
-    files,
-  };
-}
-
-function mergeMessageFiles(primary: MessageFile[], fallback: MessageFile[]): MessageFile[] {
-  const merged = new Map<string, MessageFile>();
-
-  for (const file of primary) {
-    merged.set(file.path, file);
-  }
-
-  for (const file of fallback) {
-    const existing = merged.get(file.path);
-    if (!existing) {
-      merged.set(file.path, file);
-      continue;
-    }
-
-    merged.set(file.path, {
-      ...existing,
-      filename: existing.filename || file.filename,
-      caption: existing.caption || file.caption || "",
-    });
-  }
-
-  return Array.from(merged.values());
-}
-
-function normalizeMessageText(text: string): string {
-  // Strip tool progress lines, streaming stats, and provider info that
-  // may differ between the SSE-streamed text and the API-stored text.
-  const lines = text.split("\n").filter((line) => {
-    const t = line.trim();
-    if (!t) return false;
-    if (/^[✓✗⚙📄✦]\s*[`[]/u.test(t)) return false; // tool badges
-    if (/^via\s+\S+\s+\(/u.test(t)) return false; // provider info
-    if (/^\d+s(\s*·\s*[\d.]+k?[↑↓].*)?$/u.test(t)) return false; // streaming stats
-    if (t === "Processing") return false;
-    return true;
-  });
-  return lines.join(" ").replace(/\s+/gu, " ").trim();
-}
-
-function shouldCollapseAuthoritativeDuplicate(
-  candidate: Message,
-  authoritative: Message,
-): boolean {
-  if (candidate.role !== authoritative.role) return false;
-
-  if (
-    typeof candidate.historySeq === "number" &&
-    typeof authoritative.historySeq === "number" &&
-    candidate.historySeq === authoritative.historySeq
-  ) {
-    return true;
-  }
-
-  if (
-    authoritative.clientMessageId &&
-    candidate.clientMessageId === authoritative.clientMessageId
-  ) {
-    return true;
-  }
-
-  if (
-    authoritative.responseToClientMessageId &&
-    candidate.responseToClientMessageId === authoritative.responseToClientMessageId
-  ) {
-    return true;
-  }
-
-  if (candidate.role !== "assistant") return false;
-
-  const timeDelta = Math.abs(candidate.timestamp - authoritative.timestamp);
-  if (timeDelta > 15 * 60_000) return false;
-
-  if (candidate.status === "streaming") return true;
-
-  const candidateText = normalizeMessageText(candidate.text);
-  const authoritativeText = normalizeMessageText(authoritative.text);
-  return candidateText.length > 0 && candidateText === authoritativeText;
-}
-
-function findOptimisticMatchIndex(list: Message[], authoritative: Message): number {
-  if (authoritative.clientMessageId) {
-    const directMatchIndex = list.findIndex(
-      (candidate) =>
-        typeof candidate.historySeq !== "number" &&
-        candidate.role === authoritative.role &&
-        candidate.clientMessageId === authoritative.clientMessageId,
-    );
-    if (directMatchIndex !== -1) return directMatchIndex;
-  }
-
-  if (authoritative.responseToClientMessageId) {
-    const responseMatchIndex = list.findIndex(
-      (candidate) =>
-        typeof candidate.historySeq !== "number" &&
-        candidate.role === authoritative.role &&
-        candidate.responseToClientMessageId === authoritative.responseToClientMessageId,
-    );
-    if (responseMatchIndex !== -1) return responseMatchIndex;
-  }
-
-  if (authoritative.role === "assistant") {
-    for (let index = list.length - 1; index >= 0; index -= 1) {
-      const candidate = list[index];
-      if (typeof candidate.historySeq === "number") continue;
-      if (candidate.role !== "assistant" || candidate.status !== "streaming") continue;
-
-      const timeDelta = Math.abs(candidate.timestamp - authoritative.timestamp);
-      if (timeDelta > 15 * 60_000) continue;
-
-      // Recovery can replay the committed session_result before the resumed
-      // streaming bubble receives its final `done` payload. In that window the
-      // texts differ ("Resuming..." vs final answer), but they still represent
-      // the same assistant turn and must collapse into one message.
-      return index;
-    }
-  }
-
-  const authoritativeText = normalizeMessageText(authoritative.text);
-  const authoritativeTime = authoritative.timestamp;
-
-  let bestIndex = -1;
-  let bestTimeDelta = Number.MAX_SAFE_INTEGER;
-
-  for (let index = 0; index < list.length; index += 1) {
-    const candidate = list[index];
-    if (typeof candidate.historySeq === "number") continue;
-    if (candidate.role !== authoritative.role) continue;
-    if (normalizeMessageText(candidate.text) !== authoritativeText) continue;
-    // Don't require file or tool call match — both arrive asynchronously
-    // via SSE and may differ from the API version.
-
-    const timeDelta = Math.abs(candidate.timestamp - authoritativeTime);
-    // Recovery can recreate an optimistic assistant bubble and then replay the
-    // committed session_result much later. Keep a wider assistant merge window
-    // so resumed turns are replaced in place instead of appending a duplicate
-    // assistant bubble after one or more reloads.
-    const optimisticWindowMs =
-      candidate.role === "assistant" ? 15 * 60_000 : 60_000;
-    if (timeDelta > optimisticWindowMs) continue;
-    if (timeDelta >= bestTimeDelta) continue;
-
-    bestIndex = index;
-    bestTimeDelta = timeDelta;
-  }
-
-  return bestIndex;
-}
-
-function mergeAuthoritativeIntoMessage(
-  existing: Message,
-  authoritative: Message,
-): Message {
-  return {
-    ...existing,
-    text: authoritative.text,
-    clientMessageId: authoritative.clientMessageId ?? existing.clientMessageId,
-    responseToClientMessageId:
-      authoritative.responseToClientMessageId ?? existing.responseToClientMessageId,
-    files: mergeMessageFiles(authoritative.files, existing.files),
-    toolCalls:
-      authoritative.toolCalls.length > 0 ? authoritative.toolCalls : existing.toolCalls,
-    status: "complete",
-    timestamp: authoritative.timestamp,
-    historySeq: authoritative.historySeq,
-    meta: existing.meta,
-    sourceToolCallId: authoritative.sourceToolCallId ?? existing.sourceToolCallId,
-  };
-}
-
-/** Task completion notifications are status messages, not real responses. */
-const TASK_COMPLETION_RE = /^[✓✗]\s+\S+\s+(completed|failed)\s*\(/u;
-
-function convertApiMessage(m: MessageInfo): Message | null {
-  if (m.role === "tool") return null;
-  const role = m.role === "user" ? "user" : m.role === "system" ? "system" : "assistant";
-  const mediaFiles: MessageFile[] = (m.media ?? []).map((path) => ({
-    filename: displayFilenameFromPath(path),
-    path,
-    caption: "",
-  }));
-  const parsedLegacy = parseLegacyFileDeliveries(m.content);
-  const files = mergeMessageFiles(parsedLegacy.files, mediaFiles);
-  const text = parsedLegacy.text;
-  if (!text.trim() && files.length === 0) return null;
-  // Skip task completion status messages (e.g. "✓ fm_tts completed (file.mp3)")
-  // — the file is already delivered via the media field on a separate message.
-  if (role === "assistant" && files.length === 0 && TASK_COMPLETION_RE.test(text.trim())) {
-    return null;
-  }
-
-  const toolCalls: ToolCallInfo[] =
-    m.tool_calls?.filter((tc) => tc.name).map((tc) => ({
-      id: tc.id || "",
-      name: tc.name || "",
-      status: "complete" as const,
-    })) ?? [];
-
-  return {
-    id: nextId(),
-    role,
-    text,
-    clientMessageId: m.client_message_id,
-    responseToClientMessageId: m.response_to_client_message_id,
-    files,
-    toolCalls,
-    status: "complete",
-    timestamp: m.timestamp ? new Date(m.timestamp).getTime() : Date.now(),
-    historySeq: typeof m.seq === "number" ? m.seq : undefined,
-    sourceToolCallId: m.tool_call_id,
-  };
 }
 
 function indexFilesForSession(
@@ -590,54 +366,6 @@ function indexFilesForSession(
   }
 }
 
-function shouldCoalesceFileResult(message: Message): boolean {
-  if (message.role !== "assistant" || message.files.length === 0) return false;
-  if (message.sourceToolCallId) return true;
-  if (!message.text.trim()) return true;
-  return TASK_COMPLETION_RE.test(message.text.trim());
-}
-
-function findFileResultTargetIndex(
-  key: string,
-  list: Message[],
-  fileResult: Message,
-): number {
-  if (!shouldCoalesceFileResult(fileResult)) return -1;
-
-  const byToolCall = findMessageIndexByToolCallId(
-    list,
-    fileResult.sourceToolCallId,
-  );
-  if (byToolCall !== -1) return byToolCall;
-
-  for (const file of fileResult.files) {
-    const byPath = findMessageIndexForFilePath(key, list, file);
-    if (byPath !== -1) return byPath;
-  }
-
-  const byAnchor = findBackgroundAnchorIndex(key, list);
-  if (byAnchor !== -1) return byAnchor;
-
-  return fileResult.sourceToolCallId
-    ? findRecentAssistantIndex(list, fileResult.timestamp)
-    : -1;
-}
-
-function mergeFileResultIntoTarget(target: Message, fileResult: Message): Message {
-  const files = fileResult.files.map((file) => ({
-    ...file,
-    caption: file.caption || fileResult.text || "",
-  }));
-
-  return {
-    ...target,
-    files: mergeMessageFiles(files, target.files),
-    toolCalls:
-      target.toolCalls.length > 0 ? target.toolCalls : fileResult.toolCalls,
-    sourceToolCallId: target.sourceToolCallId ?? fileResult.sourceToolCallId,
-  };
-}
-
 function coalesceFileResultsIntoAnchors(
   sessionId: string,
   messages: Message[],
@@ -647,7 +375,11 @@ function coalesceFileResultsIntoAnchors(
   const merged: Message[] = [];
 
   for (const message of messages) {
-    const targetIndex = findFileResultTargetIndex(key, merged, message);
+    const targetIndex = findFileResultTargetIndex(
+      outputPathMessageByKey.get(key),
+      merged,
+      message,
+    );
     if (targetIndex === -1) {
       merged.push(message);
       continue;
@@ -675,7 +407,7 @@ function replaceHistoryFromApi(
   // Phase 1: Convert API messages to local format, merging with optimistic
   // matches to preserve local-only state (id, meta, files from SSE).
   const authoritative = apiMessages
-    .map(convertApiMessage)
+    .map((apiMessage) => convertApiMessage(apiMessage, nextId))
     .filter((message): message is Message => message !== null)
     .map((message) => {
       const optimisticMatchIndex = findOptimisticMatchIndex(existing, message);
@@ -702,8 +434,15 @@ function replaceHistoryFromApi(
     const msg = existing[i];
     // Already confirmed by server in a prior sync — server is authoritative.
     if (typeof msg.historySeq === "number") continue;
+    // Task anchors are local projections of server task state. Preserve them
+    // across history replacement unless an authoritative causal ack consumed
+    // them above.
+    if (msg.kind === "task_anchor") {
+      pending.push(msg);
+      continue;
+    }
     // Streaming or has local-only content — keep it.
-    if (msg.status === "streaming" || msg.status === "error") {
+    if (msg.status === "streaming" || msg.status === "error" || msg.status === "stopped") {
       pending.push(msg);
       continue;
     }
@@ -731,15 +470,10 @@ function replaceHistoryFromApi(
     ...coalesceFileResultsIntoAnchors(sessionId, authoritative, topic),
     ...pending,
   ];
-  merged.sort((a, b) => {
-    const aSeq = typeof a.historySeq === "number" ? a.historySeq : Number.MAX_SAFE_INTEGER;
-    const bSeq = typeof b.historySeq === "number" ? b.historySeq : Number.MAX_SAFE_INTEGER;
-    if (aSeq !== bSeq) return aSeq - bSeq;
-    return a.timestamp - b.timestamp;
-  });
+  const sorted = sortedMessagesForDisplay(merged);
 
-  messagesByKey.set(key, merged);
-  indexFilesForSession(sessionId, merged, topic);
+  messagesByKey.set(key, sorted);
+  indexFilesForSession(sessionId, sorted, topic);
   loadedSessions.add(key);
   notify();
 }
@@ -757,7 +491,21 @@ export function addMessage(
   const id = nextId();
   const key = storeKey(sessionId, topic);
   const list = getList(sessionId, topic);
-  list.push({ ...msg, id, timestamp: Date.now() });
+  const message =
+    msg.role === "user"
+      ? reduceCreateUserMessageEvent({
+          type: "create_user_message",
+          message: { ...msg, role: "user" },
+          createId: () => id,
+        })
+      : msg.role === "assistant"
+        ? reduceCreateAssistantTurnEvent({
+            type: "create_assistant_turn",
+            message: { ...msg, role: "assistant" },
+            createId: () => id,
+          })
+        : createLocalMessage(msg, () => id);
+  list.push(message);
   // Replace the array reference so React picks up the change
   messagesByKey.set(key, [...list]);
   notify();
@@ -768,7 +516,12 @@ export function addMessage(
 export function updateMessage(
   sessionId: string,
   messageId: string,
-  updates: Partial<Pick<Message, "text" | "status" | "files" | "toolCalls" | "meta">>,
+  updates: Partial<
+    Pick<
+      Message,
+      "text" | "status" | "files" | "toolCalls" | "meta" | "sourceToolCallId"
+    >
+  >,
   topic?: string,
 ): void {
   const key = storeKey(sessionId, topic);
@@ -776,11 +529,14 @@ export function updateMessage(
   if (!list) return;
   const idx = list.findIndex((m) => m.id === messageId);
   if (idx === -1) return;
-  list[idx] = { ...list[idx], ...updates };
+  list[idx] = withRuntime({ ...list[idx], ...updates });
   if (updates.toolCalls) {
     for (const toolCall of updates.toolCalls) {
       indexToolCallForMessage(key, toolCall.id, messageId);
     }
+  }
+  if (updates.sourceToolCallId) {
+    indexToolCallForMessage(key, updates.sourceToolCallId, messageId);
   }
   messagesByKey.set(key, [...list]);
   notify();
@@ -795,6 +551,27 @@ export function setMessageMeta(
   updateMessage(sessionId, messageId, { meta }, topic);
 }
 
+/** Finalise any still-streaming assistant bubbles (e.g. on user stop). */
+export function stopStreamingMessages(sessionId: string, topic?: string): void {
+  const key = storeKey(sessionId, topic);
+  const list = messagesByKey.get(key);
+  if (!list) return;
+
+  let changed = false;
+  const next = list.map((message) => {
+    const projected = reduceStopStreamingAssistantEvent({
+      type: "stop_streaming_assistant",
+      message,
+    });
+    if (projected !== message) changed = true;
+    return projected;
+  });
+
+  if (!changed) return;
+  messagesByKey.set(key, next);
+  notify();
+}
+
 /** Append text to a streaming message. */
 export function appendText(
   sessionId: string,
@@ -807,7 +584,11 @@ export function appendText(
   if (!list) return;
   const idx = list.findIndex((m) => m.id === messageId);
   if (idx === -1) return;
-  list[idx] = { ...list[idx], text: list[idx].text + chunk };
+  list[idx] = reduceAppendAssistantTextEvent({
+    type: "append_assistant_text",
+    message: list[idx],
+    chunk,
+  });
   messagesByKey.set(key, [...list]);
   notify();
 }
@@ -826,7 +607,11 @@ export function appendFile(
   if (idx === -1) return;
   const msg = list[idx];
   if (msg.files.some((f) => f.path === file.path)) return;
-  list[idx] = { ...msg, files: [...msg.files, file] };
+  list[idx] = reduceAppendFileArtifactEvent({
+    type: "append_file_artifact",
+    message: msg,
+    file,
+  });
   messagesByKey.set(key, [...list]);
   addToFileStore({
     sessionId,
@@ -837,6 +622,73 @@ export function appendFile(
   notify();
 }
 
+/**
+ * Project a background task's current state into a task_anchor bubble.
+ *
+ * Creates or updates the anchor message for the task, merging runtime detail
+ * and ensuring the timestamp anchors to the task's started_at timestamp.
+ */
+export function ensureTaskAnchor(
+  sessionId: string,
+  task: BackgroundTaskInfo,
+  topic?: string,
+): string | null {
+  const taskId = taskIdentity(task);
+  if (!taskId) return null;
+  const key = storeKey(sessionId, topic);
+  const list = getList(sessionId, topic);
+  const anchorId = taskAnchorMessageId(sessionId, taskId);
+  const targetIndex = findTaskAnchorIndex(
+    sessionId,
+    taskMessageByKey.get(key),
+    list,
+    task,
+  );
+  const nextTaskAnchor = mergeTaskAnchorMeta(
+    targetIndex !== -1 ? list[targetIndex].taskAnchor : undefined,
+    task,
+  );
+
+  if (targetIndex !== -1) {
+    const current = list[targetIndex];
+    if (
+      current.id === anchorId &&
+      current.kind === "task_anchor" &&
+      current.status === taskMessageStatus(task) &&
+      current.sourceToolCallId === (task.tool_call_id ?? current.sourceToolCallId) &&
+      current.runtime?.status === runtimeStatusForTask(task) &&
+      sameTaskAnchorMeta(current.taskAnchor, nextTaskAnchor)
+    ) {
+      return anchorId;
+    }
+  }
+
+  if (targetIndex === -1) {
+    list.push(projectTaskAnchorMessage(sessionId, task, list, nextTaskAnchor));
+  } else {
+    list[targetIndex] = projectTaskAnchorMessage(
+      sessionId,
+      task,
+      list,
+      nextTaskAnchor,
+      list[targetIndex],
+    );
+  }
+
+  indexTaskForMessage(key, task, anchorId);
+  messagesByKey.set(key, sortedMessagesForDisplay(list));
+  notify();
+  return anchorId;
+}
+
+/**
+ * Register a background-task anchor tied to an assistant message id.
+ *
+ * Used by the SSE/WS bridges when they create the assistant bubble that will
+ * later be enriched with tool-call progress and file attachments. The anchor
+ * metadata is consulted by the file/tool-call routers to find the right
+ * bubble to attach to.
+ */
 export function registerBackgroundAnchor(
   sessionId: string,
   messageId: string,
@@ -1030,7 +882,7 @@ export function appendHistoryMessages(
   let maxSeq = getMaxHistorySeq(sessionId, topic);
 
   for (const apiMessage of apiMessages) {
-    const converted = convertApiMessage(apiMessage);
+    const converted = convertApiMessage(apiMessage, nextId);
     if (!converted) continue;
     if (
       typeof converted.historySeq === "number" &&
@@ -1044,7 +896,11 @@ export function appendHistoryMessages(
       continue;
     }
 
-    const fileResultTargetIndex = findFileResultTargetIndex(key, list, converted);
+    const fileResultTargetIndex = findFileResultTargetIndex(
+      outputPathMessageByKey.get(key),
+      list,
+      converted,
+    );
     if (fileResultTargetIndex !== -1) {
       list[fileResultTargetIndex] = mergeFileResultIntoTarget(
         list[fileResultTargetIndex],
@@ -1095,9 +951,6 @@ export function appendHistoryMessages(
         Math.abs(m.timestamp - converted.timestamp) < 120_000,
     );
     if (confirmedDupe !== -1) {
-      // Already have a confirmed message with same content — this is likely
-      // the correct instance. Skip adding a duplicate; the existing one is
-      // close enough (authoritative seq may differ but UI position is right).
       recordRuntimeCounter("octos_result_duplicate_suppressed_total", {
         kind: converted.role,
         reason: "confirmed_text_match",
@@ -1116,14 +969,9 @@ export function appendHistoryMessages(
   }
 
   if (changed) {
-    list.sort((a, b) => {
-      const aSeq = typeof a.historySeq === "number" ? a.historySeq : Number.MAX_SAFE_INTEGER;
-      const bSeq = typeof b.historySeq === "number" ? b.historySeq : Number.MAX_SAFE_INTEGER;
-      if (aSeq !== bSeq) return aSeq - bSeq;
-      return a.timestamp - b.timestamp;
-    });
-    messagesByKey.set(key, [...list]);
-    indexFilesForSession(sessionId, list, topic);
+    const sorted = sortedMessagesForDisplay(list);
+    messagesByKey.set(key, sorted);
+    indexFilesForSession(sessionId, sorted, topic);
     loadedSessions.add(key);
     notify();
   }
@@ -1137,7 +985,7 @@ export function mergeHistoryMessageIntoMessage(
   apiMessage: MessageInfo,
   topic?: string,
 ): boolean {
-  const converted = convertApiMessage(apiMessage);
+  const converted = convertApiMessage(apiMessage, nextId);
   if (!converted) return false;
 
   const key = storeKey(sessionId, topic);
@@ -1147,7 +995,11 @@ export function mergeHistoryMessageIntoMessage(
   let targetIndex = list.findIndex((message) => message.id === messageId);
   if (targetIndex === -1) return false;
 
-  const fileResultTargetIndex = findFileResultTargetIndex(key, list, converted);
+  const fileResultTargetIndex = findFileResultTargetIndex(
+    outputPathMessageByKey.get(key),
+    list,
+    converted,
+  );
   if (fileResultTargetIndex !== -1) {
     list[fileResultTargetIndex] = mergeFileResultIntoTarget(
       list[fileResultTargetIndex],
@@ -1204,15 +1056,9 @@ export function mergeHistoryMessageIntoMessage(
     }
   }
 
-  list.sort((a, b) => {
-    const aSeq = typeof a.historySeq === "number" ? a.historySeq : Number.MAX_SAFE_INTEGER;
-    const bSeq = typeof b.historySeq === "number" ? b.historySeq : Number.MAX_SAFE_INTEGER;
-    if (aSeq !== bSeq) return aSeq - bSeq;
-    return a.timestamp - b.timestamp;
-  });
-
-  messagesByKey.set(key, [...list]);
-  indexFilesForSession(sessionId, list, topic);
+  const sorted = sortedMessagesForDisplay(list);
+  messagesByKey.set(key, sorted);
+  indexFilesForSession(sessionId, sorted, topic);
   loadedSessions.add(key);
   notify();
   return true;
@@ -1231,32 +1077,18 @@ export function ensureStreamingAssistantMessage(
 ): string {
   const key = storeKey(sessionId, topic);
   const list = getList(sessionId, topic);
-  const existing = [...list]
-    .reverse()
-    .find((message) => message.role === "assistant" && message.status === "streaming");
-
-  if (existing) {
-    if (!existing.text && text) {
-      existing.text = text;
-      messagesByKey.set(key, [...list]);
-      notify();
-    }
-    return existing.id;
-  }
-
-  const id = nextId();
-  list.push({
-    id,
-    role: "assistant",
+  const projected = reduceEnsureStreamingAssistantEvent({
+    type: "ensure_streaming_assistant",
+    messages: list,
     text,
-    files: [],
-    toolCalls: [],
-    status: "streaming",
-    timestamp: Date.now(),
+    createId: nextId,
   });
-  messagesByKey.set(key, [...list]);
-  notify();
-  return id;
+
+  if (projected.changed) {
+    messagesByKey.set(key, projected.messages);
+    notify();
+  }
+  return projected.messageId;
 }
 
 function isResumePlaceholderText(text: string): boolean {
@@ -1326,14 +1158,16 @@ export function reconcileRecoveredStreamingMessages(
       continue;
     }
 
-    next.push({
-      ...message,
-      text:
-        !options?.streamActive && isResumePlaceholderText(message.text)
-          ? ""
-          : message.text,
-      status: "complete",
-    });
+    next.push(
+      withRuntime({
+        ...message,
+        text:
+          !options?.streamActive && isResumePlaceholderText(message.text)
+            ? ""
+            : message.text,
+        status: "complete",
+      }),
+    );
     changed = true;
     recordRuntimeCounter("octos_recovery_stream_cleanup_total", {
       action: "finalize_orphan",
@@ -1345,6 +1179,9 @@ export function reconcileRecoveredStreamingMessages(
   messagesByKey.set(key, next);
   notify();
 }
+
+// Re-exported for consumers that need direct access to the shared sentinel.
+export { TASK_COMPLETION_RE };
 
 // ---------------------------------------------------------------------------
 // History loading

--- a/tests/message-store-live.spec.ts
+++ b/tests/message-store-live.spec.ts
@@ -1,0 +1,110 @@
+import { expect, test, type Page } from "@playwright/test";
+import {
+  SEL,
+  createNewSession,
+  getChatThreadText,
+  login,
+  sendAndWait,
+} from "./helpers";
+
+test.skip(
+  process.env.LIVE_MESSAGE_STORE_GATE !== "1",
+  "Set LIVE_MESSAGE_STORE_GATE=1 to run this live validation gate.",
+);
+
+async function activeSessionId(page: Page): Promise<string> {
+  const id = await page.evaluate(() => localStorage.getItem("octos_current_session"));
+  expect(id).toBeTruthy();
+  return id!;
+}
+
+async function switchToSessionId(page: Page, sessionId: string): Promise<void> {
+  await expect(page.locator(`[data-session-id="${sessionId}"]`)).toBeVisible({
+    timeout: 30_000,
+  });
+  await page
+    .locator(`[data-session-id="${sessionId}"] [data-testid="session-switch-button"]`)
+    .click();
+  await page.waitForSelector(SEL.chatInput, { timeout: 15_000 });
+}
+
+async function waitForTaskAnchor(page: Page, timeoutMs = 180_000): Promise<string> {
+  await expect(page.getByTestId("task-anchor-message").first()).toBeVisible({
+    timeout: timeoutMs,
+  });
+  const taskId = await page
+    .getByTestId("task-anchor-message")
+    .first()
+    .getAttribute("data-task-id");
+  expect(taskId).toBeTruthy();
+  return taskId!;
+}
+
+test.describe("Live message-store gate", () => {
+  test.setTimeout(600_000);
+
+  test.beforeEach(async ({ page }) => {
+    await login(page);
+    await createNewSession(page);
+  });
+
+  test("normal chat does not render a background task bubble", async ({ page }) => {
+    const marker = `NORMAL_CHAT_SCOPE_${Date.now()}`;
+
+    await sendAndWait(page, `Reply briefly to this normal chat marker: ${marker}`, {
+      label: "live-normal-chat-scope",
+      maxWait: 90_000,
+    });
+
+    await expect(page.getByTestId("task-anchor-message")).toHaveCount(0);
+    await expect(page.getByTestId("assistant-message").last()).toHaveAttribute(
+      "data-message-type",
+      "assistant",
+    );
+    expect(await getChatThreadText(page)).toContain(marker);
+  });
+
+  test("deep research task anchor stays scoped across session switches", async ({
+    page,
+  }) => {
+    const originMarker = `LIVE_DEEP_RESEARCH_ORIGIN_${Date.now()}`;
+    const otherMarker = `LIVE_NORMAL_OTHER_${Date.now()}`;
+    const originSessionId = await activeSessionId(page);
+
+    await sendAndWait(
+      page,
+      `Do a deep research task for ${originMarker}. Run the pipeline directly and keep it concise.`,
+      {
+        label: "live-deep-research-scope",
+        maxWait: 180_000,
+        throwOnTimeout: false,
+      },
+    );
+    const taskId = await waitForTaskAnchor(page);
+
+    await createNewSession(page);
+    const otherSessionId = await activeSessionId(page);
+    expect(otherSessionId).not.toBe(originSessionId);
+
+    await sendAndWait(page, `Reply briefly to this normal chat marker: ${otherMarker}`, {
+      label: "live-other-session-normal",
+      maxWait: 90_000,
+    });
+
+    await expect(page.getByTestId("task-anchor-message")).toHaveCount(0);
+    let threadText = await getChatThreadText(page);
+    expect(threadText).toContain(otherMarker);
+    expect(threadText).not.toContain(originMarker);
+
+    await switchToSessionId(page, originSessionId);
+
+    await expect(page.getByTestId("task-anchor-message")).toHaveCount(1);
+    await expect(page.getByTestId("task-anchor-message")).toHaveAttribute(
+      "data-task-id",
+      taskId,
+    );
+    threadText = await getChatThreadText(page);
+    expect(threadText).toContain(originMarker);
+    expect(threadText).not.toContain(otherMarker);
+  });
+});

--- a/tests/message-store-reducer.spec.ts
+++ b/tests/message-store-reducer.spec.ts
@@ -1,0 +1,445 @@
+import { expect, test } from "@playwright/test";
+import type { BackgroundTaskInfo, MessageInfo } from "../src/api/types";
+import type { Message } from "../src/store/message-store";
+import {
+  convertApiMessage,
+  createLocalMessage,
+  findFileResultTargetIndex,
+  findMessageIndexForFilePath,
+  findOptimisticMatchIndex,
+  findTaskAnchorIndex,
+  isAssistantCompanionForFileMessage,
+  mergeAssistantDuplicate,
+  mergeFileResultIntoTarget,
+  mergeTaskAnchorMeta,
+  pathMatchKeys,
+  projectTaskAnchorMessage,
+  sameTaskAnchorMeta,
+  shouldCollapseAuthoritativeDuplicate,
+  sortedMessagesForDisplay,
+  taskIdentity,
+} from "../src/store/message-store-reducer";
+import {
+  reduceAppendAssistantTextEvent,
+  reduceEnsureStreamingAssistantEvent,
+  reduceStopStreamingAssistantEvent,
+} from "../src/store/message-store-reducers/assistant-turn-reducer";
+import { reduceProjectTaskAnchorEvent } from "../src/store/message-store-reducers/background-task-reducer";
+import { reduceAppendFileArtifactEvent } from "../src/store/message-store-reducers/file-artifact-reducer";
+import {
+  reduceConvertHistoryReplayMessageEvent,
+  reduceMergeAuthoritativeHistoryMessageEvent,
+} from "../src/store/message-store-reducers/history-replay-reducer";
+import { reduceCreateUserMessageEvent } from "../src/store/message-store-reducers/user-message-reducer";
+
+const NOW = Date.parse("2026-04-20T12:00:30.000Z");
+
+function fixedNow(): number {
+  return NOW;
+}
+
+function makeMessage(overrides: Partial<Message>): Message {
+  return {
+    id: "message",
+    role: "assistant",
+    text: "",
+    files: [],
+    toolCalls: [],
+    status: "complete",
+    timestamp: Date.parse("2026-04-20T12:00:00.000Z"),
+    ...overrides,
+  };
+}
+
+function makeApiMessage(overrides: Partial<MessageInfo>): MessageInfo {
+  return {
+    role: "assistant",
+    content: "api message",
+    timestamp: "2026-04-20T12:00:00.000Z",
+    ...overrides,
+  };
+}
+
+function makeTask(overrides: Partial<BackgroundTaskInfo> = {}): BackgroundTaskInfo {
+  return {
+    id: "task-deep-research",
+    tool_name: "Deep research",
+    tool_call_id: "call-deep-research",
+    status: "running",
+    started_at: "2026-04-20T12:00:00.000Z",
+    completed_at: null,
+    output_files: ["pf/report.md"],
+    error: null,
+    workflow_kind: "deep_research",
+    current_phase: "search",
+    progress_message: "Searching sources",
+    progress: 0.25,
+    ...overrides,
+  };
+}
+
+test.describe("message-store reducer helpers", () => {
+  test("creates deterministic optimistic local messages", () => {
+    const message = reduceCreateUserMessageEvent({
+      type: "create_user_message",
+      message: {
+        role: "user",
+        text: "Hello",
+        files: [{ filename: "photo.png", path: "pf/photo.png", caption: "" }],
+        toolCalls: [],
+        status: "complete",
+      },
+      createId: () => "local-1",
+      now: fixedNow,
+    });
+    const legacyProjection = createLocalMessage(
+      {
+        role: "user",
+        text: "Hello",
+        files: [{ filename: "photo.png", path: "pf/photo.png", caption: "" }],
+        toolCalls: [],
+        status: "complete",
+      },
+      () => "local-1",
+      fixedNow,
+    );
+
+    expect(legacyProjection).toEqual(message);
+    expect(message).toMatchObject({
+      id: "local-1",
+      role: "user",
+      text: "Hello",
+      status: "complete",
+      timestamp: NOW,
+      runtime: {
+        type: "user",
+        status: "completed",
+        updatedAt: NOW,
+      },
+    });
+    expect(message.files).toEqual([
+      { filename: "photo.png", path: "pf/photo.png", caption: "" },
+    ]);
+  });
+
+  test("assistant turn lane appends, stops, and ensures streaming messages", () => {
+    const streaming = makeMessage({
+      id: "assistant-stream",
+      role: "assistant",
+      text: "",
+      status: "streaming",
+    });
+
+    const appended = reduceAppendAssistantTextEvent({
+      type: "append_assistant_text",
+      message: streaming,
+      chunk: "Hello",
+      now: fixedNow,
+    });
+    expect(appended.text).toBe("Hello");
+    expect(appended.runtime?.status).toBe("ongoing");
+
+    const stopped = reduceStopStreamingAssistantEvent({
+      type: "stop_streaming_assistant",
+      message: streaming,
+      now: fixedNow,
+    });
+    expect(stopped).toMatchObject({
+      text: "Stopped.",
+      status: "stopped",
+      runtime: { status: "stopped", updatedAt: NOW },
+    });
+
+    const filledExisting = reduceEnsureStreamingAssistantEvent({
+      type: "ensure_streaming_assistant",
+      messages: [streaming],
+      text: "Resuming ongoing work...",
+      createId: () => "new-assistant",
+      now: fixedNow,
+    });
+    expect(filledExisting.changed).toBe(true);
+    expect(filledExisting.messageId).toBe("assistant-stream");
+    expect(filledExisting.messages).toHaveLength(1);
+    expect(filledExisting.messages[0].text).toBe("Resuming ongoing work...");
+
+    const created = reduceEnsureStreamingAssistantEvent({
+      type: "ensure_streaming_assistant",
+      messages: [],
+      text: "Resuming ongoing work...",
+      createId: () => "new-assistant",
+      now: fixedNow,
+    });
+    expect(created).toMatchObject({
+      changed: true,
+      messageId: "new-assistant",
+    });
+    expect(created.messages[0]).toMatchObject({
+      id: "new-assistant",
+      role: "assistant",
+      status: "streaming",
+      runtime: { status: "ongoing", updatedAt: NOW },
+    });
+  });
+
+  test("merges authoritative replay into the matching optimistic assistant turn", () => {
+    const optimistic = makeMessage({
+      id: "optimistic-assistant",
+      role: "assistant",
+      text: "Resuming ongoing work...",
+      status: "streaming",
+      timestamp: Date.parse("2026-04-20T12:00:05.000Z"),
+      responseToClientMessageId: "client-1",
+      files: [{ filename: "local.md", path: "pf/local.md", caption: "local" }],
+      meta: {
+        model: "mock",
+        tokens_in: 1,
+        tokens_out: 2,
+        duration_s: 3,
+      },
+    });
+    const authoritative = convertApiMessage(
+      makeApiMessage({
+        seq: 7,
+        content: "Final answer",
+        response_to_client_message_id: "client-1",
+        tool_call_id: "call-final",
+        timestamp: "2026-04-20T12:00:08.000Z",
+        media: ["pf/final.md"],
+      }),
+      () => "api-assistant",
+      fixedNow,
+    );
+
+    expect(authoritative).not.toBeNull();
+    expect(findOptimisticMatchIndex([optimistic], authoritative!)).toBe(0);
+    const merged = reduceMergeAuthoritativeHistoryMessageEvent({
+      type: "merge_authoritative_history_message",
+      existing: optimistic,
+      authoritative: authoritative!,
+      now: fixedNow,
+    });
+
+    expect(merged.id).toBe("optimistic-assistant");
+    expect(merged.text).toBe("Final answer");
+    expect(merged.status).toBe("complete");
+    expect(merged.historySeq).toBe(7);
+    expect(merged.sourceToolCallId).toBe("call-final");
+    expect(merged.meta).toBe(optimistic.meta);
+    expect(merged.files.map((file) => file.path)).toEqual([
+      "pf/final.md",
+      "pf/local.md",
+    ]);
+    expect(merged.runtime?.status).toBe("completed");
+  });
+
+  test("projects task anchors by stable task identity", () => {
+    const task = makeTask();
+    const anchorMeta = mergeTaskAnchorMeta(undefined, task);
+    const anchor = reduceProjectTaskAnchorEvent({
+      type: "project_task_anchor",
+      sessionId: "session-1",
+      task,
+      list: [],
+      taskAnchor: anchorMeta,
+      now: fixedNow,
+    });
+    const legacyProjection = projectTaskAnchorMessage(
+      "session-1",
+      task,
+      [],
+      anchorMeta,
+      undefined,
+      fixedNow,
+    );
+
+    expect(anchor).toEqual(legacyProjection);
+    expect(taskIdentity(task)).toBe("task-deep-research");
+    expect(taskIdentity({ ...task, id: "   " })).toBeNull();
+    expect(anchor).toMatchObject({
+      id: "task:session-1:task-deep-research",
+      role: "assistant",
+      kind: "task_anchor",
+      text: "",
+      status: "streaming",
+      timestamp: Date.parse(task.started_at),
+      sourceToolCallId: "call-deep-research",
+      runtime: {
+        type: "background_task",
+        status: "ongoing",
+        taskId: "task-deep-research",
+        toolCallId: "call-deep-research",
+        phase: "search",
+        detail: "Searching sources",
+      },
+    });
+    expect(anchor.taskAnchor?.outputFiles).toEqual(["pf/report.md"]);
+    expect(sameTaskAnchorMeta(anchor.taskAnchor, anchorMeta)).toBe(true);
+    expect(
+      findTaskAnchorIndex(
+        "session-1",
+        new Map([[task.id, anchor.id]]),
+        [anchor],
+        task,
+      ),
+    ).toBe(0);
+  });
+
+  test("coalesces media-only file results into the preceding assistant answer", () => {
+    const answer = makeMessage({
+      id: "answer",
+      role: "assistant",
+      text: "Research report is ready.",
+      historySeq: 1,
+      timestamp: Date.parse("2026-04-20T12:00:10.000Z"),
+    });
+    const fileResult = convertApiMessage(
+      makeApiMessage({
+        seq: 2,
+        content: "",
+        media: ["pf/research-report.md"],
+        timestamp: "2026-04-20T12:00:10.010Z",
+      }),
+      () => "file-result",
+      fixedNow,
+    );
+
+    expect(fileResult).not.toBeNull();
+    expect(findFileResultTargetIndex(undefined, [answer], fileResult!)).toBe(0);
+    const merged = mergeFileResultIntoTarget(answer, fileResult!);
+
+    expect(merged.text).toBe("Research report is ready.");
+    expect(merged.historySeq).toBe(2);
+    expect(merged.files).toEqual([
+      { filename: "research-report.md", path: "pf/research-report.md", caption: "" },
+    ]);
+
+    const appended = reduceAppendFileArtifactEvent({
+      type: "append_file_artifact",
+      message: answer,
+      file: { filename: "research-report.md", path: "pf/research-report.md", caption: "" },
+    });
+    expect(appended.files).toEqual([
+      { filename: "research-report.md", path: "pf/research-report.md", caption: "" },
+    ]);
+    expect(
+      reduceAppendFileArtifactEvent({
+        type: "append_file_artifact",
+        message: appended,
+        file: { filename: "research-report.md", path: "pf/research-report.md", caption: "" },
+      }),
+    ).toBe(appended);
+  });
+
+  test("history replay lane converts API messages through a typed event", () => {
+    const converted = reduceConvertHistoryReplayMessageEvent({
+      type: "convert_history_replay_message",
+      message: makeApiMessage({
+        seq: 3,
+        role: "user",
+        content: "From history",
+        client_message_id: "client-typed",
+        timestamp: "2026-04-20T12:00:15.000Z",
+      }),
+      createId: () => "history-user",
+      now: fixedNow,
+    });
+
+    expect(converted).toMatchObject({
+      id: "history-user",
+      role: "user",
+      text: "From history",
+      clientMessageId: "client-typed",
+      historySeq: 3,
+      runtime: {
+        type: "user",
+        status: "completed",
+        updatedAt: NOW,
+      },
+    });
+  });
+
+  test("matches output files by path aliases without prompt text heuristics", () => {
+    const anchor = makeMessage({
+      id: "task-anchor",
+      role: "assistant",
+      kind: "task_anchor",
+      taskAnchor: { taskId: "task-1", outputFiles: ["pf/research-report.md"] },
+    });
+    const outputMap = new Map(
+      pathMatchKeys("pf/research-report.md").map((key) => [key, anchor.id]),
+    );
+
+    expect(
+      findMessageIndexForFilePath(outputMap, [anchor], {
+        filename: "research-report.md",
+        path: "research-report.md",
+        caption: "",
+      }),
+    ).toBe(0);
+  });
+
+  test("identifies assistant file companions and merges duplicate payloads", () => {
+    const primary = makeMessage({
+      id: "assistant-text",
+      role: "assistant",
+      text: "Same report text",
+      historySeq: 1,
+      timestamp: Date.parse("2026-04-20T12:00:00.000Z"),
+    });
+    const duplicate = makeMessage({
+      id: "assistant-file",
+      role: "assistant",
+      text: "Same report text",
+      files: [{ filename: "report.md", path: "pf/report.md", caption: "" }],
+      historySeq: 2,
+      timestamp: Date.parse("2026-04-20T12:00:03.000Z"),
+    });
+
+    expect(isAssistantCompanionForFileMessage(primary, duplicate)).toBe(true);
+    expect(shouldCollapseAuthoritativeDuplicate(primary, primary)).toBe(true);
+
+    const merged = mergeAssistantDuplicate(primary, duplicate);
+    expect(merged.id).toBe("assistant-text");
+    expect(merged.text).toBe("Same report text");
+    expect(merged.historySeq).toBe(2);
+    expect(merged.files).toEqual(duplicate.files);
+  });
+
+  test("characterizes current task-anchor and pending display ordering", () => {
+    const user = makeMessage({
+      id: "user",
+      role: "user",
+      text: "Start research",
+      historySeq: 0,
+      timestamp: Date.parse("2026-04-20T12:00:00.000Z"),
+    });
+    const assistant = makeMessage({
+      id: "assistant",
+      role: "assistant",
+      text: "Research started.",
+      historySeq: 1,
+      timestamp: Date.parse("2026-04-20T12:00:05.000Z"),
+    });
+    const taskAnchor = makeMessage({
+      id: "task",
+      role: "assistant",
+      kind: "task_anchor",
+      timestamp: Date.parse("2026-04-20T12:00:02.000Z"),
+      taskAnchor: { taskId: "task-1" },
+    });
+    const pending = makeMessage({
+      id: "pending",
+      role: "assistant",
+      text: "Pending local stream",
+      timestamp: Date.parse("2026-04-20T11:59:59.000Z"),
+    });
+
+    // Current comparator keeps seq-ordered messages ahead of pending local
+    // messages, while task anchors still compare by timestamp against pending.
+    expect(
+      sortedMessagesForDisplay([assistant, pending, taskAnchor, user]).map(
+        (message) => message.id,
+      ),
+    ).toEqual(["user", "assistant", "pending", "task"]);
+  });
+});


### PR DESCRIPTION
## Summary

Split pure message-shape transformations out of the `src/store/message-store.ts` facade into a typed reducer layer under `src/store/message-store-reducers/`. The facade keeps session/topic maps, React subscriptions, and observability counters but delegates all per-message projections to pure reducers that can be unit-tested in isolation.

This is a cleanliness refactor. **No behavioral regressions**: the `_queued` field stays removed, user sends still POST immediately (#prev queue-removal), and `subscribeNew` is wired only after `replaceHistory` hydrates.

## Scope

**New files**
- `src/store/message-store-reducers/` — six reducers (`user-message`, `assistant-turn`, `background-task`, `file-artifact`, `history-replay`) plus `shared.ts` helpers.
- `src/store/message-store-reducer.ts` — barrel re-export.
- `tests/message-store-reducer.spec.ts` — 9 unit-style Playwright specs driving the reducers directly. All green.
- `tests/message-store-live.spec.ts` — live gate behind `LIVE_MESSAGE_STORE_GATE=1`.
- `docs/OCTOS_WEB_MESSAGE_STORE_REFACTOR_CONTRACT.md` — refactor contract.

**Modified**
- `src/store/message-store.ts` — ported to reducer consumers. **All existing public API preserved** (`registerBackgroundAnchor`, `appendFileToBackgroundAnchor`, `reconcileRecoveredStreamingMessages`, `bindBackgroundTask` with the same semantics as on `main` post queue-removal). Adds `stopStreamingMessages` and `ensureTaskAnchor` as additive public APIs.
- `src/api/types.ts` — additive optional fields on `BackgroundTaskInfo` (`workflow_kind`, `current_phase`, `lifecycle_state`, `runtime_detail`, `progress_message`, `progress`, `progress_events`) and two supporting types.
- `src/layouts/chat-layout.tsx` — small toast dismiss-on-session-switch tweak + `data-testid` for the file notification toast.

## Test plan

- [x] `npm run build` (clean, zero errors)
- [x] `npm run lint` against new/modified files (clean)
- [x] `npx playwright test tests/message-store-reducer.spec.ts` → 9 passed
- [x] `npx playwright test tests/message-store-live.spec.ts --list` → 2 discovered (gated)
- [x] `npx playwright test tests/tts-runtime-events.spec.ts tests/background-task-scope.spec.ts tests/cost-bar-stale.spec.ts tests/studio-disabled.spec.ts` (mock-route tests) → 14 passed
- [ ] Live backend specs (`session-switching`, `tts-no-duplicates`, etc.) require a running octos backend — unchanged from `main`.

## Notes

Runtime bridges (`sse-bridge`, `ws-adapter`, `task-watcher`, `runtime-provider`) are **unchanged** in this PR; they still consume the same message-store API. Phase 3 runtime routing + Phase 4 hardening ship in the stacked follow-up PR.