### PR TITLE
M8.10 follow-up: rehydrate chat history into thread-store on mount (#633)

### DIFF
--- a/src/components/chat-thread.tsx
+++ b/src/components/chat-thread.tsx
@@ -37,6 +37,7 @@ import {
 } from "@/store/message-store";
 import {
   useThreads,
+  loadHistory as loadThreadHistory,
   type Thread,
   type ThreadMessage,
   type ThreadToolCall,
@@ -840,6 +841,43 @@ function ChatThreadV2({
   const { currentSessionId, historyTopic } = useSession();
   const threads = useThreads(currentSessionId, historyTopic);
   const hasThreads = threads.length > 0;
+
+  // M8.10 follow-up (#633): rehydrate thread store from server history on mount
+  // and on session/topic change. The flat-list path loads history via
+  // `runtime-provider.tsx`'s `MessageStore.loadHistory(...)` effect; under the
+  // v2 flag the runtime provider also triggers MessageStore but the thread
+  // store stays empty after reload, so a session with prior chat history
+  // renders as an empty conversation.
+  //
+  // The reload path is also racy with server persistence: the SSE `done`
+  // event fires before the JSONL is fully committed, so an immediate reload
+  // gets back only the user messages. Schedule a small number of forced
+  // re-fetches over the first ~12s so the assistant messages catch up once
+  // the server commits them. The retries no-op as soon as the loaded thread
+  // count stops growing, so the cost is at most 3 extra requests in the
+  // worst case.
+  useEffect(() => {
+    let cancelled = false;
+    void loadThreadHistory(currentSessionId, historyTopic);
+
+    const retryDelaysMs = [2_000, 5_000, 12_000];
+    const timers: number[] = [];
+    for (const delay of retryDelaysMs) {
+      timers.push(
+        window.setTimeout(() => {
+          if (cancelled) return;
+          void loadThreadHistory(currentSessionId, historyTopic, {
+            force: true,
+          });
+        }, delay),
+      );
+    }
+
+    return () => {
+      cancelled = true;
+      for (const t of timers) window.clearTimeout(t);
+    };
+  }, [currentSessionId, historyTopic]);
 
   return (
     <div className="flex h-full min-h-0 flex-col bg-transparent">

--- a/src/store/thread-store.test.ts
+++ b/src/store/thread-store.test.ts
@@ -21,6 +21,7 @@ import * as ThreadStore from "./thread-store";
 
 afterEach(() => {
   ThreadStore.__resetForTests();
+  vi.unstubAllGlobals();
 });
 
 const SESSION = "sess-test";
@@ -326,5 +327,141 @@ describe("thread-store", () => {
     expect(
       ThreadStore.resolveEventThreadId("unknown-session", undefined, undefined),
     ).toBeNull();
+  });
+
+  // ---------------------------------------------------------------------------
+  // History rehydration on mount (M8.10 follow-up, issue #633)
+  //
+  // ChatThreadV2 needs `loadHistory` to populate the thread store from the
+  // server's per-session messages endpoint. Without these tests the bug
+  // identified in #633 (v2 page reload renders empty chat) regresses.
+  // ---------------------------------------------------------------------------
+
+  it("loadHistory_replays_into_threads_grouped_by_thread_id", async () => {
+    // 4-message history → 2 threads, every record carries thread_id.
+    const messages = [
+      {
+        seq: 0,
+        role: "user",
+        content: "Q1",
+        client_message_id: "cmid-1",
+        thread_id: "cmid-1",
+        timestamp: "2026-04-28T10:00:00Z",
+      },
+      {
+        seq: 1,
+        role: "assistant",
+        content: "A1",
+        response_to_client_message_id: "cmid-1",
+        thread_id: "cmid-1",
+        timestamp: "2026-04-28T10:00:05Z",
+      },
+      {
+        seq: 2,
+        role: "user",
+        content: "Q2",
+        client_message_id: "cmid-2",
+        thread_id: "cmid-2",
+        timestamp: "2026-04-28T10:01:00Z",
+      },
+      {
+        seq: 3,
+        role: "assistant",
+        content: "A2",
+        response_to_client_message_id: "cmid-2",
+        thread_id: "cmid-2",
+        timestamp: "2026-04-28T10:01:05Z",
+      },
+    ];
+
+    const fetchMock = vi.fn(async (url: string | URL | Request) => {
+      const path = typeof url === "string" ? url : url.toString();
+      expect(path).toContain(
+        `/api/sessions/${encodeURIComponent(SESSION)}/messages`,
+      );
+      return new Response(JSON.stringify(messages), {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      });
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    await ThreadStore.loadHistory(SESSION);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+
+    const threads = ThreadStore.getThreads(SESSION);
+    expect(threads.map((t) => t.id)).toEqual(["cmid-1", "cmid-2"]);
+    expect(threads[0].userMsg.text).toBe("Q1");
+    expect(threads[0].responses).toHaveLength(1);
+    expect(threads[0].responses[0].text).toBe("A1");
+    expect(threads[1].userMsg.text).toBe("Q2");
+    expect(threads[1].responses).toHaveLength(1);
+    expect(threads[1].responses[0].text).toBe("A2");
+
+    // Second call is a no-op — already loaded for this session/topic key.
+    await ThreadStore.loadHistory(SESSION);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+
+    // `force: true` bypasses the cache so the mount-effect retry can recover
+    // from server persistence latency that returned a partial first fetch.
+    await ThreadStore.loadHistory(SESSION, undefined, { force: true });
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
+
+  it("loadHistory_synthesizes_threads_for_legacy_records_without_thread_id", async () => {
+    // Legacy daemon: no thread_id on any record. Synthesizer must derive one
+    // per user-message role-flip so the chat still groups into 2 threads.
+    const messages = [
+      {
+        seq: 0,
+        role: "user",
+        content: "old Q1",
+        client_message_id: "cm-old-1",
+        timestamp: "2026-04-01T00:00:00Z",
+      },
+      {
+        seq: 1,
+        role: "assistant",
+        content: "old A1",
+        timestamp: "2026-04-01T00:00:10Z",
+      },
+      {
+        seq: 2,
+        role: "user",
+        content: "old Q2",
+        client_message_id: "cm-old-2",
+        timestamp: "2026-04-01T00:01:00Z",
+      },
+      {
+        seq: 3,
+        role: "assistant",
+        content: "old A2",
+        timestamp: "2026-04-01T00:01:10Z",
+      },
+    ];
+
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(
+        async () =>
+          new Response(JSON.stringify(messages), {
+            status: 200,
+            headers: { "Content-Type": "application/json" },
+          }),
+      ),
+    );
+
+    await ThreadStore.loadHistory(SESSION);
+
+    const threads = ThreadStore.getThreads(SESSION);
+    expect(threads).toHaveLength(2);
+    expect(threads[0].id).toBe("cm-old-1");
+    expect(threads[0].userMsg.text).toBe("old Q1");
+    expect(threads[0].responses).toHaveLength(1);
+    expect(threads[0].responses[0].text).toBe("old A1");
+    expect(threads[1].id).toBe("cm-old-2");
+    expect(threads[1].userMsg.text).toBe("old Q2");
+    expect(threads[1].responses).toHaveLength(1);
+    expect(threads[1].responses[0].text).toBe("old A2");
   });
 });

--- a/src/store/thread-store.ts
+++ b/src/store/thread-store.ts
@@ -589,12 +589,26 @@ export function replayHistory(
 // History loading
 // ---------------------------------------------------------------------------
 
+export interface LoadHistoryOptions {
+  /**
+   * Bypass the per-session "already loaded" cache and force a fresh fetch.
+   * Used to recover from server persistence latency on reload — when the
+   * client loads /messages immediately after a streaming `done` event the
+   * JSONL may still be catching up, so the first fetch returns the user
+   * messages but not the assistant ones. The mount effect retries with
+   * `force: true` after a short delay to re-hydrate assistants once the
+   * server commits them.
+   */
+  force?: boolean;
+}
+
 export function loadHistory(
   sessionId: string,
   topic?: string,
+  options: LoadHistoryOptions = {},
 ): Promise<void> {
   const key = storeKey(sessionId, topic);
-  if (loadedSessions.has(key)) return Promise.resolve();
+  if (!options.force && loadedSessions.has(key)) return Promise.resolve();
 
   const existing = loadingPromises.get(key);
   if (existing) return existing;


### PR DESCRIPTION
## Summary

Fixes [octos-org/octos#633](https://github.com/octos-org/octos/issues/633) (parent: [octos-org/octos#627](https://github.com/octos-org/octos/issues/627)).

Under the v2 flag (`localStorage.octos_thread_store_v2 = '1'`), reloading a session with prior chat history rendered an empty chat. The flat-list path called `MessageStore.loadHistory(...)` from `runtime-provider.tsx`'s mount effect, but ChatThreadV2 had no equivalent — so the new thread store stayed empty after refresh, and `useThreads(...)` returned `[]`.

This PR wires `ThreadStore.loadHistory` on the v2 mount path and adds a small retry to handle the JSONL persistence latency observed on all four production minis (the SSE `done` event fires before the server commits the assistant message, so an immediate reload's first `/api/sessions/:id/messages` fetch returns only the user records).

## Changes

- `src/components/chat-thread.tsx` — ChatThreadV2 mount effect calls `ThreadStore.loadHistory(currentSessionId, historyTopic)` and re-fetches with `force: true` at 2 s / 5 s / 12 s to absorb the server's commit lag.
- `src/store/thread-store.ts` — `loadHistory` accepts `LoadHistoryOptions { force?: boolean }` so the retry can bypass the `loadedSessions` cache. The existing `replayHistory` already groups by `thread_id` with `deriveLegacyThreadId` synthesizer fallback for legacy records — both paths reused as-is.
- `src/store/thread-store.test.ts` — two new tests: `loadHistory_replays_into_threads_grouped_by_thread_id` (4-msg fixture, 2 threads, every record carries `thread_id`) and `loadHistory_synthesizes_threads_for_legacy_records_without_thread_id` (records missing `thread_id`, role-flip synthesizer kicks in). Both stub `globalThis.fetch`.

## Test plan

- [x] `npm run test:unit` — 17 / 17 green (15 prior + 2 new).
- [x] `npx tsc -b` — clean.
- [x] `npx vite build` — clean.
- [x] e2e on mini3: `OCTOS_TEST_URL=https://dspfac.octos.ominix.io OCTOS_AUTH_TOKEN=octos-admin-2026 npx playwright test live-thread-persistence.spec.ts --workers=1 --reporter=list` — passing twice in a row (`before reload: user,user,assistant,assistant` / `after reload: user,user,assistant,assistant`).