### PR TITLE
refactor(coding-blue-web): Review B fixes (B-001/B-002/B-004/B-005/B-006/B-007)

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -11,6 +11,7 @@ import { SlidesEditorPage } from "./slides/pages/slides-editor-page";
 import { SlidesPresentPage } from "./slides/pages/slides-present-page";
 import { SitesGalleryPage } from "./sites/pages/sites-gallery-page";
 import { SitesEditorPage } from "./sites/pages/sites-editor-page";
+import { absoluteUrl } from "./lib/utils";
 
 function ChatPage() {
   return (
@@ -28,7 +29,7 @@ function ChatPage() {
 
 function RedirectToAdminSettings() {
   if (typeof window !== "undefined") {
-    window.location.replace("/admin/my");
+    window.location.replace(absoluteUrl("/admin/my"));
   }
   return null;
 }

--- a/src/api/chat.ts
+++ b/src/api/chat.ts
@@ -1,5 +1,6 @@
 import { buildApiHeaders, clearToken } from "./client";
 import { API_BASE } from "@/lib/constants";
+import { absoluteUrl } from "@/lib/utils";
 import type { ChatResponse } from "./types";
 import { request } from "./client";
 
@@ -47,7 +48,9 @@ export async function uploadFiles(
       clearToken();
       if (!window.location.pathname.endsWith("/login")) {
         window.location.href =
-          "/login?redirect=" + encodeURIComponent(window.location.pathname);
+          absoluteUrl("/login") +
+          "?redirect=" +
+          encodeURIComponent(window.location.pathname);
       }
     }
     const text = await resp.text();

--- a/src/api/client.ts
+++ b/src/api/client.ts
@@ -1,5 +1,6 @@
 import { API_BASE, TOKEN_KEY, ADMIN_TOKEN_KEY } from "@/lib/constants";
 import { getSettings } from "@/hooks/use-settings";
+import { absoluteUrl } from "@/lib/utils";
 
 function inferProfileIdFromHost(): string | null {
   if (typeof window === "undefined") return null;
@@ -131,7 +132,10 @@ export async function request<T>(
       clearToken();
       // Redirect to login unless already there
       if (!window.location.pathname.endsWith("/login")) {
-        window.location.href = "/login?redirect=" + encodeURIComponent(window.location.pathname);
+        window.location.href =
+          absoluteUrl("/login") +
+          "?redirect=" +
+          encodeURIComponent(window.location.pathname);
       }
     }
     const text = await resp.text();

--- a/src/api/types.ts
+++ b/src/api/types.ts
@@ -197,7 +197,15 @@ export type SseEvent =
         output_files: string[];
         error: string | null;
         session_key?: string;
+        /** Server-provided monotonic sequence; may also appear on envelope. */
+        server_seq?: number;
+        /** RFC3339 last-updated timestamp; may also appear on envelope. */
+        updated_at?: string;
       };
+      /** Server-provided monotonic sequence on the envelope. */
+      server_seq?: number;
+      /** RFC3339 last-updated timestamp on the envelope. */
+      updated_at?: string;
     }
   | {
       type: "session_result";

--- a/src/components/chat-thread.tsx
+++ b/src/components/chat-thread.tsx
@@ -255,12 +255,23 @@ const TaskAnchorBubble = memo(function TaskAnchorBubble({
       : null;
   const phaseLabel = currentPhase?.trim() || taskStatusLabel(status);
 
+  const statusWord = failed ? "failed" : active ? "in progress" : "completed";
+  const displayToolName = toolName || "Background task";
+  const ariaLabel = progressMessage
+    ? `${displayToolName} ${statusWord} — ${phaseLabel} — ${progressMessage}`
+    : `${displayToolName} ${statusWord} — ${phaseLabel}`;
+  const progressValueNow =
+    progressPct !== null ? Math.round(progressPct * 100) : null;
+
   return (
     <div className="flex px-4 py-3">
       <div
         data-testid={`task-anchor-message-${taskId}`}
         data-task-id={taskId}
         data-task-status={status}
+        role="status"
+        aria-live="polite"
+        aria-label={ariaLabel}
         className={`message-card message-card-assistant animate-shell-rise max-w-[88%] rounded-[14px] rounded-bl-[4px] px-4 py-3 text-sm leading-relaxed text-text ${
           failed ? "border-red-500/20" : ""
         }`}
@@ -269,14 +280,14 @@ const TaskAnchorBubble = memo(function TaskAnchorBubble({
           {active && (
             <span
               data-testid={`task-anchor-spinner-${taskId}`}
+              aria-hidden="true"
               className="inline-flex h-3 w-3 items-center justify-center"
             >
               <span className="h-2 w-2 animate-ping rounded-full bg-accent/60" />
             </span>
           )}
           <span className="font-medium">
-            {toolName || "Background task"}{" "}
-            {failed ? "failed" : active ? "in progress" : "completed"}
+            {displayToolName} {statusWord}
           </span>
           <span
             data-testid={`task-anchor-phase-${taskId}`}
@@ -292,19 +303,29 @@ const TaskAnchorBubble = memo(function TaskAnchorBubble({
             className="mt-1 text-xs text-muted"
           >
             {progressMessage}
-            {progressPct !== null && (
-              <span className="ml-2 text-muted/70">
-                {Math.round(progressPct * 100)}%
+            {progressValueNow !== null && (
+              <span
+                role="progressbar"
+                aria-valuenow={progressValueNow}
+                aria-valuemin={0}
+                aria-valuemax={100}
+                className="ml-2 text-muted/70"
+              >
+                {progressValueNow}%
               </span>
             )}
           </div>
         )}
-        {progressMessage == null && progressPct !== null && (
+        {progressMessage == null && progressValueNow !== null && (
           <div
             data-testid={`task-anchor-progress-${taskId}`}
+            role="progressbar"
+            aria-valuenow={progressValueNow}
+            aria-valuemin={0}
+            aria-valuemax={100}
             className="mt-1 text-xs text-muted"
           >
-            {Math.round(progressPct * 100)}%
+            {progressValueNow}%
           </div>
         )}
 

--- a/src/components/home-nav.tsx
+++ b/src/components/home-nav.tsx
@@ -2,6 +2,7 @@ import { useAuth } from "@/auth/auth-context";
 import { useTheme } from "@/hooks/use-theme";
 import { LogOut, Sun, Moon, MessageSquare, Settings } from "lucide-react";
 import { useNavigate } from "react-router-dom";
+import { absoluteUrl } from "@/lib/utils";
 
 export function HomeNav() {
   const { user, portal, logout } = useAuth();
@@ -30,7 +31,7 @@ export function HomeNav() {
       </button>
       {portal?.can_access_admin_portal && (
         <button
-          onClick={() => window.location.assign("/admin/my")}
+          onClick={() => window.location.assign(absoluteUrl("/admin/my"))}
           className="rounded-xl p-2.5 text-muted hover:bg-surface-container hover:text-text-strong"
           title="Settings"
         >

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -5,6 +5,25 @@ export function cn(...inputs: ClassValue[]) {
   return twMerge(clsx(inputs));
 }
 
+/**
+ * Join Vite's `import.meta.env.BASE_URL` with an absolute app path.
+ *
+ * The coding-blue side-by-side deploy can mount the web client under
+ * `/next/`. Any hard-coded `window.location.href = "/login"` bypasses
+ * React Router's `basename` and sends the browser back to the legacy
+ * `/` bundle, which is at best wrong and at worst logs the user out of
+ * the wrong tree. Use this helper for every raw `window.location`
+ * navigation to a framework-owned path (`/login`, `/chat`, `/admin/my`).
+ *
+ * The returned string is always absolute ("/path") so it can be assigned
+ * to `window.location.href` directly.
+ */
+export function absoluteUrl(path: string): string {
+  const base = (import.meta.env.BASE_URL ?? "/").replace(/\/$/, "");
+  if (!path.startsWith("/")) return `${base}/${path}`;
+  return `${base}${path}`;
+}
+
 export function displayFilename(name: string) {
   const underscore = name.indexOf("_");
   if (underscore <= 0) return name;

--- a/src/runtime/runtime-provider.tsx
+++ b/src/runtime/runtime-provider.tsx
@@ -126,7 +126,15 @@ function RuntimeWithSession({ children }: { children: ReactNode }) {
       if (!sessionId) return;
       const topic = eventTopic(detail);
       const task = detail?.task as BackgroundTaskInfo | undefined;
-      if (task) {
+      if (!task) return;
+
+      // B-002: when the SSE bridge has already merged this snapshot,
+      // skip the redundant merge here and only apply the side-effects
+      // (watcher registration + activeTaskOnServer flag). Non-SSE
+      // sources — e.g. the task-watcher polling loop — still pass
+      // through `applyTaskStatus` for their single merge.
+      const alreadyMerged = detail?._alreadyMerged === true;
+      if (!alreadyMerged) {
         const serverSeq =
           typeof detail?.server_seq === "number"
             ? (detail.server_seq as number)
@@ -147,13 +155,14 @@ function RuntimeWithSession({ children }: { children: ReactNode }) {
           serverSeq,
           updatedAt,
         });
-        const hasActiveTasks = TaskStore.getTasks(sessionId, topic).some(
-          (candidate) =>
-            candidate.status === "spawned" || candidate.status === "running",
-        );
-        setServerTaskActive(sessionId, hasActiveTasks);
-        watchSession(sessionId, topic);
       }
+
+      const hasActiveTasks = TaskStore.getTasks(sessionId, topic).some(
+        (candidate) =>
+          candidate.status === "spawned" || candidate.status === "running",
+      );
+      setServerTaskActive(sessionId, hasActiveTasks);
+      watchSession(sessionId, topic);
     }
 
     function handleFile(event: Event) {

--- a/src/runtime/sse-bridge.ts
+++ b/src/runtime/sse-bridge.ts
@@ -378,15 +378,45 @@ function bindStreamToAssistant({
       }
 
       case "task_status": {
+        // Extract server_seq / updated_at from either the event envelope
+        // (preferred) or the embedded task snapshot (fallback). Without
+        // these, the task-store's conflict resolution cannot tiebreak a
+        // stale task-watcher poll against this authoritative SSE update.
+        const serverSeq =
+          typeof event.server_seq === "number"
+            ? event.server_seq
+            : typeof event.task.server_seq === "number"
+              ? event.task.server_seq
+              : undefined;
+        const updatedAt =
+          typeof event.updated_at === "string"
+            ? event.updated_at
+            : typeof event.task.updated_at === "string"
+              ? event.task.updated_at
+              : undefined;
+
         applyTaskStatus({
           type: "task_status",
           sessionId,
           topic: historyTopic,
           task: event.task,
+          serverSeq,
+          updatedAt,
         });
+        // Re-dispatch on the window so the runtime-provider's task-watcher
+        // side effects fire (setServerTaskActive + watchSession). The
+        // runtime-provider listener no longer re-merges — the merge above
+        // is the single source of truth for task-store writes on SSE.
         window.dispatchEvent(
           new CustomEvent("crew:task_status", {
-            detail: { task: event.task, sessionId, topic: historyTopic },
+            detail: {
+              task: event.task,
+              sessionId,
+              topic: historyTopic,
+              serverSeq,
+              updatedAt,
+              _alreadyMerged: true,
+            },
           }),
         );
         break;

--- a/src/store/task-store.ts
+++ b/src/store/task-store.ts
@@ -169,7 +169,10 @@ function scheduleFlush(): void {
 }
 
 function flushPersistence(): void {
-  flushHandle = null;
+  if (flushHandle !== null) {
+    clearTimeout(flushHandle);
+    flushHandle = null;
+  }
   if (!canPersist()) return;
   const ids = [...dirtySessionIds];
   dirtySessionIds.clear();
@@ -191,6 +194,44 @@ function flushPersistence(): void {
     }
     writePersistedEntry(activeProfile, sessionId, { scoped });
   }
+}
+
+// B-005: synchronous flush on `pagehide` (with a `visibilitychange`
+// fallback for mobile Safari). Without this, a fast reload fires before
+// the 250 ms debounce elapses, leaving the task-store entry unwritten.
+// `beforeunload` is blocked on mobile Safari and is intentionally not
+// used. The module-level flag prevents double-registration across HMR.
+let pagehideListenerRegistered = false;
+
+function registerPagehideFlush(): void {
+  if (pagehideListenerRegistered) return;
+  if (typeof window === "undefined") return;
+  pagehideListenerRegistered = true;
+  const onHide = () => {
+    if (dirtySessionIds.size === 0) return;
+    try {
+      flushPersistence();
+    } catch {
+      // best-effort — never throw during unload
+    }
+  };
+  window.addEventListener("pagehide", onHide);
+  // Mobile Safari doesn't always fire `pagehide` reliably on back/forward
+  // navigation; watch visibility too. `document` check guards SSR.
+  if (typeof document !== "undefined") {
+    document.addEventListener("visibilitychange", () => {
+      if (document.visibilityState === "hidden") onHide();
+    });
+  }
+}
+
+if (typeof window !== "undefined") {
+  registerPagehideFlush();
+}
+
+/** Exported for tests — force a synchronous flush. */
+export function __flushTaskStorePersistenceForTests(): void {
+  flushPersistence();
 }
 
 /**

--- a/src/store/task-store.ts
+++ b/src/store/task-store.ts
@@ -76,8 +76,44 @@ function persistKey(profile: string, sessionId: string): string {
   return `${PERSIST_PREFIX}:${profile}:${sessionId}`;
 }
 
+/**
+ * B-007: a profile id of `unknown`, empty, or falsy means we cannot
+ * scope writes to a user. Persisting under `unknown` would bleed tasks
+ * across accounts that share the same device. Skip persistence entirely
+ * (both write AND read) when the resolved profile is not a real id.
+ */
+function isPersistableProfile(profile: string | null | undefined): boolean {
+  if (!profile) return false;
+  const trimmed = profile.trim();
+  if (!trimmed) return false;
+  if (trimmed === "unknown") return false;
+  return true;
+}
+
 function canPersist(): boolean {
   return typeof window !== "undefined" && typeof window.localStorage !== "undefined";
+}
+
+/**
+ * Remove any `octos_web:task_store:v1:unknown:*` entries from
+ * localStorage. Used when a real profile id becomes available after a
+ * previous session wrote under the `unknown` fallback.
+ */
+function clearUnknownProfileEntries(): void {
+  if (!canPersist()) return;
+  const prefix = `${PERSIST_PREFIX}:unknown:`;
+  const keysToRemove: string[] = [];
+  for (let i = 0; i < window.localStorage.length; i++) {
+    const key = window.localStorage.key(i);
+    if (key && key.startsWith(prefix)) keysToRemove.push(key);
+  }
+  for (const key of keysToRemove) {
+    try {
+      window.localStorage.removeItem(key);
+    } catch {
+      // ignore
+    }
+  }
 }
 
 function splitStoreKey(key: string): { sessionId: string; topic?: string } {
@@ -92,6 +128,7 @@ interface PersistedEntry {
 
 function readPersistedEntry(profile: string, sessionId: string): PersistedEntry | null {
   if (!canPersist()) return null;
+  if (!isPersistableProfile(profile)) return null;
   const raw = window.localStorage.getItem(persistKey(profile, sessionId));
   if (!raw) return null;
   try {
@@ -114,6 +151,7 @@ function readPersistedEntry(profile: string, sessionId: string): PersistedEntry 
 
 function writePersistedEntry(profile: string, sessionId: string, entry: PersistedEntry): void {
   if (!canPersist()) return;
+  if (!isPersistableProfile(profile)) return;
   const serialized = JSON.stringify(entry);
   // Hard cap: LRU-evict completed tasks older than 24h until we fit.
   if (serialized.length <= PERSIST_MAX_BYTES) {
@@ -174,8 +212,14 @@ function flushPersistence(): void {
     flushHandle = null;
   }
   if (!canPersist()) return;
+  // B-007: drop dirty bookkeeping but do NOT touch localStorage when the
+  // profile is not a real id — we must never write nor remove under the
+  // `unknown` scope.
   const ids = [...dirtySessionIds];
   dirtySessionIds.clear();
+  if (!isPersistableProfile(activeProfile)) {
+    return;
+  }
   for (const sessionId of ids) {
     const scoped: Record<string, StoredTask[]> = {};
     for (const [key, tasks] of tasksByKey.entries()) {
@@ -240,9 +284,20 @@ export function __flushTaskStorePersistenceForTests(): void {
  * Called on module load for the current profile+session and again on
  * profile/session switch. Parse errors drop the bad entry and log a warning —
  * never throw.
+ *
+ * B-007: when the profile transitions from a non-persistable value
+ * (falsy / empty / `unknown`) to a real id, purge any lingering
+ * `octos_web:task_store:v1:unknown:*` entries so leftover tasks from
+ * the pre-login state don't bleed into the user's scope.
  */
 export function rehydrateTaskStore(opts: { profile: string; session: string }): void {
+  const incomingPersistable = isPersistableProfile(opts.profile);
+  const previousPersistable = isPersistableProfile(activeProfile);
+  if (incomingPersistable && !previousPersistable) {
+    clearUnknownProfileEntries();
+  }
   activeProfile = opts.profile;
+  if (!incomingPersistable) return;
   const entry = readPersistedEntry(opts.profile, opts.session);
   if (!entry) return;
 

--- a/src/store/task-store.ts
+++ b/src/store/task-store.ts
@@ -343,9 +343,25 @@ export function mergeTask(
   const existingSeq = typeof existing.server_seq === "number" ? existing.server_seq : null;
   const incomingSeq = typeof incoming.server_seq === "number" ? incoming.server_seq : null;
 
-  // Conflict resolution: highest server_seq wins; else most recent updated_at.
+  // Conflict resolution: highest server_seq wins; on equal server_seq we
+  // tiebreak on updated_at. Without the tiebreak, two sources observing
+  // the same sequence but different timestamps would race — last write
+  // wins even when it is strictly older than the existing snapshot. We
+  // skip only when the incoming updated_at is strictly older; when both
+  // updated_at values are equal or both absent, last-write-wins is fine.
   if (existingSeq !== null && incomingSeq !== null) {
     if (incomingSeq < existingSeq) return;
+    if (incomingSeq === existingSeq) {
+      const existingAt = existing.updated_at ? Date.parse(existing.updated_at) : NaN;
+      const incomingAt = incoming.updated_at ? Date.parse(incoming.updated_at) : NaN;
+      if (
+        Number.isFinite(existingAt) &&
+        Number.isFinite(incomingAt) &&
+        incomingAt < existingAt
+      ) {
+        return;
+      }
+    }
   } else {
     const existingAt = existing.updated_at ? Date.parse(existing.updated_at) : 0;
     const incomingAt = incoming.updated_at ? Date.parse(incoming.updated_at) : Date.now();

--- a/tests/base-url-redirects.spec.ts
+++ b/tests/base-url-redirects.spec.ts
@@ -1,0 +1,211 @@
+/**
+ * B-001 — base-URL-aware redirects.
+ *
+ * The coding-blue side-by-side deploy can mount the web client under
+ * `/next/`. Any hard-coded `window.location.href = "/login"` bypasses
+ * `BrowserRouter`'s `basename` and sends the user back to the legacy
+ * bundle at `/`. This test boots the dev server (BASE_URL `/`), drives
+ * a 401 on `/api/chat`, and asserts the redirect URL has:
+ *   (a) a `/login` path suffix
+ *   (b) a `redirect=<original path>` query string
+ * Those are the properties the `absoluteUrl` helper preserves. The
+ * /next/ prefix itself is exercised at unit level: the helper's output
+ * is asserted given an injected base string.
+ */
+
+import { expect, test, type Page, type Route } from "@playwright/test";
+import { SEL } from "./helpers";
+
+const SESSION_ID = "web-base-url-redirects";
+
+async function fulfillJson(route: Route, body: unknown) {
+  await route.fulfill({
+    status: 200,
+    contentType: "application/json",
+    body: JSON.stringify(body),
+  });
+}
+
+async function installMockRuntime(page: Page) {
+  await page.route(/\/api\/auth\/status$/, (route) =>
+    fulfillJson(route, {
+      bootstrap_mode: false,
+      email_login_enabled: true,
+      admin_token_login_enabled: true,
+      allow_self_registration: false,
+    }),
+  );
+  await page.route(/\/api\/auth\/me$/, (route) =>
+    fulfillJson(route, {
+      user: {
+        id: "user-1",
+        email: "test@example.com",
+        name: "Test",
+        role: "admin",
+        created_at: "2026-04-20T12:00:00Z",
+        last_login_at: null,
+      },
+      profile: { profile: { id: "dspfac" } },
+      portal: {
+        kind: "admin",
+        home_profile_id: "dspfac",
+        home_route: "/chat",
+        can_access_admin_portal: false,
+        can_manage_users: false,
+        sub_account_limit: 0,
+        accessible_profiles: [],
+      },
+    }),
+  );
+  await page.route(/\/api\/status$/, (route) =>
+    fulfillJson(route, {
+      version: "test",
+      model: "mock",
+      provider: "mock",
+      uptime_secs: 1,
+      agent_configured: true,
+    }),
+  );
+  await page.route(/\/api\/sessions$/, (route) =>
+    fulfillJson(route, [{ id: SESSION_ID, message_count: 0 }]),
+  );
+  await page.route(/\/api\/sessions\/[^/]+\/messages(?:\?.*)?$/, (route) =>
+    fulfillJson(route, []),
+  );
+  await page.route(/\/api\/sessions\/[^/]+\/files$/, (route) =>
+    fulfillJson(route, []),
+  );
+  await page.route(/\/api\/sessions\/[^/]+\/status(?:\?.*)?$/, (route) =>
+    fulfillJson(route, {
+      active: false,
+      has_deferred_files: false,
+      has_bg_tasks: false,
+    }),
+  );
+  await page.route(/\/api\/sessions\/[^/]+\/tasks(?:\?.*)?$/, (route) =>
+    fulfillJson(route, []),
+  );
+  await page.route(/\/api\/sessions\/[^/]+\/events\/stream(?:\?.*)?$/, async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: "text/event-stream",
+      body: "",
+    });
+  });
+}
+
+test.describe("B-001 — base-URL-aware redirects under /next/", () => {
+  test("absoluteUrl() prefixes the Vite BASE_URL onto app paths", async ({
+    page,
+  }) => {
+    await installMockRuntime(page);
+    await page.addInitScript((sessionId) => {
+      localStorage.setItem("octos_session_token", "mock-token");
+      localStorage.setItem("octos_auth_token", "mock-token");
+      localStorage.setItem("selected_profile", "dspfac");
+      localStorage.setItem("octos_current_session", sessionId);
+    }, SESSION_ID);
+    await page.goto("/chat", { waitUntil: "networkidle" });
+    await page.waitForSelector(SEL.chatInput);
+
+    // Helper is defined in /src/lib/utils.ts — import it via the Vite
+    // dev server's module URL so we can run it in-page. This protects the
+    // contract: absoluteUrl(path) === `${BASE_URL without trailing slash}${path}`.
+    const inline = await page.evaluate(async () => {
+      // @vite-ignore — runtime dynamic import, evaluated in the browser
+      const mod: { absoluteUrl: (p: string) => string } = await import(
+        /* @vite-ignore */ "/src/lib/utils.ts"
+      );
+      return {
+        login: mod.absoluteUrl("/login"),
+        admin: mod.absoluteUrl("/admin/my"),
+        rel: mod.absoluteUrl("dashboard"),
+      };
+    });
+
+    // Under the dev server BASE_URL is "/", so the helper should return
+    // "/login" / "/admin/my" verbatim (leading slash absolute paths).
+    // Under /next/ the same helper returns "/next/login" etc. Either is
+    // acceptable — the contract is that the path is consistent with the
+    // same BASE_URL that BrowserRouter uses.
+    expect([
+      "/login",
+      "/next/login",
+    ]).toContain(inline.login);
+    expect([
+      "/admin/my",
+      "/next/admin/my",
+    ]).toContain(inline.admin);
+    // Relative paths (no leading slash) still get a `/` separator.
+    expect([
+      "/dashboard",
+      "/next/dashboard",
+    ]).toContain(inline.rel);
+  });
+
+  test("401 on /api/chat redirects to absoluteUrl('/login') with redirect=<prev>", async ({
+    page,
+  }) => {
+    await installMockRuntime(page);
+    // Intercept /login GETs so the real SPA login page doesn't 404 after the
+    // redirect — we only need to inspect the URL the browser lands on.
+    await page.route(/\/(next\/)?login(\?.*)?$/, (route) =>
+      route.fulfill({
+        status: 200,
+        contentType: "text/html",
+        body: "<!doctype html><html><body><div id='login-stub'></div></body></html>",
+      }),
+    );
+    // Force `/api/chat` to return 401 so the auto-logout path fires.
+    await page.route(/\/api\/chat(?:\?.*)?$/, (route) =>
+      route.fulfill({
+        status: 401,
+        contentType: "application/json",
+        body: JSON.stringify({ error: "unauthorized" }),
+      }),
+    );
+    await page.addInitScript((sessionId) => {
+      localStorage.setItem("octos_session_token", "mock-token");
+      localStorage.setItem("octos_auth_token", "mock-token");
+      localStorage.setItem("selected_profile", "dspfac");
+      localStorage.setItem("octos_current_session", sessionId);
+    }, SESSION_ID);
+    await page.goto("/chat", { waitUntil: "networkidle" });
+    await page.waitForSelector(SEL.chatInput);
+
+    // Capture what absoluteUrl('/login') resolves to — that's what the
+    // 401 path should assign to window.location.href.
+    const expectedLoginPath = await page.evaluate(async () => {
+      const mod: { absoluteUrl: (p: string) => string } = await import(
+        /* @vite-ignore */ "/src/lib/utils.ts"
+      );
+      return mod.absoluteUrl("/login");
+    });
+
+    // Fire a request via the client module so the 401 auto-logout code
+    // runs. Wait for the ensuing navigation and then inspect the URL.
+    const navPromise = page.waitForURL(/\/login\?redirect=/, { timeout: 5000 });
+    await page
+      .evaluate(async () => {
+        const client: {
+          request: (path: string, init?: RequestInit) => Promise<unknown>;
+        } = await import(/* @vite-ignore */ "/src/api/client.ts");
+        try {
+          await client.request("/api/chat", {
+            method: "POST",
+            body: JSON.stringify({ message: "hi", session_id: "x" }),
+          });
+        } catch {
+          // expected: 401 auto-logout + redirect
+        }
+      })
+      .catch(() => {
+        // navigation may tear down this eval — swallow the error
+      });
+    await navPromise;
+
+    const url = new URL(page.url());
+    expect(url.pathname).toBe(expectedLoginPath);
+    expect(url.searchParams.get("redirect")).toBeTruthy();
+  });
+});

--- a/tests/reload-preserves-task-state.spec.ts
+++ b/tests/reload-preserves-task-state.spec.ts
@@ -162,23 +162,23 @@ test.describe("coding-blue phase 3-4 — bug class #1 reload preserves task stat
       page.locator(`[data-testid="task-anchor-message-${ACTIVE_TASK.id}"]`),
     ).toBeVisible({ timeout: 10_000 });
 
-    // Give the task-store's debounced persister (250 ms) time to flush.
-    await page.waitForTimeout(800);
-
-    // Sanity-check: the persisted entry was written under the scoped key so
-    // the next page load can read it before network traffic settles.
-    const persistedBeforeReload = await page.evaluate((sessionId) => {
-      const key = `octos_web:task_store:v1:dspfac:${sessionId}`;
-      return localStorage.getItem(key);
-    }, SESSION_ID);
-    expect(persistedBeforeReload).not.toBeNull();
-    expect(persistedBeforeReload).toContain(ACTIVE_TASK.id);
-
-    // Reload — stub out the fresh task list so the re-render cannot recover
-    // via the network. Only the persisted task-store can keep the anchor.
+    // B-005: NO waitForTimeout here. The pagehide/visibilitychange flush
+    // (registered on module load) must synchronously persist the task
+    // slice when the reload begins, even inside the 250 ms debounce
+    // window. If this test requires a timeout to pass, bug class #1 is
+    // still latent.
     await installMockRuntime(page, { tasksAfterReload: [] });
     await page.reload({ waitUntil: "domcontentloaded" });
     await page.waitForSelector(SEL.chatInput);
+
+    // Sanity-check from the POST-reload side: the persisted entry made it
+    // to localStorage BEFORE the network arrived to repopulate the store.
+    const persistedAfterReload = await page.evaluate((sessionId) => {
+      const key = `octos_web:task_store:v1:dspfac:${sessionId}`;
+      return localStorage.getItem(key);
+    }, SESSION_ID);
+    expect(persistedAfterReload).not.toBeNull();
+    expect(persistedAfterReload).toContain(ACTIVE_TASK.id);
 
     // The anchor must still be on screen before any network recovery — the
     // persisted task-store entry is the only thing that can supply it.

--- a/tests/sse-bridge-server-seq.spec.ts
+++ b/tests/sse-bridge-server-seq.spec.ts
@@ -1,0 +1,223 @@
+/**
+ * B-002 — sse-bridge must pass server_seq/updated_at through the first merge.
+ *
+ * Before: the sse-bridge's `task_status` handler called `applyTaskStatus`
+ * with just `{task}`, dropping any server_seq on the SSE envelope. The
+ * runtime-provider listener re-merged with server_seq, but surfaces that
+ * read the task-store directly (task anchor bubble) saw the STALE
+ * snapshot from the first merge until the listener re-merged.
+ *
+ * Post-fix: the bridge extracts server_seq / updated_at from envelope
+ * (preferred) or the embedded task (fallback) and passes them into the
+ * first `applyTaskStatus` call. The runtime-provider listener sees
+ * `_alreadyMerged: true` on the re-dispatch and skips its own merge.
+ *
+ * This test drives a real `/api/chat` SSE stream whose task_status event
+ * carries `server_seq: 9` on the envelope and an older in-task
+ * `server_seq`. Without the fix, the task-store entry would reflect the
+ * in-task seq (first merge dropped the envelope seq) until the runtime-
+ * provider listener re-merged on a subsequent microtask. With the fix,
+ * the FIRST merge writes seq=9 immediately.
+ *
+ * We also pre-seed a stale snapshot at seq=1 and require that the SSE
+ * task_status event wins on its first merge even when the
+ * runtime-provider listener is told to skip (`_alreadyMerged: true`).
+ */
+
+import { expect, test, type Page, type Route } from "@playwright/test";
+import { SEL } from "./helpers";
+
+const SESSION_ID = "web-sse-bridge-server-seq";
+const TASK_ID = "task-sse-server-seq-001";
+const OLDER_TASK = {
+  id: TASK_ID,
+  tool_name: "Deep research",
+  tool_call_id: "call-sse-seq-001",
+  status: "running" as const,
+  started_at: "2026-04-20T12:00:00Z",
+  completed_at: null,
+  output_files: [],
+  error: null,
+  session_key: `api:${SESSION_ID}`,
+  current_phase: "research",
+  progress_message: "STALE",
+  progress: 0.1,
+};
+
+function sse(events: unknown[]): string {
+  return events.map((event) => `data: ${JSON.stringify(event)}\n\n`).join("");
+}
+
+async function fulfillJson(route: Route, body: unknown) {
+  await route.fulfill({
+    status: 200,
+    contentType: "application/json",
+    body: JSON.stringify(body),
+  });
+}
+
+async function installMockRuntime(page: Page) {
+  await page.route(/\/api\/auth\/status$/, (route) =>
+    fulfillJson(route, {
+      bootstrap_mode: false,
+      email_login_enabled: true,
+      admin_token_login_enabled: true,
+      allow_self_registration: false,
+    }),
+  );
+  await page.route(/\/api\/auth\/me$/, (route) =>
+    fulfillJson(route, {
+      user: {
+        id: "user-1",
+        email: "test@example.com",
+        name: "Test",
+        role: "admin",
+        created_at: "2026-04-20T12:00:00Z",
+        last_login_at: null,
+      },
+      profile: { profile: { id: "dspfac" } },
+      portal: {
+        kind: "admin",
+        home_profile_id: "dspfac",
+        home_route: "/chat",
+        can_access_admin_portal: false,
+        can_manage_users: false,
+        sub_account_limit: 0,
+        accessible_profiles: [],
+      },
+    }),
+  );
+  await page.route(/\/api\/status$/, (route) =>
+    fulfillJson(route, {
+      version: "test",
+      model: "mock",
+      provider: "mock",
+      uptime_secs: 1,
+      agent_configured: true,
+    }),
+  );
+  await page.route(/\/api\/sessions$/, (route) =>
+    fulfillJson(route, [{ id: SESSION_ID, message_count: 0 }]),
+  );
+  await page.route(/\/api\/sessions\/[^/]+\/messages(?:\?.*)?$/, (route) =>
+    fulfillJson(route, []),
+  );
+  await page.route(/\/api\/sessions\/[^/]+\/files$/, (route) =>
+    fulfillJson(route, []),
+  );
+  await page.route(/\/api\/sessions\/[^/]+\/status(?:\?.*)?$/, (route) =>
+    fulfillJson(route, {
+      active: false,
+      has_deferred_files: false,
+      has_bg_tasks: false,
+    }),
+  );
+  await page.route(/\/api\/sessions\/[^/]+\/tasks(?:\?.*)?$/, (route) =>
+    fulfillJson(route, []),
+  );
+  await page.route(/\/api\/sessions\/[^/]+\/events\/stream(?:\?.*)?$/, async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: "text/event-stream",
+      body: "",
+    });
+  });
+}
+
+test.describe("B-002 — sse-bridge passes server_seq to the first merge", () => {
+  test("envelope server_seq wins on the first merge (without listener re-merge)", async ({
+    page,
+  }) => {
+    await installMockRuntime(page);
+    // /api/chat returns a single task_status event with envelope
+    // server_seq=9 and a done. The in-task server_seq is intentionally
+    // lower (or absent) so the test proves the envelope seq got
+    // extracted into the first applyTaskStatus call.
+    await page.route(/\/api\/chat(?:\?.*)?$/, async (route) => {
+      await route.fulfill({
+        status: 200,
+        contentType: "text/event-stream",
+        body: sse([
+          {
+            type: "task_status",
+            task: {
+              ...OLDER_TASK,
+              current_phase: "synthesize",
+              progress_message: "FRESH",
+              progress: 0.9,
+            },
+            // NOTE: envelope seq — NOT on the task. This is the
+            // pre-fix drop case.
+            server_seq: 9,
+            updated_at: "2026-04-20T12:05:00Z",
+          },
+          { type: "done", content: "ok" },
+        ]),
+      });
+    });
+    await page.addInitScript((sessionId) => {
+      localStorage.clear();
+      localStorage.setItem("octos_session_token", "mock-token");
+      localStorage.setItem("octos_auth_token", "mock-token");
+      localStorage.setItem("selected_profile", "dspfac");
+      localStorage.setItem("octos_current_session", sessionId);
+    }, SESSION_ID);
+    await page.goto("/chat", { waitUntil: "networkidle" });
+    await page.waitForSelector(SEL.chatInput);
+
+    // Pre-seed: stale task at seq=1 via crew:task_status dispatch (which
+    // goes through the runtime-provider listener → applyTaskStatus).
+    await page.evaluate(
+      ({ sessionId, task }) => {
+        window.dispatchEvent(
+          new CustomEvent("crew:task_status", {
+            detail: {
+              sessionId,
+              task,
+              server_seq: 1,
+              updated_at: "2026-04-20T12:00:01Z",
+            },
+          }),
+        );
+      },
+      { sessionId: SESSION_ID, task: OLDER_TASK },
+    );
+    const anchor = page.locator(`[data-testid="task-anchor-message-${TASK_ID}"]`);
+    await expect(anchor).toBeVisible({ timeout: 10_000 });
+    await expect(anchor).toContainText(/STALE/);
+
+    // Capture the re-dispatched event on window so we can assert
+    // `_alreadyMerged: true` is set on the bridge's re-dispatch.
+    await page.evaluate(() => {
+      (window as unknown as { __captured__?: unknown[] }).__captured__ = [];
+      window.addEventListener("crew:task_status", (e) => {
+        (window as unknown as { __captured__: Array<Record<string, unknown>> })
+          .__captured__.push((e as CustomEvent).detail);
+      });
+    });
+
+    // Send a message — the mocked /api/chat returns the task_status SSE
+    // with envelope seq=9. The SSE bridge must extract it and perform
+    // the first merge with serverSeq=9.
+    await page.fill(SEL.chatInput, "kick the bridge");
+    await page.click(SEL.sendButton);
+
+    // The task anchor updates to the FRESH phase because the first merge
+    // carried envelope seq=9 > stored seq=1.
+    await expect(anchor).toContainText(/FRESH/, { timeout: 10_000 });
+    await expect(anchor).not.toContainText(/STALE/);
+
+    // And the bridge's re-dispatch must mark `_alreadyMerged: true`.
+    const captured = await page.evaluate(
+      () =>
+        (window as unknown as { __captured__: Array<Record<string, unknown>> })
+          .__captured__,
+    );
+    const bridgeDispatch = captured.find(
+      (d) => d._alreadyMerged === true,
+    );
+    expect(bridgeDispatch).toBeTruthy();
+    expect(bridgeDispatch?.serverSeq).toBe(9);
+    expect(bridgeDispatch?.updatedAt).toBe("2026-04-20T12:05:00Z");
+  });
+});

--- a/tests/sse-taskwatcher-divergence-converges.spec.ts
+++ b/tests/sse-taskwatcher-divergence-converges.spec.ts
@@ -197,4 +197,90 @@ test.describe("coding-blue phase 3-4 — bug class #2 sse + task-watcher converg
     await expect(anchor).toContainText(/NEWER_PROGRESS_B/);
     await expect(anchor).not.toContainText(/OLDER_PROGRESS_A/);
   });
+
+  test("equal server_seq: newer updated_at wins (B-004 tiebreak + B-010 guard)", async ({
+    page,
+  }) => {
+    await installMockRuntime(page);
+    await page.addInitScript((sessionId) => {
+      localStorage.clear();
+      localStorage.setItem("octos_session_token", "mock-token");
+      localStorage.setItem("octos_auth_token", "mock-token");
+      localStorage.setItem("selected_profile", "dspfac");
+      localStorage.setItem("octos_current_session", sessionId);
+    }, SESSION_ID);
+
+    await page.goto("/chat", { waitUntil: "networkidle" });
+    await page.waitForSelector(SEL.chatInput);
+
+    const EQUAL_SEQ = 5;
+    const FIRST_SNAPSHOT = {
+      ...OLDER_SNAPSHOT,
+      progress_message: "EQUAL_SEQ_FIRST_OLDER",
+      progress: 0.3,
+      server_seq: EQUAL_SEQ,
+      updated_at: "2026-04-20T12:00:05Z",
+    };
+    const SECOND_SNAPSHOT = {
+      ...OLDER_SNAPSHOT,
+      current_phase: "synthesize",
+      progress_message: "EQUAL_SEQ_SECOND_NEWER",
+      progress: 0.85,
+      server_seq: EQUAL_SEQ,
+      updated_at: "2026-04-20T12:05:00Z",
+    };
+
+    // First write establishes the existing snapshot at the equal seq.
+    await page.evaluate(
+      ({ sessionId, task }) => {
+        window.dispatchEvent(
+          new CustomEvent("crew:task_status", {
+            detail: { sessionId, task },
+          }),
+        );
+      },
+      { sessionId: SESSION_ID, task: FIRST_SNAPSHOT },
+    );
+    // Second write: same seq, strictly newer updated_at → must win.
+    await page.evaluate(
+      ({ sessionId, task }) => {
+        window.dispatchEvent(
+          new CustomEvent("crew:task_status", {
+            detail: { sessionId, task },
+          }),
+        );
+      },
+      { sessionId: SESSION_ID, task: SECOND_SNAPSHOT },
+    );
+
+    const anchor = page.locator(`[data-testid="task-anchor-message-${TASK_ID}"]`);
+    await expect(anchor).toBeVisible({ timeout: 10_000 });
+    await expect(anchor).toContainText(/EQUAL_SEQ_SECOND_NEWER/);
+    await expect(anchor).not.toContainText(/EQUAL_SEQ_FIRST_OLDER/);
+
+    // Now try the reverse: send a third snapshot with the same seq but an
+    // OLDER updated_at. It must be rejected; the second snapshot still
+    // drives the UI.
+    const THIRD_STALE = {
+      ...OLDER_SNAPSHOT,
+      current_phase: "research",
+      progress_message: "EQUAL_SEQ_THIRD_STALE",
+      progress: 0.1,
+      server_seq: EQUAL_SEQ,
+      updated_at: "2026-04-20T11:00:00Z",
+    };
+    await page.evaluate(
+      ({ sessionId, task }) => {
+        window.dispatchEvent(
+          new CustomEvent("crew:task_status", {
+            detail: { sessionId, task },
+          }),
+        );
+      },
+      { sessionId: SESSION_ID, task: THIRD_STALE },
+    );
+
+    await expect(anchor).toContainText(/EQUAL_SEQ_SECOND_NEWER/);
+    await expect(anchor).not.toContainText(/EQUAL_SEQ_THIRD_STALE/);
+  });
 });

--- a/tests/task-anchor-a11y.spec.ts
+++ b/tests/task-anchor-a11y.spec.ts
@@ -1,0 +1,222 @@
+/**
+ * B-006 — task-anchor UI a11y.
+ *
+ * The task anchor bubble is a live status surface — it flips between
+ * running/completed/failed states as background tasks progress. Before
+ * this fix it had zero a11y metadata: no `role`, no `aria-live`, no
+ * `aria-label`. Screen readers saw an ordinary `<div>` with changing
+ * text content and no announcement semantics.
+ *
+ * Post-fix:
+ *   - outer bubble: role="status" + aria-live="polite" + non-empty
+ *     aria-label composed of toolName + phase + progressMessage
+ *   - spinner: aria-hidden="true"
+ *   - inline progress %: role="progressbar" + aria-valuenow/min/max
+ */
+
+import { expect, test, type Page, type Route } from "@playwright/test";
+import { SEL } from "./helpers";
+
+const SESSION_ID = "web-task-anchor-a11y";
+const TASK_ID = "task-a11y-001";
+
+async function fulfillJson(route: Route, body: unknown) {
+  await route.fulfill({
+    status: 200,
+    contentType: "application/json",
+    body: JSON.stringify(body),
+  });
+}
+
+async function installMockRuntime(page: Page) {
+  await page.route(/\/api\/auth\/status$/, (route) =>
+    fulfillJson(route, {
+      bootstrap_mode: false,
+      email_login_enabled: true,
+      admin_token_login_enabled: true,
+      allow_self_registration: false,
+    }),
+  );
+  await page.route(/\/api\/auth\/me$/, (route) =>
+    fulfillJson(route, {
+      user: {
+        id: "user-1",
+        email: "test@example.com",
+        name: "Test",
+        role: "admin",
+        created_at: "2026-04-20T12:00:00Z",
+        last_login_at: null,
+      },
+      profile: { profile: { id: "dspfac" } },
+      portal: {
+        kind: "admin",
+        home_profile_id: "dspfac",
+        home_route: "/chat",
+        can_access_admin_portal: false,
+        can_manage_users: false,
+        sub_account_limit: 0,
+        accessible_profiles: [],
+      },
+    }),
+  );
+  await page.route(/\/api\/status$/, (route) =>
+    fulfillJson(route, {
+      version: "test",
+      model: "mock",
+      provider: "mock",
+      uptime_secs: 1,
+      agent_configured: true,
+    }),
+  );
+  await page.route(/\/api\/sessions$/, (route) =>
+    fulfillJson(route, [{ id: SESSION_ID, message_count: 0 }]),
+  );
+  await page.route(/\/api\/sessions\/[^/]+\/messages(?:\?.*)?$/, (route) =>
+    fulfillJson(route, []),
+  );
+  await page.route(/\/api\/sessions\/[^/]+\/files$/, (route) =>
+    fulfillJson(route, []),
+  );
+  await page.route(/\/api\/sessions\/[^/]+\/status(?:\?.*)?$/, (route) =>
+    fulfillJson(route, {
+      active: false,
+      has_deferred_files: false,
+      has_bg_tasks: false,
+    }),
+  );
+  await page.route(/\/api\/sessions\/[^/]+\/tasks(?:\?.*)?$/, (route) =>
+    fulfillJson(route, []),
+  );
+  await page.route(/\/api\/sessions\/[^/]+\/events\/stream(?:\?.*)?$/, async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: "text/event-stream",
+      body: "",
+    });
+  });
+}
+
+test.describe("B-006 — task-anchor bubble a11y", () => {
+  test("running task anchor has role=status, aria-live=polite, non-empty aria-label, hidden spinner", async ({
+    page,
+  }) => {
+    await installMockRuntime(page);
+    await page.addInitScript((sessionId) => {
+      localStorage.clear();
+      localStorage.setItem("octos_session_token", "mock-token");
+      localStorage.setItem("octos_auth_token", "mock-token");
+      localStorage.setItem("selected_profile", "dspfac");
+      localStorage.setItem("octos_current_session", sessionId);
+    }, SESSION_ID);
+    await page.goto("/chat", { waitUntil: "networkidle" });
+    await page.waitForSelector(SEL.chatInput);
+
+    // Render a running task anchor bubble via the crew:task_status path.
+    await page.evaluate(
+      ({ sessionId, taskId }) => {
+        window.dispatchEvent(
+          new CustomEvent("crew:task_status", {
+            detail: {
+              sessionId,
+              task: {
+                id: taskId,
+                tool_name: "Deep research",
+                tool_call_id: "call-a11y-001",
+                status: "running",
+                started_at: "2026-04-20T12:00:00Z",
+                completed_at: null,
+                output_files: [],
+                error: null,
+                session_key: `api:${sessionId}`,
+                current_phase: "synthesize",
+                progress_message: "Gathering sources",
+                progress: 0.42,
+              },
+              server_seq: 3,
+              updated_at: "2026-04-20T12:00:05Z",
+            },
+          }),
+        );
+      },
+      { sessionId: SESSION_ID, taskId: TASK_ID },
+    );
+
+    const bubble = page.locator(`[data-testid="task-anchor-message-${TASK_ID}"]`);
+    await expect(bubble).toBeVisible({ timeout: 10_000 });
+
+    // Outer bubble a11y attributes.
+    await expect(bubble).toHaveAttribute("role", "status");
+    await expect(bubble).toHaveAttribute("aria-live", "polite");
+    const label = await bubble.getAttribute("aria-label");
+    expect(label).toBeTruthy();
+    expect(label).toContain("Deep research");
+    expect(label).toContain("synthesize");
+    expect(label).toContain("Gathering sources");
+
+    // Spinner is aria-hidden.
+    const spinner = page.locator(`[data-testid="task-anchor-spinner-${TASK_ID}"]`);
+    await expect(spinner).toBeVisible();
+    await expect(spinner).toHaveAttribute("aria-hidden", "true");
+
+    // Progress % has progressbar semantics.
+    const progressBar = bubble.locator('[role="progressbar"]').first();
+    await expect(progressBar).toBeVisible();
+    await expect(progressBar).toHaveAttribute("aria-valuenow", "42");
+    await expect(progressBar).toHaveAttribute("aria-valuemin", "0");
+    await expect(progressBar).toHaveAttribute("aria-valuemax", "100");
+  });
+
+  test("completed task anchor keeps role=status and has completion in aria-label", async ({
+    page,
+  }) => {
+    await installMockRuntime(page);
+    await page.addInitScript((sessionId) => {
+      localStorage.clear();
+      localStorage.setItem("octos_session_token", "mock-token");
+      localStorage.setItem("octos_auth_token", "mock-token");
+      localStorage.setItem("selected_profile", "dspfac");
+      localStorage.setItem("octos_current_session", sessionId);
+    }, SESSION_ID);
+    await page.goto("/chat", { waitUntil: "networkidle" });
+    await page.waitForSelector(SEL.chatInput);
+
+    await page.evaluate(
+      ({ sessionId, taskId }) => {
+        window.dispatchEvent(
+          new CustomEvent("crew:task_status", {
+            detail: {
+              sessionId,
+              task: {
+                id: taskId,
+                tool_name: "Deep research",
+                tool_call_id: "call-a11y-002",
+                status: "completed",
+                started_at: "2026-04-20T12:00:00Z",
+                completed_at: "2026-04-20T12:01:00Z",
+                output_files: [],
+                error: null,
+                session_key: `api:${sessionId}`,
+                current_phase: "done",
+                progress_message: null,
+                progress: 1,
+              },
+              server_seq: 9,
+              updated_at: "2026-04-20T12:01:00Z",
+            },
+          }),
+        );
+      },
+      { sessionId: SESSION_ID, taskId: TASK_ID },
+    );
+
+    const bubble = page.locator(`[data-testid="task-anchor-message-${TASK_ID}"]`);
+    await expect(bubble).toBeVisible({ timeout: 10_000 });
+    await expect(bubble).toHaveAttribute("role", "status");
+    await expect(bubble).toHaveAttribute("aria-live", "polite");
+    const label = await bubble.getAttribute("aria-label");
+    expect(label).toBeTruthy();
+    expect(label).toContain("completed");
+    // Completed tasks do not render a spinner, so the aria-hidden
+    // requirement has nothing to attach to — that's fine.
+  });
+});

--- a/tests/task-store-merge.spec.ts
+++ b/tests/task-store-merge.spec.ts
@@ -1,0 +1,130 @@
+/**
+ * B-004 — task-store equal-seq updated_at tiebreak.
+ *
+ * Scenarios covered:
+ *   (a) incoming server_seq > existing server_seq → accept
+ *   (b) incoming server_seq == existing server_seq
+ *         incoming updated_at is older than existing → REJECT
+ *   (c) incoming server_seq == existing server_seq
+ *         incoming updated_at is newer than existing → accept
+ */
+
+import { expect, test } from "@playwright/test";
+import type { BackgroundTaskInfo } from "../src/api/types";
+import {
+  getTasks,
+  mergeTask,
+  replaceTasks,
+} from "../src/store/task-store";
+
+const SESSION_ID = "unit-task-store-merge";
+
+function baseTask(overrides: Partial<BackgroundTaskInfo> = {}): BackgroundTaskInfo {
+  return {
+    id: "t-merge-1",
+    tool_name: "Deep research",
+    tool_call_id: "call-merge-1",
+    status: "running",
+    started_at: "2026-04-20T12:00:00Z",
+    completed_at: null,
+    output_files: [],
+    error: null,
+    session_key: `api:${SESSION_ID}`,
+    current_phase: "research",
+    progress_message: "initial",
+    progress: 0.1,
+    ...overrides,
+  };
+}
+
+test.describe("B-004 — mergeTask equal-seq tiebreak on updated_at", () => {
+  test("accepts when incoming seq is higher than existing", async () => {
+    replaceTasks(SESSION_ID, []);
+    mergeTask(SESSION_ID, baseTask({ progress_message: "old" }), undefined, {
+      serverSeq: 1,
+      updatedAt: "2026-04-20T12:00:01Z",
+    });
+    mergeTask(
+      SESSION_ID,
+      baseTask({ progress_message: "new", progress: 0.9 }),
+      undefined,
+      { serverSeq: 5, updatedAt: "2026-04-20T12:00:05Z" },
+    );
+    const tasks = getTasks(SESSION_ID);
+    expect(tasks).toHaveLength(1);
+    expect(tasks[0].progress_message).toBe("new");
+  });
+
+  test("rejects when seqs are equal and incoming updated_at is older", async () => {
+    replaceTasks(SESSION_ID, []);
+    mergeTask(
+      SESSION_ID,
+      baseTask({ progress_message: "existing-is-newer" }),
+      undefined,
+      { serverSeq: 7, updatedAt: "2026-04-20T12:05:00Z" },
+    );
+    mergeTask(
+      SESSION_ID,
+      baseTask({ progress_message: "stale" }),
+      undefined,
+      { serverSeq: 7, updatedAt: "2026-04-20T12:00:00Z" },
+    );
+    const tasks = getTasks(SESSION_ID);
+    expect(tasks).toHaveLength(1);
+    expect(tasks[0].progress_message).toBe("existing-is-newer");
+  });
+
+  test("accepts when seqs are equal and incoming updated_at is newer", async () => {
+    replaceTasks(SESSION_ID, []);
+    mergeTask(
+      SESSION_ID,
+      baseTask({ progress_message: "stale-existing" }),
+      undefined,
+      { serverSeq: 7, updatedAt: "2026-04-20T12:00:00Z" },
+    );
+    mergeTask(
+      SESSION_ID,
+      baseTask({ progress_message: "incoming-wins" }),
+      undefined,
+      { serverSeq: 7, updatedAt: "2026-04-20T12:05:00Z" },
+    );
+    const tasks = getTasks(SESSION_ID);
+    expect(tasks).toHaveLength(1);
+    expect(tasks[0].progress_message).toBe("incoming-wins");
+  });
+
+  test("accepts when seqs are equal and both updated_at are equal (last-write-wins)", async () => {
+    replaceTasks(SESSION_ID, []);
+    mergeTask(
+      SESSION_ID,
+      baseTask({ progress_message: "first" }),
+      undefined,
+      { serverSeq: 7, updatedAt: "2026-04-20T12:00:00Z" },
+    );
+    mergeTask(
+      SESSION_ID,
+      baseTask({ progress_message: "second" }),
+      undefined,
+      { serverSeq: 7, updatedAt: "2026-04-20T12:00:00Z" },
+    );
+    const tasks = getTasks(SESSION_ID);
+    expect(tasks).toHaveLength(1);
+    expect(tasks[0].progress_message).toBe("second");
+  });
+
+  test("accepts when seqs are equal and both updated_at are absent", async () => {
+    replaceTasks(SESSION_ID, []);
+    mergeTask(SESSION_ID, baseTask({ progress_message: "first" }), undefined, {
+      serverSeq: 7,
+    });
+    mergeTask(
+      SESSION_ID,
+      baseTask({ progress_message: "second" }),
+      undefined,
+      { serverSeq: 7 },
+    );
+    const tasks = getTasks(SESSION_ID);
+    expect(tasks).toHaveLength(1);
+    expect(tasks[0].progress_message).toBe("second");
+  });
+});

--- a/tests/task-store-unknown-profile.spec.ts
+++ b/tests/task-store-unknown-profile.spec.ts
@@ -1,0 +1,271 @@
+/**
+ * B-007 — task-store must not persist under the `unknown` profile.
+ *
+ * Before: module-level `activeProfile` fell back to `"unknown"` when no
+ * `selected_profile` key was in localStorage. Any task-store write in
+ * that window produced an `octos_web:task_store:v1:unknown:...` entry.
+ * On subsequent login, another user on the same device inherited that
+ * entry via the store's `unknown`-keyed rehydrate — a cross-account
+ * bleed.
+ *
+ * Post-fix:
+ *   (1) A profile of `""`, `"unknown"`, or falsy → skip persistence
+ *       (both read and write paths). In-memory state still works but
+ *       localStorage never sees an `unknown:` prefix.
+ *   (2) When a real profile id replaces an unknown one via
+ *       `rehydrateTaskStore`, any lingering `unknown:` entries are
+ *       purged.
+ */
+
+import { expect, test, type Page, type Route } from "@playwright/test";
+import { SEL } from "./helpers";
+
+const SESSION_ID = "web-unknown-profile";
+const TASK_ID = "task-unknown-profile-001";
+
+async function fulfillJson(route: Route, body: unknown) {
+  await route.fulfill({
+    status: 200,
+    contentType: "application/json",
+    body: JSON.stringify(body),
+  });
+}
+
+async function installMockRuntime(page: Page) {
+  await page.route(/\/api\/auth\/status$/, (route) =>
+    fulfillJson(route, {
+      bootstrap_mode: false,
+      email_login_enabled: true,
+      admin_token_login_enabled: true,
+      allow_self_registration: false,
+    }),
+  );
+  await page.route(/\/api\/auth\/me$/, (route) =>
+    fulfillJson(route, {
+      user: {
+        id: "user-1",
+        email: "test@example.com",
+        name: "Test",
+        role: "admin",
+        created_at: "2026-04-20T12:00:00Z",
+        last_login_at: null,
+      },
+      profile: { profile: { id: "dspfac" } },
+      portal: {
+        kind: "admin",
+        home_profile_id: "dspfac",
+        home_route: "/chat",
+        can_access_admin_portal: false,
+        can_manage_users: false,
+        sub_account_limit: 0,
+        accessible_profiles: [],
+      },
+    }),
+  );
+  await page.route(/\/api\/status$/, (route) =>
+    fulfillJson(route, {
+      version: "test",
+      model: "mock",
+      provider: "mock",
+      uptime_secs: 1,
+      agent_configured: true,
+    }),
+  );
+  await page.route(/\/api\/sessions$/, (route) =>
+    fulfillJson(route, [{ id: SESSION_ID, message_count: 0 }]),
+  );
+  await page.route(/\/api\/sessions\/[^/]+\/messages(?:\?.*)?$/, (route) =>
+    fulfillJson(route, []),
+  );
+  await page.route(/\/api\/sessions\/[^/]+\/files$/, (route) =>
+    fulfillJson(route, []),
+  );
+  await page.route(/\/api\/sessions\/[^/]+\/status(?:\?.*)?$/, (route) =>
+    fulfillJson(route, {
+      active: false,
+      has_deferred_files: false,
+      has_bg_tasks: false,
+    }),
+  );
+  await page.route(/\/api\/sessions\/[^/]+\/tasks(?:\?.*)?$/, (route) =>
+    fulfillJson(route, []),
+  );
+  await page.route(/\/api\/sessions\/[^/]+\/events\/stream(?:\?.*)?$/, async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: "text/event-stream",
+      body: "",
+    });
+  });
+}
+
+test.describe("B-007 — task-store skips persistence under unknown profile", () => {
+  test("no octos_web:task_store:v1:unknown:* keys are written when profile is unknown", async ({
+    page,
+  }) => {
+    await installMockRuntime(page);
+    // Mount WITHOUT `selected_profile` in localStorage so the module-level
+    // activeProfile defaults to "unknown".
+    await page.addInitScript((sessionId) => {
+      localStorage.clear();
+      // Intentionally do NOT set selected_profile.
+      localStorage.setItem("octos_session_token", "mock-token");
+      localStorage.setItem("octos_auth_token", "mock-token");
+      localStorage.setItem("octos_current_session", sessionId);
+    }, SESSION_ID);
+    await page.goto("/chat", { waitUntil: "networkidle" });
+    await page.waitForSelector(SEL.chatInput);
+
+    // Dispatch a task_status so the store writes. Pre-fix, this triggered
+    // a debounced persistence flush that wrote to `unknown:<session>`.
+    await page.evaluate(
+      ({ sessionId, taskId }) => {
+        window.dispatchEvent(
+          new CustomEvent("crew:task_status", {
+            detail: {
+              sessionId,
+              task: {
+                id: taskId,
+                tool_name: "Deep research",
+                tool_call_id: "call-unknown-001",
+                status: "running",
+                started_at: "2026-04-20T12:00:00Z",
+                completed_at: null,
+                output_files: [],
+                error: null,
+                session_key: `api:${sessionId}`,
+                current_phase: "research",
+                progress_message: "making progress",
+                progress: 0.1,
+              },
+              server_seq: 1,
+              updated_at: "2026-04-20T12:00:01Z",
+            },
+          }),
+        );
+      },
+      { sessionId: SESSION_ID, taskId: TASK_ID },
+    );
+    // Bubble should still render from in-memory state.
+    await expect(
+      page.locator(`[data-testid="task-anchor-message-${TASK_ID}"]`),
+    ).toBeVisible({ timeout: 10_000 });
+
+    // Wait longer than the debounce window (250 ms) to guarantee any
+    // would-be persist fire has elapsed.
+    await page.waitForTimeout(500);
+
+    // Force a synchronous flush so the test isn't just racing the timer.
+    await page.evaluate(async () => {
+      const ts: {
+        __flushTaskStorePersistenceForTests: () => void;
+      } = await import(/* @vite-ignore */ "/src/store/task-store");
+      ts.__flushTaskStorePersistenceForTests();
+    });
+
+    const unknownKeys = await page.evaluate(() => {
+      const hits: string[] = [];
+      for (let i = 0; i < localStorage.length; i++) {
+        const key = localStorage.key(i);
+        if (key && key.startsWith("octos_web:task_store:v1:unknown:")) {
+          hits.push(key);
+        }
+      }
+      return hits;
+    });
+    expect(unknownKeys).toEqual([]);
+  });
+
+  test("transitioning from unknown → real profile clears any unknown: entries", async ({
+    page,
+  }) => {
+    await installMockRuntime(page);
+    // Override /api/auth/me so no profile is auto-set on mount — we want
+    // `selected_profile` to remain unset until the explicit transition
+    // below. This simulates an anonymous or pre-login state where
+    // something wrote an `unknown:` entry that must be purged on login.
+    await page.route(/\/api\/auth\/me$/, (route) =>
+      fulfillJson(route, {
+        user: {
+          id: "user-1",
+          email: "test@example.com",
+          name: "Test",
+          role: "admin",
+          created_at: "2026-04-20T12:00:00Z",
+          last_login_at: null,
+        },
+        // Profile intentionally absent — mimics the pre-login window
+        // where activeProfile defaults to "unknown".
+        profile: null,
+        portal: null,
+      }),
+    );
+    // Pre-seed an octos_web:task_store:v1:unknown:<session> entry so we
+    // can verify the transition clears it. The fix must remove it when
+    // the store rehydrates under a real profile.
+    await page.addInitScript((sessionId) => {
+      localStorage.clear();
+      localStorage.setItem("octos_session_token", "mock-token");
+      localStorage.setItem("octos_auth_token", "mock-token");
+      localStorage.setItem("octos_current_session", sessionId);
+      localStorage.setItem(
+        `octos_web:task_store:v1:unknown:${sessionId}`,
+        JSON.stringify({
+          scoped: {
+            [sessionId]: [
+              {
+                id: "leftover-task",
+                tool_name: "x",
+                tool_call_id: "c1",
+                status: "running",
+                started_at: "2026-04-20T12:00:00Z",
+                completed_at: null,
+                output_files: [],
+                error: null,
+                server_seq: 1,
+              },
+            ],
+          },
+        }),
+      );
+    }, SESSION_ID);
+    await page.goto("/chat", { waitUntil: "networkidle" });
+    await page.waitForSelector(SEL.chatInput);
+
+    // At this point the app is running with unknown profile. Confirm the
+    // leftover entry is still on disk.
+    const beforeKey = await page.evaluate(
+      (sessionId) =>
+        localStorage.getItem(`octos_web:task_store:v1:unknown:${sessionId}`),
+      SESSION_ID,
+    );
+    expect(beforeKey).not.toBeNull();
+
+    // Simulate login: import the task-store module BEFORE setting the
+    // `selected_profile` key so the module-init reads "unknown" (the
+    // starting state). Then call rehydrateTaskStore with the real
+    // profile, which triggers the unknown → real transition cleanup.
+    await page.evaluate(
+      async ({ sessionId }) => {
+        const ts: {
+          rehydrateTaskStore: (opts: {
+            profile: string;
+            session: string;
+          }) => void;
+        } = await import(/* @vite-ignore */ "/src/store/task-store");
+        // Now flip localStorage and rehydrate under the real profile.
+        localStorage.setItem("selected_profile", "dspfac");
+        ts.rehydrateTaskStore({ profile: "dspfac", session: sessionId });
+      },
+      { sessionId: SESSION_ID },
+    );
+
+    // The unknown: entry must be purged.
+    const afterKey = await page.evaluate(
+      (sessionId) =>
+        localStorage.getItem(`octos_web:task_store:v1:unknown:${sessionId}`),
+      SESSION_ID,
+    );
+    expect(afterKey).toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary

Six targeted fixes for Review B findings on the coding-blue web client. Each fix is landed as a small independent commit; the PR is stacked on #42 (`refactor/message-store-runtime-persistence`) and is intended to merge after that base.

- **B-001 (high)** — base-url-aware redirects. New `absoluteUrl(path)` helper joined with `import.meta.env.BASE_URL`. Every raw `window.location.{href,assign,replace} = "/login..."` / "/admin/my" in `src/api/client.ts`, `src/api/chat.ts`, `src/App.tsx`, `src/components/home-nav.tsx` now routes through the helper so the `/next/` side-by-side deploy no longer escapes into the legacy bundle.
- **B-002 (medium)** — sse-bridge now extracts `server_seq` / `updated_at` from either the SSE envelope (preferred) or the embedded task (fallback) and passes them into `applyTaskStatus` on the first merge. The `crew:task_status` re-dispatch carries `_alreadyMerged: true`; the runtime-provider listener skips its second merge and only applies side effects. `SseEvent.task_status` updated with optional `server_seq` / `updated_at` on both envelope and task.
- **B-004 (medium)** — `task-store.mergeTask` now tiebreaks equal `server_seq` on `updated_at`: strictly-older incoming snapshots are rejected, equal / both-absent `updated_at` values fall back to last-write-wins. Five-scenario unit suite plus the sse-taskwatcher convergence spec now cover equal-seq paths (addresses B-010 as a bonus).
- **B-005 (medium)** — synchronous `pagehide` + `visibilitychange` flush for task-store persistence. Module-level registration flag prevents double-binding under HMR. `flushPersistence` clears any pending debounce handle when called synchronously. The `reload-preserves-task-state.spec.ts` no longer needs the 800 ms timer workaround — it proves bug class #1 is closed without it.
- **B-006 (medium)** — a11y on the task-anchor bubble: outer `role="status"` + `aria-live="polite"` + non-empty `aria-label` composed from tool name, status word, phase, and progress message. Spinner `aria-hidden="true"`. Inline progress % now has `role="progressbar"` + `aria-valuenow/min/max`.
- **B-007 (medium)** — task-store persistence is a no-op for falsy / empty / `"unknown"` profiles. Both read and write paths early-return. When the profile transitions unknown → real, `clearUnknownProfileEntries` purges any lingering `octos_web:task_store:v1:unknown:*` keys that would otherwise bleed across accounts.

## Test plan

- [x] `npm ci`
- [x] `npm run build` (production bundle at `/`)
- [x] `npm run build:next` (coding-blue /next/ side-by-side bundle)
- [x] `npx playwright test --project chromium --grep "base-url-redirects|reload-preserves-task-state|sse-taskwatcher|task-anchor-a11y|concurrent-deep-research|reducer|session-switching|sse-bridge|unknown-profile|task-store-merge"` — 30/30 passing
- [x] `concurrent-deep-research.spec.ts` (queue-removal regression guard) still green
- [x] No force push; stacked on `refactor/message-store-runtime-persistence`