### PR TITLE
Accept per-mini base domains in profile-id host inference

### DIFF
--- a/src/api/client.ts
+++ b/src/api/client.ts
@@ -2,19 +2,42 @@ import { API_BASE, TOKEN_KEY, ADMIN_TOKEN_KEY } from "@/lib/constants";
 import { getSettings } from "@/hooks/use-settings";
 import { absoluteUrl } from "@/lib/utils";
 
-function inferProfileIdFromHost(): string | null {
-  if (typeof window === "undefined") return null;
-  const hostname = window.location.hostname;
-  const suffixes = [".octos.ominix.io", ".crew.ominix.io"];
-  for (const suffix of suffixes) {
+// Per-mini base-domain suffixes. Each mini serves profiles under its
+// own base domain (mini1=crew, mini2=bot, mini3=octos, mini5=ocean), so
+// the suffix list must cover every variant — otherwise `dspfac.bot.ominix.io`
+// resolves to a null profile id and the web client falls back to the
+// stored selection (or none at all). The landing-page subdomains themselves
+// (`crew.`, `bot.`, `octos.`, `ocean.`, `www`) must be stripped so they
+// do not get treated as profile IDs.
+const PROFILE_HOST_SUFFIXES = [
+  ".octos.ominix.io",
+  ".crew.ominix.io",
+  ".bot.ominix.io",
+  ".ocean.ominix.io",
+];
+const RESERVED_ROOT_SUBDOMAINS = new Set([
+  "crew",
+  "octos",
+  "bot",
+  "ocean",
+  "www",
+]);
+
+export function inferProfileIdFromHostname(hostname: string): string | null {
+  for (const suffix of PROFILE_HOST_SUFFIXES) {
     if (!hostname.endsWith(suffix)) continue;
     const subdomain = hostname.slice(0, -suffix.length);
-    if (!subdomain || subdomain === "crew" || subdomain === "octos" || subdomain === "www") {
+    if (!subdomain || RESERVED_ROOT_SUBDOMAINS.has(subdomain)) {
       return null;
     }
     return subdomain;
   }
   return null;
+}
+
+function inferProfileIdFromHost(): string | null {
+  if (typeof window === "undefined") return null;
+  return inferProfileIdFromHostname(window.location.hostname);
 }
 
 function isLocalBrowserHost(): boolean {

--- a/tests/base-domain-profile-host.spec.ts
+++ b/tests/base-domain-profile-host.spec.ts
@@ -1,0 +1,47 @@
+import { expect, test } from "@playwright/test";
+import { inferProfileIdFromHostname } from "../src/api/client";
+
+// `inferProfileIdFromHostname` drives the web client's per-profile
+// routing on public deploys. When a mini serves profiles under a base
+// domain other than `crew.ominix.io` (e.g. mini2's `bot.ominix.io`),
+// the suffix list must cover that domain or every page loads against
+// a null profile id — which is exactly the defect this PR fixes.
+
+test("inferProfileIdFromHost accepts crew suffix for backward compat", () => {
+  expect(inferProfileIdFromHostname("dspfac.crew.ominix.io")).toBe("dspfac");
+});
+
+test("inferProfileIdFromHost_accepts_ocean_suffix", () => {
+  // mini5 serves profiles under ocean.ominix.io — before the fix this
+  // returned null and the web client lost per-profile context.
+  expect(inferProfileIdFromHostname("dspfac.ocean.ominix.io")).toBe("dspfac");
+});
+
+test("inferProfileIdFromHost_accepts_bot_suffix", () => {
+  // mini2 case.
+  expect(inferProfileIdFromHostname("acme.bot.ominix.io")).toBe("acme");
+});
+
+test("inferProfileIdFromHost accepts octos suffix", () => {
+  expect(inferProfileIdFromHostname("newsbot.octos.ominix.io")).toBe(
+    "newsbot",
+  );
+});
+
+test("inferProfileIdFromHost strips reserved root subdomains", () => {
+  // Root landing pages (`crew.`, `bot.`, `octos.`, `ocean.`, `www`)
+  // must NOT be treated as profile ids — otherwise the web client
+  // tries to act on behalf of a nonexistent "crew" profile when the
+  // user visits the marketing root.
+  expect(inferProfileIdFromHostname("crew.ominix.io")).toBeNull();
+  expect(inferProfileIdFromHostname("bot.ominix.io")).toBeNull();
+  expect(inferProfileIdFromHostname("octos.ominix.io")).toBeNull();
+  expect(inferProfileIdFromHostname("ocean.ominix.io")).toBeNull();
+});
+
+test("inferProfileIdFromHost returns null for unrelated hosts", () => {
+  expect(inferProfileIdFromHostname("example.com")).toBeNull();
+  expect(inferProfileIdFromHostname("localhost")).toBeNull();
+  // A subdomain of a domain we don't own must never be claimed.
+  expect(inferProfileIdFromHostname("dspfac.evil.com")).toBeNull();
+});


### PR DESCRIPTION
## Summary
- `inferProfileIdFromHost` hardcoded two suffixes (`.octos.ominix.io` and `.crew.ominix.io`), so visitors to mini2 (`*.bot.ominix.io`) and mini5 (`*.ocean.ominix.io`) dropped to a null profile id and the web client lost per-profile routing.
- Expand the suffix list to all four mini base domains (`octos`, `crew`, `bot`, `ocean`) and the corresponding reserved-root strip list.
- Extract the pure function as `inferProfileIdFromHostname` so it can be unit-tested without a browser; the `window`-dependent wrapper keeps its original name and call sites.

## Paired with
- [octos#552 — Make base domain configurable per mini](https://github.com/octos-org/octos/pull/552) (server side)

## Test plan
- [x] `npx playwright test tests/base-domain-profile-host.spec.ts` (6 tests pass)
- [x] `npx playwright test tests/message-store-reducer.spec.ts` (regression — 9 existing tests still pass)
- [x] `npm run build`
- [x] `npx tsc -b --noEmit`

## Test cases
- `inferProfileIdFromHost accepts crew suffix for backward compat`
- `inferProfileIdFromHost_accepts_ocean_suffix` (mini5 case)
- `inferProfileIdFromHost_accepts_bot_suffix` (mini2 case)
- `inferProfileIdFromHost accepts octos suffix` (mini3 case)
- `inferProfileIdFromHost strips reserved root subdomains` (crew/bot/octos/ocean root pages)
- `inferProfileIdFromHost returns null for unrelated hosts` (defence-in-depth)

## Backward compatibility
- The existing `.crew.ominix.io` suffix is preserved, so mini1 still resolves profile ids correctly.

## Follow-up
- For a cleaner long-term fix the client should read `base_domain` from `/api/status` (exposed by the paired server PR) and use it as the sole suffix; this PR keeps the hardcoded list to unblock all four minis now.