### PR TITLE
fix(frontend): mirror task_status into per-tool-call runtime timeline

### DIFF
--- a/src/runtime/runtime-provider.tsx
+++ b/src/runtime/runtime-provider.tsx
@@ -13,12 +13,81 @@ import { resumeSessionStream } from "./sse-bridge";
 import * as FileStore from "@/store/file-store";
 import * as MessageStore from "@/store/message-store";
 import * as TaskStore from "@/store/task-store";
+import * as ThreadStore from "@/store/thread-store";
 import { getSessionStatus } from "@/api/sessions";
 import type { BackgroundTaskInfo } from "@/api/types";
 import { restoreWatchedSessions, unwatchSession, watchSession } from "./task-watcher";
 import { eventSessionId, eventTopic } from "./event-scope";
 /** Max sessions kept in memory simultaneously. */
 const MAX_CACHED = 5;
+
+/** Last task_status seen per `task.id`. Used to suppress synthesizing a
+ *  duplicate progress line on replays/oscillations — only emit a line
+ *  when the status actually changes for that task. Per-task scoping
+ *  also means two unrelated tasks sharing one `tool_call_id` (rare but
+ *  possible across reconnects) each contribute exactly one entry per
+ *  transition rather than collapsing into the previous task's line.
+ */
+const lastTaskStatusById = new Map<string, BackgroundTaskInfo["status"]>();
+
+/** Cap individual task labels and error suffixes so a pathological
+ *  payload cannot bloat the in-bubble timeline. The bubble renders
+ *  monospace at small text sizes — long single-line failures are
+ *  unreadable. */
+const MAX_TASK_LABEL_CHARS = 64;
+const MAX_PROGRESS_LINE_CHARS = 320;
+
+function clip(text: string, max: number): string {
+  if (text.length <= max) return text;
+  return `${text.slice(0, Math.max(0, max - 1))}…`;
+}
+
+/** Display-form a snake_case tool name. Mirrors the simplification in
+ *  `session-task-dock.tsx`'s `taskDisplayName` so the same task surfaces
+ *  with the same label everywhere ("deep_research" → "deep research").
+ *  Capped to a reasonable width. */
+function displayTaskName(tool: string): string {
+  const stripped = (tool || "task").replace(/_/g, " ").trim();
+  return clip(stripped || "task", MAX_TASK_LABEL_CHARS);
+}
+
+/** Build a human-readable progress line for a task_status transition.
+ *  Returns null when the status carries no useful narration (e.g. the
+ *  daemon emitted an unknown status string), or when this exact status
+ *  was already seen for this task and a duplicate line should be
+ *  suppressed at the source. */
+function synthesizeTaskProgressLine(
+  task: BackgroundTaskInfo,
+): string | null {
+  const previous = lastTaskStatusById.get(task.id);
+  if (previous === task.status) return null;
+  // Record the new status BEFORE returning the line so re-entrant
+  // dispatches (within the same tick) can short-circuit on the second
+  // call. Failures still record so a `failed -> failed` replay is
+  // suppressed too.
+  lastTaskStatusById.set(task.id, task.status);
+
+  const label = displayTaskName(task.tool_name);
+  switch (task.status) {
+    case "spawned":
+      return clip(`${label} started`, MAX_PROGRESS_LINE_CHARS);
+    case "running":
+      return clip(`${label} running`, MAX_PROGRESS_LINE_CHARS);
+    case "completed":
+      return clip(`${label} completed`, MAX_PROGRESS_LINE_CHARS);
+    case "failed": {
+      // Single-line normalize the error: collapse newlines/whitespace
+      // so the bubble doesn't line-break inside a tiny mono pill.
+      const detail = task.error
+        ? task.error.replace(/\s+/g, " ").trim()
+        : "";
+      const line = detail ? `${label} failed: ${detail}` : `${label} failed`;
+      return clip(line, MAX_PROGRESS_LINE_CHARS);
+    }
+    default:
+      return null;
+  }
+}
 
 /** Tracks which sessions have been mounted so we can evict old ones. */
 function RuntimeWithSession({ children }: { children: ReactNode }) {
@@ -128,6 +197,45 @@ function RuntimeWithSession({ children }: { children: ReactNode }) {
       if (task) {
         TaskStore.mergeTask(sessionId, task, topic);
         MessageStore.bindBackgroundTask(sessionId, task, topic);
+        // Mirror the status as a synthetic progress line into the
+        // tool-call's runtime timeline. Background subagents (e.g.
+        // deep_research / run_pipeline) emit their per-step
+        // `tool_progress` SSE events on the spawned task's own stream,
+        // not the parent chat stream — without this mirror the
+        // tool-call bubble in the parent thread renders empty even
+        // when the task is actively running. Only synthesize a line
+        // when the bubble has a stable id to anchor against; the
+        // helper de-duplicates consecutive identical entries so we
+        // tolerate task_status replays without doubling the timeline.
+        const progressLine = synthesizeTaskProgressLine(task);
+        if (progressLine && task.tool_call_id) {
+          MessageStore.appendToolProgressByCallId(
+            sessionId,
+            task.tool_call_id,
+            progressLine,
+            topic,
+          );
+          // Mirror into the v2 thread store when it already knows
+          // about this tool_call_id (i.e. tool_start arrived before
+          // task_status). When the lookup misses we deliberately drop
+          // the synthetic progress for v2 rather than synthesize an
+          // orphan thread — the v1 path is still authoritative until
+          // the v2 flag is flipped, and creating phantom threads for
+          // every backgrounded task on first paint would race with
+          // the real tool_start that arrives moments later.
+          const threadId = ThreadStore.findThreadIdForToolCall(
+            sessionId,
+            topic,
+            task.tool_call_id,
+          );
+          if (threadId) {
+            ThreadStore.appendToolProgress(
+              threadId,
+              task.tool_call_id,
+              progressLine,
+            );
+          }
+        }
         const hasActiveTasks = TaskStore.getTasks(sessionId, topic).some(
           (candidate) =>
             candidate.status === "spawned" || candidate.status === "running",

--- a/src/store/message-store.ts
+++ b/src/store/message-store.ts
@@ -288,7 +288,18 @@ function upsertToolCall(
   const existingById = message.toolCalls.findIndex((tc) => tc.id === toolCall.id);
   if (existingById !== -1) {
     const nextToolCalls = [...message.toolCalls];
-    nextToolCalls[existingById] = { ...nextToolCalls[existingById], ...toolCall };
+    const existing = nextToolCalls[existingById];
+    // Preserve the accumulated runtime progress timeline when the
+    // upsert delivers an empty `progress` (e.g. `bindBackgroundTask`
+    // rebinding a status update). Wiping it would erase the in-bubble
+    // timeline every time a `task_status` event lands.
+    const mergedProgress =
+      toolCall.progress.length > 0 ? toolCall.progress : existing.progress;
+    nextToolCalls[existingById] = {
+      ...existing,
+      ...toolCall,
+      progress: mergedProgress,
+    };
     return { ...message, toolCalls: nextToolCalls };
   }
 
@@ -921,6 +932,79 @@ export function bindBackgroundTask(
   messagesByKey.set(key, [...list]);
   notify();
   return list[targetIndex].id;
+}
+
+/** Maximum runtime progress entries kept per tool call. Old entries are
+ *  evicted FIFO so a long-running pipeline that emits hundreds of
+ *  `tool_progress` events (or replayed `task_status` mirrors) cannot
+ *  blow up the per-bubble timeline render cost or grow memory without
+ *  bound. */
+const MAX_TOOL_PROGRESS_ENTRIES = 100;
+
+/**
+ * Append a runtime progress entry to the tool call identified by
+ * `toolCallId` inside the assistant message that owns it. Returns true
+ * when the routing target was found and the entry was either appended
+ * or skipped because it was an exact-duplicate of the previous line.
+ * Returns false when no matching tool call could be located (e.g. the
+ * call is owned by a different session, or has not yet been registered
+ * in this store).
+ *
+ * Used by the task-watcher pathway: when the daemon emits a
+ * `task_status` SSE event for a backgrounded subagent (e.g.
+ * deep_research / run_pipeline), the SSE chat stream does NOT relay the
+ * subagent's per-step `tool_progress` events back to the parent chat
+ * stream. Instead, the per-session `events/stream` carries `task_status`
+ * transitions. This helper lets the runtime provider synthesize a
+ * progress line ("running", "completed", "failed: …") from each
+ * task_status transition so the per-tool-call runtime timeline still
+ * renders inside the bubble owning that tool_call_id.
+ */
+export function appendToolProgressByCallId(
+  sessionId: string,
+  toolCallId: string | undefined,
+  message: string,
+  topic?: string,
+): boolean {
+  if (!toolCallId || !message) return false;
+
+  const key = storeKey(sessionId, topic);
+  const list = messagesByKey.get(key);
+  if (!list) return false;
+
+  const mappedMessageId = toolCallMessageByKey.get(key)?.get(toolCallId);
+  let targetIndex = mappedMessageId
+    ? findMessageIndexById(list, mappedMessageId)
+    : -1;
+  if (targetIndex === -1) {
+    targetIndex = findMessageIndexByToolCallId(list, toolCallId);
+  }
+  if (targetIndex === -1) return false;
+
+  const target = list[targetIndex];
+  const tcIdx = target.toolCalls.findIndex((tc) => tc.id === toolCallId);
+  if (tcIdx === -1) return false;
+
+  const existing = target.toolCalls[tcIdx];
+  // Idempotency guard: skip exact-duplicate consecutive entries so a
+  // task_status replay (e.g. on stream reconnect) doesn't double-render
+  // the same line in the timeline.
+  const lastEntry = existing.progress[existing.progress.length - 1];
+  if (lastEntry && lastEntry.message === message) return true;
+
+  const appended = [...existing.progress, { message, ts: Date.now() }];
+  // Cap the timeline so a long-running pipeline cannot grow the array
+  // without bound; evict oldest entries first.
+  const capped =
+    appended.length > MAX_TOOL_PROGRESS_ENTRIES
+      ? appended.slice(appended.length - MAX_TOOL_PROGRESS_ENTRIES)
+      : appended;
+  const nextToolCalls = [...target.toolCalls];
+  nextToolCalls[tcIdx] = { ...existing, progress: capped };
+  list[targetIndex] = { ...target, toolCalls: nextToolCalls };
+  messagesByKey.set(key, [...list]);
+  notify();
+  return true;
 }
 
 export function appendFileByToolCallId(

--- a/src/store/thread-store.ts
+++ b/src/store/thread-store.ts
@@ -481,11 +481,19 @@ export function addToolCall(
   notify();
 }
 
+/** Maximum runtime progress entries kept per tool call. Old entries are
+ *  evicted FIFO so a long-running pipeline that emits hundreds of
+ *  `tool_progress` events (or replayed `task_status` mirrors) cannot
+ *  blow up the per-bubble timeline render cost or grow memory without
+ *  bound. */
+const MAX_TOOL_PROGRESS_ENTRIES = 100;
+
 export function appendToolProgress(
   threadId: string,
   toolCallId: string,
   message: string,
 ): void {
+  if (!message) return;
   const found = ensureOrphanThread(threadId);
   if (!found) return;
   // Prefer the in-flight pending; fall back to the most recent finalized
@@ -510,7 +518,21 @@ export function appendToolProgress(
     };
     tcs.push(entry);
   }
+  // Idempotency guard: skip exact-duplicate consecutive entries so a
+  // task_status replay (e.g. on stream reconnect) doesn't double-render
+  // the same line in the timeline. Mirrors the logic in
+  // `MessageStore.appendToolProgressByCallId`.
+  const lastEntry = entry.progress[entry.progress.length - 1];
+  if (lastEntry && lastEntry.message === message) {
+    return;
+  }
   entry.progress.push({ message, ts: Date.now() });
+  if (entry.progress.length > MAX_TOOL_PROGRESS_ENTRIES) {
+    entry.progress.splice(
+      0,
+      entry.progress.length - MAX_TOOL_PROGRESS_ENTRIES,
+    );
+  }
   notify();
 }
 
@@ -854,6 +876,44 @@ export function useThreads(sessionId: string, topic?: string): Thread[] {
     () => getThreads(sessionId, topic),
     () => getThreads(sessionId, topic),
   );
+}
+
+// ---------------------------------------------------------------------------
+// Tool-call → thread_id reverse lookup
+// ---------------------------------------------------------------------------
+
+/**
+ * Find the thread_id that owns the given `toolCallId` in this session, if
+ * any. Returns null when the tool call has not been registered (yet) or
+ * when the v2 thread store is empty for the session.
+ *
+ * Scans `pendingAssistant` first (in-flight turn) then finalized
+ * `responses` (most-recent-first) so a still-running deep_research bubble
+ * resolves before its post-completion sibling. Used by the runtime
+ * provider to mirror task_status transitions into the corresponding
+ * tool-call's progress timeline (issue #649 follow-up).
+ */
+export function findThreadIdForToolCall(
+  sessionId: string,
+  topic: string | undefined,
+  toolCallId: string,
+): string | null {
+  if (!toolCallId) return null;
+  const key = storeKey(sessionId, topic);
+  const state = sessionsByKey.get(key);
+  if (!state) return null;
+  for (let i = state.threads.length - 1; i >= 0; i -= 1) {
+    const thread = state.threads[i];
+    if (thread.pendingAssistant?.toolCalls.some((tc) => tc.id === toolCallId)) {
+      return thread.id;
+    }
+    for (let j = thread.responses.length - 1; j >= 0; j -= 1) {
+      if (thread.responses[j].toolCalls.some((tc) => tc.id === toolCallId)) {
+        return thread.id;
+      }
+    }
+  }
+  return null;
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- Stack on top of PR #58 (`fix/m9-frontend-thread-binding-649`) — cannot land on `main` until #58 merges.
- `deep_research` / `run_pipeline` spawn the pipeline as a background subagent. The parent chat stream emits one synthetic `tool_start` for `spawn-subagent-0` so the bubble exists, but the subagent's per-step `tool_progress` events ride the spawn child's own SSE stream and never reach the parent. The per-session `events/stream` only carries `task_status` / `session_result` / `replay_complete`, so the bubble's `tool-call-runtime-timeline` renders empty for the entire turn even while the pipeline is actively running.
- Mirror every `task_status` transition into the matching tool call's progress array as a synthetic line ("deep research running" / "completed" / "failed: …"). Lands inside the existing bubble in both the legacy `MessageStore` renderer and the v2 `ThreadStore` renderer (behind the `octos_thread_store_v2` flag), satisfying the strict-anchoring contract enforced by `live-tool-progress.spec.ts` — without touching the backend SSE protocol.

## Hardenings (codex review)
- `upsertToolCall` no longer wipes accumulated progress when `bindBackgroundTask` re-binds with `progress: []`.
- `ThreadStore.appendToolProgress` dedupes consecutive identical entries and caps the timeline at 100 entries (FIFO eviction); `MessageStore.appendToolProgressByCallId` mirrors that behaviour.
- `synthesizeTaskProgressLine` only emits when the status actually transitions for a given `task.id` — replays are suppressed at the source — and clips labels / collapses error whitespace.
- v2 thread routing only mirrors when `findThreadIdForToolCall` resolves the tool call to an existing thread; we deliberately do not synthesize orphan threads.

## Test plan
- [x] `npm run build` (clean, identical bundle pipeline as PR #58)
- [x] Deployed `dist/` to `/Users/cloud/octos-web/` on mini1 (`dspfac.crew.ominix.io`), mini3 (`dspfac.octos.ominix.io`), mini4 (`dspfac.river.ominix.io`)
- [x] `live-tool-progress.spec.ts` passes against all three minis (timelines=1, anchored to the bubble's assistant-message)
- [x] `live-tool-retry-collapse.spec.ts` passes against mini3 with `OCTOS_FORCE_TOOL_RETRY=1` (`retryCount=2`, badge rendered) and gracefully soft-skips on mini1/mini4 when the LLM nails args first try (designed behaviour per issue #636)
- [x] Codex 2nd-opinion review consumed; high/medium findings folded in