### PR TITLE
fix(thread-store, sse-bridge): drop phantom bubbles + per-thread streaming-text accumulator

### DIFF
--- a/src/runtime/sse-bridge.test.ts
+++ b/src/runtime/sse-bridge.test.ts
@@ -1,0 +1,118 @@
+/**
+ * sse-bridge unit tests — overflow-stress regression (#680 follow-up).
+ *
+ * Covers the per-thread text accumulator added to fix the cross-talk
+ * Codex flagged in PR review: pre-fix, the bridge had a single `rawText`
+ * accumulator per stream closure, so concurrent same-chat turns clobbered
+ * each other's text every time `replaceAssistantText(tid, rawText)` fired
+ * with the wrong tid's accumulated content.
+ */
+
+import { afterEach, describe, expect, it } from "vitest";
+import {
+  __getRawTextByThreadMapForTest,
+  __resetSessionStateForTest,
+  applyPerThreadTextEvent,
+} from "./sse-bridge";
+
+afterEach(() => {
+  __resetSessionStateForTest();
+});
+
+describe("applyPerThreadTextEvent", () => {
+  it("appends token to the matching thread only", () => {
+    const acc = new Map<string, string>();
+    expect(applyPerThreadTextEvent(acc, "cmid-A", "token", "Hello")).toBe(
+      "Hello",
+    );
+    expect(applyPerThreadTextEvent(acc, "cmid-B", "token", "Hi")).toBe("Hi");
+    // A's next token must extend A only, not B's text.
+    expect(applyPerThreadTextEvent(acc, "cmid-A", "token", " world")).toBe(
+      "Hello world",
+    );
+    expect(acc.get("cmid-A")).toBe("Hello world");
+    expect(acc.get("cmid-B")).toBe("Hi");
+  });
+
+  it("replace overwrites the matching thread only", () => {
+    const acc = new Map<string, string>();
+    applyPerThreadTextEvent(acc, "cmid-A", "token", "Hello");
+    applyPerThreadTextEvent(acc, "cmid-B", "token", "Hi");
+    // B's `replace` must NOT touch A's accumulator.
+    expect(applyPerThreadTextEvent(acc, "cmid-B", "replace", "Greetings")).toBe(
+      "Greetings",
+    );
+    expect(acc.get("cmid-A")).toBe("Hello");
+    expect(acc.get("cmid-B")).toBe("Greetings");
+  });
+
+  it("interleaved concurrent streams keep their text isolated", () => {
+    // The exact production scenario: two turns on the same chat send
+    // tokens in interleaved order. Each thread's accumulator must only
+    // ever hold its own text.
+    const acc = new Map<string, string>();
+    applyPerThreadTextEvent(acc, "cmid-A", "token", "The answer ");
+    applyPerThreadTextEvent(acc, "cmid-B", "token", "Beijing weather: ");
+    applyPerThreadTextEvent(acc, "cmid-A", "token", "is 2.");
+    applyPerThreadTextEvent(acc, "cmid-B", "token", "20 degrees.");
+    expect(acc.get("cmid-A")).toBe("The answer is 2.");
+    expect(acc.get("cmid-B")).toBe("Beijing weather: 20 degrees.");
+  });
+
+  it("five concurrent threads with prefix-overlapping tokens stay isolated", () => {
+    // The overflow-stress soak: 5 turns whose first chunks all happen to
+    // start with "Reply" — pre-fix the bridge's single `rawText` would
+    // appear to "extend" from each turn into the next. Per-thread
+    // accumulators give each turn its own independent state.
+    const acc = new Map<string, string>();
+    for (let i = 1; i <= 5; i++) {
+      applyPerThreadTextEvent(acc, `cmid-${i}`, "token", "Reply ");
+    }
+    for (let i = 1; i <= 5; i++) {
+      applyPerThreadTextEvent(acc, `cmid-${i}`, "token", `for thread ${i}.`);
+    }
+    for (let i = 1; i <= 5; i++) {
+      expect(acc.get(`cmid-${i}`)).toBe(`Reply for thread ${i}.`);
+    }
+  });
+});
+
+describe("session-scoped rawTextByThread map", () => {
+  // Codex 2nd-opinion follow-up regression: a turn's `replace` arrives
+  // on connection 1, then `token` deltas arrive on connection 2 (page
+  // reload, retry-fetch, multi-tab). The per-thread accumulator MUST
+  // be session-scoped — NOT per-bridge-closure — so the second closure
+  // sees the prefix written by the first and a token ` there` appends
+  // correctly to "Hello" rather than overwriting ThreadStore with just
+  // " there".
+  const SESSION = "sess-X";
+
+  it("accumulator persists across bridge closures via session scope", () => {
+    // Closure 1: replace seeds "Hello" for cmid-A.
+    const c1 = __getRawTextByThreadMapForTest(SESSION);
+    applyPerThreadTextEvent(c1, "cmid-A", "replace", "Hello");
+
+    // Closure 2 (page reload, retry-fetch, etc.) — re-reads the SAME
+    // session-scoped map. The prior accumulated text must still be
+    // there.
+    const c2 = __getRawTextByThreadMapForTest(SESSION);
+    expect(
+      c2.get("cmid-A"),
+      "session-scoped accumulator must survive bridge closure churn",
+    ).toBe("Hello");
+
+    // A `token` delta on the new closure extends correctly.
+    expect(
+      applyPerThreadTextEvent(c2, "cmid-A", "token", " there"),
+    ).toBe("Hello there");
+  });
+
+  it("accumulator is keyed by (session, topic) so concurrent topics stay isolated", () => {
+    const main = __getRawTextByThreadMapForTest(SESSION);
+    const topicA = __getRawTextByThreadMapForTest(SESSION, "topic-A");
+    applyPerThreadTextEvent(main, "cmid-X", "replace", "main");
+    applyPerThreadTextEvent(topicA, "cmid-X", "replace", "topic");
+    expect(main.get("cmid-X")).toBe("main");
+    expect(topicA.get("cmid-X")).toBe("topic");
+  });
+});

