### PR TITLE
fix(coding-blue-web): FA-11 speculative overflow delivery (web side)

### DIFF
--- a/src/runtime/runtime-provider.tsx
+++ b/src/runtime/runtime-provider.tsx
@@ -188,15 +188,31 @@ function RuntimeWithSession({ children }: { children: ReactNode }) {
       });
     }
 
+    // FA-11 defect C fix: when POST /api/chat returns `{status:"queued"}`
+    // (speculative queue mode overflow), the server will deliver the
+    // eventual reply as a `session_result` event on the session-event
+    // stream. Ensure the session is being watched so that stream is open
+    // and `appendHistoryMessages` can merge the reply into the streaming
+    // bubble via `responseToClientMessageId` correlation.
+    function handleQueuedAck(event: Event) {
+      const detail = (event as CustomEvent).detail;
+      const sessionId = eventSessionId(detail);
+      if (!sessionId) return;
+      const topic = eventTopic(detail);
+      watchSession(sessionId, topic);
+    }
+
     window.addEventListener("crew:bg_tasks", handleBgTasks);
     window.addEventListener("crew:task_status", handleTaskStatus);
     window.addEventListener("crew:file", handleFile);
+    window.addEventListener("crew:queued_ack", handleQueuedAck);
 
     return () => {
       cancelled = true;
       window.removeEventListener("crew:bg_tasks", handleBgTasks);
       window.removeEventListener("crew:task_status", handleTaskStatus);
       window.removeEventListener("crew:file", handleFile);
+      window.removeEventListener("crew:queued_ack", handleQueuedAck);
     };
   }, [currentSessionId, historyTopic, setServerTaskActive]);
 

