### PR TITLE
fix(coding-blue-web): out-of-order assistant-response race

### DIFF
--- a/src/runtime/octos-adapter.ts
+++ b/src/runtime/octos-adapter.ts
@@ -82,7 +82,7 @@ export function createOctosAdapter(
       const queue: StreamManager.StreamEvent[] = [];
       let resolve: (() => void) | null = null;
 
-      const unsub = StreamManager.subscribe(
+      const subscription = StreamManager.subscribe(
         sessionId,
         (event: StreamManager.StreamEvent) => {
           queue.push(event);
@@ -93,10 +93,11 @@ export function createOctosAdapter(
         },
       );
 
-      if (!unsub) {
+      if (!subscription) {
         // No stream found — shouldn't happen
         return;
       }
+      const unsub = subscription.unsub;
 
       try {
         while (!done) {

--- a/src/runtime/sse-bridge.ts
+++ b/src/runtime/sse-bridge.ts
@@ -560,12 +560,12 @@ function bindStreamToAssistant({
   };
 
   // Subscribe with replay — events that arrived before subscription are replayed.
-  const unsub = StreamManager.subscribe(sessionId, handleEvent, historyTopic);
-  if (unsub) {
+  const subscription = StreamManager.subscribe(sessionId, handleEvent, historyTopic);
+  if (subscription) {
     setupCleanup(
       sessionId,
       assistantMsgId,
-      unsub,
+      subscription.unsub,
       rawText,
       historyTopic,
       onComplete,
@@ -573,6 +573,7 @@ function bindStreamToAssistant({
       clientMessageId,
       sentAt,
       pendingStreamError,
+      subscription.streamId,
     );
   }
 }
@@ -589,6 +590,7 @@ function setupCleanup(
   clientMessageId?: string,
   sentAt?: number,
   pendingStreamError?: { current: string | null },
+  streamId?: number,
 ): void {
   // The subscriber is automatically cleaned up when the stream ends
   // (StreamManager clears subscribers). We also listen for stream_state
@@ -600,10 +602,19 @@ function setupCleanup(
       typeof detail?.topic === "string" && detail.topic.trim()
         ? detail.topic.trim()
         : undefined;
+    // When two prompts fire before either finishes, both subscribers share
+    // the same (sessionId, topic) but are attached to different streams.
+    // The event must match THIS stream's id — otherwise a fast sibling
+    // stream finishing first would trip this handler, unsubscribe from our
+    // still-running stream, and strand the assistant bubble on the slow
+    // poll-recovery path (see concurrent-deep-research-ordering.spec.ts).
     if (
       detail?.sessionId === sessionId &&
       detailTopic === normalizedHistoryTopic &&
-      !detail.active
+      !detail.active &&
+      (streamId === undefined ||
+        typeof detail?.streamId !== "number" ||
+        detail.streamId === streamId)
     ) {
       window.removeEventListener("crew:stream_state", handler);
       _unsub();

--- a/src/runtime/stream-manager.ts
+++ b/src/runtime/stream-manager.ts
@@ -21,6 +21,14 @@ export type StreamSubscriber = (event: StreamEvent) => void;
 
 /** State of a managed session stream. */
 interface ManagedStream {
+  /**
+   * Unique, monotonic identifier scoped to this tab. Out-of-order concurrent
+   * responses share a (sessionId, topic) but have different ids, so consumers
+   * that must discriminate "my stream" from "a sibling stream" (e.g. the
+   * sse-bridge cleanup handler below) can match on this value instead of on
+   * the session key that every concurrent stream reuses.
+   */
+  id: number;
   sessionId: string;
   topic?: string;
   /** All events received so far (for replay on resubscribe). */
@@ -37,10 +45,21 @@ interface ManagedStream {
   text: string;
 }
 
+/** Handle returned by subscribe — unsubscribe callback plus the id of the
+ * stream the callback is attached to. Consumers need the id to match
+ * per-stream lifecycle events (e.g. crew:stream_state) across concurrent
+ * streams that share the same (sessionId, topic). */
+export interface StreamSubscription {
+  unsub: () => void;
+  streamId: number;
+}
+
 /** Track all active streams so isActive reports true while ANY is running. */
 const activeStreams = new Set<ManagedStream>();
 
 const streams = new Map<string, ManagedStream>();
+
+let nextStreamId = 1;
 
 function streamKey(sessionId: string, topic?: string): string {
   const normalizedTopic = normalizeTopic(topic);
@@ -50,7 +69,9 @@ function streamKey(sessionId: string, topic?: string): string {
 function createManagedStream(sessionId: string, topic?: string): ManagedStream {
   const abort = new AbortController();
   const normalizedTopic = normalizeTopic(topic);
+  const id = nextStreamId++;
   const stream: ManagedStream = {
+    id,
     sessionId,
     topic: normalizedTopic,
     events: [],
@@ -66,7 +87,7 @@ function createManagedStream(sessionId: string, topic?: string): ManagedStream {
   activeStreams.add(stream);
   window.dispatchEvent(
     new CustomEvent("crew:stream_state", {
-      detail: { sessionId, topic: normalizedTopic, active: true },
+      detail: { sessionId, topic: normalizedTopic, active: true, streamId: id },
     }),
   );
   return stream;
@@ -141,9 +162,19 @@ function finalizeStream(sessionId: string, stream: ManagedStream): void {
   stream.active = false;
   activeStreams.delete(stream);
 
+  // Dispatch with streamId so subscribers that race concurrent streams on
+  // the same (sessionId, topic) can tell whose lifecycle event this is.
+  // Without streamId, a fast sibling stream finishing first would trip
+  // every subscriber's cleanup path — unsubscribing them from their own
+  // still-running stream.
   window.dispatchEvent(
     new CustomEvent("crew:stream_state", {
-      detail: { sessionId, topic: stream.topic, active: false },
+      detail: {
+        sessionId,
+        topic: stream.topic,
+        active: false,
+        streamId: stream.id,
+      },
     }),
   );
 
@@ -269,13 +300,15 @@ export function attachStream(
  * Subscribe to a session's stream. Replays all past events immediately,
  * then delivers new events as they arrive.
  *
- * Returns an unsubscribe function.
+ * Returns `{ unsub, streamId }` so the caller can correlate lifecycle
+ * events (crew:stream_state) with the specific stream it subscribed to.
+ * Returns null when no stream exists for the session/topic.
  */
 export function subscribe(
   sessionId: string,
   callback: StreamSubscriber,
   topic?: string,
-): (() => void) | null {
+): StreamSubscription | null {
   const stream = streams.get(streamKey(sessionId, topic));
   if (!stream) return null;
 
@@ -291,8 +324,11 @@ export function subscribe(
   // Subscribe for future events
   stream.subscribers.add(callback);
 
-  return () => {
-    stream.subscribers.delete(callback);
+  return {
+    unsub: () => {
+      stream.subscribers.delete(callback);
+    },
+    streamId: stream.id,
   };
 }
 

--- a/src/studio/components/studio-panel.tsx
+++ b/src/studio/components/studio-panel.tsx
@@ -88,7 +88,7 @@ export function StudioPanel() {
 
       // Subscribe to capture file events and completion.
       // Use the captured outputId directly to avoid stale closure over project.outputs.
-      const unsubscribe = StreamManager.subscribe(genSessionId, (streamEvt) => {
+      const subscription = StreamManager.subscribe(genSessionId, (streamEvt) => {
         const evt = streamEvt.raw as any;
         if (evt.type === "file") {
           const token = getToken();
@@ -107,14 +107,14 @@ export function StudioPanel() {
                 ? evt.content.slice(0, 200)
                 : undefined,
           });
-          unsubscribe?.();
+          subscription?.unsub();
         }
         if (evt.type === "error") {
           updateOutput(outputId, {
             status: "error",
             error: evt.message || "Generation failed",
           });
-          unsubscribe?.();
+          subscription?.unsub();
         }
       });
 

--- a/tests/concurrent-deep-research-ordering.spec.ts
+++ b/tests/concurrent-deep-research-ordering.spec.ts
@@ -1,0 +1,272 @@
+/**
+ * Extends `concurrent-deep-research.spec.ts` with strict ordering assertions.
+ *
+ * When the user fires Q1 then Q2 in rapid succession, the chat transcript must
+ * render in interleaved order: user-Q1 → assistant-A1 → user-Q2 → assistant-A2.
+ *
+ * The pre-fix bug failed three distinct ways under ordering:
+ *   1. A2 never appeared (queue-orphan)
+ *   2. A2 appeared BEFORE A1 (out-of-order because the second stream landed first)
+ *   3. A1's text was overwritten by A2 (correlation lost)
+ *
+ * This spec asserts document-order position, not just count/content.
+ */
+
+import { expect, test, type Page, type Route } from "@playwright/test";
+import { SEL } from "./helpers";
+
+const SESSION_ID = "web-ordering-deep-research";
+
+async function fulfillJson(route: Route, body: unknown) {
+  await route.fulfill({
+    status: 200,
+    contentType: "application/json",
+    body: JSON.stringify(body),
+  });
+}
+
+function sse(events: unknown[]): string {
+  return events.map((event) => `data: ${JSON.stringify(event)}\n\n`).join("");
+}
+
+interface MockMessage {
+  seq: number;
+  role: "user" | "assistant";
+  content: string;
+  timestamp: string;
+  client_message_id?: string;
+  response_to_client_message_id?: string;
+}
+
+/**
+ * Adversarial timing: the SECOND /api/chat POST completes FASTER than the
+ * first. Under the pre-fix architecture, whichever SSE stream ended first
+ * would be rendered first — producing out-of-order A2-before-A1. The fix
+ * uses `response_to_client_message_id` to pair each response with its user
+ * bubble, so ordering follows user-send-order regardless of response arrival.
+ */
+async function installOutOfOrderRuntime(page: Page) {
+  const messages: MockMessage[] = [];
+  let seq = 1;
+  let chatCount = 0;
+
+  function now() {
+    return new Date(1_777_000_000_000 + seq * 1000).toISOString();
+  }
+
+  await page.route(/\/api\/auth\/status$/, (route) =>
+    fulfillJson(route, {
+      bootstrap_mode: false,
+      email_login_enabled: true,
+      admin_token_login_enabled: true,
+      allow_self_registration: false,
+    }),
+  );
+
+  await page.route(/\/api\/auth\/me$/, (route) =>
+    fulfillJson(route, {
+      user: {
+        id: "user-1",
+        email: "test@example.com",
+        name: "Test User",
+        role: "admin",
+        created_at: "2026-04-20T12:00:00Z",
+        last_login_at: null,
+      },
+      profile: { profile: { id: "dspfac" } },
+      portal: {
+        kind: "admin",
+        home_profile_id: "dspfac",
+        home_route: "/chat",
+        can_access_admin_portal: false,
+        can_manage_users: false,
+        sub_account_limit: 0,
+        accessible_profiles: [],
+      },
+    }),
+  );
+
+  await page.route(/\/api\/status$/, (route) =>
+    fulfillJson(route, {
+      version: "test",
+      model: "mock-model",
+      provider: "mock",
+      uptime_secs: 1,
+      agent_configured: true,
+    }),
+  );
+
+  await page.route(/\/api\/sessions$/, (route) =>
+    fulfillJson(route, [{ id: SESSION_ID, message_count: messages.length }]),
+  );
+
+  await page.route(/\/api\/sessions\/[^/]+\/messages(?:\?.*)?$/, (route) =>
+    fulfillJson(route, messages),
+  );
+
+  await page.route(/\/api\/sessions\/[^/]+\/files$/, (route) =>
+    fulfillJson(route, []),
+  );
+
+  await page.route(/\/api\/sessions\/[^/]+\/status(?:\?.*)?$/, (route) =>
+    fulfillJson(route, {
+      active: false,
+      has_deferred_files: false,
+      has_bg_tasks: false,
+    }),
+  );
+
+  await page.route(/\/api\/sessions\/[^/]+\/tasks(?:\?.*)?$/, (route) =>
+    fulfillJson(route, []),
+  );
+
+  await page.route(/\/api\/sessions\/[^/]+\/events\/stream(?:\?.*)?$/, (route) =>
+    route.fulfill({
+      status: 200,
+      contentType: "text/event-stream",
+      body: sse([{ type: "replay_complete" }]),
+    }),
+  );
+
+  await page.route(/\/api\/chat$/, async (route) => {
+    const payload = JSON.parse(route.request().postData() || "{}") as {
+      message?: string;
+      session_id?: string;
+      client_message_id?: string;
+    };
+    chatCount += 1;
+    const myChatNum = chatCount;
+    const prompt = payload.message || "";
+    const clientMessageId = payload.client_message_id || `client-${myChatNum}`;
+    const response = `Research answer #${myChatNum} for: ${prompt}`;
+
+    messages.push({
+      seq: seq++,
+      role: "user",
+      content: prompt,
+      timestamp: now(),
+      client_message_id: clientMessageId,
+    });
+    messages.push({
+      seq: seq++,
+      role: "assistant",
+      content: response,
+      timestamp: now(),
+      response_to_client_message_id: clientMessageId,
+    });
+
+    // OUT-OF-ORDER: Q2 completes FAST (100ms), Q1 completes SLOW (3000ms).
+    // This reproduces the race where the second stream lands first.
+    const delayMs = myChatNum === 1 ? 3000 : 100;
+    await new Promise((resolve) => setTimeout(resolve, delayMs));
+
+    await route.fulfill({
+      status: 200,
+      contentType: "text/event-stream",
+      body: sse([
+        { type: "replace", text: response },
+        {
+          type: "done",
+          content: response,
+          model: "mock-model",
+          tokens_in: 1,
+          tokens_out: 1,
+          duration_s: 1,
+          has_bg_tasks: false,
+        },
+      ]),
+    });
+  });
+
+  await page.addInitScript((sessionId) => {
+    localStorage.clear();
+    localStorage.setItem("octos_session_token", "mock-token");
+    localStorage.setItem("octos_auth_token", "mock-token");
+    localStorage.setItem("selected_profile", "dspfac");
+    localStorage.setItem("octos_current_session", sessionId);
+  }, SESSION_ID);
+}
+
+test.describe("Concurrent deep-research ordering (coding-blue)", () => {
+  test.beforeEach(async ({ page }) => {
+    await installOutOfOrderRuntime(page);
+    await page.goto("/chat", { waitUntil: "networkidle" });
+    await page.waitForSelector(SEL.chatInput);
+  });
+
+  test("two rapid user prompts render in send-order even if Q2 responds first", async ({
+    page,
+  }) => {
+    const input = page.locator(SEL.chatInput);
+    const send = page.locator(SEL.sendButton);
+
+    // Q1
+    await input.fill("Deep research one: ALPHA ordering marker");
+    await send.click();
+
+    // Q2 fires while Q1 is still streaming. Adversarial: Q2 will respond ~3s
+    // before Q1 does (Q2 latency = 100ms, Q1 latency = 3000ms).
+    await page.waitForTimeout(300);
+    await input.fill("Deep research two: BRAVO ordering marker");
+    await send.click();
+
+    // Both user bubbles up immediately.
+    await expect(page.locator(SEL.userMessage)).toHaveCount(2, {
+      timeout: 10_000,
+    });
+
+    // Both assistant responses must land.
+    await expect(page.locator(SEL.assistantMessage)).toHaveCount(2, {
+      timeout: 15_000,
+    });
+
+    // Wait for BOTH bubbles to carry their payload. Two placeholder bubbles
+    // exist as soon as the two user POSTs go out, so toHaveCount(2) above
+    // resolves before A1's slow (~3s) response lands. The ordering-under-
+    // out-of-order invariant is about which bubble ends up with which answer
+    // once both have streamed in, not about the transient placeholder state.
+    await page.waitForFunction(() => {
+      const bubbles = Array.from(
+        document.querySelectorAll('[data-testid="assistant-message"]'),
+      );
+      if (bubbles.length < 2) return false;
+      return bubbles.every((node) => {
+        const text = (node as HTMLElement).innerText || "";
+        return /Research answer #\d/.test(text);
+      });
+    }, undefined, { timeout: 15_000 });
+
+    // --- Ordering invariants ---
+
+    // 1. User bubble order: Q1 ALPHA before Q2 BRAVO in the DOM.
+    const userTexts = await page.locator(SEL.userMessage).allInnerTexts();
+    expect(userTexts).toHaveLength(2);
+    expect(userTexts[0]).toContain("ALPHA");
+    expect(userTexts[1]).toContain("BRAVO");
+
+    // 2. Assistant bubble order: A1 (#1 answering ALPHA) before A2 (#2 answering BRAVO).
+    const assistantTexts = await page.locator(SEL.assistantMessage).allInnerTexts();
+    expect(assistantTexts).toHaveLength(2);
+    expect(assistantTexts[0]).toContain("#1");
+    expect(assistantTexts[0]).toContain("ALPHA");
+    expect(assistantTexts[1]).toContain("#2");
+    expect(assistantTexts[1]).toContain("BRAVO");
+
+    // 3. Interleaved transcript order: U1 → A1 → U2 → A2 in document order.
+    const roles = await page.evaluate(() => {
+      const nodes = Array.from(
+        document.querySelectorAll(
+          '[data-testid="user-message"], [data-testid="assistant-message"]',
+        ),
+      );
+      return nodes.map((n) =>
+        (n as HTMLElement).dataset.testid === "user-message" ? "U" : "A",
+      );
+    });
+    expect(roles).toEqual(["U", "A", "U", "A"]);
+
+    // 4. No answer collapsed / cross-attached.
+    expect(assistantTexts[0]).not.toContain("BRAVO");
+    expect(assistantTexts[1]).not.toContain("ALPHA");
+  });
+});


### PR DESCRIPTION
## Summary

Fixes the out-of-order concurrent SSE race where a fast second response would strand the slow first response on an empty placeholder. Introduces per-stream correlation so lifecycle events (`crew:stream_state`) can no longer cross-wire between sibling streams that share a `(sessionId, topic)` key.

## Root cause

`StreamManager.finalizeStream` dispatched `crew:stream_state { active: false }` keyed only on `sessionId + topic`. When Q2 (100 ms) finished before Q1 (3000 ms), the single "inactive" event matched **both** subscribers' cleanup handlers. Q1's handler unsubscribed from its own still-running stream and kicked off the 5 s poll-recovery path. Stream 1's eventual `done` event arrived but had no listener, so A1 rendered empty while A2 already held content.

## Fix

- Every `ManagedStream` now carries a monotonic `id`. The id rides in every `crew:stream_state` detail.
- `StreamManager.subscribe` returns `{ unsub, streamId }` so callers can correlate per-stream lifecycle.
- `setupCleanup` only reacts to `crew:stream_state` events whose `streamId` matches the stream the subscriber attached to. No `clientMessageId` / queue reintroduced.
- `concurrent-deep-research-ordering.spec.ts` hardens the assertion to wait for both bubbles to carry their payload before snapshotting text — two placeholder bubbles already exist right after both POSTs fire, so the pre-existing `toHaveCount(2)` resolved before A1's slow response landed. This is a minimal justified edit; the ordering invariant (U1 → A1 → U2 → A2, with `#1` in A1 and `#2` in A2) is unchanged.

## Before / after

`tests/concurrent-deep-research-ordering.spec.ts`
- Before: FAIL at 1.4 s — `expect(assistantTexts[0]).toContain("#1")` received `"2026-04-23 13:40:02"` (A1 empty).
- After: PASS in 4.0 s.

`tests/concurrent-deep-research.spec.ts` (in-order regression guard)
- Before: PASS 2.1 s
- After: PASS 2.0 s

Wider gate (`--grep "reducer|session-switching|background-task-scope|tts-runtime-events|concurrent-deep-research|base-url-redirects|reload-preserves-task-state|task-anchor-a11y|task-store-merge|task-store-unknown-profile|sse-bridge-server-seq|sse-taskwatcher|task-store-drives-ui|file-attachment-identity"`)
- 34 passed, 1 failed (`tts-runtime-events.spec.ts` "background TTS task attaches one audio card and clears spinner"). Verified this failure reproduces on plain `release/coding-blue` tip `30798ed` without this change — pre-existing, not a regression.

`npm run build` and `npm run build:next`: both clean.

## LOC

```
 src/runtime/octos-adapter.ts           |  5 ++--
 src/runtime/sse-bridge.ts              | 19 +++++++++++---
 src/runtime/stream-manager.ts          | 48 +++++++++++++++++++++++++++++-----
 src/studio/components/studio-panel.tsx |  6 ++---
 4 files changed, 63 insertions(+), 15 deletions(-)
```

Plus the untracked repro spec lands as `tests/concurrent-deep-research-ordering.spec.ts` (272 lines).

## Test plan

- [x] `npx playwright test tests/concurrent-deep-research-ordering.spec.ts --project chromium` — PASS (4.0 s)
- [x] `npx playwright test tests/concurrent-deep-research.spec.ts --project chromium` — PASS (2.0 s)
- [x] `npm run build` — clean typecheck + bundle
- [x] `npm run build:next` — clean typecheck + bundle
- [x] Wider regression grep gate — 34 pass, 1 pre-existing fail (tts-runtime-events, reproduces on baseline)