### PR TITLE
fix(coding-blue-web): anchor ordering + no-seq history dedup

### DIFF
--- a/src/components/chat-thread.tsx
+++ b/src/components/chat-thread.tsx
@@ -699,10 +699,23 @@ export function ChatThread({
   );
   const synthesizedAnchors = useMemo(() => {
     const out: Message[] = [];
+    // Guard against clock skew: if task.started_at predates the latest user
+    // prompt, push the synthesized anchor to just after it so the progress
+    // bubble never sorts ahead of the prompt that spawned it (Bug 1).
+    let latestUserTs = -Infinity;
+    for (const message of messages) {
+      if (message.role === "user" && message.timestamp > latestUserTs) {
+        latestUserTs = message.timestamp;
+      }
+    }
     for (const task of tasks) {
       if (!task.id || anchoredIds.has(task.id)) continue;
       const startedAt = Date.parse(task.started_at);
-      const timestamp = Number.isFinite(startedAt) ? startedAt : Date.now();
+      const serverTs = Number.isFinite(startedAt) ? startedAt : Date.now();
+      const timestamp =
+        Number.isFinite(latestUserTs) && serverTs <= latestUserTs
+          ? latestUserTs + 1
+          : serverTs;
       out.push({
         id: `task:${currentSessionId}:${task.id}`,
         role: "assistant",
@@ -726,7 +739,7 @@ export function ChatThread({
       });
     }
     return out;
-  }, [tasks, anchoredIds, currentSessionId]);
+  }, [tasks, anchoredIds, currentSessionId, messages]);
 
   const visibleMessages = useMemo(() => {
     const combined = synthesizedAnchors.length > 0

--- a/src/store/message-store-reducers/background-task-reducer.ts
+++ b/src/store/message-store-reducers/background-task-reducer.ts
@@ -41,8 +41,22 @@ export function taskAnchorTimelineTimestamp(
   task: BackgroundTaskInfo,
   now: Now = Date.now,
 ): number {
-  void list;
-  return taskTimestamp(task, now);
+  const serverTs = taskTimestamp(task, now);
+  // Guard against client/server clock skew: the anchor bubble must never sort
+  // ahead of the user prompt that spawned it. Walk the current list for the
+  // most recent user message and bump the anchor's timestamp to just after it
+  // so `compareMessagesForDisplay` (which falls back to timestamp for task
+  // anchors) keeps the prompt on top.
+  let latestUserTs = -Infinity;
+  for (const message of list) {
+    if (message.role === "user" && message.timestamp > latestUserTs) {
+      latestUserTs = message.timestamp;
+    }
+  }
+  if (Number.isFinite(latestUserTs) && serverTs <= latestUserTs) {
+    return latestUserTs + 1;
+  }
+  return serverTs;
 }
 
 function sameStrings(left: string[] | undefined, right: string[] | undefined): boolean {

--- a/src/store/message-store-reducers/history-replay-reducer.ts
+++ b/src/store/message-store-reducers/history-replay-reducer.ts
@@ -70,6 +70,31 @@ export function shouldCollapseAuthoritativeDuplicate(
   return candidateText.length > 0 && candidateText === authoritativeText;
 }
 
+/**
+ * Dedup layer for history messages that arrive without a `seq`.
+ *
+ * Both `appendHistoryMessages` seq-guard and the confirmed-text-dupe check
+ * require `typeof historySeq === "number"`. Legacy replay paths and some skill
+ * events emit `MessageInfo` without `seq`, so they bypass both guards and
+ * re-append on every poll (the "已记住 ..." reappear bug). This helper catches
+ * that case by matching same role + normalized text + timestamp within a
+ * short window.
+ */
+const NO_SEQ_DUP_WINDOW_MS = 10_000;
+
+export function findNoSeqDuplicateIndex(list: Message[], converted: Message): number {
+  if (typeof converted.historySeq === "number") return -1;
+  const textKey = normalizeMessageText(converted.text);
+  if (!textKey) return -1;
+  return list.findIndex(
+    (existing) =>
+      existing.kind !== "task_anchor" &&
+      existing.role === converted.role &&
+      normalizeMessageText(existing.text) === textKey &&
+      Math.abs(existing.timestamp - converted.timestamp) < NO_SEQ_DUP_WINDOW_MS,
+  );
+}
+
 export function findOptimisticMatchIndex(list: Message[], authoritative: Message): number {
   if (authoritative.clientMessageId) {
     const directMatchIndex = list.findIndex(

--- a/src/store/message-store.ts
+++ b/src/store/message-store.ts
@@ -24,6 +24,7 @@ import {
   findFileResultTargetIndex,
   findMessageIndexById,
   findMessageIndexByToolCallId,
+  findNoSeqDuplicateIndex,
   findOptimisticMatchIndex,
   findTaskAnchorIndex,
   mergeAuthoritativeIntoMessage,
@@ -869,6 +870,18 @@ export function appendHistoryMessages(
       if (typeof converted.historySeq === "number") {
         maxSeq = Math.max(maxSeq, converted.historySeq);
       }
+      continue;
+    }
+
+    // Final dedup: messages without a historySeq slip past the seq guard and
+    // the confirmed-text check (both require typeof historySeq === "number").
+    // Legacy replay / skill events occasionally emit MessageInfo with no seq,
+    // which re-appends on every poll (the "已记住 ..." reappear bug).
+    if (findNoSeqDuplicateIndex(list, converted) !== -1) {
+      recordRuntimeCounter("octos_result_duplicate_suppressed_total", {
+        kind: converted.role,
+        reason: "no_seq_text_match",
+      });
       continue;
     }
 

--- a/tests/message-store-reducer.spec.ts
+++ b/tests/message-store-reducer.spec.ts
@@ -442,4 +442,28 @@ test.describe("message-store reducer helpers", () => {
       ),
     ).toEqual(["user", "assistant", "pending", "task"]);
   });
+
+  test("task anchor sorts after user prompt when server started_at predates client timestamp", () => {
+    // Bug 1: clock skew between browser and server can place task.started_at
+    // BEFORE the user message timestamp, causing the "Deep research in
+    // progress" anchor to render ABOVE the user prompt that triggered it.
+    const userTs = Date.parse("2026-04-20T12:00:00.000Z");
+    const user = makeMessage({ id: "user", role: "user", timestamp: userTs });
+    const task = makeTask({ id: "skew", started_at: "2026-04-20T11:59:58.000Z" });
+    const anchor = projectTaskAnchorMessage(
+      "sess", task, [user], mergeTaskAnchorMeta(undefined, task), undefined, fixedNow,
+    );
+    expect(anchor.timestamp).toBeGreaterThan(user.timestamp);
+    expect(sortedMessagesForDisplay([anchor, user]).map((m) => m.id)).toEqual([
+      user.id, anchor.id,
+    ]);
+
+    // Same projector keeps the server timestamp when the task starts AFTER
+    // the prompt (no skew).
+    const later = makeTask({ id: "later", started_at: "2026-04-20T12:00:03.000Z" });
+    const laterAnchor = projectTaskAnchorMessage(
+      "sess", later, [user], mergeTaskAnchorMeta(undefined, later), undefined, fixedNow,
+    );
+    expect(laterAnchor.timestamp).toBe(Date.parse(later.started_at));
+  });
 });

--- a/tests/message-store-reducer.spec.ts
+++ b/tests/message-store-reducer.spec.ts
@@ -6,6 +6,7 @@ import {
   createLocalMessage,
   findFileResultTargetIndex,
   findMessageIndexForFilePath,
+  findNoSeqDuplicateIndex,
   findOptimisticMatchIndex,
   findTaskAnchorIndex,
   isAssistantCompanionForFileMessage,
@@ -465,5 +466,43 @@ test.describe("message-store reducer helpers", () => {
       "sess", later, [user], mergeTaskAnchorMeta(undefined, later), undefined, fixedNow,
     );
     expect(laterAnchor.timestamp).toBe(Date.parse(later.started_at));
+  });
+
+  test("findNoSeqDuplicateIndex covers role/window/seq guards for no-seq messages", () => {
+    // Bug 2: messages without historySeq bypass both the seq guard and the
+    // confirmed-text guard, so they append on every poll. The no-seq guard
+    // matches by role + normalized text + a short timestamp window.
+    const baseTs = Date.parse("2026-04-20T12:00:00.000Z");
+    const savedText = "已记住。Saratoga, CA 今天多云，11.6°C，湿度 80%，几乎无风";
+    const existing = makeMessage({ id: "a", role: "assistant", text: savedText, timestamp: baseTs });
+
+    // 1) Same role + same text within window → dedup.
+    expect(
+      findNoSeqDuplicateIndex([existing], makeMessage({
+        id: "dup", role: "assistant", text: savedText, timestamp: baseTs + 3_000,
+      })),
+    ).toBe(0);
+
+    // 2) Same role + same text but outside the 10s window → keep both.
+    expect(
+      findNoSeqDuplicateIndex([existing], makeMessage({
+        id: "stale", role: "assistant", text: savedText, timestamp: baseTs + 60_000,
+      })),
+    ).toBe(-1);
+
+    // 3) Different role → keep both (user echoing the same text).
+    expect(
+      findNoSeqDuplicateIndex([existing], makeMessage({
+        id: "user", role: "user", text: savedText, timestamp: baseTs + 1_000,
+      })),
+    ).toBe(-1);
+
+    // 4) Converted has a historySeq → let the seq-based guard handle it.
+    expect(
+      findNoSeqDuplicateIndex([existing], makeMessage({
+        id: "with-seq", role: "assistant", text: savedText, timestamp: baseTs + 2_000,
+        historySeq: 5,
+      })),
+    ).toBe(-1);
   });
 });


### PR DESCRIPTION
## Summary

Two independent UI defects observed in live chat on `dspfac.ocean.ominix.io/chat` (mini5 / `release/coding-blue`):

- **Bug 1** — Deep-research status bar renders ABOVE the user prompt that spawned it. Root cause: clock skew between browser (`Date.now`) and server (`task.started_at`) places the task-anchor timestamp before the user message timestamp, and the display comparator falls back to timestamp for task anchors. Fix: when projecting or synthesizing an anchor, walk the list for the most recent user message and bump the anchor timestamp to `latestUserTs + 1` when the server timestamp is older. Applied in both the authoritative projector (`taskAnchorTimelineTimestamp`) and the transient synthesized-anchor path in `chat-thread.tsx`.
- **Bug 2** — Assistant replies with no `historySeq` (e.g. legacy replay / some skill events) re-append on every poll because both `appendHistoryMessages` dedup layers gate on `typeof historySeq === "number"`. Fix: third dedup layer `findNoSeqDuplicateIndex(list, converted)` in the history-replay reducer, matching same role + normalized text + 10 s timestamp window. Skips task anchors. Wired into `appendHistoryMessages` after the confirmed-text check, counted under `octos_result_duplicate_suppressed_total` with `reason: "no_seq_text_match"`.

## Test plan

- [x] Typed new regression tests first (RED), then implemented the fixes (GREEN).
- [x] `npx playwright test tests/message-store-reducer.spec.ts` — 11 passed (was 9; +2 new tests covering both bugs).
- [x] `npx playwright test tests/speculative-delivery-regression.spec.ts` — 2 passed (constraint: untouched, still green).
- [x] `npx playwright test tests/task-anchor-a11y.spec.ts tests/concurrent-deep-research-ordering.spec.ts` — 3 passed.
- [x] `npx playwright test tests/task-store-merge.spec.ts` — 5 passed.
- [x] `npm run build` — tsc -b clean, vite build green.
- [x] Lint: no new errors introduced (pre-existing errors unchanged).
- [x] Size: 132 insertions (55 Bug 1 + 77 Bug 2) total — under the 150 product + 100 tests cap.