--- a/src/runtime/sse-bridge.ts
+++ b/src/runtime/sse-bridge.ts
@@ -53,6 +53,16 @@ function isThreadStoreEnabled(): boolean {
 // are tiny strings).
 // ---------------------------------------------------------------------------
 
+/** Per-session map of per-thread streaming-text accumulators. Keyed by
+ *  the same `sessionScopeKey` as the tool maps so a thread's accumulated
+ *  text survives bridge closure churn (e.g. tab refocus, page reload,
+ *  retry-fetch creating a fresh `bindStreamToAssistant`). Without this
+ *  durability, a `replace` on connection 1 would set `Hello`, the
+ *  bridge would tear down, and a `token` ` there` arriving on connection
+ *  2 would overwrite ThreadStore with just ` there` — the codex 2nd-
+ *  opinion split-connection regression. */
+const sessionRawTextByThread = new Map<string, Map<string, string>>();
+
 /** Per-session map: server-issued tool_call_id (or tool_id) → local key. */
 const sessionKeyByServerId = new Map<string, Map<string, string>>();
 /** Per-session map: local key → tool call snapshot (id, name, status, progress). */
@@ -87,6 +97,15 @@ function getToolCallsMap(scope: string): Map<string, ToolCallSnapshot> {
   return m;
 }
 
+function getRawTextByThreadMap(scope: string): Map<string, string> {
+  let m = sessionRawTextByThread.get(scope);
+  if (!m) {
+    m = new Map();
+    sessionRawTextByThread.set(scope, m);
+  }
+  return m;
+}
+
 /** Drop the session-scoped tool-call maps. Call when a session is closed
  *  / reset to free memory. Safe to omit — the maps are tiny. */
 export function clearSessionToolMaps(sessionId: string, topic?: string): void {
@@ -95,6 +114,7 @@ export function clearSessionToolMaps(sessionId: string, topic?: string): void {
     const scope = sessionScopeKey(sessionId, t);
     sessionKeyByServerId.delete(scope);
     sessionToolCalls.delete(scope);
+    sessionRawTextByThread.delete(scope);
     return;
   }
   // No topic → drop the bare session and any per-topic descendants.
@@ -106,6 +126,11 @@ export function clearSessionToolMaps(sessionId: string, topic?: string): void {
   for (const k of [...sessionToolCalls.keys()]) {
     if (k === sessionId || k.startsWith(`${sessionId}#`)) {
       sessionToolCalls.delete(k);
+    }
+  }
+  for (const k of [...sessionRawTextByThread.keys()]) {
+    if (k === sessionId || k.startsWith(`${sessionId}#`)) {
+      sessionRawTextByThread.delete(k);
     }
   }
 }
@@ -138,6 +163,62 @@ function stripThink(text: string): string {
 
 function clean(text: string): string {
   return stripToolProgress(stripThink(text));
+}
+
+/**
+ * Per-thread streaming-text accumulator.
+ *
+ * Called from the SSE bridge for each `token` / `replace` event the
+ * subscriber observes. Returns the FULL post-event text for that
+ * thread so the caller can route it to ThreadStore.replaceAssistantText
+ * with the right (thread_id, text) pair.
+ *
+ * Pre-fix the bridge accumulated into a single `rawText` variable per
+ * stream closure — when two concurrent turns on the same chat
+ * interleaved, the wrong turn's rawText got passed to ThreadStore. The
+ * overflow-stress mini1 (#680 follow-up) regression. Codex review caught
+ * this in 2nd-opinion.
+ *
+ * Exported for unit testing.
+ */
+export function applyPerThreadTextEvent(
+  acc: Map<string, string>,
+  threadId: string,
+  kind: "token" | "replace",
+  text: string,
+): string {
+  if (kind === "replace") {
+    acc.set(threadId, text);
+    return text;
+  }
+  // kind === "token"
+  const next = (acc.get(threadId) ?? "") + text;
+  acc.set(threadId, next);
+  return next;
+}
+
+/**
+ * Test-only accessor for the session-scoped per-thread streaming-text
+ * accumulator map. Exposed so the regression test for split-connection
+ * persistence (codex 2nd-opinion follow-up) can drive the scope key
+ * directly without reaching through `bindStreamToAssistant` and the
+ * full SSE plumbing.
+ */
+export function __getRawTextByThreadMapForTest(
+  sessionId: string,
+  topic?: string,
+): Map<string, string> {
+  return getRawTextByThreadMap(sessionScopeKey(sessionId, topic));
+}
+
+/**
+ * Test-only reset for the session-scoped maps. Mirrors
+ * `clearSessionToolMaps` plus the per-thread raw text map.
+ */
+export function __resetSessionStateForTest(): void {
+  sessionKeyByServerId.clear();
+  sessionToolCalls.clear();
+  sessionRawTextByThread.clear();
 }
 
 // ---------------------------------------------------------------------------
@@ -327,6 +408,23 @@ function bindStreamToAssistant({
   sentAt: number;
   historyTopic?: string;
 }): void {
+  // Per-thread streaming-text accumulator. Pre-fix this was a single
+  // `rawText` shared across every event the subscriber saw, so when two
+  // concurrent turns on the same chat interleaved their `token` /
+  // `replace` events the wrong turn's text bled into the right turn's
+  // bubble (overflow-stress mini1 #680 follow-up; codex review).
+  // The MessageStore (legacy flat-list) path still uses the legacy
+  // `assistantMsgId` key, so we keep one accumulator for it (the
+  // dominant-turn `rawText`) and one per-thread map for ThreadStore.
+  // The legacy path is gated behind the v2 flag — when v2 is on, the
+  // ThreadStore values are authoritative. When v2 is off, only `rawText`
+  // is consulted (concurrent same-chat overflow is a v2-only invariant).
+  // Codex 2nd-opinion follow-up: the per-thread accumulator must be
+  // session-scoped (NOT per-bridge-closure). A turn whose `replace`
+  // arrives on connection 1 and `token` deltas on connection 2 (page
+  // reload, retry-fetch, multi-tab) needs the prior text to persist —
+  // a fresh closure-local Map would lose the prefix and overwrite the
+  // thread's text with just the suffix.
   let rawText = "";
   let toolCallCounter = 0;
   const pendingStreamError = { current: null as string | null };
@@ -337,6 +435,11 @@ function bindStreamToAssistant({
   // events can arrive minutes after the originating stream ended (#649).
   const toolCalls = getToolCallsMap(scope);
   const keyByServerId = getKeyByServerIdMap(scope);
+  /** Session-scoped per-thread streaming-text accumulator. Survives
+   *  bridge closure churn (page reload, retry-fetch, tab refocus) so
+   *  a turn whose `replace` arrived on a previous connection still
+   *  has its prefix when a `token` delta arrives on a new one. */
+  const rawTextByThread = getRawTextByThreadMap(scope);
   /** Per-stream snapshot of just the tool calls started in THIS stream.
    *  Drives the legacy MessageStore assistant-bubble rendering (which
    *  expects per-message tool calls, not per-session). The v2 ThreadStore
@@ -403,27 +506,57 @@ function bindStreamToAssistant({
     }
 
     switch (event.type) {
-      case "token":
-        rawText += event.text;
-        MessageStore.updateMessage(sessionId, assistantMsgId, {
-          text: clean(rawText),
-        }, historyTopic);
-        if (threadStoreEnabled) {
-          const tid = resolveThreadIdForEvent(event.thread_id);
-          if (tid) ThreadStore.replaceAssistantText(tid, clean(rawText));
+      case "token": {
+        // Resolve the event's thread_id BEFORE mutating the legacy
+        // single `rawText`. Per-thread accumulation via the helper:
+        // only the matching thread's text advances, so concurrent
+        // same-chat turns can never bleed text across each other.
+        const tid = resolveThreadIdForEvent(event.thread_id);
+        if (tid) {
+          const next = applyPerThreadTextEvent(
+            rawTextByThread,
+            tid,
+            "token",
+            event.text,
+          );
+          if (threadStoreEnabled) {
+            ThreadStore.replaceAssistantText(tid, clean(next));
+          }
+        }
+        // Legacy MessageStore path: only advance the per-stream rawText
+        // when this event matches THIS bridge's bound clientMessageId.
+        // Otherwise we would splice another turn's text into this
+        // bubble (the overflow-stress content-mispair signature).
+        if (!clientMessageId || tid === clientMessageId) {
+          rawText += event.text;
+          MessageStore.updateMessage(sessionId, assistantMsgId, {
+            text: clean(rawText),
+          }, historyTopic);
         }
         break;
+      }
 
-      case "replace":
-        rawText = event.text;
-        MessageStore.updateMessage(sessionId, assistantMsgId, {
-          text: clean(rawText),
-        }, historyTopic);
-        if (threadStoreEnabled) {
-          const tid = resolveThreadIdForEvent(event.thread_id);
-          if (tid) ThreadStore.replaceAssistantText(tid, clean(rawText));
+      case "replace": {
+        const tid = resolveThreadIdForEvent(event.thread_id);
+        if (tid) {
+          const next = applyPerThreadTextEvent(
+            rawTextByThread,
+            tid,
+            "replace",
+            event.text,
+          );
+          if (threadStoreEnabled) {
+            ThreadStore.replaceAssistantText(tid, clean(next));
+          }
+        }
+        if (!clientMessageId || tid === clientMessageId) {
+          rawText = event.text;
+          MessageStore.updateMessage(sessionId, assistantMsgId, {
+            text: clean(rawText),
+          }, historyTopic);
         }
         break;
+      }
 
       case "tool_start": {
         // Prefer the server-issued tool_call_id (then the legacy
@@ -657,21 +790,41 @@ function bindStreamToAssistant({
       }
 
       case "done": {
-        if (event.content) {
+        const tid = resolveThreadIdForEvent(event.thread_id);
+        // `ownsLegacy` gates every legacy MessageStore side effect of
+        // `done` — including the bubble status flip, meta annotation,
+        // background-anchor registration, and the `onComplete` callback.
+        // Without this gate, a `done` for sibling thread A would still
+        // mark THIS bridge's bubble (bound to clientMessageId B) as
+        // complete and fire B's onComplete, even though B's own done
+        // hasn't arrived yet. Codex 2nd-opinion review.
+        const ownsLegacy = !clientMessageId || tid === clientMessageId;
+
+        // Use the per-thread accumulator for ThreadStore — never the
+        // legacy chat-wide `rawText` which may hold a sibling turn's
+        // content. The chat-wide `rawText` continues to drive the
+        // legacy MessageStore path, but is only advanced for matching
+        // events (token/replace handlers above).
+        const threadRaw =
+          (tid && rawTextByThread.get(tid)) ||
+          (event.content ?? (ownsLegacy ? rawText : ""));
+        const finalThreadText = clean(threadRaw);
+        if (event.content && ownsLegacy) {
           rawText = event.content;
         }
-        const finalText = clean(rawText);
-        MessageStore.updateMessage(sessionId, assistantMsgId, {
-          text: finalText,
-          status: "complete",
-        }, historyTopic);
+        const finalLegacyText = clean(rawText);
+        if (ownsLegacy) {
+          MessageStore.updateMessage(sessionId, assistantMsgId, {
+            text: finalLegacyText,
+            status: "complete",
+          }, historyTopic);
+        }
 
         if (threadStoreEnabled) {
-          const tid = resolveThreadIdForEvent(event.thread_id);
           if (tid) {
             // Replace text first so the finalized message holds the cleaned
             // final text rather than the raw token stream.
-            ThreadStore.replaceAssistantText(tid, finalText);
+            ThreadStore.replaceAssistantText(tid, finalThreadText);
             ThreadStore.finalizeAssistant(tid, {
               committedSeq: event.committed_seq,
               meta:
@@ -684,10 +837,16 @@ function bindStreamToAssistant({
                     }
                   : undefined,
             });
+            // Drop the per-thread accumulator now that this thread has
+            // finalized — keeps the session map bounded and prevents a
+            // stale prefix from contaminating any future re-bind on the
+            // same cmid (which shouldn't happen by design, but guards
+            // against double-finalize replays).
+            rawTextByThread.delete(tid);
           }
         }
 
-        if (event.model || event.tokens_in || event.tokens_out) {
+        if (ownsLegacy && (event.model || event.tokens_in || event.tokens_out)) {
           MessageStore.setMessageMeta(sessionId, assistantMsgId, {
             model: event.model || "",
             tokens_in: event.tokens_in || 0,
@@ -710,10 +869,15 @@ function bindStreamToAssistant({
           );
         }
 
-        // Detect queue/adaptive mode changes from command responses
-        detectModeUpdate(finalText, sessionId);
+        // Detect queue/adaptive mode changes from command responses.
+        // Use the legacy text — the global mode-update detector is keyed
+        // off whichever turn's done event fires; it's not thread-scoped.
+        if (ownsLegacy) {
+          detectModeUpdate(finalLegacyText, sessionId);
+        }
 
-        // Clear thinking state
+        // Clear thinking state — global per-session, fires on every done
+        // (any turn's completion ends the "thinking" indicator).
         window.dispatchEvent(
           new CustomEvent("crew:thinking", {
             detail: {
@@ -729,7 +893,7 @@ function bindStreamToAssistant({
         // session runtime's incremental sync loop (appendHistoryMessages).
         // We no longer call replaceHistory here — it races with the sync loop
         // and can wipe optimistic messages or create duplicates.
-        if (event.has_bg_tasks) {
+        if (ownsLegacy && event.has_bg_tasks) {
           MessageStore.registerBackgroundAnchor(
             sessionId,
             assistantMsgId,
@@ -743,7 +907,9 @@ function bindStreamToAssistant({
           );
         }
 
-        onComplete?.();
+        if (ownsLegacy) {
+          onComplete?.();
+        }
         break;
       }
 

--- a/src/store/thread-store.test.ts
+++ b/src/store/thread-store.test.ts
@@ -464,4 +464,116 @@ describe("thread-store", () => {
     expect(threads[1].responses).toHaveLength(1);
     expect(threads[1].responses[0].text).toBe("old A2");
   });
+
+  // ---------------------------------------------------------------------------
+  // overflow-stress regression (mini1, post-#680): phantom assistant bubble
+  //
+  // Production failure mode: under tight concurrent windows, the daemon emits
+  // a `token` or `replace` event tagged with thread_id=cmid-X, but cmid-X has
+  // already been finalized (its `done` arrived earlier). Pre-fix, the thread
+  // store called `ensurePendingAssistant` unconditionally — creating a SECOND
+  // assistant slot for an already-finalized thread. The DOM then rendered an
+  // extra bubble (`filled=8/5` on a 5-message scenario) that never paired
+  // with any user prompt.
+  //
+  // The right behaviour: late streaming chunks for an already-finalized
+  // thread are cross-talk artifacts. Drop them and bump a counter rather
+  // than silently spawn a phantom bubble.
+  // ---------------------------------------------------------------------------
+
+  it("appendAssistantToken_does_not_spawn_phantom_after_finalize", () => {
+    makeUser("Q1", "cmid-1");
+    ThreadStore.appendAssistantToken("cmid-1", "Done.");
+    ThreadStore.finalizeAssistant("cmid-1", { committedSeq: 1 });
+
+    // Late cross-talk token arrives for the already-finalized thread.
+    ThreadStore.appendAssistantToken("cmid-1", " stray late chunk");
+
+    const [thread] = ThreadStore.getThreads(SESSION);
+    expect(
+      thread.pendingAssistant,
+      "late token must NOT spawn a phantom pending — that bubble would render as an extra assistant in the DOM",
+    ).toBeNull();
+    expect(thread.responses).toHaveLength(1);
+    expect(thread.responses[0].text).toBe("Done.");
+  });
+
+  it("replaceAssistantText_does_not_spawn_phantom_after_finalize", () => {
+    makeUser("Q1", "cmid-1");
+    ThreadStore.replaceAssistantText("cmid-1", "Final answer.");
+    ThreadStore.finalizeAssistant("cmid-1", { committedSeq: 1 });
+
+    // Late cross-talk replace arrives for the already-finalized thread.
+    ThreadStore.replaceAssistantText("cmid-1", "Stale replace from another stream");
+
+    const [thread] = ThreadStore.getThreads(SESSION);
+    expect(
+      thread.pendingAssistant,
+      "late replace must NOT spawn a phantom pending",
+    ).toBeNull();
+    expect(thread.responses).toHaveLength(1);
+    expect(thread.responses[0].text).toBe("Final answer.");
+  });
+
+  it("late_tool_progress_after_finalize_attaches_to_finalized_response_not_phantom", () => {
+    // spawn_only background flow: tool_start fires during the stream, then
+    // `done` finalizes. tool_progress / file events keep arriving for the
+    // background task minutes later. They must update the finalized
+    // response's tool call entry — never spawn a fresh pending bubble.
+    makeUser("run deep_research", "cmid-1");
+    ThreadStore.addToolCall("cmid-1", "tc-research-1", "deep_research");
+    ThreadStore.replaceAssistantText("cmid-1", "Researching...");
+    ThreadStore.finalizeAssistant("cmid-1", { committedSeq: 5 });
+
+    // Late progress for the spawn_only tool — must attach to the existing
+    // finalized response, not create a phantom pending bubble.
+    ThreadStore.appendToolProgress(
+      "cmid-1",
+      "tc-research-1",
+      "[info] late progress chunk",
+    );
+
+    const [thread] = ThreadStore.getThreads(SESSION);
+    expect(
+      thread.pendingAssistant,
+      "late tool_progress must update the finalized response's tool call, not phantom-spawn",
+    ).toBeNull();
+    expect(thread.responses).toHaveLength(1);
+    const tcs = thread.responses[0].toolCalls;
+    expect(tcs).toHaveLength(1);
+    expect(tcs[0].progress.map((p) => p.message)).toContain(
+      "[info] late progress chunk",
+    );
+  });
+
+  it("five_concurrent_threads_do_not_spawn_phantom_bubbles_under_late_cross_talk", () => {
+    // The exact production scenario: 5 user messages spawn 5 threads;
+    // they finalize independently; then late cross-talk events fire.
+    // The DOM must only show 5 assistant bubbles — never 6+.
+    const cmids = ["cm-1", "cm-2", "cm-3", "cm-4", "cm-5"];
+    for (const cmid of cmids) {
+      makeUser(`Q-${cmid}`, cmid);
+      ThreadStore.replaceAssistantText(cmid, `A-${cmid}`);
+      ThreadStore.finalizeAssistant(cmid, { committedSeq: 1 });
+    }
+
+    // Cross-talk: a stray token tagged with cmid-2 arrives long after
+    // cmid-2 finalized. Pre-fix, this would phantom-spawn an extra
+    // assistant bubble inside cmid-2's thread.
+    ThreadStore.appendAssistantToken("cm-2", " stray late chunk");
+    ThreadStore.replaceAssistantText("cm-4", "Stale replace text");
+
+    const threads = ThreadStore.getThreads(SESSION);
+    // Each thread should have exactly one finalized response and zero
+    // pending assistants — total assistant bubbles in DOM == 5.
+    let totalAssistants = 0;
+    for (const t of threads) {
+      expect(t.pendingAssistant).toBeNull();
+      totalAssistants += t.responses.filter((r) => r.role === "assistant").length;
+    }
+    expect(
+      totalAssistants,
+      "5 user messages must yield exactly 5 assistant bubbles, not 6+ phantom bubbles from late cross-talk",
+    ).toBe(5);
+  });
 });

--- a/src/store/thread-store.ts
+++ b/src/store/thread-store.ts
@@ -383,11 +383,32 @@ export function addUserMessage(
   };
 }
 
+/** Late streaming chunks (`token` / `replace`) for an already-finalized
+ *  thread are cross-talk artifacts from concurrent same-chat streams.
+ *  Pre-fix, `ensurePendingAssistant` unconditionally created a fresh
+ *  pending slot for them — which the renderer painted as a phantom
+ *  assistant bubble (`filled=8/5` on a 5-message scenario, observed on
+ *  mini1 after #680). Drop the event and bump a counter instead.
+ *
+ *  A thread is "finalized" when it has at least one assistant response
+ *  AND no in-flight pending. New turns on the same chat get their OWN
+ *  thread (rooted at a fresh client_message_id) — there is no legitimate
+ *  case where streaming text should reopen a finalized thread bucket. */
+function isFinalizedAndIdle(thread: Thread): boolean {
+  if (thread.pendingAssistant) return false;
+  return thread.responses.some((r) => r.role === "assistant");
+}
+
 export function appendAssistantToken(threadId: string, token: string): void {
   const found = ensureOrphanThread(threadId);
   if (!found) return;
-  // New text means a new turn — open a fresh pending slot if the old one
-  // was already finalized (background follow-up message).
+  if (isFinalizedAndIdle(found.thread)) {
+    recordRuntimeCounter("octos_thread_phantom_chunk_dropped_total", {
+      surface: "thread_store",
+      kind: "token",
+    });
+    return;
+  }
   const slot = ensurePendingAssistant(found.thread);
   slot.text += token;
   notify();
@@ -396,6 +417,13 @@ export function appendAssistantToken(threadId: string, token: string): void {
 export function replaceAssistantText(threadId: string, text: string): void {
   const found = ensureOrphanThread(threadId);
   if (!found) return;
+  if (isFinalizedAndIdle(found.thread)) {
+    recordRuntimeCounter("octos_thread_phantom_chunk_dropped_total", {
+      surface: "thread_store",
+      kind: "replace",
+    });
+    return;
+  }
   const slot = ensurePendingAssistant(found.thread);
   slot.text = text;
   notify();


### PR DESCRIPTION
Two follow-up bugs surfaced by today's stress soaks (after #58 #649 frontend fix landed):

## Class 1 — phantom bubble

`appendAssistantToken` / `replaceAssistantText` were calling `ensurePendingAssistant` unconditionally — a late SSE event for an already-finalized thread would spawn a phantom pending slot, surfacing as filled=8/5 (more bubbles than expected).

Fix: `isFinalizedAndIdle(thread)` guard. Drop the late event and bump `octos_thread_phantom_chunk_dropped_total` instead of phantom-spawning.

## Class 2 — sse-bridge cross-talk (codex caught)

Bridge had a single per-stream `rawText` accumulator. When two interleaved turns both invoked `replaceAssistantText(tid, rawText)`, ThreadStore got contaminated content (turn B saw turn A's prefix).

Fix:
- Extract `applyPerThreadTextEvent(acc, threadId, kind, text)` helper
- Promote accumulator to **session-scoped** `sessionRawTextByThread` keyed by `(session, topic)` — survives connection closures
- `done` legacy MessageStore mutations gated by `ownsLegacy` so a sibling turn's done no longer marks this bubble complete

## Tests

10 new unit tests across thread-store.test.ts (4 phantom-bubble) and new sse-bridge.test.ts (6: helper isolation + session-scoped persistence + split-connection regression).

## Refs

- Server-side companion PR: octos-org/octos PR (link tbd) on api_channel.last_content keying
- Codex 2nd-opinion: /tmp/codex-overflow-stress.log + .v2.log
- Branch is rebased onto fix/m9-frontend-thread-binding-649 (PR #58); merge after #58 lands or rebase onto main first.