### PR TITLE
fix(chat): close 3 user-visible thread-store gap-fix bugs (PR J)

### DIFF
--- a/src/store/thread-store.test.ts
+++ b/src/store/thread-store.test.ts
@@ -834,6 +834,83 @@ describe("thread-store", () => {
     ]);
   });
 
+  // ---------------------------------------------------------------------------
+  // PR J Fix 2: Sweep still-running tool chips on `done` without `tool_end`
+  //
+  // If the server emits `done` for an assistant turn without a preceding
+  // explicit `tool_end` for some tool calls (suppressed/lost terminal event),
+  // the tool chips would otherwise stay visually "running" forever.
+  // ---------------------------------------------------------------------------
+
+  it("finalizeAssistant_sweeps_running_tool_calls_to_complete", () => {
+    makeUser("kick off pipeline", "cmid-1");
+    ThreadStore.addToolCall("cmid-1", "call_A", "run_pipeline");
+    ThreadStore.appendToolProgress("cmid-1", "call_A", "[info] step 1");
+    // No tool_end fires — server omits it. `done` arrives.
+    ThreadStore.finalizeAssistant("cmid-1", { committedSeq: 3 });
+
+    const [thread] = ThreadStore.getThreads(SESSION);
+    expect(thread.pendingAssistant).toBeNull();
+    expect(thread.responses).toHaveLength(1);
+    const tcs = thread.responses[0].toolCalls;
+    expect(tcs).toHaveLength(1);
+    expect(
+      tcs[0].status,
+      "running tool chip must flip to complete on done — never stay spinning",
+    ).toBe("complete");
+    expect(tcs[0].id).toBe("call_A");
+  });
+
+  it("finalizeAssistant_does_not_regress_already_complete_tool_calls", () => {
+    makeUser("call_with_proper_tool_end", "cmid-1");
+    ThreadStore.addToolCall("cmid-1", "call_A", "run_pipeline");
+    ThreadStore.setToolCallStatus("cmid-1", "call_A", "complete");
+    ThreadStore.finalizeAssistant("cmid-1", { committedSeq: 3 });
+
+    const [thread] = ThreadStore.getThreads(SESSION);
+    const tcs = thread.responses[0].toolCalls;
+    expect(tcs[0].status).toBe("complete");
+  });
+
+  it("finalizeAssistant_preserves_error_status_on_tool_calls", () => {
+    // Errors must NOT be silently overwritten to "complete" by the sweep —
+    // that would hide a user-visible failure.
+    makeUser("call_that_failed", "cmid-1");
+    ThreadStore.addToolCall("cmid-1", "call_A", "run_pipeline");
+    ThreadStore.setToolCallStatus("cmid-1", "call_A", "error");
+    ThreadStore.finalizeAssistant("cmid-1", { committedSeq: 3 });
+
+    const [thread] = ThreadStore.getThreads(SESSION);
+    expect(thread.responses[0].toolCalls[0].status).toBe("error");
+  });
+
+  it("finalizeAssistant_sweeps_when_done_arrives_with_no_progress_no_end", () => {
+    // Edge case: tool_start fires, but no tool_progress and no tool_end —
+    // `done` is the only terminal signal we get. Chip must still complete.
+    makeUser("instant tool", "cmid-1");
+    ThreadStore.addToolCall("cmid-1", "call_A", "fast_tool");
+    ThreadStore.finalizeAssistant("cmid-1", { committedSeq: 1 });
+
+    const [thread] = ThreadStore.getThreads(SESSION);
+    const tc = thread.responses[0].toolCalls[0];
+    expect(tc.status).toBe("complete");
+    expect(tc.id).toBe("call_A");
+  });
+
+  it("finalizeAssistant_sweeps_multiple_running_tool_calls_in_one_turn", () => {
+    makeUser("parallel tools", "cmid-1");
+    ThreadStore.addToolCall("cmid-1", "call_A", "search");
+    ThreadStore.addToolCall("cmid-1", "call_B", "fetch");
+    ThreadStore.setToolCallStatus("cmid-1", "call_A", "complete");
+    // call_B never gets a tool_end — sweep should clean it up.
+    ThreadStore.finalizeAssistant("cmid-1", { committedSeq: 2 });
+
+    const [thread] = ThreadStore.getThreads(SESSION);
+    const tcs = thread.responses[0].toolCalls;
+    expect(tcs.find((tc) => tc.id === "call_A")?.status).toBe("complete");
+    expect(tcs.find((tc) => tc.id === "call_B")?.status).toBe("complete");
+  });
+
   it("replayHistory_does_not_merge_when_companion_has_text_content", () => {
     // Both records have text → real two-bubble conversation, never merge.
     ThreadStore.replayHistory(SESSION, [

--- a/src/store/thread-store.test.ts
+++ b/src/store/thread-store.test.ts
@@ -944,4 +944,214 @@ describe("thread-store", () => {
     const [thread] = ThreadStore.getThreads(SESSION);
     expect(thread.responses).toHaveLength(2);
   });
+
+  // ---------------------------------------------------------------------------
+  // PR J Fix 3: Media + upload hardening
+  //
+  // (a) Duplicate assistant+file collapse: same thread, overlapping file
+  //     paths, compatible text → ONE bubble after replay.
+  // (b) historySeq max preservation across any file-merge operation.
+  // (c) User upload combo (image + audio) — both attach to the user bubble.
+  // ---------------------------------------------------------------------------
+
+  it("replayHistory_collapses_duplicate_assistant_records_with_overlapping_file", () => {
+    ThreadStore.replayHistory(SESSION, [
+      {
+        seq: 0,
+        role: "user",
+        content: "make audio",
+        client_message_id: "cm-1",
+        thread_id: "cm-1",
+        timestamp: "2026-04-28T10:00:00Z",
+      },
+      {
+        seq: 1,
+        role: "assistant",
+        content: "Here is your audio.",
+        media: ["/a.mp3"],
+        response_to_client_message_id: "cm-1",
+        thread_id: "cm-1",
+        timestamp: "2026-04-28T10:00:05Z",
+      },
+      {
+        seq: 2,
+        role: "assistant",
+        content: "Here is your audio.",
+        media: ["/a.mp3"],
+        response_to_client_message_id: "cm-1",
+        thread_id: "cm-1",
+        timestamp: "2026-04-28T10:00:06Z",
+      },
+    ]);
+
+    const [thread] = ThreadStore.getThreads(SESSION);
+    expect(thread.responses).toHaveLength(1);
+    expect(thread.responses[0].files.map((f) => f.path)).toEqual(["/a.mp3"]);
+  });
+
+  it("replayHistory_preserves_max_historySeq_after_duplicate_file_merge", () => {
+    ThreadStore.replayHistory(SESSION, [
+      {
+        seq: 5,
+        role: "user",
+        content: "Q",
+        client_message_id: "cm-1",
+        thread_id: "cm-1",
+        timestamp: "2026-04-28T10:00:00Z",
+      },
+      {
+        seq: 6,
+        role: "assistant",
+        content: "Answer with a file.",
+        media: ["/a.mp3"],
+        response_to_client_message_id: "cm-1",
+        thread_id: "cm-1",
+        timestamp: "2026-04-28T10:00:05Z",
+      },
+      {
+        seq: 10,
+        role: "assistant",
+        content: "Answer with a file.",
+        media: ["/a.mp3", "/b.mp3"],
+        response_to_client_message_id: "cm-1",
+        thread_id: "cm-1",
+        timestamp: "2026-04-28T10:00:08Z",
+      },
+    ]);
+
+    const [thread] = ThreadStore.getThreads(SESSION);
+    expect(thread.responses).toHaveLength(1);
+    expect(thread.responses[0].historySeq).toBe(10);
+    // Files unioned, no duplicates.
+    expect(thread.responses[0].files.map((f) => f.path).sort()).toEqual([
+      "/a.mp3",
+      "/b.mp3",
+    ]);
+  });
+
+  it("replayHistory_does_not_collapse_assistant_records_with_distinct_files", () => {
+    ThreadStore.replayHistory(SESSION, [
+      {
+        seq: 0,
+        role: "user",
+        content: "Q",
+        client_message_id: "cm-1",
+        thread_id: "cm-1",
+        timestamp: "2026-04-28T10:00:00Z",
+      },
+      {
+        seq: 1,
+        role: "assistant",
+        content: "First file.",
+        media: ["/a.mp3"],
+        response_to_client_message_id: "cm-1",
+        thread_id: "cm-1",
+        timestamp: "2026-04-28T10:00:05Z",
+      },
+      {
+        seq: 2,
+        role: "assistant",
+        content: "Second file.",
+        media: ["/b.mp3"],
+        response_to_client_message_id: "cm-1",
+        thread_id: "cm-1",
+        timestamp: "2026-04-28T10:00:08Z",
+      },
+    ]);
+
+    const [thread] = ThreadStore.getThreads(SESSION);
+    // Distinct file paths AND distinct text → two real bubbles, no merge.
+    expect(thread.responses).toHaveLength(2);
+  });
+
+  it("replayHistory_keeps_max_historySeq_after_media_companion_merge", () => {
+    // Re-assert Fix 1's seq invariant using a wider seq gap so the test
+    // is decisive: companion at seq 12 must produce a merged bubble whose
+    // historySeq is 12, not the prior 11.
+    ThreadStore.replayHistory(SESSION, [
+      {
+        seq: 10,
+        role: "user",
+        content: "research",
+        client_message_id: "cm-1",
+        thread_id: "cm-1",
+        timestamp: "2026-04-28T10:00:00Z",
+      },
+      {
+        seq: 11,
+        role: "assistant",
+        content: "Report body.",
+        response_to_client_message_id: "cm-1",
+        thread_id: "cm-1",
+        timestamp: "2026-04-28T10:00:05Z",
+      },
+      {
+        seq: 12,
+        role: "assistant",
+        content: "",
+        media: ["/r.mp3"],
+        response_to_client_message_id: "cm-1",
+        thread_id: "cm-1",
+        timestamp: "2026-04-28T10:00:06Z",
+      },
+    ]);
+
+    const [thread] = ThreadStore.getThreads(SESSION);
+    expect(thread.responses).toHaveLength(1);
+    expect(thread.responses[0].historySeq).toBe(12);
+    expect(thread.responses[0].intra_thread_seq).toBe(12);
+  });
+
+  it("user_message_with_image_and_audio_attaches_both_files_to_user_bubble", () => {
+    // Issue: image+voice combined upload regressed — only one of the two
+    // files attached to the user bubble. Fix is at the `addUserMessage`
+    // level — both paths must end up on `userMsg.files`.
+    const result = ThreadStore.addUserMessage(SESSION, {
+      text: "look at this",
+      clientMessageId: "cm-1",
+      files: [
+        { filename: "photo.png", path: "/uploads/photo.png", caption: "" },
+        { filename: "voice.m4a", path: "/uploads/voice.m4a", caption: "" },
+      ],
+    });
+    expect(result.threadId).toBe("cm-1");
+
+    const [thread] = ThreadStore.getThreads(SESSION);
+    const paths = thread.userMsg.files.map((f) => f.path);
+    expect(
+      paths,
+      "image+voice upload regression: both files must attach to the user bubble",
+    ).toEqual(["/uploads/photo.png", "/uploads/voice.m4a"]);
+    expect(thread.userMsg.role).toBe("user");
+  });
+
+  it("replayHistory_user_message_with_image_and_audio_preserves_both_files", () => {
+    // History reload of an image+voice user turn: both media paths must
+    // round-trip onto `thread.userMsg.files`.
+    ThreadStore.replayHistory(SESSION, [
+      {
+        seq: 0,
+        role: "user",
+        content: "look at this",
+        client_message_id: "cm-1",
+        thread_id: "cm-1",
+        timestamp: "2026-04-28T10:00:00Z",
+        media: ["/uploads/photo.png", "/uploads/voice.m4a"],
+      },
+      {
+        seq: 1,
+        role: "assistant",
+        content: "OK",
+        response_to_client_message_id: "cm-1",
+        thread_id: "cm-1",
+        timestamp: "2026-04-28T10:00:01Z",
+      },
+    ]);
+
+    const [thread] = ThreadStore.getThreads(SESSION);
+    expect(thread.userMsg.files.map((f) => f.path)).toEqual([
+      "/uploads/photo.png",
+      "/uploads/voice.m4a",
+    ]);
+  });
 });

--- a/src/store/thread-store.test.ts
+++ b/src/store/thread-store.test.ts
@@ -656,4 +656,215 @@ describe("thread-store", () => {
       "5 user messages must yield exactly 5 assistant bubbles, not 6+ phantom bubbles from late cross-talk",
     ).toBe(5);
   });
+
+  // ---------------------------------------------------------------------------
+  // PR J Fix 1: Adjacent media-only companion coalescing
+  //
+  // After reload: assistant text record N (e.g. Chinese-language deep-research
+  // report) followed by record N+1 carrying just the report's audio/podcast
+  // as files (no new text) renders as ONE bubble — not two duplicate bubbles
+  // where the second is empty with just files.
+  // ---------------------------------------------------------------------------
+
+  it("replayHistory_merges_adjacent_media_only_companion_into_text_record", () => {
+    ThreadStore.replayHistory(SESSION, [
+      {
+        seq: 0,
+        role: "user",
+        content: "深度研究今日中美关系",
+        client_message_id: "cm-1",
+        thread_id: "cm-1",
+        timestamp: "2026-04-28T10:00:00Z",
+      },
+      {
+        seq: 1,
+        role: "assistant",
+        content: "## 深度研究报告\n今日要点……",
+        response_to_client_message_id: "cm-1",
+        thread_id: "cm-1",
+        timestamp: "2026-04-28T10:00:05Z",
+      },
+      {
+        seq: 2,
+        role: "assistant",
+        content: "",
+        media: ["/tmp/report.mp3"],
+        response_to_client_message_id: "cm-1",
+        thread_id: "cm-1",
+        timestamp: "2026-04-28T10:00:06Z",
+      },
+    ]);
+
+    const [thread] = ThreadStore.getThreads(SESSION);
+    expect(
+      thread.responses,
+      "Chinese report + media-only companion should render as ONE bubble, not two",
+    ).toHaveLength(1);
+    expect(thread.responses[0].text).toContain("深度研究报告");
+    expect(thread.responses[0].files.map((f) => f.path)).toEqual([
+      "/tmp/report.mp3",
+    ]);
+    expect(
+      thread.responses[0].historySeq,
+      "merged record must keep max(historySeq) so later messages stay ordered",
+    ).toBe(2);
+  });
+
+  it("replayHistory_merges_companion_with_only_file_marker_text", () => {
+    // Companion text contains only a `[file:...]` placeholder line — also
+    // counts as media-only since the marker is not user-visible content.
+    ThreadStore.replayHistory(SESSION, [
+      {
+        seq: 0,
+        role: "user",
+        content: "make me a podcast",
+        client_message_id: "cm-1",
+        thread_id: "cm-1",
+        timestamp: "2026-04-28T10:00:00Z",
+      },
+      {
+        seq: 1,
+        role: "assistant",
+        content: "Here is your podcast.",
+        response_to_client_message_id: "cm-1",
+        thread_id: "cm-1",
+        timestamp: "2026-04-28T10:00:05Z",
+      },
+      {
+        seq: 2,
+        role: "assistant",
+        content: "[file: podcast.mp3]",
+        media: ["/tmp/podcast.mp3"],
+        response_to_client_message_id: "cm-1",
+        thread_id: "cm-1",
+        timestamp: "2026-04-28T10:00:06Z",
+      },
+    ]);
+
+    const [thread] = ThreadStore.getThreads(SESSION);
+    expect(thread.responses).toHaveLength(1);
+    expect(thread.responses[0].text).toBe("Here is your podcast.");
+    expect(thread.responses[0].files.map((f) => f.path)).toEqual([
+      "/tmp/podcast.mp3",
+    ]);
+  });
+
+  it("replayHistory_does_not_merge_when_seq_is_not_adjacent", () => {
+    // Gap in seq → not the deep_research-companion pattern, keep separate.
+    ThreadStore.replayHistory(SESSION, [
+      {
+        seq: 0,
+        role: "user",
+        content: "Q",
+        client_message_id: "cm-1",
+        thread_id: "cm-1",
+        timestamp: "2026-04-28T10:00:00Z",
+      },
+      {
+        seq: 1,
+        role: "assistant",
+        content: "Text answer.",
+        response_to_client_message_id: "cm-1",
+        thread_id: "cm-1",
+        timestamp: "2026-04-28T10:00:05Z",
+      },
+      {
+        seq: 5,
+        role: "assistant",
+        content: "",
+        media: ["/tmp/standalone.mp3"],
+        response_to_client_message_id: "cm-1",
+        thread_id: "cm-1",
+        timestamp: "2026-04-28T10:00:30Z",
+      },
+    ]);
+
+    const [thread] = ThreadStore.getThreads(SESSION);
+    expect(
+      thread.responses,
+      "non-adjacent seq must NOT collapse — that media bubble is from a different background task",
+    ).toHaveLength(2);
+  });
+
+  it("replayHistory_does_not_merge_across_threads", () => {
+    // Companion shape but on a different thread → two threads, no merge.
+    ThreadStore.replayHistory(SESSION, [
+      {
+        seq: 0,
+        role: "user",
+        content: "Q1",
+        client_message_id: "cm-1",
+        thread_id: "cm-1",
+        timestamp: "2026-04-28T10:00:00Z",
+      },
+      {
+        seq: 1,
+        role: "assistant",
+        content: "Text answer.",
+        response_to_client_message_id: "cm-1",
+        thread_id: "cm-1",
+        timestamp: "2026-04-28T10:00:05Z",
+      },
+      {
+        seq: 2,
+        role: "user",
+        content: "Q2",
+        client_message_id: "cm-2",
+        thread_id: "cm-2",
+        timestamp: "2026-04-28T10:00:06Z",
+      },
+      {
+        seq: 3,
+        role: "assistant",
+        content: "",
+        media: ["/tmp/cross.mp3"],
+        response_to_client_message_id: "cm-2",
+        thread_id: "cm-2",
+        timestamp: "2026-04-28T10:00:07Z",
+      },
+    ]);
+
+    const threads = ThreadStore.getThreads(SESSION);
+    expect(threads).toHaveLength(2);
+    expect(threads[0].responses).toHaveLength(1);
+    expect(threads[0].responses[0].files).toHaveLength(0);
+    expect(threads[1].responses).toHaveLength(1);
+    expect(threads[1].responses[0].files.map((f) => f.path)).toEqual([
+      "/tmp/cross.mp3",
+    ]);
+  });
+
+  it("replayHistory_does_not_merge_when_companion_has_text_content", () => {
+    // Both records have text → real two-bubble conversation, never merge.
+    ThreadStore.replayHistory(SESSION, [
+      {
+        seq: 0,
+        role: "user",
+        content: "Q",
+        client_message_id: "cm-1",
+        thread_id: "cm-1",
+        timestamp: "2026-04-28T10:00:00Z",
+      },
+      {
+        seq: 1,
+        role: "assistant",
+        content: "First answer.",
+        response_to_client_message_id: "cm-1",
+        thread_id: "cm-1",
+        timestamp: "2026-04-28T10:00:05Z",
+      },
+      {
+        seq: 2,
+        role: "assistant",
+        content: "Follow-up note.",
+        media: ["/tmp/extra.mp3"],
+        response_to_client_message_id: "cm-1",
+        thread_id: "cm-1",
+        timestamp: "2026-04-28T10:00:06Z",
+      },
+    ]);
+
+    const [thread] = ThreadStore.getThreads(SESSION);
+    expect(thread.responses).toHaveLength(2);
+  });
 });

