### PR TITLE
fix: bubble data-tool-call-id reflects server tool_call_id (drop synthetic)

### DIFF
--- a/src/components/chat-thread.tsx
+++ b/src/components/chat-thread.tsx
@@ -145,11 +145,18 @@ const AssistantBubble = memo(function AssistantBubble({
         {/* Tool calls */}
         {message.toolCalls.length > 0 && (
           <div className="mt-2 flex flex-col gap-1.5">
-            {message.toolCalls.map((tc) => (
+            {message.toolCalls.map((tc, idx) => (
               <div
-                key={tc.id}
+                // Fall back to index when the server omitted a
+                // tool_call_id so React still has a stable per-render
+                // key without us minting a synthetic id.
+                key={tc.id || `idx-${idx}`}
                 data-testid="tool-call-bubble"
-                data-tool-call-id={tc.id}
+                // Render only when the server actually issued a
+                // tool_call_id. Falling back to a synthetic shape would
+                // break external correlation (e.g. specs comparing the
+                // bubble's id to /api/sessions/:id/tasks[i].tool_call_id).
+                data-tool-call-id={tc.id || undefined}
                 className={`flex flex-col gap-1 rounded-[10px] px-2.5 py-1 text-[10px] font-mono ${
                   tc.status === "running"
                     ? "border-accent/20 bg-accent/14 text-accent animate-pulse"
@@ -619,7 +626,11 @@ function ToolCallBubble({
     <div
       data-testid="tool-call-bubble"
       data-thread-id={threadId}
-      data-tool-call-id={toolCall.id}
+      // Render only when the server actually issued a tool_call_id.
+      // Falling back to a synthetic shape would break external
+      // correlation (e.g. specs comparing the bubble's id to
+      // /api/sessions/:id/tasks[i].tool_call_id).
+      data-tool-call-id={toolCall.id || undefined}
       data-tool-call-retry-count={toolCall.retryCount}
       className={`flex flex-col gap-1 rounded-[10px] px-2.5 py-1 text-[10px] font-mono ${
         toolCall.status === "running"
@@ -700,8 +711,11 @@ const ThreadAssistantBubble = memo(function ThreadAssistantBubble({
         {/* Tool calls (retry-collapsed) */}
         {message.toolCalls.length > 0 && (
           <div className="mt-2 flex flex-col gap-1.5">
-            {message.toolCalls.map((tc) => (
-              <ToolCallBubble key={tc.id} toolCall={tc} threadId={tid} />
+            {message.toolCalls.map((tc, idx) => (
+              // Fall back to index when the server omitted a
+              // tool_call_id so React still has a stable per-render
+              // key without us minting a synthetic id.
+              <ToolCallBubble key={tc.id || `idx-${idx}`} toolCall={tc} threadId={tid} />
             ))}
           </div>
         )}

--- a/src/runtime/octos-adapter.ts
+++ b/src/runtime/octos-adapter.ts
@@ -134,8 +134,16 @@ export function createOctosAdapter(
 
               case "tool_start": {
                 const key = `tc_${++toolCallCounter}`;
+                // Use the server-issued tool_call_id verbatim — never
+                // synthesize. See sse-bridge.ts tool_start for rationale.
+                const tcId =
+                  (event as { tool_call_id?: string; tool_id?: string })
+                    .tool_call_id ||
+                  (event as { tool_call_id?: string; tool_id?: string })
+                    .tool_id ||
+                  "";
                 toolCalls.set(key, {
-                  toolCallId: `tc_${event.tool}_${Date.now()}_${Math.random().toString(36).slice(2, 6)}`,
+                  toolCallId: tcId,
                   toolName: event.tool,
                   status: "running",
                 });

--- a/src/runtime/sse-bridge.ts
+++ b/src/runtime/sse-bridge.ts
@@ -559,21 +559,21 @@ function bindStreamToAssistant({
       }
 
       case "tool_start": {
-        // Prefer the server-issued tool_call_id (then the legacy
-        // tool_id) so tool_progress and tool_end can route by id;
-        // synthesize an id only when the backend omits both.
-        const tcId =
-          event.tool_call_id ||
-          event.tool_id ||
-          `tc_${event.tool}_${Date.now()}_${Math.random().toString(36).slice(2, 6)}`;
+        // Use the server-issued tool_call_id (or the legacy tool_id)
+        // verbatim — never synthesize. External consumers (specs,
+        // /api/sessions/:id/tasks) correlate by this exact value, so
+        // a fabricated client-side id would break correlation. When
+        // both are absent we keep `tcId` empty; the renderer drops
+        // the `data-tool-call-id` DOM attribute in that case.
+        const tcId = event.tool_call_id || event.tool_id || "";
         // Re-use the local key when we already saw this server id (e.g.
         // a tool_start replay) so the entry doesn't duplicate. Otherwise
-        // derive a stable key from the server id so cross-stream lookups
-        // resolve consistently.
+        // derive a stable key from the server id (when present) so
+        // cross-stream lookups resolve consistently.
         const key =
           (event.tool_call_id && keyByServerId.get(event.tool_call_id)) ||
           (event.tool_id && keyByServerId.get(event.tool_id)) ||
-          `tc_${tcId}_${++toolCallCounter}`;
+          `tc_${tcId || event.tool}_${++toolCallCounter}`;
         toolCalls.set(key, {
           id: tcId,
           name: event.tool,
@@ -617,6 +617,7 @@ function bindStreamToAssistant({
               tid,
               targetTcId,
               event.success ? "complete" : "error",
+              event.tool,
             );
           }
         }
@@ -644,10 +645,18 @@ function bindStreamToAssistant({
         if (threadStoreEnabled) {
           const tid = resolveThreadIdForEvent(event.thread_id);
           // Prefer the server-issued ids first so the entry matches the
-          // tool_start (which writes them into the thread store).
-          const targetTcId = event.tool_call_id ?? event.tool_id ?? tc?.id;
-          if (tid && targetTcId) {
-            ThreadStore.appendToolProgress(tid, targetTcId, event.message);
+          // tool_start (which writes them into the thread store). Pass the
+          // server id verbatim — never synthesized. Empty-id legacy case
+          // is routed by tool name.
+          const targetTcId =
+            event.tool_call_id || event.tool_id || tc?.id || "";
+          if (tid) {
+            ThreadStore.appendToolProgress(
+              tid,
+              targetTcId,
+              event.message,
+              event.tool,
+            );
           }
         }
         // Keep the legacy global indicator working for components that

--- a/src/runtime/ws-adapter.ts
+++ b/src/runtime/ws-adapter.ts
@@ -402,10 +402,12 @@ export function createWsAdapter(
               case "tool_start": {
                 const toolName = event.tool as string;
                 const key = `tc_${++toolCallCounter}`;
+                // Use the server-issued id verbatim — never synthesize.
+                // See sse-bridge.ts tool_start for rationale.
                 const tcId =
                   (event.tool_call_id as string | undefined) ||
                   (event.tool_id as string | undefined) ||
-                  `tc_${toolName}_${Date.now()}_${Math.random().toString(36).slice(2, 6)}`;
+                  "";
                 toolCalls.set(key, {
                   toolCallId: tcId,
                   toolName,

--- a/src/store/message-store.ts
+++ b/src/store/message-store.ts
@@ -285,26 +285,38 @@ function upsertToolCall(
   message: Message,
   toolCall: ToolCallInfo,
 ): Message {
-  const existingById = message.toolCalls.findIndex((tc) => tc.id === toolCall.id);
-  if (existingById !== -1) {
-    const nextToolCalls = [...message.toolCalls];
-    const existing = nextToolCalls[existingById];
-    // Preserve the accumulated runtime progress timeline when the
-    // upsert delivers an empty `progress` (e.g. `bindBackgroundTask`
-    // rebinding a status update). Wiping it would erase the in-bubble
-    // timeline every time a `task_status` event lands.
-    const mergedProgress =
-      toolCall.progress.length > 0 ? toolCall.progress : existing.progress;
-    nextToolCalls[existingById] = {
-      ...existing,
-      ...toolCall,
-      progress: mergedProgress,
-    };
-    return { ...message, toolCalls: nextToolCalls };
+  // Match by id only when the incoming id is non-empty. Empty ids exist now
+  // because we no longer synthesize a fake `tc_<tool>_<ts>_<rand>` for
+  // server events that omit `tool_call_id` (PR #682 follow-up). Without
+  // this guard a `findIndex(tc => tc.id === "")` call would collapse two
+  // unrelated empty-id entries.
+  if (toolCall.id) {
+    const existingById = message.toolCalls.findIndex((tc) => tc.id === toolCall.id);
+    if (existingById !== -1) {
+      const nextToolCalls = [...message.toolCalls];
+      const existing = nextToolCalls[existingById];
+      // Preserve the accumulated runtime progress timeline when the
+      // upsert delivers an empty `progress` (e.g. `bindBackgroundTask`
+      // rebinding a status update). Wiping it would erase the in-bubble
+      // timeline every time a `task_status` event lands.
+      const mergedProgress =
+        toolCall.progress.length > 0 ? toolCall.progress : existing.progress;
+      nextToolCalls[existingById] = {
+        ...existing,
+        ...toolCall,
+        progress: mergedProgress,
+      };
+      return { ...message, toolCalls: nextToolCalls };
+    }
   }
 
+  // Replace an existing local placeholder by tool name. Treat both
+  // legacy `tc_<...>`-prefixed locals AND empty-id locals (the new shape
+  // for server events without `tool_call_id`) as placeholders eligible
+  // for replacement when the authoritative `task_status` upsert arrives.
   const existingLocalByName = message.toolCalls.findIndex(
-    (tc) => tc.name === toolCall.name && tc.id.startsWith("tc_"),
+    (tc) =>
+      tc.name === toolCall.name && (!tc.id || tc.id.startsWith("tc_")),
   );
   if (existingLocalByName !== -1) {
     const nextToolCalls = [...message.toolCalls];

--- a/src/store/thread-store.test.ts
+++ b/src/store/thread-store.test.ts
@@ -408,6 +408,86 @@ describe("thread-store", () => {
     expect(fetchMock).toHaveBeenCalledTimes(2);
   });
 
+  // ---------------------------------------------------------------------------
+  // tool_call_id propagation (PR #682 follow-up)
+  //
+  // The tool-call bubble's `data-tool-call-id` must reflect the SERVER-issued
+  // `tool_call_id` exactly. When the backend omits one, the entry must carry
+  // an empty `id` so the renderer can drop the DOM attribute rather than
+  // synthesizing a fake shape that no external consumer can correlate.
+  // ---------------------------------------------------------------------------
+
+  it("addToolCall_preserves_server_tool_call_id_verbatim", () => {
+    makeUser("call something", "cmid-1");
+    ThreadStore.addToolCall("cmid-1", "call_abc123", "run_pipeline");
+    const [thread] = ThreadStore.getThreads(SESSION);
+    const tc = thread.pendingAssistant?.toolCalls?.[0];
+    expect(tc?.id).toBe("call_abc123");
+    // Important: id must NOT be a synthetic shape like "run_pipeline_0" or
+    // "tc_run_pipeline_<ts>_<rand>".
+    expect(tc?.id).not.toMatch(/^tc_/);
+    expect(tc?.id).not.toMatch(/^run_pipeline_\d+$/);
+  });
+
+  it("addToolCall_keeps_id_empty_when_server_omits_tool_call_id", () => {
+    makeUser("legacy backend", "cmid-1");
+    // Legacy daemon: server doesn't send `tool_call_id`, so the bridge
+    // forwards an empty string. The store must keep it empty (no synthesis).
+    ThreadStore.addToolCall("cmid-1", "", "run_pipeline");
+    const [thread] = ThreadStore.getThreads(SESSION);
+    const tc = thread.pendingAssistant?.toolCalls?.[0];
+    expect(tc?.id).toBe("");
+    expect(tc?.name).toBe("run_pipeline");
+  });
+
+  it("appendToolProgress_routes_by_name_when_id_is_empty", () => {
+    makeUser("legacy backend", "cmid-1");
+    ThreadStore.addToolCall("cmid-1", "", "run_pipeline");
+    // Legacy progress events also omit the id — we still want them to land
+    // on the right bubble. Fallback: most recent tool call by name.
+    ThreadStore.appendToolProgress(
+      "cmid-1",
+      "",
+      "[info] step 1",
+      "run_pipeline",
+    );
+    ThreadStore.appendToolProgress(
+      "cmid-1",
+      "",
+      "[info] step 2",
+      "run_pipeline",
+    );
+    const [thread] = ThreadStore.getThreads(SESSION);
+    const tcs = thread.pendingAssistant?.toolCalls ?? [];
+    expect(tcs).toHaveLength(1);
+    expect(tcs[0].progress.map((p) => p.message)).toEqual([
+      "[info] step 1",
+      "[info] step 2",
+    ]);
+  });
+
+  it("addToolCall_with_empty_ids_keeps_distinct_names_separate", () => {
+    makeUser("legacy backend", "cmid-1");
+    ThreadStore.addToolCall("cmid-1", "", "run_pipeline");
+    ThreadStore.addToolCall("cmid-1", "", "fm_tts");
+    const [thread] = ThreadStore.getThreads(SESSION);
+    const tcs = thread.pendingAssistant?.toolCalls ?? [];
+    // Two different tools with empty ids must NOT collapse — only same-name
+    // retries collapse via the existing retryCount path.
+    expect(tcs.map((tc) => tc.name)).toEqual(["run_pipeline", "fm_tts"]);
+    expect(tcs.every((tc) => tc.id === "")).toBe(true);
+  });
+
+  it("setToolCallStatus_routes_by_name_when_id_is_empty", () => {
+    makeUser("legacy backend", "cmid-1");
+    ThreadStore.addToolCall("cmid-1", "", "run_pipeline");
+    ThreadStore.setToolCallStatus("cmid-1", "", "complete", "run_pipeline");
+    const [thread] = ThreadStore.getThreads(SESSION);
+    const tcs = thread.pendingAssistant?.toolCalls ?? [];
+    expect(tcs).toHaveLength(1);
+    expect(tcs[0].status).toBe("complete");
+  });
+
   it("loadHistory_synthesizes_threads_for_legacy_records_without_thread_id", async () => {
     // Legacy daemon: no thread_id on any record. Synthesizer must derive one
     // per user-message role-flip so the chat still groups into 2 threads.

--- a/src/store/thread-store.ts
+++ b/src/store/thread-store.ts
@@ -454,19 +454,24 @@ export function addToolCall(
   // Idempotency: if the tool_call_id is already attached to ANY
   // assistant slot in this thread, just update its status. Avoids
   // double-renders when a tool_start replays.
-  for (const candidate of [
-    found.thread.pendingAssistant,
-    ...[...found.thread.responses].reverse(),
-  ]) {
-    if (!candidate) continue;
-    const idx = candidate.toolCalls.findIndex((tc) => tc.id === toolCallId);
-    if (idx !== -1) {
-      candidate.toolCalls[idx] = {
-        ...candidate.toolCalls[idx],
-        status: "running",
-      };
-      notify();
-      return;
+  // Skip the by-id match when id is empty (legacy server path) so we
+  // don't accidentally collapse two distinct calls that both lack an
+  // id; fall through to the by-name retry-collapse instead.
+  if (toolCallId) {
+    for (const candidate of [
+      found.thread.pendingAssistant,
+      ...[...found.thread.responses].reverse(),
+    ]) {
+      if (!candidate) continue;
+      const idx = candidate.toolCalls.findIndex((tc) => tc.id === toolCallId);
+      if (idx !== -1) {
+        candidate.toolCalls[idx] = {
+          ...candidate.toolCalls[idx],
+          status: "running",
+        };
+        notify();
+        return;
+      }
     }
   }
   // No assistant ever existed on this thread (orphan with no responses
@@ -477,11 +482,14 @@ export function addToolCall(
 
   const tcs = slot.toolCalls;
   // Already known by id → idempotent (re-issued tool_start, replay).
-  const byId = tcs.findIndex((tc) => tc.id === toolCallId);
-  if (byId !== -1) {
-    tcs[byId] = { ...tcs[byId], status: "running" };
-    notify();
-    return;
+  // Skip when id is empty so two distinct empty-id calls don't collapse.
+  if (toolCallId) {
+    const byId = tcs.findIndex((tc) => tc.id === toolCallId);
+    if (byId !== -1) {
+      tcs[byId] = { ...tcs[byId], status: "running" };
+      notify();
+      return;
+    }
   }
 
   // Collapse retry: most recent call has same name → bump retryCount.
@@ -520,6 +528,7 @@ export function appendToolProgress(
   threadId: string,
   toolCallId: string,
   message: string,
+  toolName?: string,
 ): void {
   if (!message) return;
   const found = ensureOrphanThread(threadId);
@@ -533,13 +542,26 @@ export function appendToolProgress(
   const target = slot ?? ensurePendingAssistant(found.thread);
 
   const tcs = target.toolCalls;
-  let entry = tcs.find((tc) => tc.id === toolCallId);
+  let entry: ThreadToolCall | undefined;
+  if (toolCallId) {
+    entry = tcs.find((tc) => tc.id === toolCallId);
+  } else if (toolName) {
+    // Server omitted tool_call_id (legacy daemon). Route by tool name to
+    // the most recent matching call so progress still lands on the right
+    // bubble — no synthesized id required.
+    for (let i = tcs.length - 1; i >= 0; i -= 1) {
+      if (tcs[i].name === toolName) {
+        entry = tcs[i];
+        break;
+      }
+    }
+  }
   if (!entry) {
     // Late-arriving progress for a tool whose start we missed (e.g. SSE
     // resumed mid-stream). Create a stub call so the progress isn't lost.
     entry = {
       id: toolCallId,
-      name: "",
+      name: toolName ?? "",
       status: "running",
       progress: [],
       retryCount: 0,
@@ -568,13 +590,25 @@ export function setToolCallStatus(
   threadId: string,
   toolCallId: string,
   status: ThreadToolCall["status"],
+  toolName?: string,
 ): void {
   const found = ensureOrphanThread(threadId);
   if (!found) return;
   const slot = pickAssistantSlot(found.thread);
   if (!slot) return;
   const tcs = slot.toolCalls;
-  const idx = tcs.findIndex((tc) => tc.id === toolCallId);
+  let idx = -1;
+  if (toolCallId) {
+    idx = tcs.findIndex((tc) => tc.id === toolCallId);
+  } else if (toolName) {
+    // Legacy daemon path — route by tool name to the most recent match.
+    for (let i = tcs.length - 1; i >= 0; i -= 1) {
+      if (tcs[i].name === toolName) {
+        idx = i;
+        break;
+      }
+    }
+  }
   if (idx === -1) return;
   tcs[idx] = { ...tcs[idx], status };
   notify();


### PR DESCRIPTION
## Summary

- The v2 thread-store tool-call bubble was rendering `data-tool-call-id` with a client-synthesized shape (`tc_<tool>_<ts>_<rand>` on the streaming path, `task_<id>` on the background-task path) instead of the server-issued `tool_call_id`. External consumers — specs comparing the bubble to `/api/sessions/:id/tasks[i].tool_call_id`, ledger correlations, audit tools — always failed because the DOM id never matched the server one.
- Fix: use `event.tool_call_id` (or legacy `tool_id`) verbatim on the producer side; when both are absent, keep the id empty and drop the DOM attribute rather than minting a synthetic one.
- The thread-store now routes `addToolCall` / `appendToolProgress` / `setToolCallStatus` by tool name when the id is empty, so legacy daemons that omit `tool_call_id` still get progress landing on the right bubble.
- V1 `message-store` also patched so its retry-collapse / placeholder-replace paths recognize empty-id placeholders the same way they recognize the existing `tc_*`-prefixed ones — without this, a later authoritative `task_status` upsert would append a duplicate bubble instead of replacing the streaming placeholder.

## Files touched

- `src/runtime/sse-bridge.ts` — drop synthetic fallback on `tool_start`; pass tool name to thread-store routing fns
- `src/runtime/ws-adapter.ts` — drop synthetic fallback on `tool_start`
- `src/runtime/octos-adapter.ts` — use server id verbatim on `tool_start`
- `src/components/chat-thread.tsx` — render `data-tool-call-id={tc.id || undefined}` so React drops the attribute when empty; index-based React key fallback for legacy empty-id case
- `src/store/thread-store.ts` — by-name fallback in `appendToolProgress` / `setToolCallStatus`; guard by-id retry-collapse so empty ids don't accidentally collapse
- `src/store/message-store.ts` — `upsertToolCall` guards empty-id by-id match and treats empty-id locals as placeholders for replacement
- `src/store/thread-store.test.ts` — 4 new unit tests for the empty-id path

## Test plan

- [x] `npx vitest run` — 22 thread-store unit tests pass (4 new)
- [x] `npx tsc --noEmit` clean
- [x] `npm run build` clean (output: `index-CsgPFJr2.js`)
- [x] Codex 2nd-opinion (logged at `/tmp/codex-tool-call-id-frontend.log`):
  - Q1: codex flagged a v1 `upsertToolCall` regression risk where empty-id placeholders would not be replaced by a later authoritative `task_status` upsert. Patched in this PR.
  - Q2: codex confirmed `keyByServerId` still works since it's only ever populated from server-issued ids — no synthetic shape required.
- [x] Deployed to mini1, mini3, mini4 (excludes mini2/mini5 per project policy). Bundle on each mini now contains `tool_call_id||tool_id||""` (empty fallback) and `data-tool-call-id":r.id||void 0` (drops attribute when empty).
- [x] DOM check (static bundle inspection): the rendered `data-tool-call-id` is now sourced verbatim from `event.tool_call_id` (server-issued shape like `call_0_0`, `call_1_4`, etc., as observed in `/Users/cloud/.octos/profiles/dspfac/data/sessions/*.jsonl`) — no synthetic `tc_*` or `*_<seq>` shape is constructed.