### PR TITLE
feat(coding): /coding workspace on UI Protocol v1 over WebSocket (PR J)

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -11,6 +11,7 @@ import { SlidesEditorPage } from "./slides/pages/slides-editor-page";
 import { SlidesPresentPage } from "./slides/pages/slides-present-page";
 import { SitesGalleryPage } from "./sites/pages/sites-gallery-page";
 import { SitesEditorPage } from "./sites/pages/sites-editor-page";
+import { CodingWorkspacePage } from "./coding/coding-workspace-page";
 
 function ChatPage() {
   return (
@@ -42,6 +43,7 @@ export function App() {
           <Route element={<AuthGuard />}>
             <Route path="/" element={<HomePage />} />
             <Route path="/chat/*" element={<ChatPage />} />
+            <Route path="/coding" element={<CodingWorkspacePage />} />
             <Route path="/studio/*" element={<Navigate to="/" replace />} />
             <Route path="/settings" element={<RedirectToAdminSettings />} />
             <Route path="/slides" element={<SlidesGalleryPage />} />

--- a/src/coding/app-ui-protocol.ts
+++ b/src/coding/app-ui-protocol.ts
@@ -1,0 +1,257 @@
+import { getSelectedProfileId, getToken } from "@/api/client";
+
+export const APP_UI_API_V1 = "octos-app-ui/v1alpha1";
+export const UI_PROTOCOL_V1 = "octos-ui/v1alpha1";
+export const JSON_RPC_VERSION = "2.0";
+export const UI_FEATURES = ["approval.typed.v1", "pane.snapshots.v1"] as const;
+
+export const UI_METHODS = {
+  sessionOpen: "session/open",
+  turnStart: "turn/start",
+  turnInterrupt: "turn/interrupt",
+  approvalRespond: "approval/respond",
+  approvalRequested: "approval/requested",
+  messageDelta: "message/delta",
+  taskUpdated: "task/updated",
+  taskOutputDelta: "task/output/delta",
+  taskOutputRead: "task/output/read",
+  diffPreviewGet: "diff/preview/get",
+  turnStarted: "turn/started",
+  turnCompleted: "turn/completed",
+  turnError: "turn/error",
+  warning: "warning",
+} as const;
+
+export type ApprovalDecision = "approve" | "deny";
+export type ApprovalScope = "request" | "turn" | "session";
+export type CodingConnectionState =
+  | "connecting"
+  | "connected"
+  | "offline"
+  | "error";
+
+export interface RpcRequest<TParams = unknown> {
+  jsonrpc: typeof JSON_RPC_VERSION;
+  id: string;
+  method: string;
+  params: TParams;
+}
+
+export interface RpcNotification<TParams = unknown> {
+  jsonrpc: typeof JSON_RPC_VERSION;
+  method: string;
+  params: TParams;
+}
+
+export interface RpcResponse<TResult = unknown> {
+  jsonrpc: typeof JSON_RPC_VERSION;
+  id: string;
+  result?: TResult;
+  error?: {
+    code: number;
+    message: string;
+    data?: unknown;
+  };
+}
+
+export interface AppUiEvent {
+  kind: "snapshot" | "protocol" | "progress" | "status" | "error";
+  payload?: unknown;
+}
+
+export interface SessionOpenParams {
+  session_id: string;
+  profile_id?: string;
+}
+
+export interface TurnStartParams {
+  session_id: string;
+  turn_id: string;
+  input: Array<{ kind: "text"; text: string }>;
+}
+
+export interface ApprovalRespondParams {
+  session_id: string;
+  approval_id: string;
+  decision: ApprovalDecision;
+  approval_scope?: ApprovalScope;
+  client_note?: string;
+}
+
+export interface ApprovalTypedDetails {
+  kind: string;
+  command?: {
+    command_line?: string;
+    cwd?: string;
+    argv?: string[];
+  };
+  diff?: {
+    preview_id?: string;
+    summary?: string;
+    files?: Array<{ path?: string; status?: string }>;
+  };
+  filesystem?: {
+    operation?: string;
+    path?: string;
+    paths?: string[];
+  };
+  network?: {
+    host?: string;
+    url?: string;
+    method?: string;
+  };
+  sandbox_escalation?: {
+    justification?: string;
+    requested_permissions?: string[];
+    suggested_prefix_rule?: string[];
+  };
+}
+
+export interface ApprovalRequestedEvent {
+  session_id: string;
+  approval_id: string;
+  turn_id: string;
+  tool_name: string;
+  title: string;
+  body: string;
+  approval_kind?: string;
+  approval_scope?: ApprovalScope;
+  risk?: string;
+  typed_details?: ApprovalTypedDetails;
+  render_hints?: {
+    default_decision?: ApprovalDecision;
+    primary_label?: string;
+    secondary_label?: string;
+    danger?: boolean;
+    monospace_fields?: string[];
+  };
+}
+
+export interface MessageDeltaEvent {
+  session_id: string;
+  turn_id?: string;
+  delta?: string;
+  text?: string;
+  content?: string;
+}
+
+export interface TaskUpdatedEvent {
+  session_id: string;
+  task_id?: string;
+  id?: string;
+  title?: string;
+  state?: string;
+  runtime_detail?: string;
+  output_tail?: string;
+}
+
+export interface TaskOutputDeltaEvent {
+  session_id: string;
+  task_id: string;
+  chunk?: string;
+  text?: string;
+  output?: string;
+  cursor?: { offset?: number };
+}
+
+export interface PaneSnapshot {
+  workspace?: {
+    root?: string;
+    entries?: Array<{
+      path?: string;
+      kind?: string;
+      detail?: string;
+      status?: string;
+    }>;
+  };
+  artifacts?: {
+    items?: Array<{
+      title?: string;
+      path?: string;
+      kind?: string;
+      detail?: string;
+    }>;
+  };
+  git?: {
+    status?: Array<{ path?: string; status?: string }>;
+    history?: Array<{ commit?: string; summary?: string }>;
+  };
+}
+
+export interface DiffPreviewResult {
+  status?: string;
+  source?: string;
+  preview?: {
+    preview_id?: string;
+    title?: string;
+    files?: Array<{
+      path?: string;
+      old_path?: string;
+      status?: string;
+      hunks?: Array<{
+        header?: string;
+        lines?: Array<{
+          kind?: "added" | "removed" | "context" | string;
+          content?: string;
+          old_line?: number;
+          new_line?: number;
+        }>;
+      }>;
+    }>;
+  };
+}
+
+export interface TaskOutputReadResult {
+  task_id?: string;
+  output?: string;
+  text?: string;
+  cursor?: { offset?: number };
+}
+
+export function createRpcRequest<TParams>(
+  method: string,
+  params: TParams,
+): RpcRequest<TParams> {
+  return {
+    jsonrpc: JSON_RPC_VERSION,
+    id: crypto.randomUUID(),
+    method,
+    params,
+  };
+}
+
+export function createCodingSessionId(): string {
+  const profileId = getSelectedProfileId();
+  const chatId = `coding-${crypto.randomUUID()}`;
+  return profileId ? `${profileId}:api:${chatId}` : `api:${chatId}`;
+}
+
+export function uiProtocolWebSocketUrl(): string {
+  const baseUrl = new URL("/api/ui-protocol/ws", window.location.origin);
+  const token = getToken();
+  if (token) baseUrl.searchParams.set("token", token);
+  UI_FEATURES.forEach((feature) => {
+    baseUrl.searchParams.append("ui_feature", feature);
+  });
+  baseUrl.protocol = baseUrl.protocol === "https:" ? "wss:" : "ws:";
+  return baseUrl.toString();
+}
+
+export function protocolNotificationFromEvent(
+  detail: unknown,
+): RpcNotification | null {
+  if (!detail || typeof detail !== "object") return null;
+  const maybeEvent = detail as AppUiEvent | RpcNotification;
+  if ("kind" in maybeEvent && maybeEvent.kind === "protocol") {
+    return protocolNotificationFromEvent(maybeEvent.payload);
+  }
+  if (
+    "jsonrpc" in maybeEvent &&
+    maybeEvent.jsonrpc === JSON_RPC_VERSION &&
+    "method" in maybeEvent &&
+    typeof maybeEvent.method === "string"
+  ) {
+    return maybeEvent as RpcNotification;
+  }
+  return null;
+}

--- a/src/coding/coding-workspace-page.tsx
+++ b/src/coding/coding-workspace-page.tsx
@@ -1,0 +1,473 @@
+import { useState } from "react";
+import {
+  Check,
+  Code2,
+  FileText,
+  GitBranch,
+  Home,
+  Loader2,
+  PackageOpen,
+  Play,
+  ShieldAlert,
+  Square,
+  Terminal,
+  X,
+} from "lucide-react";
+import { useNavigate } from "react-router-dom";
+import {
+  useCodingAppUi,
+  type CodingApproval,
+  type CodingDiffPreview,
+  type CodingPaneState,
+  type CodingTask,
+} from "./use-coding-app-ui";
+import type { ApprovalTypedDetails } from "./app-ui-protocol";
+
+function typedSummary(details?: ApprovalTypedDetails): string | null {
+  if (!details) return null;
+  if (details.command?.command_line) return details.command.command_line;
+  if (details.command?.argv?.length) return details.command.argv.join(" ");
+  if (details.diff?.summary) return details.diff.summary;
+  if (details.filesystem?.path) {
+    return `${details.filesystem.operation ?? "filesystem"} ${details.filesystem.path}`;
+  }
+  if (details.network?.url) return details.network.url;
+  if (details.network?.host) return details.network.host;
+  if (details.sandbox_escalation?.justification) {
+    return details.sandbox_escalation.justification;
+  }
+  return null;
+}
+
+function ApprovalCard({
+  approval,
+  onApprove,
+  onDeny,
+}: {
+  approval: CodingApproval;
+  onApprove: (approval: CodingApproval) => void;
+  onDeny: (approval: CodingApproval) => void;
+}) {
+  const summary = typedSummary(approval.typed_details);
+  const pending = !approval.local_status || approval.local_status === "pending";
+
+  return (
+    <article
+      data-testid="coding-approval-card"
+      className="glass-section rounded-[8px] p-4"
+    >
+      <div className="flex items-start gap-3">
+        <div className="mt-0.5 flex h-8 w-8 shrink-0 items-center justify-center rounded-[8px] bg-amber-500/12 text-amber-400">
+          <ShieldAlert size={17} />
+        </div>
+        <div className="min-w-0 flex-1">
+          <div className="flex flex-wrap items-center gap-2">
+            <h3 className="text-sm font-semibold text-text-strong">
+              {approval.title}
+            </h3>
+            {approval.approval_kind && (
+              <span className="rounded-[6px] border border-outline px-2 py-0.5 text-[11px] text-muted">
+                {approval.approval_kind}
+              </span>
+            )}
+            {approval.risk && (
+              <span className="rounded-[6px] bg-amber-500/10 px-2 py-0.5 text-[11px] text-amber-300">
+                {approval.risk}
+              </span>
+            )}
+          </div>
+          <p className="mt-2 text-sm leading-relaxed text-text">
+            {approval.body}
+          </p>
+          {summary && (
+            <pre className="mt-3 max-h-32 overflow-auto rounded-[8px] bg-code-block-bg p-3 text-xs leading-relaxed text-code-text">
+              {summary}
+            </pre>
+          )}
+          <div className="mt-4 flex items-center gap-2">
+            <button
+              data-testid="coding-approval-approve"
+              disabled={!pending}
+              onClick={() => onApprove(approval)}
+              className="inline-flex items-center gap-2 rounded-[8px] bg-accent px-3 py-2 text-sm font-medium text-white hover:bg-accent-dim disabled:cursor-not-allowed disabled:opacity-55"
+            >
+              <Check size={15} />
+              Approve
+            </button>
+            <button
+              data-testid="coding-approval-deny"
+              disabled={!pending}
+              onClick={() => onDeny(approval)}
+              className="inline-flex items-center gap-2 rounded-[8px] border border-outline px-3 py-2 text-sm font-medium text-text hover:bg-surface-elevated disabled:cursor-not-allowed disabled:opacity-55"
+            >
+              <X size={15} />
+              Deny
+            </button>
+            {!pending && (
+              <span
+                data-testid="coding-approval-status"
+                className="ml-1 text-xs uppercase tracking-[0.12em] text-muted"
+              >
+                {approval.local_status}
+              </span>
+            )}
+          </div>
+        </div>
+      </div>
+    </article>
+  );
+}
+
+function DiffPreviewPanel({ diffs }: { diffs: CodingDiffPreview[] }) {
+  return (
+    <section data-testid="coding-diff-preview" className="space-y-3">
+      <div className="flex items-center gap-2">
+        <FileText size={15} className="text-muted" />
+        <h2 className="text-sm font-semibold text-text-strong">Diff Preview</h2>
+      </div>
+      {diffs.length === 0 ? (
+        <div className="text-sm text-muted">No diff previews yet.</div>
+      ) : (
+        diffs.map((diff) => (
+          <article key={diff.id} className="rounded-[8px] border border-outline bg-surface-container">
+            <div className="border-b border-outline px-3 py-2 text-sm font-medium text-text-strong">
+              {diff.result.preview?.title ?? "Inline patch"}
+            </div>
+            <div className="max-h-72 overflow-auto font-mono text-xs">
+              {diff.result.preview?.files?.map((file) => (
+                <div key={`${diff.id}:${file.path}`}>
+                  <div className="bg-surface-elevated px-3 py-1 text-text-strong">
+                    {file.status ?? "modified"} {file.path}
+                  </div>
+                  {file.hunks?.map((hunk, hunkIndex) => (
+                    <div key={`${file.path}:${hunkIndex}`}>
+                      <div className="px-3 py-1 text-accent">{hunk.header}</div>
+                      {hunk.lines?.map((line, lineIndex) => {
+                        const kind = line.kind ?? "context";
+                        const sign =
+                          kind === "added" ? "+" : kind === "removed" ? "-" : " ";
+                        const tone =
+                          kind === "added"
+                            ? "bg-emerald-500/10 text-emerald-300"
+                            : kind === "removed"
+                              ? "bg-red-500/10 text-red-300"
+                              : "text-text";
+                        return (
+                          <div
+                            key={`${file.path}:${hunkIndex}:${lineIndex}`}
+                            className={`px-3 py-0.5 ${tone}`}
+                          >
+                            <span className="mr-2 text-muted">
+                              {line.old_line ?? ""}
+                              {" "}
+                              {line.new_line ?? ""}
+                            </span>
+                            <span>{sign}</span>
+                            <span>{line.content}</span>
+                          </div>
+                        );
+                      })}
+                    </div>
+                  ))}
+                </div>
+              ))}
+            </div>
+          </article>
+        ))
+      )}
+    </section>
+  );
+}
+
+function InspectorPanels({
+  panes,
+  tasks,
+  taskOutputs,
+}: {
+  panes: CodingPaneState;
+  tasks: CodingTask[];
+  taskOutputs: Record<string, string>;
+}) {
+  return (
+    <section className="grid gap-3 xl:grid-cols-2">
+      <div className="rounded-[8px] border border-outline bg-surface-container p-3">
+        <div className="mb-2 flex items-center gap-2 text-sm font-semibold text-text-strong">
+          <FileText size={15} className="text-muted" />
+          Workspace
+        </div>
+        <div data-testid="coding-workspace-pane" className="space-y-1 text-xs text-text">
+          {(panes.workspace ?? []).slice(0, 12).map((entry) => (
+            <div key={entry.path} className="flex gap-2">
+              <span className="text-muted">{entry.kind ?? "file"}</span>
+              <span className="truncate">{entry.path}</span>
+            </div>
+          ))}
+          {(panes.workspace ?? []).length === 0 && (
+            <div className="text-muted">No workspace snapshot yet.</div>
+          )}
+        </div>
+      </div>
+
+      <div className="rounded-[8px] border border-outline bg-surface-container p-3">
+        <div className="mb-2 flex items-center gap-2 text-sm font-semibold text-text-strong">
+          <PackageOpen size={15} className="text-muted" />
+          Artifacts
+        </div>
+        <div data-testid="coding-artifacts-pane" className="space-y-1 text-xs text-text">
+          {(panes.artifacts ?? []).slice(0, 10).map((item) => (
+            <div key={`${item.path}:${item.title}`} className="truncate">
+              {item.title ?? item.path}
+            </div>
+          ))}
+          {(panes.artifacts ?? []).length === 0 && (
+            <div className="text-muted">No artifacts yet.</div>
+          )}
+        </div>
+      </div>
+
+      <div className="rounded-[8px] border border-outline bg-surface-container p-3">
+        <div className="mb-2 flex items-center gap-2 text-sm font-semibold text-text-strong">
+          <GitBranch size={15} className="text-muted" />
+          Git
+        </div>
+        <div data-testid="coding-git-pane" className="space-y-1 text-xs text-text">
+          {(panes.gitStatus ?? []).slice(0, 10).map((item) => (
+            <div key={`${item.path}:${item.status}`} className="flex gap-2">
+              <span className="text-muted">{item.status ?? "changed"}</span>
+              <span className="truncate">{item.path}</span>
+            </div>
+          ))}
+          {(panes.gitHistory ?? []).slice(0, 4).map((item) => (
+            <div key={`${item.commit}:${item.summary}`} className="truncate text-muted">
+              {item.commit} {item.summary}
+            </div>
+          ))}
+          {(panes.gitStatus ?? []).length === 0 && (panes.gitHistory ?? []).length === 0 && (
+            <div className="text-muted">No git snapshot yet.</div>
+          )}
+        </div>
+      </div>
+
+      <div className="rounded-[8px] border border-outline bg-surface-container p-3">
+        <div className="mb-2 flex items-center gap-2 text-sm font-semibold text-text-strong">
+          <Terminal size={15} className="text-muted" />
+          Task Output
+        </div>
+        <div data-testid="coding-task-output-pane" className="space-y-2 text-xs text-text">
+          {tasks.slice(0, 4).map((task) => (
+            <div key={task.id}>
+              <div className="font-medium text-text-strong">{task.title}</div>
+              <pre className="mt-1 max-h-28 overflow-auto whitespace-pre-wrap rounded-[8px] bg-code-block-bg p-2 text-code-text">
+                {taskOutputs[task.id] || task.detail || "No output loaded yet."}
+              </pre>
+            </div>
+          ))}
+          {tasks.length === 0 && <div className="text-muted">No task output yet.</div>}
+        </div>
+      </div>
+    </section>
+  );
+}
+
+export function CodingWorkspacePage() {
+  const navigate = useNavigate();
+  const [prompt, setPrompt] = useState("");
+  const {
+    sessionId,
+    connectionState,
+    turnStatus,
+    activeTurnId,
+    logs,
+    approvals,
+    tasks,
+    panes,
+    diffs,
+    taskOutputs,
+    submitPrompt,
+    interruptTurn,
+    respondApproval,
+  } = useCodingAppUi();
+
+  return (
+    <div className="chat-shell flex h-screen flex-col bg-surface-dark p-3">
+      <header className="glass-toolbar mb-3 flex items-center gap-3 rounded-[8px] px-4 py-3">
+        <button
+          onClick={() => navigate("/")}
+          className="glass-icon-button rounded-[8px] p-2"
+          title="Home"
+          aria-label="Home"
+        >
+          <Home size={16} />
+        </button>
+        <div className="flex h-9 w-9 items-center justify-center rounded-[8px] bg-accent-container text-accent">
+          <Code2 size={19} />
+        </div>
+        <div className="min-w-0 flex-1">
+          <div className="shell-kicker">Coding Workspace</div>
+          <div className="truncate text-lg font-semibold text-text-strong">
+            AppUi / UI Protocol v1
+          </div>
+        </div>
+        <div
+          data-testid="coding-connection-state"
+          className="flex items-center gap-2 rounded-[8px] border border-outline px-3 py-2 text-xs text-muted"
+        >
+          {connectionState === "connecting" && (
+            <Loader2 size={13} className="animate-spin" />
+          )}
+          {connectionState}
+        </div>
+        <div
+          data-testid="coding-turn-status"
+          className="rounded-[8px] border border-outline px-3 py-2 text-xs text-muted"
+        >
+          {turnStatus}
+        </div>
+      </header>
+
+      <main className="grid min-h-0 flex-1 gap-3 lg:grid-cols-[minmax(0,1fr)_360px]">
+        <section className="glass-panel flex min-h-0 flex-col rounded-[8px]">
+          <div className="border-b border-outline px-4 py-3">
+            <div className="shell-kicker">Session</div>
+            <div
+              data-testid="coding-session-id"
+              className="mt-1 truncate font-mono text-xs text-muted"
+            >
+              {sessionId}
+            </div>
+          </div>
+          <div
+            data-testid="coding-log"
+            className="min-h-0 flex-1 space-y-3 overflow-auto px-4 py-4"
+          >
+            {logs.map((entry) => (
+              <div
+                key={entry.id}
+                className={`message-card rounded-[8px] px-3 py-2 text-sm leading-relaxed ${
+                  entry.kind === "user"
+                    ? "message-card-user ml-auto max-w-[78%]"
+                    : "message-card-assistant mr-auto max-w-[86%]"
+                }`}
+              >
+                <div className="mb-1 text-[10px] uppercase tracking-[0.12em] text-muted">
+                  {entry.kind}
+                </div>
+                <div className="whitespace-pre-wrap text-text">{entry.text}</div>
+              </div>
+            ))}
+          </div>
+          <form
+            className="border-t border-outline p-3"
+            onSubmit={(event) => {
+              event.preventDefault();
+              submitPrompt(prompt);
+              setPrompt("");
+            }}
+          >
+            <div className="flex gap-2">
+              <textarea
+                data-testid="coding-prompt-input"
+                value={prompt}
+                onChange={(event) => setPrompt(event.target.value)}
+                rows={2}
+                className="min-h-12 flex-1 resize-none rounded-[8px] border border-outline bg-surface-container px-3 py-2 text-sm text-text outline-none placeholder:text-muted focus:border-accent"
+                placeholder="Describe the coding task"
+              />
+              <button
+                data-testid="coding-submit"
+                type="submit"
+                className="flex h-12 w-12 shrink-0 items-center justify-center rounded-[8px] bg-accent text-white hover:bg-accent-dim"
+                title="Start turn"
+                aria-label="Start turn"
+              >
+                <Play size={17} />
+              </button>
+              <button
+                data-testid="coding-interrupt"
+                type="button"
+                disabled={!activeTurnId}
+                onClick={interruptTurn}
+                className="flex h-12 w-12 shrink-0 items-center justify-center rounded-[8px] border border-outline text-text hover:bg-surface-elevated disabled:cursor-not-allowed disabled:opacity-45"
+                title="Interrupt turn"
+                aria-label="Interrupt turn"
+              >
+                <Square size={15} />
+              </button>
+            </div>
+          </form>
+        </section>
+
+        <aside className="flex min-h-0 flex-col gap-3">
+          <section
+            data-testid="coding-approvals"
+            className="glass-panel min-h-0 flex-1 overflow-auto rounded-[8px] p-3"
+          >
+            <div className="mb-3 flex items-center justify-between">
+              <div>
+                <div className="shell-kicker">Coding Only</div>
+                <h2 className="text-sm font-semibold text-text-strong">
+                  Approvals
+                </h2>
+              </div>
+              <span className="rounded-[6px] bg-surface-container px-2 py-1 text-xs text-muted">
+                {approvals.filter((approval) => !approval.local_status || approval.local_status === "pending").length}
+              </span>
+            </div>
+            <div className="space-y-3">
+              {approvals.length === 0 ? (
+                <div className="shell-empty-state rounded-[8px] p-4 text-sm text-muted">
+                  Approval requests for this coding session will appear here.
+                </div>
+              ) : (
+                approvals.map((approval) => (
+                  <ApprovalCard
+                    key={approval.approval_id}
+                    approval={approval}
+                    onApprove={(item) => respondApproval(item, "approve")}
+                    onDeny={(item) => respondApproval(item, "deny")}
+                  />
+                ))
+              )}
+            </div>
+          </section>
+
+          <section className="glass-panel max-h-[36%] overflow-auto rounded-[8px] p-3">
+            <div className="mb-3 flex items-center gap-2">
+              <Terminal size={15} className="text-muted" />
+              <h2 className="text-sm font-semibold text-text-strong">Tasks</h2>
+            </div>
+            {tasks.length === 0 ? (
+              <div className="text-sm text-muted">No task updates yet.</div>
+            ) : (
+              <div className="space-y-2">
+                {tasks.map((task) => (
+                  <div
+                    key={task.id}
+                    className="rounded-[8px] border border-outline bg-surface-container p-3"
+                  >
+                    <div className="text-sm font-medium text-text-strong">
+                      {task.title}
+                    </div>
+                    <div className="mt-1 text-xs text-muted">{task.state}</div>
+                    {task.detail && (
+                      <div className="mt-2 text-xs leading-relaxed text-text">
+                        {task.detail}
+                      </div>
+                    )}
+                  </div>
+                ))}
+              </div>
+            )}
+          </section>
+        </aside>
+      </main>
+
+      <section className="glass-panel mt-3 max-h-[36vh] overflow-auto rounded-[8px] p-3">
+        <div className="grid gap-4 xl:grid-cols-[minmax(0,1fr)_minmax(0,1fr)]">
+          <DiffPreviewPanel diffs={diffs} />
+          <InspectorPanels panes={panes} tasks={tasks} taskOutputs={taskOutputs} />
+        </div>
+      </section>
+    </div>
+  );
+}

--- a/src/coding/use-coding-app-ui.ts
+++ b/src/coding/use-coding-app-ui.ts
@@ -1,0 +1,457 @@
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import {
+  type ApprovalDecision,
+  type ApprovalRequestedEvent,
+  type ApprovalRespondParams,
+  type CodingConnectionState,
+  type DiffPreviewResult,
+  type MessageDeltaEvent,
+  type PaneSnapshot,
+  type RpcNotification,
+  type RpcResponse,
+  type TaskOutputDeltaEvent,
+  type TaskOutputReadResult,
+  type TaskUpdatedEvent,
+  UI_METHODS,
+  createCodingSessionId,
+  createRpcRequest,
+  protocolNotificationFromEvent,
+  uiProtocolWebSocketUrl,
+} from "./app-ui-protocol";
+import { getSelectedProfileId } from "@/api/client";
+
+export interface CodingLogEntry {
+  id: string;
+  kind: "user" | "assistant" | "system" | "error";
+  text: string;
+}
+
+export interface CodingTask {
+  id: string;
+  title: string;
+  state: string;
+  detail?: string;
+}
+
+export interface CodingApproval extends ApprovalRequestedEvent {
+  local_status?: "pending" | "approved" | "denied";
+}
+
+export interface CodingDiffPreview {
+  id: string;
+  result: DiffPreviewResult;
+}
+
+export interface CodingPaneState {
+  workspace: NonNullable<PaneSnapshot["workspace"]>["entries"];
+  artifacts: NonNullable<PaneSnapshot["artifacts"]>["items"];
+  gitStatus: NonNullable<PaneSnapshot["git"]>["status"];
+  gitHistory: NonNullable<PaneSnapshot["git"]>["history"];
+}
+
+interface PendingRequest {
+  method: string;
+  taskId?: string;
+  previewId?: string;
+}
+
+function appendLog(
+  entries: CodingLogEntry[],
+  entry: Omit<CodingLogEntry, "id">,
+): CodingLogEntry[] {
+  return [...entries, { ...entry, id: crypto.randomUUID() }].slice(-120);
+}
+
+function notificationSessionId(notification: RpcNotification): string | undefined {
+  const params = notification.params as { session_id?: unknown } | undefined;
+  return typeof params?.session_id === "string" ? params.session_id : undefined;
+}
+
+export function useCodingAppUi() {
+  const [sessionId] = useState(createCodingSessionId);
+  const [connectionState, setConnectionState] =
+    useState<CodingConnectionState>("connecting");
+  const [logs, setLogs] = useState<CodingLogEntry[]>(() => [
+    {
+      id: crypto.randomUUID(),
+      kind: "system",
+      text: "Coding workspace initialized for AppUi/UI Protocol v1.",
+    },
+  ]);
+  const [approvals, setApprovals] = useState<CodingApproval[]>([]);
+  const [tasks, setTasks] = useState<CodingTask[]>([]);
+  const [turnStatus, setTurnStatus] = useState("idle");
+  const [activeTurnId, setActiveTurnId] = useState<string | null>(null);
+  const [panes, setPanes] = useState<CodingPaneState>({
+    workspace: [],
+    artifacts: [],
+    gitStatus: [],
+    gitHistory: [],
+  });
+  const [diffs, setDiffs] = useState<CodingDiffPreview[]>([]);
+  const [taskOutputs, setTaskOutputs] = useState<Record<string, string>>({});
+  const socketRef = useRef<WebSocket | null>(null);
+  const pendingRequestsRef = useRef(new Map<string, PendingRequest>());
+
+  const sendProtocol = useCallback((
+    method: string,
+    params: unknown,
+    pending: Omit<PendingRequest, "method"> = {},
+  ) => {
+    const socket = socketRef.current;
+    if (!socket || socket.readyState !== WebSocket.OPEN) {
+      setLogs((current) =>
+        appendLog(current, {
+          kind: "error",
+          text: `UI Protocol transport is not connected; queued method ${method} locally.`,
+        }),
+      );
+      return null;
+    }
+    const request = createRpcRequest(method, params);
+    pendingRequestsRef.current.set(request.id, { method, ...pending });
+    socket.send(JSON.stringify(request));
+    return request.id;
+  }, []);
+
+  const ingestPanes = useCallback((snapshot?: PaneSnapshot) => {
+    if (!snapshot) return;
+    setPanes({
+      workspace: snapshot.workspace?.entries ?? [],
+      artifacts: snapshot.artifacts?.items ?? [],
+      gitStatus: snapshot.git?.status ?? [],
+      gitHistory: snapshot.git?.history ?? [],
+    });
+  }, []);
+
+  const appendTaskOutput = useCallback((taskId: string, output: string) => {
+    if (!output) return;
+    setTaskOutputs((current) => ({
+      ...current,
+      [taskId]: `${current[taskId] ?? ""}${output}`.slice(-12_000),
+    }));
+  }, []);
+
+  const requestTaskOutput = useCallback(
+    (taskId: string) => {
+      sendProtocol(
+        UI_METHODS.taskOutputRead,
+        { session_id: sessionId, task_id: taskId, limit_bytes: 4000 },
+        { taskId },
+      );
+    },
+    [sendProtocol, sessionId],
+  );
+
+  const requestDiffPreview = useCallback(
+    (previewId: string) => {
+      sendProtocol(
+        UI_METHODS.diffPreviewGet,
+        { session_id: sessionId, preview_id: previewId },
+        { previewId },
+      );
+    },
+    [sendProtocol, sessionId],
+  );
+
+  const ingestResponse = useCallback(
+    (response: RpcResponse) => {
+      const pending = pendingRequestsRef.current.get(response.id);
+      if (pending) pendingRequestsRef.current.delete(response.id);
+
+      if (response.error) {
+        setLogs((current) =>
+          appendLog(current, {
+            kind: "error",
+            text: `${pending?.method ?? "request"} failed: ${response.error?.message}`,
+          }),
+        );
+        return;
+      }
+
+      const result = response.result as
+        | { opened?: { panes?: PaneSnapshot } }
+        | DiffPreviewResult
+        | TaskOutputReadResult
+        | undefined;
+
+      if (pending?.method === UI_METHODS.sessionOpen || "opened" in (result ?? {})) {
+        const opened = (response.result as { opened?: { panes?: PaneSnapshot } })
+          ?.opened;
+        ingestPanes(opened?.panes);
+        return;
+      }
+      if (
+        pending?.method === UI_METHODS.diffPreviewGet ||
+        "preview" in (result ?? {})
+      ) {
+        const result = response.result as DiffPreviewResult;
+        const id = result.preview?.preview_id ?? pending?.previewId;
+        if (!id) return;
+        setDiffs((current) => {
+          const next = { id, result };
+          const existing = current.findIndex((item) => item.id === id);
+          if (existing === -1) return [next, ...current].slice(0, 12);
+          return current.map((item, index) => (index === existing ? next : item));
+        });
+        return;
+      }
+      if (pending?.method === UI_METHODS.taskOutputRead || "text" in (result ?? {})) {
+        const result = response.result as TaskOutputReadResult;
+        const taskId = result.task_id ?? pending?.taskId;
+        const output = result.output ?? result.text;
+        if (taskId && output) appendTaskOutput(taskId, output);
+      }
+    },
+    [appendTaskOutput, ingestPanes],
+  );
+
+  const ingestNotification = useCallback(
+    (notification: RpcNotification) => {
+      const eventSessionId = notificationSessionId(notification);
+      if (eventSessionId && eventSessionId !== sessionId) return;
+
+      switch (notification.method) {
+        case UI_METHODS.approvalRequested: {
+          const approval = notification.params as ApprovalRequestedEvent;
+          setApprovals((current) => {
+            const existing = current.find(
+              (item) => item.approval_id === approval.approval_id,
+            );
+            if (existing) return current;
+            return [{ ...approval, local_status: "pending" }, ...current];
+          });
+          if (approval.typed_details?.diff?.preview_id) {
+            requestDiffPreview(approval.typed_details.diff.preview_id);
+          }
+          break;
+        }
+        case UI_METHODS.messageDelta: {
+          const params = notification.params as MessageDeltaEvent;
+          const text = params.delta ?? params.text ?? params.content;
+          if (text) {
+            setLogs((current) =>
+              appendLog(current, { kind: "assistant", text }),
+            );
+          }
+          break;
+        }
+        case UI_METHODS.taskUpdated: {
+          const params = notification.params as TaskUpdatedEvent;
+          const id = params.task_id ?? params.id ?? crypto.randomUUID();
+          setTasks((current) => {
+            const nextTask = {
+              id,
+              title: params.title ?? "Coding task",
+              state: params.state ?? "running",
+              detail: params.runtime_detail ?? params.output_tail,
+            };
+            const existing = current.findIndex((task) => task.id === id);
+            if (existing === -1) return [nextTask, ...current].slice(0, 20);
+            return current.map((task, index) =>
+              index === existing ? { ...task, ...nextTask } : task,
+            );
+          });
+          if (params.output_tail) appendTaskOutput(id, params.output_tail);
+          requestTaskOutput(id);
+          break;
+        }
+        case UI_METHODS.taskOutputDelta: {
+          const params = notification.params as TaskOutputDeltaEvent;
+          appendTaskOutput(
+            params.task_id,
+            params.chunk ?? params.output ?? params.text ?? "",
+          );
+          break;
+        }
+        case UI_METHODS.turnStarted: {
+          const params = notification.params as { turn_id?: string };
+          setActiveTurnId(params.turn_id ?? null);
+          setTurnStatus("running");
+          setLogs((current) =>
+            appendLog(current, { kind: "system", text: "turn started" }),
+          );
+          break;
+        }
+        case UI_METHODS.turnCompleted:
+          setActiveTurnId(null);
+          setTurnStatus("completed");
+          setLogs((current) =>
+            appendLog(current, { kind: "system", text: "turn completed" }),
+          );
+          break;
+        case UI_METHODS.turnError:
+          setActiveTurnId(null);
+          setTurnStatus("error");
+          setLogs((current) =>
+            appendLog(current, {
+              kind: "error",
+              text: "turn error",
+            }),
+          );
+          break;
+        case UI_METHODS.warning: {
+          const params = notification.params as { message?: string };
+          setLogs((current) =>
+            appendLog(current, {
+              kind: "system",
+              text: params.message ?? "warning",
+            }),
+          );
+          break;
+        }
+      }
+    },
+    [appendTaskOutput, requestDiffPreview, requestTaskOutput, sessionId],
+  );
+
+  useEffect(() => {
+    let closedByEffect = false;
+    const socket = new WebSocket(uiProtocolWebSocketUrl());
+    socketRef.current = socket;
+
+    socket.addEventListener("open", () => {
+      setConnectionState("connected");
+      const profileId = getSelectedProfileId();
+      sendProtocol(UI_METHODS.sessionOpen, {
+        session_id: sessionId,
+        ...(profileId ? { profile_id: profileId } : {}),
+      });
+    });
+    socket.addEventListener("message", (event) => {
+      try {
+        const decoded = JSON.parse(String(event.data));
+        if (decoded && typeof decoded === "object" && "id" in decoded) {
+          ingestResponse(decoded as RpcResponse);
+          return;
+        }
+        const notification = protocolNotificationFromEvent(decoded);
+        if (notification) ingestNotification(notification);
+      } catch {
+        setLogs((current) =>
+          appendLog(current, {
+            kind: "error",
+            text: "Received an invalid UI Protocol frame.",
+          }),
+        );
+      }
+    });
+    socket.addEventListener("error", () => {
+      if (!closedByEffect) setConnectionState("error");
+    });
+    socket.addEventListener("close", () => {
+      if (!closedByEffect) setConnectionState("offline");
+    });
+
+    return () => {
+      closedByEffect = true;
+      socket.close();
+      if (socketRef.current === socket) socketRef.current = null;
+    };
+  }, [ingestNotification, ingestResponse, sendProtocol, sessionId]);
+
+  useEffect(() => {
+    function onAppUiEvent(event: Event) {
+      const detail = (event as CustomEvent).detail;
+      const payload =
+        detail && typeof detail === "object" && "kind" in detail
+          ? (detail as { payload?: unknown }).payload
+          : detail;
+      if (payload && typeof payload === "object" && "id" in payload) {
+        ingestResponse(payload as RpcResponse);
+        return;
+      }
+      const notification = protocolNotificationFromEvent(detail);
+      if (notification) ingestNotification(notification);
+    }
+    window.addEventListener("octos:app-ui:event", onAppUiEvent);
+    return () => window.removeEventListener("octos:app-ui:event", onAppUiEvent);
+  }, [ingestNotification, ingestResponse]);
+
+  const submitPrompt = useCallback(
+    (text: string) => {
+      const trimmed = text.trim();
+      if (!trimmed) return;
+      const turnId = crypto.randomUUID();
+      setActiveTurnId(turnId);
+      setTurnStatus("submitted");
+      setLogs((current) => appendLog(current, { kind: "user", text: trimmed }));
+      sendProtocol(UI_METHODS.turnStart, {
+        session_id: sessionId,
+        turn_id: turnId,
+        input: [{ kind: "text", text: trimmed }],
+      });
+    },
+    [sendProtocol, sessionId],
+  );
+
+  const interruptTurn = useCallback(() => {
+    if (!activeTurnId) return;
+    sendProtocol(UI_METHODS.turnInterrupt, {
+      session_id: sessionId,
+      turn_id: activeTurnId,
+    });
+    setTurnStatus("interrupt requested");
+  }, [activeTurnId, sendProtocol, sessionId]);
+
+  const respondApproval = useCallback(
+    (
+      approval: ApprovalRequestedEvent,
+      decision: ApprovalDecision,
+      note?: string,
+    ) => {
+      const params: ApprovalRespondParams = {
+        session_id: sessionId,
+        approval_id: approval.approval_id,
+        decision,
+        approval_scope: "request",
+        ...(note?.trim() ? { client_note: note.trim() } : {}),
+      };
+      setApprovals((current) =>
+        current.map((item) =>
+          item.approval_id === approval.approval_id
+            ? {
+                ...item,
+                local_status: decision === "approve" ? "approved" : "denied",
+              }
+            : item,
+        ),
+      );
+      sendProtocol(UI_METHODS.approvalRespond, params);
+    },
+    [sendProtocol, sessionId],
+  );
+
+  return useMemo(
+    () => ({
+      sessionId,
+      connectionState,
+      turnStatus,
+      activeTurnId,
+      logs,
+      approvals,
+      tasks,
+      panes,
+      diffs,
+      taskOutputs,
+      submitPrompt,
+      interruptTurn,
+      respondApproval,
+    }),
+    [
+      activeTurnId,
+      approvals,
+      connectionState,
+      diffs,
+      interruptTurn,
+      logs,
+      panes,
+      respondApproval,
+      sessionId,
+      submitPrompt,
+      taskOutputs,
+      tasks,
+      turnStatus,
+    ],
+  );
+}

--- a/src/components/home-nav.tsx
+++ b/src/components/home-nav.tsx
@@ -1,6 +1,6 @@
 import { useAuth } from "@/auth/auth-context";
 import { useTheme } from "@/hooks/use-theme";
-import { LogOut, Sun, Moon, MessageSquare, Settings } from "lucide-react";
+import { LogOut, Sun, Moon, MessageSquare, Code2, Settings } from "lucide-react";
 import { useNavigate } from "react-router-dom";
 
 export function HomeNav() {
@@ -27,6 +27,13 @@ export function HomeNav() {
       >
         <MessageSquare size={16} />
         Chat
+      </button>
+      <button
+        onClick={() => navigate("/coding")}
+        className="flex items-center gap-2 rounded-xl bg-surface-container px-4 py-2.5 text-sm text-text hover:bg-surface-elevated"
+      >
+        <Code2 size={16} />
+        Coding
       </button>
       {portal?.can_access_admin_portal && (
         <button

--- a/src/pages/home-page.tsx
+++ b/src/pages/home-page.tsx
@@ -1,6 +1,6 @@
 import { useNavigate } from "react-router-dom";
 import { HomeNav } from "@/components/home-nav";
-import { MessageSquare, ArrowRight, Presentation, Globe } from "lucide-react";
+import { MessageSquare, ArrowRight, Presentation, Globe, Code2 } from "lucide-react";
 
 export function HomePage() {
   const navigate = useNavigate();
@@ -12,7 +12,7 @@ export function HomePage() {
       <div className="flex-1 overflow-y-auto">
         <div className="mx-auto max-w-5xl px-6 py-8">
           {/* Quick actions */}
-          <div className="mb-10 grid grid-cols-1 gap-4 md:grid-cols-3">
+          <div className="mb-10 grid grid-cols-1 gap-4 md:grid-cols-4">
             <button
               onClick={() => navigate("/chat")}
               className="flex items-center gap-4 rounded-2xl bg-surface-container p-6 text-left hover:bg-surface-elevated elevation-1 transition-all"
@@ -23,6 +23,19 @@ export function HomePage() {
               <div className="min-w-0 flex-1">
                 <div className="text-sm font-medium text-text-strong">Start chat</div>
                 <div className="text-xs text-muted">Research, ask questions, explore</div>
+              </div>
+              <ArrowRight size={16} className="ml-auto shrink-0 text-muted" />
+            </button>
+            <button
+              onClick={() => navigate("/coding")}
+              className="flex items-center gap-4 rounded-2xl bg-surface-container p-6 text-left hover:bg-surface-elevated elevation-1 transition-all"
+            >
+              <div className="flex h-12 w-12 shrink-0 items-center justify-center rounded-2xl bg-violet-500/10 text-violet-500">
+                <Code2 size={24} />
+              </div>
+              <div className="min-w-0 flex-1">
+                <div className="text-sm font-medium text-text-strong">Coding</div>
+                <div className="text-xs text-muted">Focused app workspace</div>
               </div>
               <ArrowRight size={16} className="ml-auto shrink-0 text-muted" />
             </button>

--- a/tests/coding-workspace.spec.ts
+++ b/tests/coding-workspace.spec.ts
@@ -1,0 +1,192 @@
+import { test, expect, type Page } from "@playwright/test";
+
+async function mockAuthenticatedApp(page: Page) {
+  await page.route("**/api/auth/status", async (route) => {
+    await route.fulfill({
+      contentType: "application/json",
+      body: JSON.stringify({
+        bootstrap_mode: false,
+        email_login_enabled: true,
+        admin_token_login_enabled: true,
+        allow_self_registration: false,
+      }),
+    });
+  });
+  await page.route("**/api/auth/me", async (route) => {
+    await route.fulfill({
+      contentType: "application/json",
+      body: JSON.stringify({
+        user: {
+          id: "test-user",
+          email: "test@example.com",
+          name: "Test User",
+          role: "user",
+          created_at: "2026-04-27T00:00:00Z",
+          last_login_at: null,
+        },
+        profile: { profile: { id: "dspfac" } },
+        portal: {
+          kind: "owner",
+          home_profile_id: "dspfac",
+          home_route: "/",
+          can_access_admin_portal: false,
+          can_manage_users: false,
+          sub_account_limit: 0,
+          accessible_profiles: [],
+        },
+      }),
+    });
+  });
+  await page.addInitScript(() => {
+    localStorage.setItem("octos_session_token", "test-token");
+    localStorage.setItem("selected_profile", "dspfac");
+  });
+}
+
+test.describe("coding workspace", () => {
+  test("renders coding-only approval controls from UI Protocol events", async ({
+    page,
+  }) => {
+    await mockAuthenticatedApp(page);
+    await page.goto("/coding");
+
+    await expect(page.getByText("AppUi / UI Protocol v1")).toBeVisible();
+    const sessionId = await page
+      .locator("[data-testid='coding-session-id']")
+      .textContent();
+    expect(sessionId).toContain(":api:coding-");
+
+    await page.evaluate((session_id) => {
+      window.dispatchEvent(
+        new CustomEvent("octos:app-ui:event", {
+          detail: {
+            kind: "protocol",
+            payload: {
+              jsonrpc: "2.0",
+              method: "approval/requested",
+              params: {
+                session_id,
+                approval_id: "00000000-0000-0000-0000-000000000001",
+                turn_id: "00000000-0000-0000-0000-000000000002",
+                tool_name: "shell",
+                title: "Run command",
+                body: "Allow this coding command for the current request.",
+                approval_kind: "command",
+                typed_details: {
+                  kind: "command",
+                  command: {
+                    command_line: "npm test -- coding-workspace.spec.ts",
+                    cwd: "/workspace",
+                  },
+                },
+              },
+            },
+          },
+        }),
+      );
+    }, sessionId?.trim());
+
+    await expect(page.locator("[data-testid='coding-approval-card']")).toBeVisible();
+    await expect(page.getByText("npm test -- coding-workspace.spec.ts")).toBeVisible();
+
+    await page.evaluate((session_id) => {
+      window.dispatchEvent(
+        new CustomEvent("octos:app-ui:event", {
+          detail: {
+            jsonrpc: "2.0",
+            id: "session-open-1",
+            result: {
+              opened: {
+                session_id,
+                panes: {
+                  workspace: {
+                    entries: [{ path: "src/parser.rs", kind: "file" }],
+                  },
+                  artifacts: {
+                    items: [{ title: "cargo-test.log", path: "target/log.txt" }],
+                  },
+                  git: {
+                    status: [{ path: "src/parser.rs", status: "modified" }],
+                    history: [{ commit: "abc123", summary: "initial" }],
+                  },
+                },
+              },
+            },
+          },
+        }),
+      );
+      window.dispatchEvent(
+        new CustomEvent("octos:app-ui:event", {
+          detail: {
+            kind: "protocol",
+            payload: {
+              jsonrpc: "2.0",
+              method: "task/updated",
+              params: {
+                session_id,
+                task_id: "task-1",
+                title: "Run cargo test",
+                state: "running",
+                output_tail: "running 6 tests",
+              },
+            },
+          },
+        }),
+      );
+      window.dispatchEvent(
+        new CustomEvent("octos:app-ui:event", {
+          detail: {
+            jsonrpc: "2.0",
+            id: "diff-1",
+            result: {
+              status: "ready",
+              preview: {
+                preview_id: "00000000-0000-0000-0000-000000000003",
+                title: "Parser patch",
+                files: [
+                  {
+                    path: "src/parser.rs",
+                    status: "modified",
+                    hunks: [
+                      {
+                        header: "@@ -1 +1 @@",
+                        lines: [
+                          { kind: "removed", content: "old", old_line: 1 },
+                          { kind: "added", content: "new", new_line: 1 },
+                        ],
+                      },
+                    ],
+                  },
+                ],
+              },
+            },
+          },
+        }),
+      );
+    }, sessionId?.trim());
+
+    await expect(page.locator("[data-testid='coding-workspace-pane']")).toContainText(
+      "src/parser.rs",
+    );
+    await expect(page.locator("[data-testid='coding-artifacts-pane']")).toContainText(
+      "cargo-test.log",
+    );
+    await expect(page.locator("[data-testid='coding-git-pane']")).toContainText(
+      "modified",
+    );
+    await expect(page.locator("[data-testid='coding-task-output-pane']")).toContainText(
+      "running 6 tests",
+    );
+    await expect(page.locator("[data-testid='coding-diff-preview']")).toContainText(
+      "Parser patch",
+    );
+
+    await page.locator("[data-testid='coding-approval-deny']").click();
+    await expect(page.locator("[data-testid='coding-approval-status']")).toHaveText(
+      "denied",
+    );
+
+    await page.goto("/");
+    await expect(page.locator("[data-testid='coding-approvals']")).toHaveCount(0);
+  });
+});


### PR DESCRIPTION
## Summary

Adds a new `/coding` workspace route to the production SPA that speaks **UI Protocol v1 over WebSocket**, consuming the typed `turn_id` envelope delivered by the M8.10 thread-binding fixes in `octos-org/octos` PRs #745-#750. This is the first client-side surface to consume the typed protocol end-to-end.

`/coding` is a **parallel** route alongside the existing `/chat` page. **It is NOT a migration of `/chat`.** `/chat` keeps its REST+SSE transport and will migrate later via a separate workstream (message-store reducer refactor — contract drafted, lands as a sibling docs PR).

## Files

- `src/coding/app-ui-protocol.ts` — typed envelope, JSON-RPC client, WS URL builder
- `src/coding/use-coding-app-ui.ts` — React hook driving session/turn/approval lifecycle
- `src/coding/coding-workspace-page.tsx` — `/coding` page UI (workspace / artifacts / git / task output / diff preview / approvals)
- `tests/coding-workspace.spec.ts` — Playwright spec with mocked WebSocket protocol events
- `src/App.tsx` — `/coding` route registration
- `src/components/home-nav.tsx` — top-nav "Coding" button next to "Chat"
- `src/pages/home-page.tsx` — quick-action tile on the home page

## Test plan

- [x] `npx tsc -b --noEmit` passes
- [x] `npx playwright test tests/coding-workspace.spec.ts` passes (mocked WS events drive approval/diff/task panes; deny flow asserts status; route unmount clears approvals)
- [ ] Manual: `/coding` route loads in browser (dev or staging build)
- [ ] Manual: WebSocket connects to `/api/ui-protocol/ws` against a deployed mini (mini1 or mini3 running `0.1.1+43981ade`)
- [ ] Manual: complete one turn end-to-end (session open -> turn -> approval -> task output -> diff -> result) against deployed server

## Dependencies / non-dependencies

- Depends on server-side fixes in `octos-org/octos` PRs #745-#750 (already deployed to mini1/mini3 as `0.1.1+43981ade`).
- Does **not** depend on the message-store reducer refactor (lands separately as PR K).
- Does **not** depend on the 6 client-side M8.10 fixes for `/chat` (lands separately as PR L from branch `docs/2026-04-17-phase3-control`).