### PR TITLE
fix(sse-bridge): route session_result events into ThreadStore (closes M8.10 wave-6 leak — PR M)

### DIFF
--- a/src/runtime/sse-bridge.ts
+++ b/src/runtime/sse-bridge.ts
@@ -757,6 +757,23 @@ function bindStreamToAssistant({
       }
 
       case "session_result": {
+        // M8.10 wave-6 fix (PR M): the v2 renderer reads ONLY ThreadStore
+        // and ignores MessageStore. Without this branch a late
+        // session_result for a deep_research / mofa / run_pipeline turn
+        // landed solely in the legacy store, leaving the v2 UI frozen on
+        // the finalized spawn-ack. Server stamps `message.thread_id` for
+        // both non-media and media-bearing paths; we use it directly and
+        // fall through to `deriveLegacyThreadId` inside the helper for
+        // the legacy-daemon edge case.
+        if (threadStoreEnabled && event.message) {
+          const tid =
+            event.message.thread_id ?? (event as { thread_id?: string }).thread_id;
+          ThreadStore.appendPersistedMessage(
+            sessionId,
+            historyTopic,
+            tid ? { ...event.message, thread_id: tid } : event.message,
+          );
+        }
         if (event.message) {
           const previousSeq = MessageStore.getMaxHistorySeq(sessionId, historyTopic);
           const merged = MessageStore.mergeHistoryMessageIntoMessage(

--- a/src/store/thread-store.test.ts
+++ b/src/store/thread-store.test.ts
@@ -1154,4 +1154,148 @@ describe("thread-store", () => {
       "/uploads/voice.m4a",
     ]);
   });
+
+  // -------------------------------------------------------------------------
+  // appendPersistedMessage — M8.10 wave-6 leak (PR M, session_result routing)
+  // -------------------------------------------------------------------------
+
+  it("appendPersistedMessage_routes_late_assistant_into_existing_thread", () => {
+    // Fixture: deep_research turn whose spawn-ack assistant has already
+    // finalized. The late session_result carrying the actual report must
+    // land in the SAME thread's responses, not a new orphan.
+    makeUser("deep research today's news", "cm-deep");
+    ThreadStore.replaceAssistantText("cm-deep", "spawned");
+    ThreadStore.finalizeAssistant("cm-deep", { committedSeq: 1 });
+
+    ThreadStore.appendPersistedMessage(SESSION, undefined, {
+      seq: 5,
+      role: "assistant",
+      content: "## Today\nReport body...",
+      response_to_client_message_id: "cm-deep",
+      thread_id: "cm-deep",
+      timestamp: "2026-04-28T10:05:00Z",
+    });
+
+    const [thread] = ThreadStore.getThreads(SESSION);
+    expect(thread.id).toBe("cm-deep");
+    expect(thread.responses).toHaveLength(2);
+    expect(thread.responses[1].text).toContain("Report body");
+    expect(thread.responses[1].historySeq).toBe(5);
+  });
+
+  it("appendPersistedMessage_with_media_only_companion_merges_into_text_response", () => {
+    // Late media-only delivery (e.g. podcast.mp3) must fold into the
+    // previous text response on the same thread — same rule replayHistory
+    // applies on a fresh page load.
+    makeUser("make me a podcast", "cm-pod");
+    ThreadStore.appendPersistedMessage(SESSION, undefined, {
+      seq: 1,
+      role: "assistant",
+      content: "Here is your podcast.",
+      response_to_client_message_id: "cm-pod",
+      thread_id: "cm-pod",
+      timestamp: "2026-04-28T10:00:05Z",
+    });
+    ThreadStore.appendPersistedMessage(SESSION, undefined, {
+      seq: 2,
+      role: "assistant",
+      content: "",
+      media: ["/tmp/podcast.mp3"],
+      response_to_client_message_id: "cm-pod",
+      thread_id: "cm-pod",
+      timestamp: "2026-04-28T10:00:06Z",
+    });
+
+    const [thread] = ThreadStore.getThreads(SESSION);
+    expect(thread.responses).toHaveLength(1);
+    expect(thread.responses[0].text).toBe("Here is your podcast.");
+    expect(thread.responses[0].files.map((f) => f.path)).toEqual([
+      "/tmp/podcast.mp3",
+    ]);
+  });
+
+  it("appendPersistedMessage_idempotent", () => {
+    makeUser("Q", "cm-1");
+    const msg = {
+      seq: 7,
+      role: "assistant" as const,
+      content: "Answer.",
+      response_to_client_message_id: "cm-1",
+      thread_id: "cm-1",
+      timestamp: "2026-04-28T10:00:05Z",
+    };
+    ThreadStore.appendPersistedMessage(SESSION, undefined, msg);
+    ThreadStore.appendPersistedMessage(SESSION, undefined, msg);
+
+    const [thread] = ThreadStore.getThreads(SESSION);
+    const finalized = thread.responses.filter((r) => r.role === "assistant");
+    expect(
+      finalized,
+      "second call with same seq must be a no-op",
+    ).toHaveLength(1);
+  });
+
+  it("appendPersistedMessage_falls_back_to_legacy_thread_id_when_thread_id_missing", () => {
+    // Legacy daemon: server omits thread_id. Helper must derive it from
+    // client_message_id / response_to_client_message_id and find the
+    // existing thread anyway.
+    makeUser("Q", "cm-legacy");
+    ThreadStore.appendPersistedMessage(SESSION, undefined, {
+      seq: 3,
+      role: "assistant",
+      content: "Late answer.",
+      response_to_client_message_id: "cm-legacy",
+      timestamp: "2026-04-28T10:00:05Z",
+    });
+
+    const [thread] = ThreadStore.getThreads(SESSION);
+    expect(thread.id).toBe("cm-legacy");
+    expect(thread.responses).toHaveLength(1);
+    expect(thread.responses[0].text).toBe("Late answer.");
+  });
+
+  it("appendPersistedMessage_does_not_disturb_pendingAssistant_for_other_thread", () => {
+    // Thread A still streaming, thread B receives a late session_result.
+    // A's pendingAssistant must be untouched.
+    makeUser("slow Q", "cm-A");
+    makeUser("fast Q", "cm-B");
+    ThreadStore.appendAssistantToken("cm-A", "still typing");
+
+    ThreadStore.appendPersistedMessage(SESSION, undefined, {
+      seq: 9,
+      role: "assistant",
+      content: "B's answer.",
+      response_to_client_message_id: "cm-B",
+      thread_id: "cm-B",
+      timestamp: "2026-04-28T10:00:05Z",
+    });
+
+    const threads = ThreadStore.getThreads(SESSION);
+    const a = threads.find((t) => t.id === "cm-A")!;
+    const b = threads.find((t) => t.id === "cm-B")!;
+    expect(a.pendingAssistant?.text).toBe("still typing");
+    expect(a.pendingAssistant?.status).toBe("streaming");
+    expect(b.responses).toHaveLength(1);
+    expect(b.responses[0].text).toBe("B's answer.");
+  });
+
+  it("appendPersistedMessage_creates_orphan_thread_when_thread_unknown", () => {
+    // Late session_result for a thread we never saw open (e.g. mid-stream
+    // page reload). Helper must synthesize a placeholder thread so the
+    // record is at least visible — no silent drop.
+    ThreadStore.appendPersistedMessage(SESSION, undefined, {
+      seq: 4,
+      role: "assistant",
+      content: "Orphan late answer.",
+      response_to_client_message_id: "cm-unseen",
+      thread_id: "cm-unseen",
+      timestamp: "2026-04-28T10:00:05Z",
+    });
+
+    const threads = ThreadStore.getThreads(SESSION);
+    expect(threads).toHaveLength(1);
+    expect(threads[0].id).toBe("cm-unseen");
+    expect(threads[0].responses).toHaveLength(1);
+    expect(threads[0].responses[0].text).toBe("Orphan late answer.");
+  });
 });