--- a/src/runtime/stream-manager.ts
+++ b/src/runtime/stream-manager.ts
@@ -104,6 +104,47 @@ async function consumeSseResponse(
 
   const contentType = resp.headers.get("content-type") || "";
   if (contentType.includes("application/json")) {
+    // FA-11 defect C fix: under `/queue speculative`, when a second POST
+    // /api/chat arrives while an earlier SSE stream is still live, the
+    // gateway returns a JSON ack:
+    //   {"status":"queued","message":"…"}
+    // Previously we silently dropped it and the assistant bubble stayed
+    // "streaming" forever — the bubble would only clear after the 15-minute
+    // polling fallback consumed the session_result via /messages.
+    //
+    // Recognise the ack and emit a lightweight side-channel event so the
+    // runtime provider can guarantee a session-event-stream subscription is
+    // live. The overflow reply the gateway is about to produce will arrive
+    // as a `session_result` event on that stream and merge into the
+    // streaming bubble via `responseToClientMessageId` correlation.
+    try {
+      const body = await resp.text();
+      if (body) {
+        let parsed: unknown;
+        try {
+          parsed = JSON.parse(body);
+        } catch {
+          parsed = undefined;
+        }
+        if (
+          parsed &&
+          typeof parsed === "object" &&
+          (parsed as { status?: string }).status === "queued"
+        ) {
+          window.dispatchEvent(
+            new CustomEvent("crew:queued_ack", {
+              detail: {
+                sessionId: stream.sessionId,
+                topic: stream.topic,
+                streamId: stream.id,
+              },
+            }),
+          );
+        }
+      }
+    } catch {
+      // ignore JSON body read errors — stream-end handling below still runs
+    }
     stream.active = false;
     return;
   }

--- a/tests/speculative-delivery-regression.spec.ts
+++ b/tests/speculative-delivery-regression.spec.ts
@@ -1,0 +1,294 @@
+/**
+ * FA-12 regression guard — speculative queue overflow delivery.
+ *
+ * Under `/queue speculative`, when a second user prompt arrives while the
+ * first prompt's SSE stream is still live, the gateway returns a JSON ack:
+ *   `{"status":"queued","message":"…"}`
+ * and delivers the eventual reply as a `session_result` event on the
+ * session-event-stream.
+ *
+ * Before FA-12:
+ *   - stream-manager silently dropped the JSON ack body → bubble B stayed
+ *     in "streaming" state forever.
+ *   - webhook_proxy force-stamped `content-type: text/event-stream` on the
+ *     outer response, so the JSON body looked like malformed SSE anyway.
+ *   - session_actor's `serve_overflow` emitted the overflow reply with
+ *     empty metadata → ApiChannel::send routed it only via pending (which
+ *     was removed 2s earlier) and silently dropped the message.
+ *
+ * This spec mocks the full triangle and asserts that bubble B receives
+ * content via the `session_result` event on the events/stream.
+ */
+
+import { expect, test, type Page, type Route } from "@playwright/test";
+import { SEL } from "./helpers";
+
+const SESSION_ID = "web-speculative-delivery";
+
+async function fulfillJson(route: Route, body: unknown) {
+  await route.fulfill({
+    status: 200,
+    contentType: "application/json",
+    body: JSON.stringify(body),
+  });
+}
+
+function sse(events: unknown[]): string {
+  return events.map((event) => `data: ${JSON.stringify(event)}\n\n`).join("");
+}
+
+interface MockMessage {
+  seq: number;
+  role: "user" | "assistant";
+  content: string;
+  timestamp: string;
+  client_message_id?: string;
+  response_to_client_message_id?: string;
+}
+
+async function installMockRuntime(page: Page) {
+  const messages: MockMessage[] = [];
+  let seq = 1;
+  let chatCount = 0;
+  // Captured clientMessageId of prompt B so the events/stream handler can
+  // emit a matching response_to_client_message_id.
+  let pendingBravoClientMessageId: string | null = null;
+
+  function now() {
+    return new Date(1_777_000_000_000 + seq * 1000).toISOString();
+  }
+
+  // Auth / status stubs
+  await page.route(/\/api\/auth\/status$/, (route) =>
+    fulfillJson(route, {
+      bootstrap_mode: false,
+      email_login_enabled: true,
+      admin_token_login_enabled: true,
+      allow_self_registration: false,
+    }),
+  );
+  await page.route(/\/api\/auth\/me$/, (route) =>
+    fulfillJson(route, {
+      user: {
+        id: "user-1",
+        email: "test@example.com",
+        name: "Test User",
+        role: "admin",
+        created_at: "2026-04-20T12:00:00Z",
+        last_login_at: null,
+      },
+      profile: { profile: { id: "dspfac" } },
+      portal: {
+        kind: "admin",
+        home_profile_id: "dspfac",
+        home_route: "/chat",
+        can_access_admin_portal: false,
+        can_manage_users: false,
+        sub_account_limit: 0,
+        accessible_profiles: [],
+      },
+    }),
+  );
+  await page.route(/\/api\/status$/, (route) =>
+    fulfillJson(route, {
+      version: "test",
+      model: "mock-model",
+      provider: "mock",
+      uptime_secs: 1,
+      agent_configured: true,
+    }),
+  );
+  await page.route(/\/api\/sessions$/, (route) =>
+    fulfillJson(route, [{ id: SESSION_ID, message_count: messages.length }]),
+  );
+  await page.route(/\/api\/sessions\/[^/]+\/messages(?:\?.*)?$/, (route) =>
+    fulfillJson(route, messages),
+  );
+  await page.route(/\/api\/sessions\/[^/]+\/files$/, (route) =>
+    fulfillJson(route, []),
+  );
+  await page.route(/\/api\/sessions\/[^/]+\/status(?:\?.*)?$/, (route) =>
+    fulfillJson(route, {
+      active: false,
+      has_deferred_files: false,
+      has_bg_tasks: false,
+    }),
+  );
+  await page.route(/\/api\/sessions\/[^/]+\/tasks(?:\?.*)?$/, (route) =>
+    fulfillJson(route, []),
+  );
+
+  // The events/stream stub models the FA-12 session-event delivery path:
+  // after a short delay, emit `session_result` for prompt B carrying the
+  // correlation id so the client's `findOptimisticMatchIndex` can merge it
+  // into bubble B.
+  await page.route(/\/api\/sessions\/[^/]+\/events\/stream(?:\?.*)?$/, async (route) => {
+    // Wait until the overflow reply would have been generated server-side.
+    // The polling loop in sse-bridge.ts wakes on crew:queued_ack and starts
+    // this stream; we delay briefly then emit the session_result.
+    let resolved = false;
+    const start = Date.now();
+    while (!pendingBravoClientMessageId && Date.now() - start < 3000) {
+      await new Promise((r) => setTimeout(r, 50));
+    }
+    const clientMessageId = pendingBravoClientMessageId ?? "unknown";
+    resolved = true;
+    // A brief extra delay so the bubble has a chance to render in streaming state.
+    await new Promise((r) => setTimeout(r, 200));
+
+    const events: unknown[] = [{ type: "replay_complete" }];
+    if (resolved) {
+      events.push({
+        type: "session_result",
+        topic: null,
+        message: {
+          seq: 42,
+          role: "assistant",
+          content: "Speculative overflow response for BRAVO",
+          timestamp: now(),
+          response_to_client_message_id: clientMessageId,
+          media: [],
+          tool_calls: [],
+        },
+      });
+    }
+
+    await route.fulfill({
+      status: 200,
+      contentType: "text/event-stream",
+      body: sse(events),
+    });
+  });
+
+  // /api/chat path. First POST (ALPHA) returns a normal SSE stream with
+  // `done`. Second POST (BRAVO) returns a JSON queued-ack — no SSE stream.
+  await page.route(/\/api\/chat$/, async (route) => {
+    const payload = JSON.parse(route.request().postData() || "{}") as {
+      message?: string;
+      session_id?: string;
+      client_message_id?: string;
+    };
+    chatCount += 1;
+    const myChatNum = chatCount;
+    const prompt = payload.message || "";
+    const clientMessageId = payload.client_message_id || `client-${myChatNum}`;
+
+    if (myChatNum === 1) {
+      // ALPHA: normal SSE stream
+      const response = `Answer for ALPHA: ${prompt}`;
+      messages.push({
+        seq: seq++,
+        role: "user",
+        content: prompt,
+        timestamp: now(),
+        client_message_id: clientMessageId,
+      });
+      messages.push({
+        seq: seq++,
+        role: "assistant",
+        content: response,
+        timestamp: now(),
+        response_to_client_message_id: clientMessageId,
+      });
+      await new Promise((resolve) => setTimeout(resolve, 100));
+      await route.fulfill({
+        status: 200,
+        contentType: "text/event-stream",
+        body: sse([
+          { type: "replace", text: response },
+          {
+            type: "done",
+            content: response,
+            model: "mock-model",
+            tokens_in: 1,
+            tokens_out: 1,
+            duration_s: 1,
+            has_bg_tasks: false,
+          },
+        ]),
+      });
+      return;
+    }
+
+    // BRAVO: queued JSON ack. Record the correlation id so the
+    // events/stream mock can emit a matching session_result.
+    pendingBravoClientMessageId = clientMessageId;
+    messages.push({
+      seq: seq++,
+      role: "user",
+      content: prompt,
+      timestamp: now(),
+      client_message_id: clientMessageId,
+    });
+    // Do NOT push the assistant message here — it arrives via session_result
+    // on the events/stream, mirroring the overflow path.
+    await route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify({
+        status: "queued",
+        message: "Message queued — response will arrive on the existing stream",
+      }),
+    });
+  });
+
+  await page.addInitScript((sessionId) => {
+    localStorage.clear();
+    localStorage.setItem("octos_session_token", "mock-token");
+    localStorage.setItem("octos_auth_token", "mock-token");
+    localStorage.setItem("selected_profile", "dspfac");
+    localStorage.setItem("octos_current_session", sessionId);
+  }, SESSION_ID);
+}
+
+test.describe("FA-12 speculative delivery regression", () => {
+  test.beforeEach(async ({ page }) => {
+    await installMockRuntime(page);
+    await page.goto("/chat", { waitUntil: "networkidle" });
+    await page.waitForSelector(SEL.chatInput);
+  });
+
+  test("JSON queued ack delivers overflow reply into bubble B", async ({ page }) => {
+    const input = page.locator(SEL.chatInput);
+    const send = page.locator(SEL.sendButton);
+
+    // Prompt ALPHA — normal SSE response.
+    await input.fill("FA-12 ALPHA prompt");
+    await send.click();
+
+    // Wait for ALPHA's bubble to finalize so its SSE stream is live when
+    // BRAVO fires. We only need the stream to have started, not finished,
+    // but the mock is fast enough to complete regardless.
+    await page.waitForTimeout(400);
+
+    // Prompt BRAVO — server returns JSON ack; overflow reply comes via
+    // events/stream.
+    await input.fill("FA-12 BRAVO prompt — speculative overflow");
+    await send.click();
+
+    // Both user bubbles present.
+    await expect(page.locator(SEL.userMessage)).toHaveCount(2, {
+      timeout: 10_000,
+    });
+    // Both assistant bubbles present.
+    await expect(page.locator(SEL.assistantMessage)).toHaveCount(2, {
+      timeout: 15_000,
+    });
+
+    // The critical assertion: BRAVO's bubble (the second assistant bubble)
+    // must receive the overflow text via the session_result event path.
+    // Before the FA-12 fix, it stayed empty / stuck in "streaming".
+    await page.waitForFunction(() => {
+      const bubbles = document.querySelectorAll('[data-testid="assistant-message"]');
+      if (bubbles.length < 2) return false;
+      const text = (bubbles[1] as HTMLElement).innerText || "";
+      return text.includes("Speculative overflow response for BRAVO");
+    }, undefined, { timeout: 15_000 });
+
+    const bubbles = page.locator(SEL.assistantMessage);
+    const textA = (await bubbles.nth(0).innerText()).trim();
+    const textB = (await bubbles.nth(1).innerText()).trim();
+    expect(textA).toContain("ALPHA");
+    expect(textB).toContain("Speculative overflow response for BRAVO");
+  });
+});


