### PR TITLE
feat(flags): chat_app_ui_v1 for UI Protocol v1 transport rollout (Phase C-3, closes #69)

### DIFF
--- a/src/lib/feature-flags.test.ts
+++ b/src/lib/feature-flags.test.ts
@@ -1,0 +1,38 @@
+/**
+ * feature-flags unit tests (Phase C-3, issue #69).
+ */
+
+import { afterEach, describe, expect, it } from "vitest";
+import { isChatAppUiV1Enabled } from "./feature-flags";
+
+afterEach(() => {
+  window.localStorage.clear();
+});
+
+describe("isChatAppUiV1Enabled", () => {
+  it("returns false when localStorage is unset (default OFF)", () => {
+    expect(isChatAppUiV1Enabled()).toBe(false);
+  });
+
+  it("returns true when localStorage is set to '1'", () => {
+    window.localStorage.setItem("chat_app_ui_v1", "1");
+    expect(isChatAppUiV1Enabled()).toBe(true);
+  });
+
+  it("returns false when localStorage is set to '0'", () => {
+    window.localStorage.setItem("chat_app_ui_v1", "0");
+    expect(isChatAppUiV1Enabled()).toBe(false);
+  });
+
+  it("returns false for any non-'1' value (conservative)", () => {
+    for (const v of ["true", "yes", "on", "enabled", "", " 1", "1 "]) {
+      window.localStorage.setItem("chat_app_ui_v1", v);
+      expect(isChatAppUiV1Enabled()).toBe(false);
+    }
+  });
+
+  it("does not read other flags (octos_thread_store_v2 is independent)", () => {
+    window.localStorage.setItem("octos_thread_store_v2", "1");
+    expect(isChatAppUiV1Enabled()).toBe(false);
+  });
+});

--- a/src/lib/feature-flags.ts
+++ b/src/lib/feature-flags.ts
@@ -1,0 +1,27 @@
+/**
+ * Feature flag helpers (Phase C-3, issue #69).
+ *
+ * Mirrors the inline `localStorage.getItem("octos_thread_store_v2") === "1"`
+ * pattern used by the M8.10 thread-store rollout. Each flag is OFF by default
+ * and opt-in via `localStorage.setItem('<name>', '1')` in DevTools. Reads are
+ * fresh on every call so toggling does not require a page reload, and any
+ * environment without `window` (SSR, tests without `jsdom`) returns false.
+ *
+ * `chat_app_ui_v1` gates the UI Protocol v1 transport rollout (Phase C-2 wires
+ * the flag into the chat surface; this PR is scaffolding only).
+ */
+
+const CHAT_APP_UI_V1 = "chat_app_ui_v1";
+
+function readFlag(name: string): boolean {
+  if (typeof window === "undefined") return false;
+  try {
+    return window.localStorage.getItem(name) === "1";
+  } catch {
+    return false;
+  }
+}
+
+export function isChatAppUiV1Enabled(): boolean {
+  return readFlag(CHAT_APP_UI_V1);
+}


### PR DESCRIPTION
## Summary

Phase C-3 of the UI Protocol v1 rollout (master tracker #66, this issue #69). Pure scaffolding — adds the `chat_app_ui_v1` feature flag and its `isChatAppUiV1Enabled()` helper. No call sites yet (C-2 wires it into the chat surface).

- `src/lib/feature-flags.ts` — exports `isChatAppUiV1Enabled()`. Reads `localStorage.getItem('chat_app_ui_v1') === '1'` fresh on every call so DevTools toggles take effect on the next render without a page reload. SSR-safe (`typeof window === 'undefined'` guard) and try/catch'd against storage exceptions, mirroring the inline pattern used by the existing `octos_thread_store_v2` flag (see `src/runtime/sse-bridge.ts`, `src/components/chat-thread.tsx`, `src/sites/components/sites-chat.tsx`, `src/store/thread-store.ts`).
- `src/lib/feature-flags.test.ts` — 5 Vitest cases: default OFF, `'1'` → true, `'0'` → false, conservative non-`'1'` rejection (incl. `'true'`, whitespace-padded `'1'`), and isolation from `octos_thread_store_v2`.

Default is OFF. No existing flag behavior changes. C-2 (parallel branch) will be the first importer.

## Test plan

- [x] `npx tsc -b --noEmit` — clean
- [x] `npx vitest run` — 59/59 pass (5 new + 54 existing)
- [ ] Reviewer: open DevTools, run `localStorage.setItem('chat_app_ui_v1', '1')`, confirm `isChatAppUiV1Enabled()` returns `true` (call site lands in C-2 PR)
- [ ] Reviewer: confirm `octos_thread_store_v2` rollout is unaffected (no files outside `src/lib/feature-flags.*` touched)

Closes #69
Tracker: #66