--- a/src/store/thread-store.ts
+++ b/src/store/thread-store.ts
@@ -653,8 +653,18 @@ export function finalizeAssistant(
     const thread = state.byId.get(threadId);
     if (!thread || !thread.pendingAssistant) continue;
 
+    // Sweep any still-running tool calls to "complete" — the assistant
+    // turn ended, so a tool whose explicit `tool_end` was suppressed or
+    // lost over the wire would otherwise leave the chip spinning forever.
+    // Only flip running → complete; preserve "error" and existing
+    // "complete" entries (tool_end already arrived for those).
+    const sweptToolCalls = thread.pendingAssistant.toolCalls.map((tc) =>
+      tc.status === "running" ? { ...tc, status: "complete" as const } : tc,
+    );
+
     const finalized: ThreadMessage = {
       ...thread.pendingAssistant,
+      toolCalls: sweptToolCalls,
       status: opts.status ?? "complete",
       historySeq: opts.committedSeq ?? thread.pendingAssistant.historySeq,
       intra_thread_seq:

--- a/src/store/thread-store.ts
+++ b/src/store/thread-store.ts
@@ -681,6 +681,47 @@ function fileFromMediaPath(path: string): MessageFile {
   };
 }
 
+/** Detect a "media-only companion" assistant record — a follow-on bubble
+ *  that carries just the report's audio/podcast/etc. with no original text
+ *  of its own. Common shapes:
+ *    • completely empty content
+ *    • content is only a `[file: ...]` placeholder line
+ *    • content is just whitespace
+ *  Used by adjacent-merge in `replayHistory` to fold the companion into
+ *  its preceding text record so the user sees one bubble, not two. */
+function isMediaOnlyCompanion(m: ThreadMessage): boolean {
+  if (m.files.length === 0) return false;
+  if (m.toolCalls.length > 0) return false;
+  const trimmed = m.text.trim();
+  if (trimmed.length === 0) return true;
+  // Strip [file: ...] markers; if nothing else remains it's media-only.
+  const stripped = trimmed.replace(/\[file:[^\]]*\]/gi, "").trim();
+  return stripped.length === 0;
+}
+
+/** Merge a media-only companion's files into the preceding assistant
+ *  record. Dedupes by `path`, preserves
+ *  `historySeq = max(prev.historySeq, companion.historySeq)` so later
+ *  ordering stays correct. */
+function mergeMediaCompanionInto(
+  prev: ThreadMessage,
+  companion: ThreadMessage,
+): void {
+  const seenPaths = new Set(prev.files.map((f) => f.path));
+  for (const f of companion.files) {
+    if (!seenPaths.has(f.path)) {
+      prev.files.push(f);
+      seenPaths.add(f.path);
+    }
+  }
+  const prevSeq = prev.historySeq ?? Number.NEGATIVE_INFINITY;
+  const compSeq = companion.historySeq ?? Number.NEGATIVE_INFINITY;
+  if (compSeq > prevSeq) {
+    prev.historySeq = companion.historySeq;
+    prev.intra_thread_seq = companion.intra_thread_seq ?? prev.intra_thread_seq;
+  }
+}
+
 function buildResponseFromApi(m: MessageInfo): ThreadMessage {
   const role: ThreadMessage["role"] =
     m.role === "user"
@@ -816,7 +857,38 @@ export function replayHistory(
       state.threads.push(thread);
     }
 
-    thread.responses.push(buildResponseFromApi(apiMessage));
+    const built = buildResponseFromApi(apiMessage);
+
+    // Adjacent media-only companion coalescing: deep_research returns a
+    // text report (record N) immediately followed by a media-only file
+    // delivery (record N+1) that carries the audio/podcast as files but
+    // no new text of its own. Render them as ONE bubble with text +
+    // attached files instead of two.
+    //
+    // Conditions: both records are assistant-role on the same thread,
+    // historySeq is exactly +1 (no other records between them), and the
+    // incoming record matches `isMediaOnlyCompanion`.
+    if (
+      built.role === "assistant" &&
+      isMediaOnlyCompanion(built) &&
+      thread.responses.length > 0
+    ) {
+      const last = thread.responses[thread.responses.length - 1];
+      const lastSeq = last.historySeq;
+      const builtSeq = built.historySeq;
+      if (
+        last.role === "assistant" &&
+        typeof lastSeq === "number" &&
+        typeof builtSeq === "number" &&
+        builtSeq === lastSeq + 1 &&
+        last.text.trim().length > 0
+      ) {
+        mergeMediaCompanionInto(last, built);
+        continue;
+      }
+    }
+
+    thread.responses.push(built);
   }
 
   // Re-attach any in-flight pendings that didn't surface in the API

