### PR TITLE
Anchor tool_progress timeline inside per-tool-call bubble (#618)

### DIFF
--- a/src/api/types.ts
+++ b/src/api/types.ts
@@ -122,7 +122,7 @@ export type SseEvent =
   | { type: "replace"; text: string }
   | { type: "tool_start"; tool: string; tool_call_id?: string; tool_id?: string }
   | { type: "tool_end"; tool: string; success: boolean; tool_call_id?: string; tool_id?: string }
-  | { type: "tool_progress"; tool: string; message: string }
+  | { type: "tool_progress"; tool: string; message: string; tool_call_id?: string; tool_id?: string }
   | { type: "stream_end" }
   | {
       type: "cost_update";

--- a/src/components/chat-thread.tsx
+++ b/src/components/chat-thread.tsx
@@ -137,20 +137,37 @@ const AssistantBubble = memo(function AssistantBubble({
 
         {/* Tool calls */}
         {message.toolCalls.length > 0 && (
-          <div className="mt-2 flex flex-wrap gap-1.5">
+          <div className="mt-2 flex flex-col gap-1.5">
             {message.toolCalls.map((tc) => (
-              <span
+              <div
                 key={tc.id}
-                className={`glass-pill inline-flex items-center gap-1 rounded-[10px] px-2.5 py-1 text-[10px] font-mono ${
+                data-testid="tool-call-bubble"
+                data-tool-call-id={tc.id}
+                className={`flex flex-col gap-1 rounded-[10px] px-2.5 py-1 text-[10px] font-mono ${
                   tc.status === "running"
                     ? "border-accent/20 bg-accent/14 text-accent animate-pulse"
                     : tc.status === "error"
                       ? "border-red-500/20 bg-red-500/12 text-red-400"
                       : "text-muted"
-                }`}
+                } glass-pill`}
               >
-                {tc.name}
-              </span>
+                <span>{tc.name}</span>
+                {tc.progress.length > 0 && (
+                  <ul
+                    data-testid="tool-call-runtime-timeline"
+                    className="m-0 mt-1 flex list-none flex-col gap-0.5 border-l border-current/20 pl-2"
+                  >
+                    {tc.progress.map((entry, idx) => (
+                      <li key={idx} className="opacity-80">
+                        {entry.message.replace(
+                          /^\[(info|debug|warn|error)\]\s*/i,
+                          "",
+                        )}
+                      </li>
+                    ))}
+                  </ul>
+                )}
+              </div>
             ))}
           </div>
         )}

--- a/src/runtime/sse-bridge.ts
+++ b/src/runtime/sse-bridge.ts
@@ -225,11 +225,18 @@ function bindStreamToAssistant({
   const pendingStreamError = { current: null as string | null };
   const toolCalls = new Map<
     string,
-    { id: string; name: string; status: "running" | "complete" | "error" }
+    {
+      id: string;
+      name: string;
+      status: "running" | "complete" | "error";
+      progress: { message: string; ts: number }[];
+    }
   >();
   /** Maps tool name to the most recent toolCall key (for tool_end matching). */
   const activeToolByName = new Map<string, string>();
   const normalizedHistoryTopic = historyTopic?.trim() || undefined;
+  /** Maps server-side tool_call_id to the local toolCalls map key. */
+  const keyByServerId = new Map<string, string>();
 
   const handleEvent = (evt: StreamManager.StreamEvent) => {
     const event = evt.raw;
@@ -266,12 +273,24 @@ function bindStreamToAssistant({
 
       case "tool_start": {
         const key = `tc_${++toolCallCounter}`;
+        // Prefer the server-issued tool_call_id (then the legacy
+        // tool_id) so tool_progress and tool_end can route by id;
+        // synthesize an id only when the backend omits both.
         const tcId =
           event.tool_call_id ||
           event.tool_id ||
           `tc_${event.tool}_${Date.now()}_${Math.random().toString(36).slice(2, 6)}`;
-        toolCalls.set(key, { id: tcId, name: event.tool, status: "running" });
+        toolCalls.set(key, {
+          id: tcId,
+          name: event.tool,
+          status: "running",
+          progress: [],
+        });
         activeToolByName.set(event.tool, key);
+        // Map every server-issued id we know about to this local key so
+        // tool_progress / tool_end events can route by either field.
+        if (event.tool_call_id) keyByServerId.set(event.tool_call_id, key);
+        if (event.tool_id) keyByServerId.set(event.tool_id, key);
         MessageStore.updateMessage(sessionId, assistantMsgId, {
           toolCalls: Array.from(toolCalls.values()),
         }, historyTopic);
@@ -279,7 +298,10 @@ function bindStreamToAssistant({
       }
 
       case "tool_end": {
-        const key = activeToolByName.get(event.tool);
+        const key =
+          (event.tool_call_id && keyByServerId.get(event.tool_call_id)) ||
+          (event.tool_id && keyByServerId.get(event.tool_id)) ||
+          activeToolByName.get(event.tool);
         const tc = key ? toolCalls.get(key) : undefined;
         if (tc) tc.status = event.success ? "complete" : "error";
         MessageStore.updateMessage(sessionId, assistantMsgId, {
@@ -288,7 +310,23 @@ function bindStreamToAssistant({
         break;
       }
 
-      case "tool_progress":
+      case "tool_progress": {
+        // Anchor the entry to its tool call when the backend gave us
+        // an id. Otherwise fall back to most-recent-by-name so older
+        // streams still surface something in the right bubble.
+        const key =
+          (event.tool_call_id && keyByServerId.get(event.tool_call_id)) ||
+          (event.tool_id && keyByServerId.get(event.tool_id)) ||
+          activeToolByName.get(event.tool);
+        const tc = key ? toolCalls.get(key) : undefined;
+        if (tc) {
+          tc.progress.push({ message: event.message, ts: Date.now() });
+          MessageStore.updateMessage(sessionId, assistantMsgId, {
+            toolCalls: Array.from(toolCalls.values()),
+          });
+        }
+        // Keep the legacy global indicator working for components that
+        // listen to `crew:tool_progress` (project files, site preview).
         window.dispatchEvent(
           new CustomEvent("crew:tool_progress", {
             detail: {
@@ -296,10 +334,12 @@ function bindStreamToAssistant({
               message: event.message,
               sessionId,
               topic: historyTopic,
+              tool_call_id: event.tool_call_id,
             },
           }),
         );
         break;
+      }
 
       case "thinking":
         window.dispatchEvent(

--- a/src/runtime/ws-adapter.ts
+++ b/src/runtime/ws-adapter.ts
@@ -417,6 +417,7 @@ export function createWsAdapter(
                     id: tc.toolCallId,
                     name: tc.toolName,
                     status: tc.status as "running" | "complete" | "error",
+                    progress: [],
                   })),
                 }, historyTopic);
                 yield buildResult(text, toolCalls);
@@ -435,6 +436,7 @@ export function createWsAdapter(
                     id: t.toolCallId,
                     name: t.toolName,
                     status: t.status as "running" | "complete" | "error",
+                    progress: [],
                   })),
                 }, historyTopic);
                 yield buildResult(text, toolCalls);

--- a/src/store/message-store.ts
+++ b/src/store/message-store.ts
@@ -18,10 +18,23 @@ import { recordRuntimeCounter } from "@/runtime/observability";
 // Types
 // ---------------------------------------------------------------------------
 
+export interface ToolProgressEntry {
+  message: string;
+  ts: number;
+}
+
 export interface ToolCallInfo {
   id: string;
   name: string;
   status: "running" | "complete" | "error";
+  /**
+   * Per-tool runtime progress events captured from the SSE
+   * `tool_progress` stream, keyed to this call by `tool_call_id`. Used
+   * by the chat thread to render a timeline inside the tool-call bubble
+   * so users see what a long-running tool (e.g. `run_pipeline`,
+   * `deep_search`) is doing while it runs.
+   */
+  progress: ToolProgressEntry[];
 }
 
 export interface MessageFile {
@@ -556,6 +569,7 @@ function convertApiMessage(m: MessageInfo): Message | null {
       id: tc.id || "",
       name: tc.name || "",
       status: "complete" as const,
+      progress: [],
     })) ?? [];
 
   return {
@@ -900,6 +914,7 @@ export function bindBackgroundTask(
     id: toolCallId,
     name: normalizedToolName || task.tool_name || "background_task",
     status: taskToolStatus(task),
+    progress: [],
   });
 
   indexTaskForMessage(key, task, list[targetIndex].id);


### PR DESCRIPTION
## Summary

Fix #618: tool_progress SSE events now render inside their owning tool-call bubble.

Backend already emits `tool_progress` with `tool_call_id`, but the frontend dropped the id and broadcast a generic CustomEvent. Per-tool-call progress was effectively invisible.

The e2e contract in `e2e/tests/live-tool-progress.spec.ts` requires `[data-testid='tool-call-bubble']` and `[data-testid='tool-call-runtime-timeline']` — neither existed.

## Changes

- `api/types.ts` — declare optional `tool_call_id` on tool_* SSE events
- `store/message-store.ts` — `ToolCallInfo.progress: ToolProgressEntry[]`
- `runtime/sse-bridge.ts` — adopt server-issued `tool_call_id`, route progress events to the matching call by id (fallback to active-tool-by-name for older streams), match `tool_end` by id too
- `runtime/ws-adapter.ts` — populate `progress: []` for type compat
- `components/chat-thread.tsx` — replace pill span with `data-testid='tool-call-bubble'` containing `data-testid='tool-call-runtime-timeline'`

Existing `ToolProgressIndicator` (last-event-wins bar) kept as redundancy for events with no matching id.

## Test plan

- [x] npx tsc -b clean
- [x] npx vite build clean
- [ ] e2e test `live-tool-progress.spec.ts` against fleet (post-deploy)