### PR DESCRIPTION
## Summary

Client-side half of the FA-12 coding-blue release blocker. Pairs with the octos server PR for the speculative queue overflow delivery race.

- **Defect C** (`src/runtime/stream-manager.ts`, `src/runtime/runtime-provider.tsx`): when POST /api/chat returns `content-type: application/json` with body `{status:"queued",...}`, recognise it as a speculative overflow ack. Dispatch a `crew:queued_ack` window event carrying (sessionId, topic, streamId). The runtime provider handles it by calling `watchSession` so task-watcher guarantees the `/api/sessions/:id/events/stream` subscription is open. The eventual overflow reply arrives as a `session_result` event on that stream and merges into the streaming bubble via `findOptimisticMatchIndex` correlation on `responseToClientMessageId`.

No client-side message queue reintroduced. The merge path reuses the existing reducer-layer correlation via `responseToClientMessageId`.

## Commits

- `e8f17d2` fix(coding-blue-web): handle JSON queued ack + route session_result to correlated bubble (FA-11 defect C)
- `980c9ac` test(coding-blue-web): speculative-delivery regression guard

## Dependency

This PR requires the octos server PR (https://github.com/octos-org/octos/pull/532) to ship together. The client wires the JSON ack into the session-event-stream path, but that only produces a visible bubble if the server side attaches `_session_result` metadata to the overflow reply (Defect B) and passes the JSON ack through instead of wrapping it as SSE (Defect A).

## Test plan

- [x] `npm run build` — clean
- [x] `npm run build:next` — clean
- [x] `npx playwright test tests/speculative-delivery-regression.spec.ts` — passes (new test)
- [x] `npx playwright test tests/concurrent-deep-research.spec.ts tests/concurrent-deep-research-ordering.spec.ts` — both pass (regression guard)
- [ ] Post-deploy: rerun `tests/coding-blue-long-running.spec.ts` queue-speculative subtest against mini1; rerun `tests/speculative-root-cause.spec.ts` FA-11 probe.

## Sibling

- octos PR: https://github.com/octos-org/octos/pull/532