--- a/src/store/thread-store.ts
+++ b/src/store/thread-store.ts
@@ -732,6 +732,58 @@ function mergeMediaCompanionInto(
   }
 }
 
+/** Locate a prior assistant response in the same thread that already
+ *  carries at least one of the incoming record's file paths AND whose
+ *  text either matches the incoming text verbatim or is empty (in
+ *  either direction). Returns -1 when no duplicate exists. */
+function findDuplicateAssistantWithFile(
+  responses: ThreadMessage[],
+  incoming: ThreadMessage,
+): number {
+  const incomingPaths = new Set(incoming.files.map((f) => f.path));
+  if (incomingPaths.size === 0) return -1;
+  const incomingText = incoming.text.trim();
+  for (let i = responses.length - 1; i >= 0; i -= 1) {
+    const r = responses[i];
+    if (r.role !== "assistant") continue;
+    if (r.files.length === 0) continue;
+    const hasOverlap = r.files.some((f) => incomingPaths.has(f.path));
+    if (!hasOverlap) continue;
+    const rText = r.text.trim();
+    const textsCompatible =
+      rText === incomingText ||
+      rText.length === 0 ||
+      incomingText.length === 0;
+    if (textsCompatible) return i;
+  }
+  return -1;
+}
+
+/** Merge `incoming` into `prev` for the duplicate-file collapse: union
+ *  the file lists by path, prefer non-empty text, and preserve
+ *  `historySeq = max(...)`. */
+function mergeDuplicateAssistantFile(
+  prev: ThreadMessage,
+  incoming: ThreadMessage,
+): void {
+  const seenPaths = new Set(prev.files.map((f) => f.path));
+  for (const f of incoming.files) {
+    if (!seenPaths.has(f.path)) {
+      prev.files.push(f);
+      seenPaths.add(f.path);
+    }
+  }
+  if (prev.text.trim().length === 0 && incoming.text.trim().length > 0) {
+    prev.text = incoming.text;
+  }
+  const prevSeq = prev.historySeq ?? Number.NEGATIVE_INFINITY;
+  const incSeq = incoming.historySeq ?? Number.NEGATIVE_INFINITY;
+  if (incSeq > prevSeq) {
+    prev.historySeq = incoming.historySeq;
+    prev.intra_thread_seq = incoming.intra_thread_seq ?? prev.intra_thread_seq;
+  }
+}
+
 function buildResponseFromApi(m: MessageInfo): ThreadMessage {
   const role: ThreadMessage["role"] =
     m.role === "user"
@@ -894,6 +946,25 @@ export function replayHistory(
         last.text.trim().length > 0
       ) {
         mergeMediaCompanionInto(last, built);
+        continue;
+      }
+    }
+
+    // Duplicate assistant+file collapse: a prior assistant record on the
+    // same thread already carries one or more of the incoming record's
+    // file paths (overlap) AND the text either matches verbatim or one
+    // side is empty. This handles the replay shape where the persistence
+    // layer wrote both a streaming snapshot and a final delivery for the
+    // same file. Without this, the user sees two assistant bubbles with
+    // the same MP3/PNG attached.
+    if (
+      built.role === "assistant" &&
+      built.files.length > 0 &&
+      thread.responses.length > 0
+    ) {
+      const dupIdx = findDuplicateAssistantWithFile(thread.responses, built);
+      if (dupIdx !== -1) {
+        mergeDuplicateAssistantFile(thread.responses[dupIdx], built);
         continue;
       }
     }


