### PR TITLE
fix(web): keep optimistic timestamp on merge, drop empty assistant bubbles

### DIFF
--- a/src/components/chat-thread.tsx
+++ b/src/components/chat-thread.tsx
@@ -45,6 +45,10 @@ import { ThinkingIndicator } from "./thinking-indicator";
 import { ToolProgressIndicator } from "./tool-progress-indicator";
 import { buildFileUrl } from "@/api/files";
 import { displayFilenameFromPath } from "@/lib/utils";
+import {
+  isEmptyCompletedAssistantBubble,
+  isFileOnlyAssistantMessage,
+} from "@/lib/message-display";
 import { nextTopicForCommand } from "@/lib/slash-commands";
 import { getToken } from "@/api/client";
 
@@ -659,14 +663,8 @@ interface ChatThreadProps {
   hideFileOnlyAssistantMessages?: boolean;
 }
 
-function isFileOnlyAssistantMessage(message: Message): boolean {
-  return (
-    message.role === "assistant" &&
-    !message.text.trim() &&
-    message.files.length > 0 &&
-    message.toolCalls.length === 0
-  );
-}
+// Visibility helpers — pure, no React/CSS deps — live in lib/message-display
+// so unit tests can import them without the full chat-thread tree.
 
 export function ChatThread({
   hideFileOnlyAssistantMessages = false,
@@ -754,9 +752,16 @@ export function ChatThread({
     const combined = synthesizedAnchors.length > 0
       ? [...messages, ...synthesizedAnchors].sort((a, b) => a.timestamp - b.timestamp)
       : messages;
+    // Always drop empty completed assistant bubbles — these are stray
+    // `done` events with no text, or queued placeholders whose stream was
+    // canceled. They render as a metadata-only bubble showing just a
+    // timestamp string (anomaly 2).
+    const withoutEmpty = combined.filter(
+      (message) => !isEmptyCompletedAssistantBubble(message),
+    );
     return hideFileOnlyAssistantMessages
-      ? combined.filter((message) => !isFileOnlyAssistantMessage(message))
-      : combined;
+      ? withoutEmpty.filter((message) => !isFileOnlyAssistantMessage(message))
+      : withoutEmpty;
   }, [hideFileOnlyAssistantMessages, messages, synthesizedAnchors]);
 
   const hasMessages = visibleMessages.length > 0;

--- a/src/lib/message-display.ts
+++ b/src/lib/message-display.ts
@@ -1,0 +1,50 @@
+/**
+ * Pure visibility helpers for chat-thread message rendering.
+ *
+ * Lives in `lib/` so unit tests can import these without pulling in the
+ * full chat-thread tree (which transitively loads CSS via the markdown
+ * renderer's KaTeX import).
+ */
+
+import type { Message } from "@/store/message-store";
+
+/**
+ * Assistant message that is visible only as inline file attachments.
+ *
+ * Used by topic surfaces (e.g. slides delivery) that show the file panel
+ * separately and want to suppress the duplicate file-only assistant bubble
+ * in the conversation timeline.
+ */
+export function isFileOnlyAssistantMessage(message: Message): boolean {
+  return (
+    message.role === "assistant" &&
+    !message.text.trim() &&
+    message.files.length > 0 &&
+    message.toolCalls.length === 0
+  );
+}
+
+/**
+ * Empty completed assistant bubble — should NOT render.
+ *
+ * Anomaly 2: a `done` event with empty content (or a queued M9 placeholder
+ * whose stream was canceled before any token arrived) leaves an assistant
+ * message with `text=""`, `files=[]`, `toolCalls=[]` and `status="complete"`.
+ * The AssistantBubble shell still renders MessageMetaInline, so the user
+ * sees a bubble with only a timestamp string. Filter those out at the list
+ * level so they never reach AssistantBubble.
+ *
+ * Streaming bubbles (typing dots) and task_anchor placeholders are exempt:
+ * task_anchor has its own data-testid and intentionally renders without
+ * text; streaming bubbles still need the dots to confirm liveness.
+ */
+export function isEmptyCompletedAssistantBubble(message: Message): boolean {
+  if (message.role !== "assistant") return false;
+  if (message.kind === "task_anchor") return false;
+  if (message.status === "streaming") return false;
+  return (
+    !message.text.trim() &&
+    message.files.length === 0 &&
+    message.toolCalls.length === 0
+  );
+}

--- a/src/store/message-store-reducers/history-replay-reducer.ts
+++ b/src/store/message-store-reducers/history-replay-reducer.ts
@@ -187,6 +187,18 @@ export function mergeAuthoritativeIntoMessage(
   authoritative: Message,
   now: Now = Date.now,
 ): Message {
+  // Keep the EARLIER of the two timestamps. The optimistic timestamp
+  // (client-T, set at the moment the user pressed send) is usually a more
+  // chronologically accurate anchor than the authoritative server timestamp,
+  // which can be 100ms-1s later due to network + persistence. Without this
+  // guard, the merged user bubble jumps forward in the timestamp-primary
+  // comparator and lands AFTER its triggering assistant placeholder, which
+  // still has its earlier client-T. Result: assistant bubble visually
+  // precedes the user bubble that triggered it (anomaly 1).
+  //
+  // Math.min keeps whichever came first; on backfilled history where the
+  // optimistic side is missing, both timestamps are equal so this is a no-op.
+  const mergedTimestamp = Math.min(existing.timestamp, authoritative.timestamp);
   const merged: Message = {
     ...existing,
     text: authoritative.text,
@@ -197,7 +209,7 @@ export function mergeAuthoritativeIntoMessage(
     toolCalls:
       authoritative.toolCalls.length > 0 ? authoritative.toolCalls : existing.toolCalls,
     status: "complete",
-    timestamp: authoritative.timestamp,
+    timestamp: mergedTimestamp,
     historySeq: authoritative.historySeq,
     meta: existing.meta,
     sourceToolCallId: authoritative.sourceToolCallId ?? existing.sourceToolCallId,

--- a/tests/message-store-reducer.spec.ts
+++ b/tests/message-store-reducer.spec.ts
@@ -34,6 +34,7 @@ import {
   reduceMergeAuthoritativeHistoryMessageEvent,
 } from "../src/store/message-store-reducers/history-replay-reducer";
 import { reduceCreateUserMessageEvent } from "../src/store/message-store-reducers/user-message-reducer";
+import { isEmptyCompletedAssistantBubble } from "../src/lib/message-display";
 
 const NOW = Date.parse("2026-04-20T12:00:30.000Z");
 
@@ -708,5 +709,174 @@ test.describe("message-store reducer helpers", () => {
     expect(
       sortedMessagesForDisplay([userMessage, withSeq, followUp]).map((m) => m.id),
     ).toEqual(["user-1", "assistant-1", "user-2"]);
+  });
+
+  test("merge_keeps_optimistic_timestamp_when_authoritative_is_later", () => {
+    // Anomaly 1: when the optimistic user bubble's timestamp gets overwritten
+    // by the authoritative server timestamp (which arrives later), the user
+    // bubble can sort AFTER its triggering assistant placeholder, since the
+    // assistant placeholder was created right after the user pressed send
+    // and still has the earlier client-T. Result: assistant bubble visually
+    // appears BEFORE the user bubble that prompted it.
+    //
+    // The merge must keep the EARLIER timestamp so chronological order is
+    // preserved across the optimistic→authoritative transition.
+    const optimisticUserTs = Date.parse("2026-04-25T10:00:00.000Z");
+    const optimisticUser = makeMessage({
+      id: "optimistic-user",
+      role: "user",
+      text: "Hi assistant",
+      timestamp: optimisticUserTs,
+      clientMessageId: "cmid-1",
+      status: "complete",
+    });
+    const authoritativeUser = convertApiMessage(
+      makeApiMessage({
+        seq: 4,
+        role: "user",
+        content: "Hi assistant",
+        client_message_id: "cmid-1",
+        // Server stamp is 1.2s later (typical network + persistence delay).
+        timestamp: "2026-04-25T10:00:01.200Z",
+      }),
+      () => "api-user",
+      fixedNow,
+    );
+    expect(authoritativeUser).not.toBeNull();
+
+    const merged = reduceMergeAuthoritativeHistoryMessageEvent({
+      type: "merge_authoritative_history_message",
+      existing: optimisticUser,
+      authoritative: authoritativeUser!,
+      now: fixedNow,
+    });
+
+    // Optimistic timestamp wins because it is earlier.
+    expect(merged.timestamp).toBe(optimisticUserTs);
+    // Authoritative seq still adopted.
+    expect(merged.historySeq).toBe(4);
+
+    // Sort regression: an assistant placeholder created 100ms after the
+    // optimistic user send (cmid-keyed response) must STILL render after
+    // the merged user bubble.
+    const assistantPlaceholder = makeMessage({
+      id: "assistant-placeholder",
+      role: "assistant",
+      text: "Hello!",
+      timestamp: optimisticUserTs + 100,
+      responseToClientMessageId: "cmid-1",
+      status: "complete",
+    });
+    const order = sortedMessagesForDisplay([assistantPlaceholder, merged]).map(
+      (m) => m.id,
+    );
+    expect(order).toEqual(["optimistic-user", "assistant-placeholder"]);
+
+    // Symmetric guard: when authoritative timestamp is EARLIER than the
+    // optimistic timestamp (e.g. clock skew), keep that earlier server
+    // timestamp.
+    const skewedAuthoritative = convertApiMessage(
+      makeApiMessage({
+        seq: 5,
+        role: "user",
+        content: "Hi assistant",
+        client_message_id: "cmid-1",
+        timestamp: "2026-04-25T09:59:59.500Z",
+      }),
+      () => "api-user-skew",
+      fixedNow,
+    );
+    expect(skewedAuthoritative).not.toBeNull();
+    const mergedSkewed = reduceMergeAuthoritativeHistoryMessageEvent({
+      type: "merge_authoritative_history_message",
+      existing: optimisticUser,
+      authoritative: skewedAuthoritative!,
+      now: fixedNow,
+    });
+    expect(mergedSkewed.timestamp).toBe(skewedAuthoritative!.timestamp);
+  });
+
+  test("empty_completed_assistant_bubble_is_filtered_from_display", () => {
+    // Anomaly 2: a `done` event with empty content (or a queued M9
+    // placeholder whose stream was canceled) leaves an assistant message
+    // with text="", files=[], toolCalls=[], status="complete". The
+    // AssistantBubble shell still renders MessageMetaInline so the user
+    // sees a metadata-only bubble showing just a timestamp string. The
+    // chat-thread component must filter those out before rendering.
+    const empty = makeMessage({
+      id: "empty-done",
+      role: "assistant",
+      text: "",
+      files: [],
+      toolCalls: [],
+      status: "complete",
+      timestamp: Date.parse("2026-04-25T10:08:44.000Z"),
+    });
+    expect(isEmptyCompletedAssistantBubble(empty)).toBe(true);
+
+    // Whitespace-only text is also filtered.
+    const whitespace = makeMessage({
+      id: "whitespace",
+      role: "assistant",
+      text: "   \n  \t",
+      status: "complete",
+    });
+    expect(isEmptyCompletedAssistantBubble(whitespace)).toBe(true);
+
+    // A streaming placeholder still renders (typing dots).
+    const streaming = makeMessage({
+      id: "streaming",
+      role: "assistant",
+      text: "",
+      status: "streaming",
+    });
+    expect(isEmptyCompletedAssistantBubble(streaming)).toBe(false);
+
+    // task_anchor placeholders intentionally render without text.
+    const taskAnchor = makeMessage({
+      id: "task-anchor",
+      role: "assistant",
+      kind: "task_anchor",
+      text: "",
+      status: "complete",
+      taskAnchor: { taskId: "task-1" },
+    });
+    expect(isEmptyCompletedAssistantBubble(taskAnchor)).toBe(false);
+
+    // Assistants with text, files, or tool calls always render.
+    const withText = makeMessage({
+      id: "with-text",
+      role: "assistant",
+      text: "Hi",
+      status: "complete",
+    });
+    expect(isEmptyCompletedAssistantBubble(withText)).toBe(false);
+
+    const withFiles = makeMessage({
+      id: "with-files",
+      role: "assistant",
+      text: "",
+      files: [{ filename: "a.md", path: "pf/a.md", caption: "" }],
+      status: "complete",
+    });
+    expect(isEmptyCompletedAssistantBubble(withFiles)).toBe(false);
+
+    const withTools = makeMessage({
+      id: "with-tools",
+      role: "assistant",
+      text: "",
+      toolCalls: [{ id: "tc1", name: "shell", status: "complete" }],
+      status: "complete",
+    });
+    expect(isEmptyCompletedAssistantBubble(withTools)).toBe(false);
+
+    // User messages aren't considered (separate code path).
+    const user = makeMessage({
+      id: "user",
+      role: "user",
+      text: "",
+      status: "complete",
+    });
+    expect(isEmptyCompletedAssistantBubble(user)).toBe(false);
   });
 });


### PR DESCRIPTION
## Summary
- Anomaly 1: `mergeAuthoritativeIntoMessage` now keeps the earlier of optimistic and authoritative timestamps via `Math.min`. The previous code overwrote the optimistic client-T (set at send time) with the later server-T, so the merged user bubble could sort after its triggering assistant placeholder, making the assistant bubble appear above its user prompt.
- Anomaly 2: `ChatThread` filters out empty completed assistant bubbles before rendering. A `done` event with empty content (or a canceled M9 placeholder) was rendering as a bubble with only a `MessageMetaInline` timestamp string. The new `isEmptyCompletedAssistantBubble` helper lives in `src/lib/message-display.ts` (pure module, no CSS deps) so the reducer tests can import it.
- Both fixes are render-level / reducer-level only; no protocol or storage changes.

## Test plan
- [x] `pnpm exec tsc --noEmit` clean
- [x] `npx playwright test tests/message-store-reducer.spec.ts` — 18 passing (16 baseline + 2 new):
  - `merge_keeps_optimistic_timestamp_when_authoritative_is_later`
  - `empty_completed_assistant_bubble_is_filtered_from_display`
- [x] `pnpm build` succeeds
- [x] Deployed to mini1/2/3/5; bundle hash `index-C7kNquI9.js` confirmed across all four
- [x] Re-smoke against `https://dspfac.ocean.ominix.io` (mini5) passes both new invariants:
  - first DOM bubble is the user prompt; first assistant bubble appears after the last user bubble
  - no assistant bubbles whose visible text is only a timestamp string