--- a/src/store/thread-store.ts
+++ b/src/store/thread-store.ts
@@ -1133,7 +1133,17 @@ export function appendPersistedMessage(
     thread.responses.length > 0
   ) {
     const last = thread.responses[thread.responses.length - 1];
-    if (last.role === "assistant" && last.text.trim().length > 0) {
+    const lastSeq = last.historySeq;
+    const builtSeq = built.historySeq;
+    const adjacent =
+      typeof lastSeq === "number" &&
+      typeof builtSeq === "number" &&
+      builtSeq === lastSeq + 1;
+    if (
+      adjacent &&
+      last.role === "assistant" &&
+      last.text.trim().length > 0
+    ) {
       mergeMediaCompanionInto(last, built);
       notify();
       return;

--- a/src/store/thread-store.ts
+++ b/src/store/thread-store.ts
@@ -1003,6 +1003,165 @@ export function replayHistory(
   notify();
 }
 
+/**
+ * Ingest a single persisted `MessageInfo` (e.g. from a `session_result` SSE
+ * event) into the appropriate thread without replaying the whole session.
+ *
+ * Closes the M8.10 wave-6 leak: pre-fix, late `session_result` events for
+ * deep_research / mofa / run_pipeline turns landed only in the legacy
+ * MessageStore — which the v2 renderer ignores — leaving the v2 UI stuck on
+ * the finalized spawn-ack. Now the `sse-bridge` handler also calls this
+ * helper so the persisted record reaches `ThreadStore.responses`.
+ *
+ * Routing:
+ *   • Use `message.thread_id` when present (server stamps it for both the
+ *     non-media and media-bearing `_session_result` paths).
+ *   • Fall back to `deriveLegacyThreadId` for legacy daemons that omit it.
+ *
+ * Merge: applies the same media-only-companion and duplicate-assistant-file
+ * rules `replayHistory` uses against the existing tail of the thread, so a
+ * late audio/podcast delivery folds into the spawn-ack assistant bubble
+ * instead of producing an orphan duplicate.
+ *
+ * Idempotent: a second call for the same `historySeq` (from a replay) is a
+ * no-op.
+ *
+ * Notes:
+ *   • Does NOT touch `pendingAssistant` — a different turn in the same
+ *     thread may still be running (rare but possible during overlap).
+ *   • Skips `system` messages (mirrors `replayHistory`).
+ */
+export function appendPersistedMessage(
+  sessionId: string,
+  topic: string | undefined,
+  message: MessageInfo,
+): void {
+  if (message.role === "system") return;
+
+  // Prefer the explicit thread_id stamped by the server. For legacy
+  // daemons that omit it, walk the obvious fallbacks before reaching for
+  // `deriveLegacyThreadId` (which synthesizes a fresh id for an
+  // assistant record with no ambient context — wrong for a single late
+  // session_result delivery).
+  const directThreadId =
+    message.thread_id ||
+    message.response_to_client_message_id ||
+    (message.role === "user" ? message.client_message_id : undefined);
+  const ctx = { currentThreadId: null as string | null };
+  const threadId = directThreadId || deriveLegacyThreadId(message, ctx);
+  if (!threadId) return;
+
+  const key = storeKey(sessionId, topic);
+  let state = sessionsByKey.get(key);
+
+  // Locate (or adopt) the thread. Prefer the live session's bucket; fall
+  // back to a globally-known thread (e.g. orphan bucket created earlier on
+  // a different scope key); finally synthesize a placeholder so the late
+  // record is at least visible.
+  let thread: Thread | undefined = state?.byId.get(threadId);
+  if (!thread) {
+    const found = findThreadById(threadId);
+    if (found) {
+      state = found.state;
+      thread = found.thread;
+    }
+  }
+  if (!thread) {
+    if (!state) {
+      state = ensureSession(key);
+    }
+    const placeholderUser: ThreadMessage = {
+      id: nextId(),
+      role: "user",
+      text: "",
+      files: [],
+      toolCalls: [],
+      status: "complete",
+      timestamp: message.timestamp
+        ? new Date(message.timestamp).getTime()
+        : Date.now(),
+      clientMessageId: threadId,
+    };
+    thread = {
+      id: threadId,
+      userMsg: placeholderUser,
+      responses: [],
+      pendingAssistant: null,
+    };
+    insertThreadInTimestampOrder(state, thread);
+  }
+
+  if (message.role === "user") {
+    // Persisted user record echoing back through session_result — only
+    // adopt its text/files if the existing user bubble is the empty
+    // placeholder (orphan thread case). Don't clobber a real send.
+    if (thread.userMsg.text === "" && thread.userMsg.files.length === 0) {
+      const built = buildResponseFromApi(message);
+      thread.userMsg = {
+        ...thread.userMsg,
+        text: built.text,
+        files: built.files,
+        historySeq: built.historySeq,
+        intra_thread_seq: built.intra_thread_seq,
+        clientMessageId: message.client_message_id ?? threadId,
+      };
+      notify();
+    }
+    return;
+  }
+
+  // Idempotency: skip if a response with the same historySeq is already in
+  // the thread. The server-side seq is per-session monotonic so this is a
+  // safe identity check — and the only one available since `MessageInfo`
+  // has no stable id field.
+  const incomingSeq = typeof message.seq === "number" ? message.seq : undefined;
+  if (incomingSeq !== undefined) {
+    for (const r of thread.responses) {
+      if (r.historySeq === incomingSeq) return;
+    }
+  }
+
+  const built = buildResponseFromApi(message);
+
+  // Adjacent media-only companion: late media-bearing record whose text is
+  // empty / a `[file:...]` marker folds into the prior text response on
+  // this thread. Mirrors the `replayHistory` rule so the runtime path
+  // produces the same shape as a fresh page load.
+  if (
+    built.role === "assistant" &&
+    isMediaOnlyCompanion(built) &&
+    thread.responses.length > 0
+  ) {
+    const last = thread.responses[thread.responses.length - 1];
+    if (last.role === "assistant" && last.text.trim().length > 0) {
+      mergeMediaCompanionInto(last, built);
+      notify();
+      return;
+    }
+  }
+
+  // Duplicate assistant+file collapse: a prior response on the same thread
+  // already carries this media. Mirrors `replayHistory` so a streamed
+  // snapshot followed by a persisted final delivery doesn't produce two
+  // bubbles holding the same MP3/PNG.
+  if (
+    built.role === "assistant" &&
+    built.files.length > 0 &&
+    thread.responses.length > 0
+  ) {
+    const dupIdx = findDuplicateAssistantWithFile(thread.responses, built);
+    if (dupIdx !== -1) {
+      mergeDuplicateAssistantFile(thread.responses[dupIdx], built);
+      notify();
+      return;
+    }
+  }
+
+  thread.responses.push(built);
+  sortResponsesInThread(thread);
+  notify();
+}
+
 // ---------------------------------------------------------------------------
 // History loading
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Context

- Wave-6 closeout: `/tmp/wave6-closeout.md`
- Codex review pinpointing root cause: `/tmp/codex-failure-bc-review.log`
- Builds on PR J (#64): closes a 4th client-side gap PR J's pre-merge review missed.

## Root cause

`sse-bridge.ts` `case "session_result"` updated only the legacy `MessageStore`. With `octos_thread_store_v2=1` (the live-thread-interleave spec config), `ChatThreadV2` reads only `ThreadStore.useThreads(...)` and ignores `MessageStore` — so the persisted `MessageInfo` carried by a late deep_research / mofa / run_pipeline `session_result` SSE event landed in the dead store and the v2 UI stayed frozen on the finalized spawn-ack. Server side is already correct: `session_actor.rs:3821-3861` stamps both `metadata.thread_id` and `_session_result.thread_id`, and `api_channel.rs:1004-1012` injects top-level `thread_id` for non-media events. The data was there; the client just didn't ingest it.

## Fix summary

1. `ThreadStore.appendPersistedMessage(sessionId, topic, message)` — single-record ingest helper that:
   - Routes by `message.thread_id`, falling back to `response_to_client_message_id` and `deriveLegacyThreadId` for legacy daemons.
   - Reuses the existing `isMediaOnlyCompanion` / `mergeMediaCompanionInto` and `findDuplicateAssistantWithFile` / `mergeDuplicateAssistantFile` helpers so the runtime path produces the same shape as a fresh page load.
   - Idempotent on `historySeq`.
   - Synthesizes an orphan placeholder thread when the late record references a thread we never saw open (mid-stream page reload).
   - Does NOT disturb `pendingAssistant` — a different turn on the same thread may still be running.
2. Wires the helper from `sse-bridge.ts case "session_result"` before the existing legacy `MessageStore` code path, gated on `threadStoreEnabled`. The legacy path remains intact for users with the v2 flag off.

No server change — server-side stamping is already correct; client was the sole leak site.

## Test plan

- [x] `npx tsc -b --noEmit` — passes
- [x] `npx vitest run` — 54/54 pass (6 new tests for `appendPersistedMessage`):
  - `appendPersistedMessage_routes_late_assistant_into_existing_thread`
  - `appendPersistedMessage_with_media_only_companion_merges_into_text_response`
  - `appendPersistedMessage_idempotent`
  - `appendPersistedMessage_falls_back_to_legacy_thread_id_when_thread_id_missing`
  - `appendPersistedMessage_does_not_disturb_pendingAssistant_for_other_thread`
  - `appendPersistedMessage_creates_orphan_thread_when_thread_unknown`
- [ ] Empirical: re-run wave-6 (`live-thread-interleave.spec.ts` + 4 overflow-stress scenarios) against deployed fix to confirm M8.10 critical-spec failure is closed.

## Diff

```
 src/runtime/sse-bridge.ts      |  17 +++++
 src/store/thread-store.ts      | 159 ++++++++++++++++++++++++++++++++++++++
 src/store/thread-store.test.ts | 144 +++++++++++++++++++++++++++++++++
 3 files changed, 320 insertions(+)
```

Note: PR J merged the 3 known gaps (#64); this PR closes a 4th gap codex's PR J pre-merge review missed.