### PR TITLE
M8.10 follow-up: route isRunning + sites-chat through active store

### DIFF
--- a/src/components/chat-thread.tsx
+++ b/src/components/chat-thread.tsx
@@ -982,11 +982,22 @@ function Composer() {
     adaptiveMode,
   } =
     useSession();
+  // M8.10: under v2 flag the message-store is empty (events flow through
+  // thread-store), so `messages.some(streaming)` is always false and the
+  // cancel button never appears. Read isRunning from whichever store is
+  // active.
   const messages = useMessages(currentSessionId, historyTopic);
-  const isRunning = useMemo(
-    () => messages.some((m) => m.status === "streaming"),
-    [messages],
-  );
+  const threadsForRunning = useThreads(currentSessionId, historyTopic);
+  const isRunning = useMemo(() => {
+    if (isThreadStoreV2Enabled()) {
+      return threadsForRunning.some(
+        (t) =>
+          t.pendingAssistant !== null &&
+          t.pendingAssistant.status === "streaming",
+      );
+    }
+    return messages.some((m) => m.status === "streaming");
+  }, [messages, threadsForRunning]);
 
   const [text, setText] = useState("");
   const [cmdFeedback, setCmdFeedback] = useState<string | null>(null);

--- a/src/sites/components/sites-chat.tsx
+++ b/src/sites/components/sites-chat.tsx
@@ -10,7 +10,80 @@ import {
   type SessionSendRequest,
 } from "@/runtime/session-context";
 import * as MessageStore from "@/store/message-store";
-import { useMessages } from "@/store/message-store";
+import { useMessages, type Message } from "@/store/message-store";
+import { useThreads, type Thread } from "@/store/thread-store";
+
+function isThreadStoreV2Enabled(): boolean {
+  if (typeof window === "undefined") return false;
+  try {
+    return window.localStorage.getItem("octos_thread_store_v2") === "1";
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Read messages from whichever store is currently active. Under the
+ * v2 thread-store flag the legacy message-store is empty, so callers
+ * that do raw history lookups (e.g. SitesChat looking for the last
+ * user message to seed scaffold prompts) must read threads instead.
+ *
+ * Returns a flat list ordered by user-message send time then per-thread
+ * sequence — matches the rendered DOM order.
+ */
+function flattenThreadsToMessages(threads: Thread[]): Message[] {
+  const flatToolCalls = (
+    tcs: Array<{ id: string; name: string; status: "running" | "complete" | "error" }>,
+  ) => tcs.map((tc) => ({ id: tc.id, name: tc.name, status: tc.status, progress: [] }));
+
+  const out: Message[] = [];
+  for (const t of threads) {
+    if (t.userMsg.role !== "tool") {
+      out.push({
+        id: t.userMsg.id,
+        role: t.userMsg.role,
+        text: t.userMsg.text,
+        clientMessageId: t.id,
+        files: t.userMsg.files,
+        toolCalls: flatToolCalls(t.userMsg.toolCalls),
+        status: t.userMsg.status,
+        timestamp: t.userMsg.timestamp,
+        historySeq: t.userMsg.historySeq,
+        meta: t.userMsg.meta,
+      });
+    }
+    for (const r of t.responses) {
+      if (r.role === "tool") continue;
+      out.push({
+        id: r.id,
+        role: r.role,
+        text: r.text,
+        responseToClientMessageId: t.id,
+        files: r.files,
+        toolCalls: flatToolCalls(r.toolCalls),
+        status: r.status,
+        timestamp: r.timestamp,
+        historySeq: r.historySeq,
+        meta: r.meta,
+      });
+    }
+    if (t.pendingAssistant && t.pendingAssistant.role !== "tool") {
+      out.push({
+        id: t.pendingAssistant.id,
+        role: t.pendingAssistant.role,
+        text: t.pendingAssistant.text,
+        responseToClientMessageId: t.id,
+        files: t.pendingAssistant.files,
+        toolCalls: flatToolCalls(t.pendingAssistant.toolCalls),
+        status: t.pendingAssistant.status,
+        timestamp: t.pendingAssistant.timestamp,
+        historySeq: t.pendingAssistant.historySeq,
+        meta: t.pendingAssistant.meta,
+      });
+    }
+  }
+  return out;
+}
 
 import { buildSitePreviewUrl, hydrateSiteProjectFromSession } from "../api";
 import { useSites } from "../context/sites-context";
@@ -71,7 +144,15 @@ export function SitesChat({ sessionId }: Props) {
   const projectTitle = project?.title;
   const projectScaffolded = project?.scaffolded;
   const historyTopic = project?.preset ? `site ${project.preset}` : undefined;
-  const messages = useMessages(sessionId, historyTopic);
+  // M8.10: read from whichever store is active so the scaffold lookup
+  // for the last user message works under both flag states.
+  const flatMessages = useMessages(sessionId, historyTopic);
+  const threads = useThreads(sessionId, historyTopic);
+  const messages = useMemo(
+    () =>
+      isThreadStoreV2Enabled() ? flattenThreadsToMessages(threads) : flatMessages,
+    [flatMessages, threads],
+  );
 
   useEffect(() => {
     void MessageStore.loadHistory(sessionId, historyTopic);

--- a/tsconfig.app.json
+++ b/tsconfig.app.json
@@ -28,5 +28,6 @@
     },
     "baseUrl": "."
   },
-  "include": ["src"]
+  "include": ["src"],
+  "exclude": ["**/*.test.ts", "**/*.test.tsx", "src/**/__tests__/**"]
 }


### PR DESCRIPTION
Two consumers missed by PR #3 (#53):

1. **Composer.isRunning** (chat-thread.tsx) — derived from `messages.some(streaming)`. Under v2 flag, events flow into thread-store; legacy message-store stays empty. Result: cancel button never appears while a request is in flight. Live e2e \`live-thread-interleave\` on mini3 caught this.

2. **SitesChat** (sites/components/sites-chat.tsx) — looks up last user message to seed scaffold prompt. Same problem.

Both now read from whichever store the flag has active.

Also: tsconfig.app.json excludes test files (vitest tests referenced unresolved \`vitest\` types under tsc -b), unblocking npm run build.

## Validation

Deployed to mini3 and ran:
- \`live-thread-interleave\` ✓ (15.8s) — slow Q + fast Q correctly pair under v2
- \`live-tool-retry-collapse\` ✓ (19.9s) — retries collapse into one bubble
- 4 existing live specs ✓ (file-delivery, msg-order — flag-off path unaffected)

Tracking: octos-org/octos#627