### PR TITLE
fix: route SSE events by thread_id in v2 store + emit data-thread-id (#649 frontend)

### DIFF
--- a/src/components/chat-thread.tsx
+++ b/src/components/chat-thread.tsx
@@ -563,8 +563,10 @@ function threadMessageVisibleText(message: ThreadMessage): string {
 
 const ThreadUserBubble = memo(function ThreadUserBubble({
   message,
+  threadId,
 }: {
   message: ThreadMessage;
+  threadId: string;
 }) {
   const visibleText = threadMessageVisibleText(message);
   return (
@@ -573,6 +575,7 @@ const ThreadUserBubble = memo(function ThreadUserBubble({
         {visibleText && (
           <div
             data-testid="user-message"
+            data-thread-id={threadId}
             className="message-card message-card-user rounded-[14px] rounded-br-[4px] px-4 py-2.5 text-sm leading-relaxed text-text"
           >
             {visibleText}
@@ -593,7 +596,13 @@ const ThreadUserBubble = memo(function ThreadUserBubble({
   );
 });
 
-function ToolCallBubble({ toolCall }: { toolCall: ThreadToolCall }) {
+function ToolCallBubble({
+  toolCall,
+  threadId,
+}: {
+  toolCall: ThreadToolCall;
+  threadId: string;
+}) {
   const retryBadge =
     toolCall.retryCount >= 1 ? (
       <span
@@ -609,6 +618,7 @@ function ToolCallBubble({ toolCall }: { toolCall: ThreadToolCall }) {
   return (
     <div
       data-testid="tool-call-bubble"
+      data-thread-id={threadId}
       data-tool-call-id={toolCall.id}
       data-tool-call-retry-count={toolCall.retryCount}
       className={`flex flex-col gap-1 rounded-[10px] px-2.5 py-1 text-[10px] font-mono ${
@@ -626,6 +636,7 @@ function ToolCallBubble({ toolCall }: { toolCall: ThreadToolCall }) {
       {toolCall.progress.length > 0 && (
         <ul
           data-testid="tool-call-runtime-timeline"
+          data-thread-id={threadId}
           className="m-0 mt-1 flex list-none flex-col gap-0.5 border-l border-current/20 pl-2"
         >
           {toolCall.progress.map((entry, idx) => (
@@ -646,16 +657,22 @@ const ThreadAssistantBubble = memo(function ThreadAssistantBubble({
   message,
   isStreaming,
   showLiveIndicators,
+  threadId,
 }: {
   message: ThreadMessage;
   isStreaming: boolean;
   showLiveIndicators: boolean;
+  threadId: string;
 }) {
+  // Prefer the explicit thread.id passed by the renderer over the
+  // message's own backref so a finalized assistant whose origin tid
+  // got rewritten still tags its DOM with the canonical thread bucket.
+  const tid = threadId || message.responseToClientMessageId || "";
   return (
     <div className="flex px-4 py-3">
       <div
         data-testid="assistant-message"
-        data-thread-id={message.responseToClientMessageId ?? ""}
+        data-thread-id={tid}
         className="message-card message-card-assistant animate-shell-rise max-w-[88%] rounded-[14px] rounded-bl-[4px] px-4 py-3 text-sm leading-relaxed text-text"
       >
         {message.text ? (
@@ -684,7 +701,7 @@ const ThreadAssistantBubble = memo(function ThreadAssistantBubble({
         {message.toolCalls.length > 0 && (
           <div className="mt-2 flex flex-col gap-1.5">
             {message.toolCalls.map((tc) => (
-              <ToolCallBubble key={tc.id} toolCall={tc} />
+              <ToolCallBubble key={tc.id} toolCall={tc} threadId={tid} />
             ))}
           </div>
         )}
@@ -765,13 +782,14 @@ function ThreadView({
   );
   return (
     <div data-testid="chat-thread-bundle" data-thread-id={thread.id}>
-      <ThreadUserBubble message={thread.userMsg} />
+      <ThreadUserBubble message={thread.userMsg} threadId={thread.id} />
       {visibleResponses.map((response) => (
         <ThreadAssistantBubble
           key={response.id}
           message={response}
           isStreaming={false}
           showLiveIndicators={false}
+          threadId={thread.id}
         />
       ))}
       {thread.pendingAssistant && (
@@ -780,6 +798,7 @@ function ThreadView({
           message={thread.pendingAssistant}
           isStreaming={thread.pendingAssistant.status === "streaming"}
           showLiveIndicators={thread.pendingAssistant.status === "streaming"}
+          threadId={thread.id}
         />
       )}
     </div>

--- a/src/runtime/sse-bridge.ts
+++ b/src/runtime/sse-bridge.ts
@@ -35,6 +35,82 @@ function isThreadStoreEnabled(): boolean {
 }
 
 // ---------------------------------------------------------------------------
+// Session-scoped tool-call key map (M8.10 follow-up #649).
+//
+// Background tasks (spawn_only tools) start a tool_call inside one stream
+// and finalize via tool_progress / tool_end / file events that may arrive
+// **after** the originating stream closed — possibly minutes later, on a
+// different SSE connection bound to a newer user turn. The earlier per-
+// stream `keyByServerId` map evaporated when its closure went out of
+// scope, so the late event lost its server-id → local-key mapping and
+// fell through to `activeToolByName` lookups inside the *new* stream
+// closure, mis-binding the result to the latest user bubble.
+//
+// Hoisting the map to a module-level, per-session container keeps the
+// mapping live for the lifetime of the session so late events still find
+// their bubble. Cleared explicitly only when a session is closed (no need
+// to GC: real sessions hold ≤ a few hundred tool calls and the entries
+// are tiny strings).
+// ---------------------------------------------------------------------------
+
+/** Per-session map: server-issued tool_call_id (or tool_id) → local key. */
+const sessionKeyByServerId = new Map<string, Map<string, string>>();
+/** Per-session map: local key → tool call snapshot (id, name, status, progress). */
+interface ToolCallSnapshot {
+  id: string;
+  name: string;
+  status: "running" | "complete" | "error";
+  progress: { message: string; ts: number }[];
+}
+const sessionToolCalls = new Map<string, Map<string, ToolCallSnapshot>>();
+
+function sessionScopeKey(sessionId: string, topic?: string): string {
+  const t = topic?.trim();
+  return t ? `${sessionId}#${t}` : sessionId;
+}
+
+function getKeyByServerIdMap(scope: string): Map<string, string> {
+  let m = sessionKeyByServerId.get(scope);
+  if (!m) {
+    m = new Map();
+    sessionKeyByServerId.set(scope, m);
+  }
+  return m;
+}
+
+function getToolCallsMap(scope: string): Map<string, ToolCallSnapshot> {
+  let m = sessionToolCalls.get(scope);
+  if (!m) {
+    m = new Map();
+    sessionToolCalls.set(scope, m);
+  }
+  return m;
+}
+
+/** Drop the session-scoped tool-call maps. Call when a session is closed
+ *  / reset to free memory. Safe to omit — the maps are tiny. */
+export function clearSessionToolMaps(sessionId: string, topic?: string): void {
+  const t = topic?.trim();
+  if (t) {
+    const scope = sessionScopeKey(sessionId, t);
+    sessionKeyByServerId.delete(scope);
+    sessionToolCalls.delete(scope);
+    return;
+  }
+  // No topic → drop the bare session and any per-topic descendants.
+  for (const k of [...sessionKeyByServerId.keys()]) {
+    if (k === sessionId || k.startsWith(`${sessionId}#`)) {
+      sessionKeyByServerId.delete(k);
+    }
+  }
+  for (const k of [...sessionToolCalls.keys()]) {
+    if (k === sessionId || k.startsWith(`${sessionId}#`)) {
+      sessionToolCalls.delete(k);
+    }
+  }
+}
+
+// ---------------------------------------------------------------------------
 // Helpers (shared with the old adapter, kept local)
 // ---------------------------------------------------------------------------
 
@@ -254,20 +330,28 @@ function bindStreamToAssistant({
   let rawText = "";
   let toolCallCounter = 0;
   const pendingStreamError = { current: null as string | null };
-  const toolCalls = new Map<
-    string,
-    {
-      id: string;
-      name: string;
-      status: "running" | "complete" | "error";
-      progress: { message: string; ts: number }[];
-    }
-  >();
-  /** Maps tool name to the most recent toolCall key (for tool_end matching). */
-  const activeToolByName = new Map<string, string>();
   const normalizedHistoryTopic = historyTopic?.trim() || undefined;
-  /** Maps server-side tool_call_id to the local toolCalls map key. */
-  const keyByServerId = new Map<string, string>();
+  const scope = sessionScopeKey(sessionId, normalizedHistoryTopic);
+  // Session-scoped maps survive across stream closures — necessary for
+  // spawn_only / background tasks whose tool_progress / tool_end / file
+  // events can arrive minutes after the originating stream ended (#649).
+  const toolCalls = getToolCallsMap(scope);
+  const keyByServerId = getKeyByServerIdMap(scope);
+  /** Per-stream snapshot of just the tool calls started in THIS stream.
+   *  Drives the legacy MessageStore assistant-bubble rendering (which
+   *  expects per-message tool calls, not per-session). The v2 ThreadStore
+   *  path uses the session-scoped `toolCalls` above instead. */
+  const streamLocalToolCallKeys = new Set<string>();
+  /** Maps tool name to the most recent toolCall key (for tool_end matching).
+   *  Per-stream by design: this is only used as a *fallback* for legacy
+   *  daemons that omit tool_call_id. Cross-stream tool name collisions
+   *  would mis-route, so we keep this scoped to the current stream. */
+  const activeToolByName = new Map<string, string>();
+
+  const streamToolCallsForLegacyView = (): ToolCallSnapshot[] =>
+    Array.from(streamLocalToolCallKeys)
+      .map((k) => toolCalls.get(k))
+      .filter((tc): tc is ToolCallSnapshot => tc !== undefined);
 
   // M8.10 PR #3: snapshot the flag once per stream so toggling mid-stream
   // doesn't tear data across two stores. The bridge mirrors data into the
@@ -275,11 +359,19 @@ function bindStreamToAssistant({
   // until PR #5 flips the default and removes it.
   const threadStoreEnabled = isThreadStoreEnabled();
 
-  /** Resolve the thread_id for an event. Falls back to `clientMessageId`
-   *  (the bound user message for this stream) when the server omitted the
-   *  field — that's the right answer 99% of the time because every send-
-   *  bound stream is rooted at exactly one user cmid. As a final fallback
-   *  use the cross-thread synthesizer in the store. */
+  /** Resolve the thread_id for an event.
+   *
+   * Trust `event.thread_id` whenever it is present — the daemon now stamps
+   * it on every emitted SSE event (octos PRs #664 wire + #673 persisted)
+   * so the client must NOT override it with the active-stream cmid.
+   * Sticky-stream cmid was the M8.10 thread-binding bug: a late
+   * background-task tool_progress arriving on a stream rooted at a
+   * different turn would adopt that newer turn's cmid and the result
+   * would render under the wrong user bubble.
+   *
+   * The clientMessageId fallback only fires when the server omitted the
+   * field (legacy daemons / theoretical edge case — should be never on
+   * the post-#664+#673 wire). The synthesizer is a last resort. */
   const resolveThreadIdForEvent = (
     payloadThreadId: string | undefined,
   ): string | null => {
@@ -334,7 +426,6 @@ function bindStreamToAssistant({
         break;
 
       case "tool_start": {
-        const key = `tc_${++toolCallCounter}`;
         // Prefer the server-issued tool_call_id (then the legacy
         // tool_id) so tool_progress and tool_end can route by id;
         // synthesize an id only when the backend omits both.
@@ -342,19 +433,28 @@ function bindStreamToAssistant({
           event.tool_call_id ||
           event.tool_id ||
           `tc_${event.tool}_${Date.now()}_${Math.random().toString(36).slice(2, 6)}`;
+        // Re-use the local key when we already saw this server id (e.g.
+        // a tool_start replay) so the entry doesn't duplicate. Otherwise
+        // derive a stable key from the server id so cross-stream lookups
+        // resolve consistently.
+        const key =
+          (event.tool_call_id && keyByServerId.get(event.tool_call_id)) ||
+          (event.tool_id && keyByServerId.get(event.tool_id)) ||
+          `tc_${tcId}_${++toolCallCounter}`;
         toolCalls.set(key, {
           id: tcId,
           name: event.tool,
           status: "running",
-          progress: [],
+          progress: toolCalls.get(key)?.progress ?? [],
         });
+        streamLocalToolCallKeys.add(key);
         activeToolByName.set(event.tool, key);
         // Map every server-issued id we know about to this local key so
         // tool_progress / tool_end events can route by either field.
         if (event.tool_call_id) keyByServerId.set(event.tool_call_id, key);
         if (event.tool_id) keyByServerId.set(event.tool_id, key);
         MessageStore.updateMessage(sessionId, assistantMsgId, {
-          toolCalls: Array.from(toolCalls.values()),
+          toolCalls: streamToolCallsForLegacyView(),
         }, historyTopic);
         if (threadStoreEnabled) {
           const tid = resolveThreadIdForEvent(event.thread_id);
@@ -371,14 +471,18 @@ function bindStreamToAssistant({
         const tc = key ? toolCalls.get(key) : undefined;
         if (tc) tc.status = event.success ? "complete" : "error";
         MessageStore.updateMessage(sessionId, assistantMsgId, {
-          toolCalls: Array.from(toolCalls.values()),
+          toolCalls: streamToolCallsForLegacyView(),
         }, historyTopic);
-        if (threadStoreEnabled && tc) {
+        if (threadStoreEnabled) {
           const tid = resolveThreadIdForEvent(event.thread_id);
-          if (tid) {
+          // Use the server-issued id first so a late tool_end on a
+          // different stream still finds the right entry by id, even
+          // if the local snapshot was already finalized away.
+          const targetTcId = event.tool_call_id ?? event.tool_id ?? tc?.id;
+          if (tid && targetTcId) {
             ThreadStore.setToolCallStatus(
               tid,
-              tc.id,
+              targetTcId,
               event.success ? "complete" : "error",
             );
           }
@@ -389,7 +493,10 @@ function bindStreamToAssistant({
       case "tool_progress": {
         // Anchor the entry to its tool call when the backend gave us
         // an id. Otherwise fall back to most-recent-by-name so older
-        // streams still surface something in the right bubble.
+        // streams still surface something in the right bubble. The
+        // session-scoped maps mean late tool_progress events for a
+        // background task whose tool_start fired in an earlier stream
+        // still resolve to the right local entry.
         const key =
           (event.tool_call_id && keyByServerId.get(event.tool_call_id)) ||
           (event.tool_id && keyByServerId.get(event.tool_id)) ||
@@ -398,12 +505,14 @@ function bindStreamToAssistant({
         if (tc) {
           tc.progress.push({ message: event.message, ts: Date.now() });
           MessageStore.updateMessage(sessionId, assistantMsgId, {
-            toolCalls: Array.from(toolCalls.values()),
-          });
+            toolCalls: streamToolCallsForLegacyView(),
+          }, historyTopic);
         }
         if (threadStoreEnabled) {
           const tid = resolveThreadIdForEvent(event.thread_id);
-          const targetTcId = tc?.id ?? event.tool_call_id ?? event.tool_id;
+          // Prefer the server-issued ids first so the entry matches the
+          // tool_start (which writes them into the thread store).
+          const targetTcId = event.tool_call_id ?? event.tool_id ?? tc?.id;
           if (tid && targetTcId) {
             ThreadStore.appendToolProgress(tid, targetTcId, event.message);
           }
@@ -625,7 +734,7 @@ function bindStreamToAssistant({
             sessionId,
             assistantMsgId,
             historyTopic,
-            Array.from(toolCalls.values()).map((toolCall) => toolCall.name),
+            streamToolCallsForLegacyView().map((toolCall) => toolCall.name),
           );
           window.dispatchEvent(
             new CustomEvent("crew:bg_tasks", {

--- a/src/store/thread-store.ts
+++ b/src/store/thread-store.ts
@@ -143,6 +143,98 @@ function synthesizeThreadIdForOrphan(state: SessionState): string | null {
   return null;
 }
 
+/** Lookup a thread by id across every active session. Used by mutators
+ *  that take a thread_id without an explicit session — the cmid is
+ *  globally unique so this is unambiguous. */
+function findThreadById(
+  threadId: string,
+): { state: SessionState; thread: Thread } | null {
+  for (const state of sessionsByKey.values()) {
+    const thread = state.byId.get(threadId);
+    if (thread) return { state, thread };
+  }
+  return null;
+}
+
+/** Pick a "best guess" session to host a brand-new orphan thread bucket
+ *  created in response to a late background event whose user message we
+ *  never saw (page reload, multi-tab, etc.). Picks the session with the
+ *  most-recent thread; falls back to the only-known session. Returns null
+ *  when no sessions are tracked at all. */
+function pickHostSessionForOrphan(): SessionState | null {
+  let best: { state: SessionState; ts: number } | null = null;
+  for (const state of sessionsByKey.values()) {
+    if (state.threads.length === 0) {
+      if (!best) best = { state, ts: 0 };
+      continue;
+    }
+    const lastTs = state.threads[state.threads.length - 1].userMsg.timestamp;
+    if (!best || lastTs > best.ts) best = { state, ts: lastTs };
+  }
+  return best?.state ?? null;
+}
+
+/** Create an orphan thread bucket for a late event whose user message
+ *  was never added to the store (e.g. mid-stream page reload, late
+ *  background tool_progress that arrives after history hydration). The
+ *  user bubble shows as a placeholder so the conversation stays visible
+ *  and the late assistant content lands in the right place. */
+function ensureOrphanThread(threadId: string): {
+  state: SessionState;
+  thread: Thread;
+} | null {
+  const found = findThreadById(threadId);
+  if (found) return found;
+  const host = pickHostSessionForOrphan();
+  if (!host) return null;
+  const placeholderUser: ThreadMessage = {
+    id: nextId(),
+    role: "user",
+    text: "",
+    files: [],
+    toolCalls: [],
+    status: "complete",
+    timestamp: Date.now(),
+    clientMessageId: threadId,
+  };
+  const thread: Thread = {
+    id: threadId,
+    userMsg: placeholderUser,
+    responses: [],
+    pendingAssistant: null,
+  };
+  insertThreadInTimestampOrder(host, thread);
+  recordRuntimeCounter("octos_thread_orphan_created_total", {
+    surface: "thread_store",
+  });
+  return { state: host, thread };
+}
+
+/** Pick the assistant slot to mutate for a late event on this thread.
+ *  Prefer the in-flight `pendingAssistant`; fall back to the most recent
+ *  finalized assistant response so background tool_progress / file
+ *  events that arrive AFTER `done` still land on the right bubble.
+ *  Returns null if neither exists (caller may decide to create a new
+ *  pending). */
+function pickAssistantSlot(thread: Thread): ThreadMessage | null {
+  if (thread.pendingAssistant) return thread.pendingAssistant;
+  for (let i = thread.responses.length - 1; i >= 0; i -= 1) {
+    if (thread.responses[i].role === "assistant") return thread.responses[i];
+  }
+  return null;
+}
+
+/** Get-or-create the in-flight assistant slot for a thread. Used when
+ *  fresh assistant content (token / replace) arrives after the original
+ *  pending was finalized — we open a follow-on pending so the new text
+ *  has somewhere to render. */
+function ensurePendingAssistant(thread: Thread): ThreadMessage {
+  if (!thread.pendingAssistant) {
+    thread.pendingAssistant = makeAssistantPlaceholder(thread.id);
+  }
+  return thread.pendingAssistant;
+}
+
 function makeUserMessage(opts: {
   text: string;
   clientMessageId: string;
@@ -230,17 +322,50 @@ export function addUserMessage(
   });
   const pendingAssistant = makeAssistantPlaceholder(opts.clientMessageId);
 
-  // If a thread already exists with this id (e.g. the user already typed and
-  // it was hydrated from history), don't double-insert. Replace the pending
-  // assistant so the new turn has a fresh in-flight bubble.
+  // If a thread already exists with this id, adopt it instead of
+  // double-inserting. Two flavours:
+  //  • Orphan bucket — created earlier by a late background event whose
+  //    user message hadn't been added yet. Preserve its `responses` and
+  //    in-flight `pendingAssistant` (codex review #2: replacing them
+  //    with an empty placeholder would discard runtime progress).
+  //  • Hydrated history thread — `responses` is already populated and
+  //    `pendingAssistant` is null. Open a fresh pending for the new turn.
   const existing = state.byId.get(opts.clientMessageId);
   if (existing) {
     existing.userMsg = userMsg;
-    existing.pendingAssistant = pendingAssistant;
+    if (!existing.pendingAssistant) {
+      existing.pendingAssistant = pendingAssistant;
+    }
     notify();
     return {
       threadId: opts.clientMessageId,
-      pendingAssistantId: pendingAssistant.id,
+      pendingAssistantId: existing.pendingAssistant.id,
+    };
+  }
+
+  // Adopt any orphan thread bucket that was created earlier (a late
+  // background event arrived ahead of the user message) — even if it
+  // landed in a different session's state. Carry over its responses
+  // and in-flight pending so the runtime progress isn't dropped.
+  for (const otherState of sessionsByKey.values()) {
+    if (otherState === state) continue;
+    const orphan = otherState.byId.get(opts.clientMessageId);
+    if (!orphan) continue;
+    const adopted: Thread = {
+      id: opts.clientMessageId,
+      userMsg,
+      responses: orphan.responses,
+      pendingAssistant: orphan.pendingAssistant ?? pendingAssistant,
+    };
+    // Detach from the wrong session.
+    otherState.byId.delete(opts.clientMessageId);
+    const idx = otherState.threads.indexOf(orphan);
+    if (idx !== -1) otherState.threads.splice(idx, 1);
+    insertThreadInTimestampOrder(state, adopted);
+    notify();
+    return {
+      threadId: adopted.id,
+      pendingAssistantId: adopted.pendingAssistant!.id,
     };
   }
 
@@ -259,23 +384,21 @@ export function addUserMessage(
 }
 
 export function appendAssistantToken(threadId: string, token: string): void {
-  for (const state of sessionsByKey.values()) {
-    const thread = state.byId.get(threadId);
-    if (!thread || !thread.pendingAssistant) continue;
-    thread.pendingAssistant.text += token;
-    notify();
-    return;
-  }
+  const found = ensureOrphanThread(threadId);
+  if (!found) return;
+  // New text means a new turn — open a fresh pending slot if the old one
+  // was already finalized (background follow-up message).
+  const slot = ensurePendingAssistant(found.thread);
+  slot.text += token;
+  notify();
 }
 
 export function replaceAssistantText(threadId: string, text: string): void {
-  for (const state of sessionsByKey.values()) {
-    const thread = state.byId.get(threadId);
-    if (!thread || !thread.pendingAssistant) continue;
-    thread.pendingAssistant.text = text;
-    notify();
-    return;
-  }
+  const found = ensureOrphanThread(threadId);
+  if (!found) return;
+  const slot = ensurePendingAssistant(found.thread);
+  slot.text = text;
+  notify();
 }
 
 /**
@@ -292,44 +415,70 @@ export function addToolCall(
   toolCallId: string,
   name: string,
 ): void {
-  for (const state of sessionsByKey.values()) {
-    const thread = state.byId.get(threadId);
-    if (!thread || !thread.pendingAssistant) continue;
-
-    const tcs = thread.pendingAssistant.toolCalls;
-    // Already known by id → idempotent (re-issued tool_start, replay).
-    const byId = tcs.findIndex((tc) => tc.id === toolCallId);
-    if (byId !== -1) {
-      tcs[byId] = { ...tcs[byId], status: "running" };
-      notify();
-      return;
-    }
-
-    // Collapse retry: most recent call has same name → bump retryCount.
-    const last = tcs[tcs.length - 1];
-    if (last && last.name === name) {
-      tcs[tcs.length - 1] = {
-        ...last,
-        id: toolCallId,
+  const found = ensureOrphanThread(threadId);
+  if (!found) return;
+  // Prefer an existing assistant slot — the in-flight pending or the
+  // most recent finalized response. Late/replayed tool_start events
+  // arriving after finalize attach to the existing finalized response
+  // rather than spawning a phantom streaming bubble that never gets a
+  // `done` (codex review #1).
+  let slot = pickAssistantSlot(found.thread);
+  // Idempotency: if the tool_call_id is already attached to ANY
+  // assistant slot in this thread, just update its status. Avoids
+  // double-renders when a tool_start replays.
+  for (const candidate of [
+    found.thread.pendingAssistant,
+    ...[...found.thread.responses].reverse(),
+  ]) {
+    if (!candidate) continue;
+    const idx = candidate.toolCalls.findIndex((tc) => tc.id === toolCallId);
+    if (idx !== -1) {
+      candidate.toolCalls[idx] = {
+        ...candidate.toolCalls[idx],
         status: "running",
-        retryCount: last.retryCount + 1,
-        // Carry forward progress so the user keeps the running narration.
-        progress: last.progress,
       };
       notify();
       return;
     }
+  }
+  // No assistant ever existed on this thread (orphan with no responses
+  // at all) → bootstrap a pending so the tool has somewhere to render.
+  if (!slot) {
+    slot = ensurePendingAssistant(found.thread);
+  }
 
-    tcs.push({
-      id: toolCallId,
-      name,
-      status: "running",
-      progress: [],
-      retryCount: 0,
-    });
+  const tcs = slot.toolCalls;
+  // Already known by id → idempotent (re-issued tool_start, replay).
+  const byId = tcs.findIndex((tc) => tc.id === toolCallId);
+  if (byId !== -1) {
+    tcs[byId] = { ...tcs[byId], status: "running" };
     notify();
     return;
   }
+
+  // Collapse retry: most recent call has same name → bump retryCount.
+  const last = tcs[tcs.length - 1];
+  if (last && last.name === name) {
+    tcs[tcs.length - 1] = {
+      ...last,
+      id: toolCallId,
+      status: "running",
+      retryCount: last.retryCount + 1,
+      // Carry forward progress so the user keeps the running narration.
+      progress: last.progress,
+    };
+    notify();
+    return;
+  }
+
+  tcs.push({
+    id: toolCallId,
+    name,
+    status: "running",
+    progress: [],
+    retryCount: 0,
+  });
+  notify();
 }
 
 export function appendToolProgress(
@@ -337,28 +486,32 @@ export function appendToolProgress(
   toolCallId: string,
   message: string,
 ): void {
-  for (const state of sessionsByKey.values()) {
-    const thread = state.byId.get(threadId);
-    if (!thread || !thread.pendingAssistant) continue;
+  const found = ensureOrphanThread(threadId);
+  if (!found) return;
+  // Prefer the in-flight pending; fall back to the most recent finalized
+  // assistant so a late spawn_only tool_progress (#649) still updates
+  // the bubble even after `done` finalized the turn.
+  const slot = pickAssistantSlot(found.thread);
+  // No assistant slot at all yet (e.g. orphan thread, never had one) —
+  // open a new pending so the progress has somewhere to render.
+  const target = slot ?? ensurePendingAssistant(found.thread);
 
-    const tcs = thread.pendingAssistant.toolCalls;
-    let target = tcs.find((tc) => tc.id === toolCallId);
-    if (!target) {
-      // Late-arriving progress for a tool whose start we missed (e.g. SSE
-      // resumed mid-stream). Create a stub call so the progress isn't lost.
-      target = {
-        id: toolCallId,
-        name: "",
-        status: "running",
-        progress: [],
-        retryCount: 0,
-      };
-      tcs.push(target);
-    }
-    target.progress.push({ message, ts: Date.now() });
-    notify();
-    return;
+  const tcs = target.toolCalls;
+  let entry = tcs.find((tc) => tc.id === toolCallId);
+  if (!entry) {
+    // Late-arriving progress for a tool whose start we missed (e.g. SSE
+    // resumed mid-stream). Create a stub call so the progress isn't lost.
+    entry = {
+      id: toolCallId,
+      name: "",
+      status: "running",
+      progress: [],
+      retryCount: 0,
+    };
+    tcs.push(entry);
   }
+  entry.progress.push({ message, ts: Date.now() });
+  notify();
 }
 
 export function setToolCallStatus(
@@ -366,36 +519,32 @@ export function setToolCallStatus(
   toolCallId: string,
   status: ThreadToolCall["status"],
 ): void {
-  for (const state of sessionsByKey.values()) {
-    const thread = state.byId.get(threadId);
-    if (!thread || !thread.pendingAssistant) continue;
-
-    const tcs = thread.pendingAssistant.toolCalls;
-    const idx = tcs.findIndex((tc) => tc.id === toolCallId);
-    if (idx === -1) return;
-    tcs[idx] = { ...tcs[idx], status };
-    notify();
-    return;
-  }
+  const found = ensureOrphanThread(threadId);
+  if (!found) return;
+  const slot = pickAssistantSlot(found.thread);
+  if (!slot) return;
+  const tcs = slot.toolCalls;
+  const idx = tcs.findIndex((tc) => tc.id === toolCallId);
+  if (idx === -1) return;
+  tcs[idx] = { ...tcs[idx], status };
+  notify();
 }
 
-/** Append a delivered file to the current pending assistant in the thread. */
+/** Append a delivered file to the assistant slot in the thread (pending
+ *  in-flight, or the most recent finalized response if the turn has
+ *  already ended — the late-arrival case for spawn_only background
+ *  tasks). */
 export function appendAssistantFile(
   threadId: string,
   file: MessageFile,
 ): boolean {
-  for (const state of sessionsByKey.values()) {
-    const thread = state.byId.get(threadId);
-    if (!thread || !thread.pendingAssistant) continue;
-    if (thread.pendingAssistant.files.some((f) => f.path === file.path)) return true;
-    thread.pendingAssistant.files = [
-      ...thread.pendingAssistant.files,
-      file,
-    ];
-    notify();
-    return true;
-  }
-  return false;
+  const found = ensureOrphanThread(threadId);
+  if (!found) return false;
+  const slot = pickAssistantSlot(found.thread) ?? ensurePendingAssistant(found.thread);
+  if (slot.files.some((f) => f.path === file.path)) return true;
+  slot.files = [...slot.files, file];
+  notify();
+  return true;
 }
 
 export interface FinalizeAssistantOptions {
@@ -521,6 +670,17 @@ export function replayHistory(
   topic?: string,
 ): void {
   const key = storeKey(sessionId, topic);
+  // Carry over any in-flight pending assistants from the previous state
+  // so a replay triggered by retry-fetch (or by a tab regaining focus)
+  // doesn't wipe runtime progress that hasn't been persisted yet.
+  // Codex review #2.
+  const previous = sessionsByKey.get(key);
+  const carryPending = new Map<string, ThreadMessage>();
+  if (previous) {
+    for (const t of previous.threads) {
+      if (t.pendingAssistant) carryPending.set(t.id, t.pendingAssistant);
+    }
+  }
   const state = { threads: [] as Thread[], byId: new Map<string, Thread>() };
 
   const ctx = { currentThreadId: null as string | null };
@@ -540,7 +700,7 @@ export function replayHistory(
           id: threadId,
           userMsg,
           responses: [],
-          pendingAssistant: null,
+          pendingAssistant: carryPending.get(threadId) ?? null,
         };
         state.byId.set(threadId, thread);
         state.threads.push(thread);
@@ -566,13 +726,34 @@ export function replayHistory(
         id: threadId,
         userMsg: placeholderUser,
         responses: [],
-        pendingAssistant: null,
+        pendingAssistant: carryPending.get(threadId) ?? null,
       };
       state.byId.set(threadId, thread);
       state.threads.push(thread);
     }
 
     thread.responses.push(buildResponseFromApi(apiMessage));
+  }
+
+  // Re-attach any in-flight pendings that didn't surface in the API
+  // response yet (e.g. a fresh background turn whose user message lives
+  // only in the live store). They show up as user-rooted threads carried
+  // forward verbatim.
+  for (const [tid, pending] of carryPending) {
+    if (state.byId.has(tid)) continue;
+    if (previous) {
+      const prevThread = previous.byId.get(tid);
+      if (prevThread) {
+        const carried: Thread = {
+          id: tid,
+          userMsg: prevThread.userMsg,
+          responses: prevThread.responses,
+          pendingAssistant: pending,
+        };
+        state.byId.set(tid, carried);
+        state.threads.push(carried);
+      }
+    }
   }
 
   // Sort threads by user-msg timestamp; sort responses within each thread by


### PR DESCRIPTION
## Summary

Frontend half of M8.10 thread-binding fix #649. Server PRs `octos-org/octos#664` (wire) and `octos-org/octos#673` (persisted) stamp `thread_id` on every SSE event; this PR makes the React thread-store v2 renderer honor that field instead of falling back to active-stream sticky cmid for routing.

Reference: `octos-org/octos#649`.

- `sse-bridge.ts`: session-scoped `keyByServerId` + tool-call map so late `tool_progress` / `tool_end` / `file` events for spawn_only background tasks find their bubble across stream closures. `streamLocalToolCallKeys` keeps the legacy v1 view per-stream.
- `thread-store.ts`: mutators no longer drop events when `pendingAssistant` is null — they attach to the last finalized assistant via `pickAssistantSlot`. `addToolCall` does **not** create a phantom pending after finalize. Orphan thread buckets are created when a late event predates its user message; `addUserMessage` and `replayHistory` preserve in-flight pending state instead of wiping it.
- `chat-thread.tsx` (ChatThreadV2 only): `data-thread-id` on user bubble, tool-call bubble, runtime-timeline. `ThreadAssistantBubble` reads thread id from the parent `ThreadView` instead of `message.responseToClientMessageId` so finalized assistants whose origin field was synthesized still tag the canonical thread.

## Test plan

- [x] `npm run build` succeeds; `data-thread-id` appears 5x in the production bundle.
- [x] `npx tsc --noEmit -p tsconfig.app.json` clean.
- [x] `vitest run` → 17/17 thread-store tests pass.
- [x] Codex 2nd-opinion: APPROVED-TO-SHIP after fixing the two bugs it flagged (phantom pending after finalize, orphan pending replacement).
- [ ] Live e2e against `dspfac.octos.ominix.io` (mini3): `octos-org/octos` `e2e/tests/live-overflow-thread-binding.spec.ts` and `live-overflow-stress.spec.ts` should turn GREEN.