### PR DESCRIPTION
## Context

Server-side fixes for the M8.10 thread-binding chain landed today in `octos-org/octos` (#745-#750: typed envelope, fail-closed thread_id). On the client, `octos-web` main has the `thread-store.ts` paradigm (1023 lines, shipped via PRs #53-#62) which subsumes the **core** routing bug — events route by `thread_id`/`tool_call_id`, originating-turn binding is preserved. The codex paradigm review (`/tmp/codex-octos-web-paradigm-review.log`) identified 3 unique-surface gaps not covered by main's existing work; this PR closes them in the thread-store paradigm. **It does NOT cherry-pick from `docs/2026-04-17-phase3-control`** — that branch fixes the same symptoms in the legacy message-store paradigm and would hard-conflict.

## Fix 1 — Adjacent media-only companion coalescing

**Bug**: After history reload, an assistant text record N (e.g. a Chinese-language deep_research report) followed immediately by a media-only file-delivery record N+1 (no new text, just the audio/podcast as files) rendered as TWO separate assistant bubbles — the second an empty bubble with attachments only.

**Fix**: `src/store/thread-store.ts::replayHistory` — detect same thread_id, adjacent `historySeq`, both role=assistant, trailing record matches `isMediaOnlyCompanion` (empty/whitespace text or text reduces to `[file:...]` markers only). Merge files (deduped by path) into the preceding text record and preserve `historySeq = max(...)`.

**Codex call-out**: see `/tmp/codex-octos-web-paradigm-review.log` line 10 (3846fff: "Not subsumed").

**Tests added** in `src/store/thread-store.test.ts`:
- `replayHistory_merges_adjacent_media_only_companion_into_text_record`
- `replayHistory_merges_companion_with_only_file_marker_text`
- `replayHistory_does_not_merge_when_seq_is_not_adjacent`
- `replayHistory_does_not_merge_across_threads`
- `replayHistory_does_not_merge_when_companion_has_text_content`

## Fix 2 — Sweep running tool chips on `done` without `tool_end`

**Bug**: Tool progress chips stayed visually "running" (spinner, "in progress" badge) forever if the server emitted `done` for an assistant turn without a preceding explicit `tool_end` for some tool calls (terminal event suppressed/lost).

**Scope**: this fix lives in `ThreadStore.finalizeAssistant`, which on main is reached only by the `done` handler in `sse-bridge.ts`. Stream `error` and `abort` paths today record `pendingStreamError` / clear thinking via `MessageStore`-only routes — they do not pass through `finalizeAssistant`. Routing those fallbacks through `finalizeAssistant` so the sweep covers them too is a tracked follow-up, not part of this PR.

**Fix**: `src/store/thread-store.ts::finalizeAssistant` — sweep `pendingAssistant.toolCalls` and flip any `status === "running"` entry to `"complete"` at the same finalize moment. `error` and existing `complete` entries are preserved verbatim, so a real failure is not masked and a properly tool_end'd call is not regressed.

**Codex call-out**: see `/tmp/codex-octos-web-paradigm-review.log` line 8 (5c86214: "Unique gap: branch closes running tool chips on `done` when no `tool_end` arrives").

**Tests added**:
- `finalizeAssistant_sweeps_running_tool_calls_to_complete`
- `finalizeAssistant_does_not_regress_already_complete_tool_calls`
- `finalizeAssistant_preserves_error_status_on_tool_calls`
- `finalizeAssistant_sweeps_when_done_arrives_with_no_progress_no_end`
- `finalizeAssistant_sweeps_multiple_running_tool_calls_in_one_turn`

## Fix 3 — Media + upload hardening

**Bug**: (a) Persistence sometimes wrote both a streaming snapshot and a final delivery for the same file → two assistant bubbles with the same MP3/PNG attached. (b) After any file-merge operation the merged record needs `historySeq = max(...)` so later messages stay correctly ordered. (c) Image+voice combined upload regression — the test coverage gap codex flagged on `08bd63f`.

**Fix**: `src/store/thread-store.ts::replayHistory` — duplicate assistant+file collapse: same thread, prior assistant has overlapping file paths AND text matches verbatim or one side is empty. Union files by path, prefer non-empty text, preserve max `historySeq`. The `addUserMessage` path already mirrors `files` correctly through `sendMessage`; tests assert image+voice both attach via the live and the replay paths.

**Codex call-out**: see `/tmp/codex-octos-web-paradigm-review.log` line 11 (08bd63f: "Partially subsumed... main lacks seq+1 adjacent merge, duplicate assistant-with-file collapse, companion suppression in appendHistory, and historySeq max preservation after file merge").

**Tests added**:
- `replayHistory_collapses_duplicate_assistant_records_with_overlapping_file`
- `replayHistory_preserves_max_historySeq_after_duplicate_file_merge`
- `replayHistory_does_not_collapse_assistant_records_with_distinct_files`
- `replayHistory_keeps_max_historySeq_after_media_companion_merge`
- `user_message_with_image_and_audio_attaches_both_files_to_user_bubble`
- `replayHistory_user_message_with_image_and_audio_preserves_both_files`

## Paradigm note

Re-implemented in the thread-store paradigm. `docs/2026-04-17-phase3-control` fixes the same symptoms in the legacy message-store and would hard-conflict (paradigm clash); per codex recommendation, only the thread-store layer is touched here. Total diff: 155 LOC code + 498 LOC tests across 2 files (`thread-store.ts`, `thread-store.test.ts`); no other surfaces touched.

## Test plan

- [x] `npx tsc -b --noEmit` → exit 0
- [x] `npx vitest run` → 48/48 pass (42 thread-store + 6 sse-bridge), 16 of which are new for this PR
- [x] `npx eslint src/store/thread-store.ts src/store/thread-store.test.ts` → clean
- [ ] Existing Playwright suites still green: `tests/background-task-scope.spec.ts`, `tests/session-switching.spec.ts`, `tests/session-recovery.spec.ts`, `tests/tts-runtime-events.spec.ts` (manual verify against a deployed mini)
- [ ] Manual /chat verification on a deployed mini: deep_research with audio output produces ONE merged bubble; tool chips never spin past `done`; image+voice user upload shows both attachments