### PR TITLE
feat(runtime): UI Protocol v1 client bridge for /chat (Phase C-1, closes #67)

### DIFF
--- a/src/runtime/ui-protocol-bridge.test.ts
+++ b/src/runtime/ui-protocol-bridge.test.ts
@@ -1,0 +1,851 @@
+/**
+ * Unit tests for the UI Protocol v1 client bridge (Phase C-1).
+ *
+ * Covers:
+ *   - lifecycle transitions: connecting → connected → closed
+ *   - re-startable after stop
+ *   - reconnect with exponential backoff under fake timers
+ *   - send queue: buffer while not-connected, drain on connected, oldest-drop overflow
+ *   - fail-closed type guards: malformed event drops + warning
+ *   - notification dispatch routes to typed handlers
+ *   - RPC correlation by id; mismatched id surfaces as warning
+ *   - RPC timeout rejects after configured ms
+ *   - keepalive ping ticks every 30s while connected
+ *   - subscriber unsubscribe removes the handler
+ */
+
+import {
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  vi,
+} from "vitest";
+import {
+  BridgeRpcError,
+  BridgeStoppedError,
+  BridgeTimeoutError,
+  METHODS,
+  __INTERNAL_GUARDS_FOR_TEST__ as guards,
+  createUiProtocolBridge,
+} from "./ui-protocol-bridge";
+import type {
+  ApprovalRequestedEvent,
+  ConnectionState,
+  MessageDeltaEvent,
+  MessagePersistedEvent,
+  TaskOutputDeltaEvent,
+  TaskUpdatedEvent,
+  TurnCompletedEvent,
+  TurnErrorEvent,
+  TurnStartedEvent,
+  WarningEvent,
+} from "./ui-protocol-types";
+
+// ---------------------------------------------------------------------------
+// MockWebSocket
+//
+// vitest's jsdom env doesn't ship a controllable WebSocket. We hand-roll one
+// so each test can drive open/message/close events directly and assert what
+// frames the bridge sent.
+// ---------------------------------------------------------------------------
+
+class MockWebSocket {
+  static CONNECTING = 0;
+  static OPEN = 1;
+  static CLOSING = 2;
+  static CLOSED = 3;
+
+  static instances: MockWebSocket[] = [];
+
+  readonly url: string;
+  readonly protocols?: string | string[];
+  readyState = MockWebSocket.CONNECTING;
+  CONNECTING = MockWebSocket.CONNECTING;
+  OPEN = MockWebSocket.OPEN;
+  CLOSING = MockWebSocket.CLOSING;
+  CLOSED = MockWebSocket.CLOSED;
+
+  sent: string[] = [];
+
+  onopen: ((ev?: unknown) => void) | null = null;
+  onmessage: ((ev: { data: unknown }) => void) | null = null;
+  onerror: ((ev?: unknown) => void) | null = null;
+  onclose: ((ev: { code: number; reason?: string }) => void) | null = null;
+
+  constructor(url: string, protocols?: string | string[]) {
+    this.url = url;
+    this.protocols = protocols;
+    MockWebSocket.instances.push(this);
+  }
+
+  // --- helpers test cases use ------------------------------------------------
+
+  triggerOpen(): void {
+    this.readyState = MockWebSocket.OPEN;
+    this.onopen?.({});
+  }
+
+  triggerMessage(payload: unknown): void {
+    const data =
+      typeof payload === "string" ? payload : JSON.stringify(payload);
+    this.onmessage?.({ data });
+  }
+
+  triggerNonText(): void {
+    this.onmessage?.({ data: new ArrayBuffer(4) });
+  }
+
+  triggerClose(code = 1006, reason = "abnormal"): void {
+    this.readyState = MockWebSocket.CLOSED;
+    this.onclose?.({ code, reason });
+  }
+
+  // --- WebSocket API --------------------------------------------------------
+
+  send(data: string): void {
+    if (this.readyState !== MockWebSocket.OPEN) {
+      throw new Error(`mock-ws: send while readyState=${this.readyState}`);
+    }
+    this.sent.push(data);
+  }
+
+  close(code = 1000): void {
+    this.readyState = MockWebSocket.CLOSED;
+    // Mirror real-browser behavior: close() triggers onclose synchronously
+    // in our test harness (real browsers schedule a microtask).
+    this.onclose?.({ code });
+  }
+
+  // No-op listener API (the bridge uses on*-style props, not addEventListener).
+  addEventListener(): void {}
+  removeEventListener(): void {}
+}
+
+function lastInstance(): MockWebSocket {
+  const w = MockWebSocket.instances[MockWebSocket.instances.length - 1];
+  if (!w) throw new Error("test: no MockWebSocket instance yet");
+  return w;
+}
+
+function findRequest(
+  ws: MockWebSocket,
+  method: string,
+): { id: string; params: unknown } {
+  for (const text of ws.sent) {
+    const parsed = JSON.parse(text) as {
+      id?: string;
+      method: string;
+      params?: unknown;
+    };
+    if (parsed.method === method && typeof parsed.id === "string") {
+      return { id: parsed.id, params: parsed.params };
+    }
+  }
+  throw new Error(`test: no ${method} request sent. sent=${ws.sent.join("|")}`);
+}
+
+function makeBridgeOpts(extra: Record<string, unknown> = {}) {
+  let counter = 0;
+  return {
+    origin: "https://test.local",
+    getToken: () => "test-token",
+    getProfileId: () => null,
+    webSocketImpl: MockWebSocket as unknown as typeof WebSocket,
+    generateId: () => `rpc-${++counter}`,
+    ...extra,
+  };
+}
+
+beforeEach(() => {
+  MockWebSocket.instances = [];
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+// ---------------------------------------------------------------------------
+// guard tests — cheap, exhaustive
+// ---------------------------------------------------------------------------
+
+describe("type guards (fail-closed)", () => {
+  it("rejects message/delta without turn_id and produces null", () => {
+    expect(
+      guards.guardMessageDelta({
+        session_id: "s",
+        delta: "hi",
+      }),
+    ).toBeNull();
+  });
+
+  it("accepts message/delta with all required string fields", () => {
+    const ev = guards.guardMessageDelta({
+      session_id: "s",
+      turn_id: "t",
+      delta: "hi",
+    });
+    expect(ev).toEqual({
+      session_id: "s",
+      turn_id: "t",
+      delta: "hi",
+      message_id: undefined,
+    });
+  });
+
+  it("rejects message/persisted whose message lacks thread_id", () => {
+    expect(
+      guards.guardMessagePersisted({
+        session_id: "s",
+        turn_id: "t",
+        message: { id: "m", role: "assistant", content: "" },
+      }),
+    ).toBeNull();
+  });
+
+  it("accepts message/persisted with thread_id", () => {
+    const ev = guards.guardMessagePersisted({
+      session_id: "s",
+      turn_id: "t",
+      message: {
+        id: "m",
+        thread_id: "th",
+        role: "assistant",
+        content: "hi",
+      },
+    });
+    expect(ev?.message.thread_id).toBe("th");
+  });
+
+  it("rejects task/updated without task_id", () => {
+    expect(
+      guards.guardTaskUpdated({
+        session_id: "s",
+        turn_id: "t",
+        state: "running",
+      }),
+    ).toBeNull();
+  });
+
+  it("rejects task/output/delta without chunk", () => {
+    expect(
+      guards.guardTaskOutputDelta({
+        session_id: "s",
+        turn_id: "t",
+        task_id: "k",
+      }),
+    ).toBeNull();
+  });
+
+  it("rejects approval/requested missing tool_name", () => {
+    expect(
+      guards.guardApprovalRequested({
+        session_id: "s",
+        approval_id: "a",
+        turn_id: "t",
+        title: "x",
+        body: "y",
+      }),
+    ).toBeNull();
+  });
+
+  it("accepts approval/requested with valid scope and drops invalid scope", () => {
+    const ok = guards.guardApprovalRequested({
+      session_id: "s",
+      approval_id: "a",
+      turn_id: "t",
+      tool_name: "shell",
+      title: "x",
+      body: "y",
+      approval_scope: "turn",
+    });
+    expect(ok?.approval_scope).toBe("turn");
+    const bogus = guards.guardApprovalRequested({
+      session_id: "s",
+      approval_id: "a",
+      turn_id: "t",
+      tool_name: "shell",
+      title: "x",
+      body: "y",
+      approval_scope: "forever",
+    });
+    expect(bogus?.approval_scope).toBeUndefined();
+  });
+
+  it("rejects turn/error without an error object", () => {
+    expect(
+      guards.guardTurnError({ session_id: "s", turn_id: "t" }),
+    ).toBeNull();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Lifecycle
+// ---------------------------------------------------------------------------
+
+describe("connection lifecycle", () => {
+  it("transitions connecting → connected on session/open ack", async () => {
+    const states: ConnectionState[] = [];
+    const bridge = createUiProtocolBridge(makeBridgeOpts());
+    bridge.onConnectionStateChange((s) => states.push(s));
+    const startPromise = bridge.start({ sessionId: "sess-1" });
+    // Give the bridge a tick to construct the socket.
+    await Promise.resolve();
+    const ws = lastInstance();
+    ws.triggerOpen();
+    // The bridge sent session/open immediately after onopen; reply success.
+    await Promise.resolve();
+    const open = findRequest(ws, METHODS.SESSION_OPEN);
+    ws.triggerMessage({
+      jsonrpc: "2.0",
+      id: open.id,
+      result: { opened: { session_id: "sess-1" } },
+    });
+    await startPromise;
+    expect(states).toEqual(["connecting", "connected"]);
+  });
+
+  it("includes auth token, profile, and ui_feature query params in the URL", async () => {
+    const bridge = createUiProtocolBridge(
+      makeBridgeOpts({ getProfileId: () => "prof-x" }),
+    );
+    void bridge.start({ sessionId: "sess-1" });
+    await Promise.resolve();
+    const ws = lastInstance();
+    expect(ws.url.startsWith("wss://test.local/api/ui-protocol/ws?")).toBe(
+      true,
+    );
+    expect(ws.url).toContain("token=test-token");
+    expect(ws.url).toContain("ui_feature=approval.typed.v1");
+    expect(ws.url).toContain("ui_feature=pane.snapshots.v1");
+    expect(ws.protocols).toEqual(["octos.bearer.test-token"]);
+  });
+
+  it("session/open params include profile_id when provided to start()", async () => {
+    const bridge = createUiProtocolBridge(makeBridgeOpts());
+    void bridge.start({ sessionId: "sess-1", profileId: "prof-y" });
+    await Promise.resolve();
+    const ws = lastInstance();
+    ws.triggerOpen();
+    await Promise.resolve();
+    const open = findRequest(ws, METHODS.SESSION_OPEN);
+    expect(open.params).toEqual({
+      session_id: "sess-1",
+      profile_id: "prof-y",
+    });
+  });
+
+  it("stop() emits closed, closes the socket, and rejects pending RPCs", async () => {
+    vi.useFakeTimers();
+    const states: ConnectionState[] = [];
+    const bridge = createUiProtocolBridge(makeBridgeOpts());
+    bridge.onConnectionStateChange((s) => states.push(s));
+    void bridge.start({ sessionId: "sess-1" });
+    await Promise.resolve();
+    const ws = lastInstance();
+    ws.triggerOpen();
+    await Promise.resolve();
+    const open = findRequest(ws, METHODS.SESSION_OPEN);
+    ws.triggerMessage({
+      jsonrpc: "2.0",
+      id: open.id,
+      result: { opened: { session_id: "sess-1" } },
+    });
+    await Promise.resolve();
+
+    // Pending RPC that should reject on stop().
+    const pending = bridge.sendTurn("turn-1", [{ kind: "text", text: "hi" }]);
+    let caught: unknown;
+    pending.catch((err) => {
+      caught = err;
+    });
+
+    await bridge.stop();
+    await Promise.resolve();
+    await Promise.resolve();
+    expect(states).toContain("closed");
+    expect(ws.readyState).toBe(MockWebSocket.CLOSED);
+    expect(caught).toBeInstanceOf(BridgeStoppedError);
+  });
+
+  it("supports start → stop → start again", async () => {
+    const bridge = createUiProtocolBridge(makeBridgeOpts());
+    void bridge.start({ sessionId: "sess-1" });
+    await Promise.resolve();
+    let ws = lastInstance();
+    ws.triggerOpen();
+    await Promise.resolve();
+    let open = findRequest(ws, METHODS.SESSION_OPEN);
+    ws.triggerMessage({
+      jsonrpc: "2.0",
+      id: open.id,
+      result: { opened: { session_id: "sess-1" } },
+    });
+    await Promise.resolve();
+    await bridge.stop();
+
+    void bridge.start({ sessionId: "sess-2" });
+    await Promise.resolve();
+    ws = lastInstance();
+    expect(ws.url).toContain("token=test-token");
+    ws.triggerOpen();
+    await Promise.resolve();
+    open = findRequest(ws, METHODS.SESSION_OPEN);
+    expect(open.params).toEqual({ session_id: "sess-2" });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Reconnect
+// ---------------------------------------------------------------------------
+
+describe("reconnect with exponential backoff", () => {
+  it("schedules retries on backoff schedule and re-opens on each tick", async () => {
+    vi.useFakeTimers();
+    const bridge = createUiProtocolBridge(makeBridgeOpts());
+    const states: ConnectionState[] = [];
+    bridge.onConnectionStateChange((s) => states.push(s));
+    void bridge.start({ sessionId: "sess-1" });
+    await Promise.resolve();
+    const ws1 = lastInstance();
+    ws1.triggerOpen();
+    await Promise.resolve();
+    const open1 = findRequest(ws1, METHODS.SESSION_OPEN);
+    ws1.triggerMessage({
+      jsonrpc: "2.0",
+      id: open1.id,
+      result: { opened: { session_id: "sess-1" } },
+    });
+    await Promise.resolve();
+    expect(states).toContain("connected");
+
+    // Drop the socket abnormally — this should schedule a reconnect.
+    ws1.triggerClose(1006, "abnormal");
+    expect(states).toContain("reconnecting");
+    expect(MockWebSocket.instances).toHaveLength(1);
+
+    // Advance the first backoff tick (1s).
+    await vi.advanceTimersByTimeAsync(1000);
+    expect(MockWebSocket.instances).toHaveLength(2);
+
+    // Drop again to advance the schedule to 2s.
+    const ws2 = lastInstance();
+    ws2.triggerClose(1006, "abnormal");
+    await vi.advanceTimersByTimeAsync(2000);
+    expect(MockWebSocket.instances).toHaveLength(3);
+
+    // 2s is too short for the third schedule (4s) — verify nothing fired.
+    const ws3 = lastInstance();
+    ws3.triggerClose(1006, "abnormal");
+    await vi.advanceTimersByTimeAsync(2000);
+    expect(MockWebSocket.instances).toHaveLength(3);
+    await vi.advanceTimersByTimeAsync(2000);
+    expect(MockWebSocket.instances).toHaveLength(4);
+  });
+
+  it("transitions to error after maxReconnectAttempts", async () => {
+    vi.useFakeTimers();
+    const bridge = createUiProtocolBridge(
+      makeBridgeOpts({ maxReconnectAttempts: 2 }),
+    );
+    const states: ConnectionState[] = [];
+    bridge.onConnectionStateChange((s) => states.push(s));
+    void bridge.start({ sessionId: "sess-1" });
+    await Promise.resolve();
+    const ws1 = lastInstance();
+    ws1.triggerClose(1006);
+    await vi.advanceTimersByTimeAsync(1000);
+    const ws2 = lastInstance();
+    ws2.triggerClose(1006);
+    await vi.advanceTimersByTimeAsync(2000);
+    const ws3 = lastInstance();
+    ws3.triggerClose(1006);
+    expect(states).toContain("error");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Send queue
+// ---------------------------------------------------------------------------
+
+describe("send queue", () => {
+  it("queues frames while not connected and drains on connected", async () => {
+    const bridge = createUiProtocolBridge(makeBridgeOpts());
+    void bridge.start({ sessionId: "sess-1" });
+    await Promise.resolve();
+    const ws = lastInstance();
+
+    // Bridge is in `connecting` — issuing a turn now should defer the frame
+    // until session/open completes and state flips to `connected`.
+    void bridge.sendTurn("turn-1", [{ kind: "text", text: "hello" }]);
+    expect(ws.sent.find((f) => f.includes(METHODS.TURN_START))).toBeUndefined();
+
+    ws.triggerOpen();
+    await Promise.resolve();
+    const open = findRequest(ws, METHODS.SESSION_OPEN);
+    ws.triggerMessage({
+      jsonrpc: "2.0",
+      id: open.id,
+      result: { opened: { session_id: "sess-1" } },
+    });
+    await Promise.resolve();
+    expect(ws.sent.find((f) => f.includes(METHODS.TURN_START))).toBeDefined();
+  });
+
+  it("drops oldest entries when the queue overflows and emits warning", async () => {
+    const bridge = createUiProtocolBridge(
+      makeBridgeOpts({ sendQueueLimit: 2 }),
+    );
+    const warnings: WarningEvent[] = [];
+    bridge.onWarning((w) => warnings.push(w));
+    void bridge.start({ sessionId: "sess-1" });
+    await Promise.resolve();
+    const ws = lastInstance();
+    void bridge.sendTurn("turn-A", [{ kind: "text", text: "a" }]);
+    void bridge.sendTurn("turn-B", [{ kind: "text", text: "b" }]);
+    void bridge.sendTurn("turn-C", [{ kind: "text", text: "c" }]);
+    expect(warnings.some((w) => w.reason === "send_queue_overflow")).toBe(true);
+
+    ws.triggerOpen();
+    await Promise.resolve();
+    const open = findRequest(ws, METHODS.SESSION_OPEN);
+    ws.triggerMessage({
+      jsonrpc: "2.0",
+      id: open.id,
+      result: { opened: { session_id: "sess-1" } },
+    });
+    await Promise.resolve();
+
+    // Only B and C should have actually been sent — A was the oldest entry
+    // and got dropped to make room for C when the queue hit the cap.
+    const turnFrames = ws.sent
+      .map((f) => JSON.parse(f) as { method: string; params?: { turn_id?: string } })
+      .filter((f) => f.method === METHODS.TURN_START)
+      .map((f) => f.params?.turn_id);
+    expect(turnFrames).toEqual(["turn-B", "turn-C"]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Notification dispatch
+// ---------------------------------------------------------------------------
+
+describe("notification dispatch", () => {
+  async function freshConnected() {
+    const bridge = createUiProtocolBridge(makeBridgeOpts());
+    void bridge.start({ sessionId: "sess-1" });
+    await Promise.resolve();
+    const ws = lastInstance();
+    ws.triggerOpen();
+    await Promise.resolve();
+    const open = findRequest(ws, METHODS.SESSION_OPEN);
+    ws.triggerMessage({
+      jsonrpc: "2.0",
+      id: open.id,
+      result: { opened: { session_id: "sess-1" } },
+    });
+    await Promise.resolve();
+    return { bridge, ws };
+  }
+
+  it("routes message/delta to its handler", async () => {
+    const { bridge, ws } = await freshConnected();
+    const seen: MessageDeltaEvent[] = [];
+    bridge.onMessageDelta((e) => seen.push(e));
+    ws.triggerMessage({
+      jsonrpc: "2.0",
+      method: METHODS.MESSAGE_DELTA,
+      params: { session_id: "sess-1", turn_id: "t1", delta: "hi" },
+    });
+    expect(seen).toHaveLength(1);
+    expect(seen[0].turn_id).toBe("t1");
+  });
+
+  it("emits warning when message/delta is missing turn_id", async () => {
+    const { bridge, ws } = await freshConnected();
+    const warnings: WarningEvent[] = [];
+    const deltas: MessageDeltaEvent[] = [];
+    bridge.onWarning((w) => warnings.push(w));
+    bridge.onMessageDelta((e) => deltas.push(e));
+    ws.triggerMessage({
+      jsonrpc: "2.0",
+      method: METHODS.MESSAGE_DELTA,
+      params: { session_id: "sess-1", delta: "hi" },
+    });
+    expect(deltas).toHaveLength(0);
+    expect(warnings.some((w) => w.reason === "invalid_event:message/delta")).toBe(
+      true,
+    );
+  });
+
+  it("routes message/persisted, task/updated, task/output/delta", async () => {
+    const { bridge, ws } = await freshConnected();
+    const persisted: MessagePersistedEvent[] = [];
+    const tasks: TaskUpdatedEvent[] = [];
+    const outputs: TaskOutputDeltaEvent[] = [];
+    bridge.onMessagePersisted((e) => persisted.push(e));
+    bridge.onTaskUpdated((e) => tasks.push(e));
+    bridge.onTaskOutputDelta((e) => outputs.push(e));
+
+    ws.triggerMessage({
+      jsonrpc: "2.0",
+      method: METHODS.MESSAGE_PERSISTED,
+      params: {
+        session_id: "sess-1",
+        turn_id: "t1",
+        message: {
+          id: "m1",
+          thread_id: "th1",
+          role: "assistant",
+          content: "ok",
+        },
+      },
+    });
+    ws.triggerMessage({
+      jsonrpc: "2.0",
+      method: METHODS.TASK_UPDATED,
+      params: {
+        session_id: "sess-1",
+        turn_id: "t1",
+        task_id: "task-A",
+        state: "running",
+      },
+    });
+    ws.triggerMessage({
+      jsonrpc: "2.0",
+      method: METHODS.TASK_OUTPUT_DELTA,
+      params: {
+        session_id: "sess-1",
+        turn_id: "t1",
+        task_id: "task-A",
+        chunk: "log line",
+      },
+    });
+
+    expect(persisted).toHaveLength(1);
+    expect(persisted[0].message.thread_id).toBe("th1");
+    expect(tasks[0].task_id).toBe("task-A");
+    expect(outputs[0].chunk).toBe("log line");
+  });
+
+  it("routes turn lifecycle and approval/requested", async () => {
+    const { bridge, ws } = await freshConnected();
+    const lifecycle: Array<
+      TurnStartedEvent | TurnCompletedEvent | TurnErrorEvent
+    > = [];
+    const approvals: ApprovalRequestedEvent[] = [];
+    bridge.onTurnLifecycle((e) => lifecycle.push(e));
+    bridge.onApprovalRequested((e) => approvals.push(e));
+    ws.triggerMessage({
+      jsonrpc: "2.0",
+      method: METHODS.TURN_STARTED,
+      params: { session_id: "sess-1", turn_id: "t1" },
+    });
+    ws.triggerMessage({
+      jsonrpc: "2.0",
+      method: METHODS.TURN_ERROR,
+      params: {
+        session_id: "sess-1",
+        turn_id: "t1",
+        error: { code: -32603, message: "boom" },
+      },
+    });
+    ws.triggerMessage({
+      jsonrpc: "2.0",
+      method: METHODS.APPROVAL_REQUESTED,
+      params: {
+        session_id: "sess-1",
+        approval_id: "ap1",
+        turn_id: "t1",
+        tool_name: "shell",
+        title: "Confirm rm",
+        body: "rm -rf /tmp/foo",
+      },
+    });
+    expect(lifecycle).toHaveLength(2);
+    expect(approvals).toHaveLength(1);
+    expect(approvals[0].approval_id).toBe("ap1");
+  });
+
+  it("routes warning notifications to onWarning", async () => {
+    const { bridge, ws } = await freshConnected();
+    const warnings: WarningEvent[] = [];
+    bridge.onWarning((w) => warnings.push(w));
+    ws.triggerMessage({
+      jsonrpc: "2.0",
+      method: METHODS.WARNING,
+      params: { reason: "ledger_replay_lossy", context: { dropped: 12 } },
+    });
+    expect(warnings.find((w) => w.reason === "ledger_replay_lossy")).toBeDefined();
+  });
+
+  it("emits warning on unparseable JSON and non-text frame", async () => {
+    const { bridge, ws } = await freshConnected();
+    const warnings: WarningEvent[] = [];
+    bridge.onWarning((w) => warnings.push(w));
+    ws.triggerMessage("not-json");
+    ws.triggerNonText();
+    expect(warnings.some((w) => w.reason === "json_parse_error")).toBe(true);
+    expect(warnings.some((w) => w.reason === "non_text_frame")).toBe(true);
+  });
+
+  it("returns an unsubscribe function that removes the handler", async () => {
+    const { bridge, ws } = await freshConnected();
+    const seen: MessageDeltaEvent[] = [];
+    const unsub = bridge.onMessageDelta((e) => seen.push(e));
+    ws.triggerMessage({
+      jsonrpc: "2.0",
+      method: METHODS.MESSAGE_DELTA,
+      params: { session_id: "sess-1", turn_id: "t1", delta: "a" },
+    });
+    unsub();
+    ws.triggerMessage({
+      jsonrpc: "2.0",
+      method: METHODS.MESSAGE_DELTA,
+      params: { session_id: "sess-1", turn_id: "t1", delta: "b" },
+    });
+    expect(seen).toHaveLength(1);
+    expect(seen[0].delta).toBe("a");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// RPC correlation + timeout
+// ---------------------------------------------------------------------------
+
+describe("rpc correlation", () => {
+  it("routes the response with matching id to the right pending promise", async () => {
+    const bridge = createUiProtocolBridge(makeBridgeOpts());
+    void bridge.start({ sessionId: "sess-1" });
+    await Promise.resolve();
+    const ws = lastInstance();
+    ws.triggerOpen();
+    await Promise.resolve();
+    const open = findRequest(ws, METHODS.SESSION_OPEN);
+    ws.triggerMessage({
+      jsonrpc: "2.0",
+      id: open.id,
+      result: { opened: { session_id: "sess-1" } },
+    });
+    await Promise.resolve();
+
+    const promise = bridge.sendTurn("turn-1", [{ kind: "text", text: "hi" }]);
+    const turnFrame = findRequest(ws, METHODS.TURN_START);
+    ws.triggerMessage({
+      jsonrpc: "2.0",
+      id: turnFrame.id,
+      result: { accepted: true },
+    });
+    await expect(promise).resolves.toEqual({ accepted: true });
+  });
+
+  it("rejects with BridgeRpcError on error response", async () => {
+    const bridge = createUiProtocolBridge(makeBridgeOpts());
+    void bridge.start({ sessionId: "sess-1" });
+    await Promise.resolve();
+    const ws = lastInstance();
+    ws.triggerOpen();
+    await Promise.resolve();
+    const open = findRequest(ws, METHODS.SESSION_OPEN);
+    ws.triggerMessage({
+      jsonrpc: "2.0",
+      id: open.id,
+      result: { opened: { session_id: "sess-1" } },
+    });
+    await Promise.resolve();
+
+    const promise = bridge.sendTurn("turn-1", [{ kind: "text", text: "hi" }]);
+    const turnFrame = findRequest(ws, METHODS.TURN_START);
+    ws.triggerMessage({
+      jsonrpc: "2.0",
+      id: turnFrame.id,
+      error: { code: -32004, message: "method_not_supported" },
+    });
+    await expect(promise).rejects.toBeInstanceOf(BridgeRpcError);
+  });
+
+  it("emits warning when response id matches no pending promise", async () => {
+    const bridge = createUiProtocolBridge(makeBridgeOpts());
+    void bridge.start({ sessionId: "sess-1" });
+    await Promise.resolve();
+    const ws = lastInstance();
+    ws.triggerOpen();
+    await Promise.resolve();
+    const open = findRequest(ws, METHODS.SESSION_OPEN);
+    ws.triggerMessage({
+      jsonrpc: "2.0",
+      id: open.id,
+      result: { opened: { session_id: "sess-1" } },
+    });
+    await Promise.resolve();
+    const warnings: WarningEvent[] = [];
+    bridge.onWarning((w) => warnings.push(w));
+    ws.triggerMessage({
+      jsonrpc: "2.0",
+      id: "bogus-id",
+      result: { ok: true },
+    });
+    expect(warnings.some((w) => w.reason === "rpc_id_unmatched")).toBe(true);
+  });
+
+  it("times out pending RPCs after rpcTimeoutMs", async () => {
+    vi.useFakeTimers();
+    const bridge = createUiProtocolBridge(
+      makeBridgeOpts({ rpcTimeoutMs: 5000 }),
+    );
+    void bridge.start({ sessionId: "sess-1" });
+    await Promise.resolve();
+    const ws = lastInstance();
+    ws.triggerOpen();
+    await Promise.resolve();
+    const open = findRequest(ws, METHODS.SESSION_OPEN);
+    ws.triggerMessage({
+      jsonrpc: "2.0",
+      id: open.id,
+      result: { opened: { session_id: "sess-1" } },
+    });
+    await Promise.resolve();
+
+    const promise = bridge.sendTurn("turn-1", [{ kind: "text", text: "hi" }]);
+    let captured: unknown;
+    promise.catch((err) => {
+      captured = err;
+    });
+    await vi.advanceTimersByTimeAsync(5001);
+    expect(captured).toBeInstanceOf(BridgeTimeoutError);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Keepalive
+// ---------------------------------------------------------------------------
+
+describe("keepalive", () => {
+  it("sends a ping every 30s while connected", async () => {
+    vi.useFakeTimers();
+    const bridge = createUiProtocolBridge(
+      makeBridgeOpts({
+        keepaliveIntervalMs: 30000,
+        keepaliveTimeoutMs: 60000,
+      }),
+    );
+    void bridge.start({ sessionId: "sess-1" });
+    await Promise.resolve();
+    const ws = lastInstance();
+    ws.triggerOpen();
+    await Promise.resolve();
+    const open = findRequest(ws, METHODS.SESSION_OPEN);
+    ws.triggerMessage({
+      jsonrpc: "2.0",
+      id: open.id,
+      result: { opened: { session_id: "sess-1" } },
+    });
+    await Promise.resolve();
+
+    const pingsBefore = ws.sent.filter((f) => f.includes('"ping"')).length;
+    await vi.advanceTimersByTimeAsync(30000);
+    const pingsAfter = ws.sent.filter((f) => f.includes('"ping"')).length;
+    expect(pingsAfter).toBeGreaterThan(pingsBefore);
+  });
+});

--- a/src/runtime/ui-protocol-bridge.ts
+++ b/src/runtime/ui-protocol-bridge.ts
@@ -1,0 +1,1034 @@
+/**
+ * UI Protocol v1 client bridge for /chat (Phase C-1).
+ *
+ * Strict, fail-closed adapter around the JSON-RPC over WebSocket transport
+ * served at `/api/ui-protocol/ws`. Pure adapter: no rendering, no store
+ * mutations. Phase C-2 wires it into the existing runtime; this PR only
+ * lands the bridge surface plus tests.
+ *
+ * Failure mode: required fields missing on a notification surface as a
+ * `warning` event and the notification is dropped. Synthesizing UUIDs
+ * defeats the entire point of the strict typing — the prior /coding bridge
+ * (PR #63, BLOCKed by codex review) had `turn_id?: string` and a synthetic
+ * fallback, which is exactly the M8.10 thread-binding bug class.
+ */
+
+import { getToken, getSelectedProfileId } from "@/api/client";
+import type {
+  ApprovalDecision,
+  ApprovalRequestedEvent,
+  ApprovalRespondResult,
+  ApprovalScope,
+  ConnectionState,
+  MessageDeltaEvent,
+  MessagePersistedEvent,
+  RpcErrorPayload,
+  SessionOpenResult,
+  TaskOutputDeltaEvent,
+  TaskUpdatedEvent,
+  TurnCompletedEvent,
+  TurnErrorEvent,
+  TurnInterruptResult,
+  TurnStartInput,
+  TurnStartResult,
+  TurnStartedEvent,
+  WarningEvent,
+} from "./ui-protocol-types";
+
+export type {
+  ApprovalDecision,
+  ApprovalRequestedEvent,
+  ApprovalRespondResult,
+  ApprovalScope,
+  ConnectionState,
+  MessageDeltaEvent,
+  MessagePersistedEvent,
+  PersistedMessage,
+  PersistedMessageFile,
+  SessionOpenResult,
+  SessionOpenedResult,
+  TaskOutputDeltaEvent,
+  TaskUpdatedEvent,
+  TurnCompletedEvent,
+  TurnErrorEvent,
+  TurnInterruptResult,
+  TurnStartInput,
+  TurnStartResult,
+  TurnStartedEvent,
+  UiCursor,
+  WarningEvent,
+} from "./ui-protocol-types";
+
+// ---------------------------------------------------------------------------
+// Wire constants
+// ---------------------------------------------------------------------------
+
+export const UI_PROTOCOL_WS_PATH = "/api/ui-protocol/ws";
+
+export const METHODS = {
+  // client → server
+  SESSION_OPEN: "session/open",
+  TURN_START: "turn/start",
+  TURN_INTERRUPT: "turn/interrupt",
+  APPROVAL_RESPOND: "approval/respond",
+  TASK_OUTPUT_READ: "task/output/read",
+  DIFF_PREVIEW_GET: "diff/preview/get",
+  TURN_STATE_GET: "turn/state/get",
+  PING: "ping",
+  // server → client
+  MESSAGE_DELTA: "message/delta",
+  MESSAGE_PERSISTED: "message/persisted",
+  TASK_UPDATED: "task/updated",
+  TASK_OUTPUT_DELTA: "task/output/delta",
+  TURN_STARTED: "turn/started",
+  TURN_COMPLETED: "turn/completed",
+  TURN_ERROR: "turn/error",
+  APPROVAL_REQUESTED: "approval/requested",
+  WARNING: "warning",
+} as const;
+
+export const UI_PROTOCOL_FEATURES = [
+  "approval.typed.v1",
+  "pane.snapshots.v1",
+] as const;
+
+const JSON_RPC_VERSION = "2.0";
+
+// Backoff schedule per task spec: 1s, 2s, 4s, 8s, 16s, 30s, then capped at 30s.
+const RECONNECT_BACKOFF_MS = [1000, 2000, 4000, 8000, 16000, 30000] as const;
+const RECONNECT_BACKOFF_CAP_MS = 30000;
+const DEFAULT_MAX_RECONNECT_ATTEMPTS = 8;
+const DEFAULT_RPC_TIMEOUT_MS = 30000;
+const DEFAULT_SEND_QUEUE_LIMIT = 64;
+const DEFAULT_KEEPALIVE_MS = 30000;
+const DEFAULT_KEEPALIVE_TIMEOUT_MS = 60000;
+const NORMAL_CLOSURE = 1000;
+
+// ---------------------------------------------------------------------------
+// Public API
+// ---------------------------------------------------------------------------
+
+export class BridgeStoppedError extends Error {
+  constructor(message = "ui-protocol-bridge stopped") {
+    super(message);
+    this.name = "BridgeStoppedError";
+  }
+}
+
+export class BridgeRpcError extends Error {
+  readonly code: number;
+  readonly data: unknown;
+  constructor(code: number, message: string, data?: unknown) {
+    super(`rpc-error[${code}] ${message}`);
+    this.name = "BridgeRpcError";
+    this.code = code;
+    this.data = data;
+  }
+}
+
+export class BridgeTimeoutError extends Error {
+  constructor(method: string, timeoutMs: number) {
+    super(`rpc timeout: ${method} after ${timeoutMs}ms`);
+    this.name = "BridgeTimeoutError";
+  }
+}
+
+export interface UiProtocolBridge {
+  start(opts: { sessionId: string; profileId?: string }): Promise<void>;
+  stop(): Promise<void>;
+
+  sendTurn(turn_id: string, input: TurnStartInput[]): Promise<TurnStartResult>;
+  interruptTurn(turn_id: string, reason?: string): Promise<TurnInterruptResult>;
+  respondToApproval(
+    approval_id: string,
+    decision: ApprovalDecision,
+    scope?: ApprovalScope,
+    client_note?: string,
+  ): Promise<ApprovalRespondResult>;
+
+  onMessageDelta(handler: (e: MessageDeltaEvent) => void): () => void;
+  onMessagePersisted(handler: (e: MessagePersistedEvent) => void): () => void;
+  onTaskUpdated(handler: (e: TaskUpdatedEvent) => void): () => void;
+  onTaskOutputDelta(handler: (e: TaskOutputDeltaEvent) => void): () => void;
+  onTurnLifecycle(
+    handler: (
+      e: TurnStartedEvent | TurnCompletedEvent | TurnErrorEvent,
+    ) => void,
+  ): () => void;
+  onApprovalRequested(handler: (e: ApprovalRequestedEvent) => void): () => void;
+  onConnectionStateChange(handler: (state: ConnectionState) => void): () => void;
+  onWarning(handler: (e: WarningEvent) => void): () => void;
+}
+
+export interface BridgeConfig {
+  /** Override the WS endpoint origin. Defaults to `window.location.origin`. */
+  origin?: string;
+  /** Override the auth token resolver (test/SSR injection). */
+  getToken?: () => string | null;
+  /** Override the profile resolver (test/SSR injection). */
+  getProfileId?: () => string | null;
+  /** Override `WebSocket` constructor (test injection). */
+  webSocketImpl?: typeof WebSocket;
+  /** Override the UUID generator (test injection). */
+  generateId?: () => string;
+  /** Override the timer scheduler (test injection — vitest fake timers). */
+  setTimeout?: (fn: () => void, ms: number) => unknown;
+  clearTimeout?: (handle: unknown) => void;
+  /** Override `Date.now()` (test injection). */
+  now?: () => number;
+  /** Override the negotiated `ui_feature` capability list. */
+  features?: readonly string[];
+  /** Per-RPC timeout. Default 30s. */
+  rpcTimeoutMs?: number;
+  /** Send queue cap before oldest entries are dropped. Default 64. */
+  sendQueueLimit?: number;
+  /** Reconnect attempts before the bridge transitions to `error`. Default 8. */
+  maxReconnectAttempts?: number;
+  /** Keepalive interval in `'connected'` state. Default 30s. */
+  keepaliveIntervalMs?: number;
+  /** Silence threshold before a keepalive triggers reconnect. Default 60s. */
+  keepaliveTimeoutMs?: number;
+}
+
+// ---------------------------------------------------------------------------
+// Wire envelope shapes
+// ---------------------------------------------------------------------------
+
+interface JsonRpcRequest {
+  jsonrpc: "2.0";
+  id: string;
+  method: string;
+  params?: unknown;
+}
+
+interface JsonRpcResponse {
+  jsonrpc: "2.0";
+  id: string;
+  result?: unknown;
+  error?: RpcErrorPayload;
+}
+
+interface JsonRpcNotification {
+  jsonrpc: "2.0";
+  method: string;
+  params?: unknown;
+}
+
+type QueuedFrame = string;
+
+interface PendingRpc {
+  method: string;
+  resolve: (value: unknown) => void;
+  reject: (err: Error) => void;
+  timer: unknown;
+}
+
+type Listener<T> = (value: T) => void;
+
+class Subscribers<T> {
+  private readonly handlers: Set<Listener<T>> = new Set();
+
+  add(handler: Listener<T>): () => void {
+    this.handlers.add(handler);
+    return () => {
+      this.handlers.delete(handler);
+    };
+  }
+
+  emit(value: T): void {
+    for (const h of [...this.handlers]) {
+      try {
+        h(value);
+      } catch {
+        // Subscriber errors must not break dispatch; the bridge swallows
+        // them so a buggy listener can't poison sibling subscribers.
+      }
+    }
+  }
+
+  clear(): void {
+    this.handlers.clear();
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Type guards (fail-closed)
+// ---------------------------------------------------------------------------
+
+function isString(v: unknown): v is string {
+  return typeof v === "string" && v.length > 0;
+}
+
+function isPlainObject(v: unknown): v is Record<string, unknown> {
+  return typeof v === "object" && v !== null && !Array.isArray(v);
+}
+
+function guardMessageDelta(p: unknown): MessageDeltaEvent | null {
+  if (!isPlainObject(p)) return null;
+  if (!isString(p.session_id) || !isString(p.turn_id)) return null;
+  if (typeof p.delta !== "string") return null;
+  return {
+    session_id: p.session_id,
+    turn_id: p.turn_id,
+    delta: p.delta,
+    message_id: typeof p.message_id === "string" ? p.message_id : undefined,
+  };
+}
+
+function guardMessagePersisted(p: unknown): MessagePersistedEvent | null {
+  if (!isPlainObject(p)) return null;
+  if (!isString(p.session_id) || !isString(p.turn_id)) return null;
+  if (!isPlainObject(p.message)) return null;
+  const m = p.message;
+  if (!isString(m.id) || !isString(m.thread_id)) return null;
+  if (typeof m.content !== "string") return null;
+  if (m.role !== "assistant" && m.role !== "user" && m.role !== "tool") {
+    return null;
+  }
+  return {
+    session_id: p.session_id,
+    turn_id: p.turn_id,
+    message: m as unknown as MessagePersistedEvent["message"],
+  };
+}
+
+function guardTaskUpdated(p: unknown): TaskUpdatedEvent | null {
+  if (!isPlainObject(p)) return null;
+  if (!isString(p.session_id) || !isString(p.turn_id) || !isString(p.task_id)) {
+    return null;
+  }
+  if (typeof p.state !== "string") return null;
+  return {
+    session_id: p.session_id,
+    turn_id: p.turn_id,
+    task_id: p.task_id,
+    state: p.state,
+    title: typeof p.title === "string" ? p.title : undefined,
+    runtime_detail:
+      typeof p.runtime_detail === "string" ? p.runtime_detail : undefined,
+    output_tail:
+      typeof p.output_tail === "string" ? p.output_tail : undefined,
+  };
+}
+
+function guardTaskOutputDelta(p: unknown): TaskOutputDeltaEvent | null {
+  if (!isPlainObject(p)) return null;
+  if (!isString(p.session_id) || !isString(p.turn_id) || !isString(p.task_id)) {
+    return null;
+  }
+  if (typeof p.chunk !== "string") return null;
+  let cursor: { offset: number } | undefined;
+  if (isPlainObject(p.cursor) && typeof p.cursor.offset === "number") {
+    cursor = { offset: p.cursor.offset };
+  }
+  return {
+    session_id: p.session_id,
+    turn_id: p.turn_id,
+    task_id: p.task_id,
+    chunk: p.chunk,
+    cursor,
+  };
+}
+
+function guardTurnStarted(p: unknown): TurnStartedEvent | null {
+  if (!isPlainObject(p)) return null;
+  if (!isString(p.session_id) || !isString(p.turn_id)) return null;
+  return { session_id: p.session_id, turn_id: p.turn_id };
+}
+
+function guardTurnCompleted(p: unknown): TurnCompletedEvent | null {
+  if (!isPlainObject(p)) return null;
+  if (!isString(p.session_id) || !isString(p.turn_id)) return null;
+  return {
+    session_id: p.session_id,
+    turn_id: p.turn_id,
+    reason: typeof p.reason === "string" ? p.reason : undefined,
+  };
+}
+
+function guardTurnError(p: unknown): TurnErrorEvent | null {
+  if (!isPlainObject(p)) return null;
+  if (!isString(p.session_id) || !isString(p.turn_id)) return null;
+  if (!isPlainObject(p.error)) return null;
+  const err = p.error;
+  if (typeof err.code !== "number" || typeof err.message !== "string") {
+    return null;
+  }
+  return {
+    session_id: p.session_id,
+    turn_id: p.turn_id,
+    error: { code: err.code, message: err.message, data: err.data },
+  };
+}
+
+function guardApprovalRequested(p: unknown): ApprovalRequestedEvent | null {
+  if (!isPlainObject(p)) return null;
+  if (
+    !isString(p.session_id) ||
+    !isString(p.approval_id) ||
+    !isString(p.turn_id) ||
+    !isString(p.tool_name) ||
+    typeof p.title !== "string" ||
+    typeof p.body !== "string"
+  ) {
+    return null;
+  }
+  const scope = p.approval_scope;
+  const approval_scope: ApprovalScope | undefined =
+    scope === "request" || scope === "turn" || scope === "session"
+      ? scope
+      : undefined;
+  return {
+    session_id: p.session_id,
+    approval_id: p.approval_id,
+    turn_id: p.turn_id,
+    tool_name: p.tool_name,
+    title: p.title,
+    body: p.body,
+    approval_kind:
+      typeof p.approval_kind === "string" ? p.approval_kind : undefined,
+    approval_scope,
+    risk: typeof p.risk === "string" ? p.risk : undefined,
+    typed_details: isPlainObject(p.typed_details)
+      ? (p.typed_details as ApprovalRequestedEvent["typed_details"])
+      : undefined,
+    render_hints: isPlainObject(p.render_hints)
+      ? (p.render_hints as ApprovalRequestedEvent["render_hints"])
+      : undefined,
+  };
+}
+
+function guardWarning(p: unknown): WarningEvent | null {
+  if (!isPlainObject(p)) return null;
+  if (typeof p.reason !== "string") return null;
+  return { reason: p.reason, context: p.context };
+}
+
+// ---------------------------------------------------------------------------
+// Bridge implementation
+// ---------------------------------------------------------------------------
+
+class UiProtocolBridgeImpl implements UiProtocolBridge {
+  private readonly cfg: Required<
+    Pick<
+      BridgeConfig,
+      | "rpcTimeoutMs"
+      | "sendQueueLimit"
+      | "maxReconnectAttempts"
+      | "keepaliveIntervalMs"
+      | "keepaliveTimeoutMs"
+    >
+  > & {
+    origin: string | null;
+    getToken: () => string | null;
+    getProfileId: () => string | null;
+    webSocketImpl: typeof WebSocket;
+    generateId: () => string;
+    setTimeout: (fn: () => void, ms: number) => unknown;
+    clearTimeout: (handle: unknown) => void;
+    now: () => number;
+    features: readonly string[];
+  };
+
+  private state: ConnectionState = "idle";
+  private ws: WebSocket | null = null;
+  private sessionId: string | null = null;
+  private profileId: string | null | undefined = undefined;
+  private stopped = false;
+  private reconnectAttempts = 0;
+  private reconnectTimer: unknown = null;
+  private keepaliveTimer: unknown = null;
+  private lastInboundAt = 0;
+  private readonly pending: Map<string, PendingRpc> = new Map();
+  private readonly sendQueue: QueuedFrame[] = [];
+
+  private readonly subMessageDelta = new Subscribers<MessageDeltaEvent>();
+  private readonly subMessagePersisted = new Subscribers<MessagePersistedEvent>();
+  private readonly subTaskUpdated = new Subscribers<TaskUpdatedEvent>();
+  private readonly subTaskOutputDelta = new Subscribers<TaskOutputDeltaEvent>();
+  private readonly subTurnLifecycle = new Subscribers<
+    TurnStartedEvent | TurnCompletedEvent | TurnErrorEvent
+  >();
+  private readonly subApprovalRequested = new Subscribers<ApprovalRequestedEvent>();
+  private readonly subWarning = new Subscribers<WarningEvent>();
+  private readonly subState = new Subscribers<ConnectionState>();
+
+  private readonly notificationTable: Record<
+    string,
+    {
+      guard: (p: unknown) => unknown | null;
+      emit: (v: unknown) => void;
+    }
+  > = {
+    [METHODS.MESSAGE_DELTA]: {
+      guard: guardMessageDelta,
+      emit: (v) => this.subMessageDelta.emit(v as MessageDeltaEvent),
+    },
+    [METHODS.MESSAGE_PERSISTED]: {
+      guard: guardMessagePersisted,
+      emit: (v) => this.subMessagePersisted.emit(v as MessagePersistedEvent),
+    },
+    [METHODS.TASK_UPDATED]: {
+      guard: guardTaskUpdated,
+      emit: (v) => this.subTaskUpdated.emit(v as TaskUpdatedEvent),
+    },
+    [METHODS.TASK_OUTPUT_DELTA]: {
+      guard: guardTaskOutputDelta,
+      emit: (v) => this.subTaskOutputDelta.emit(v as TaskOutputDeltaEvent),
+    },
+    [METHODS.TURN_STARTED]: {
+      guard: guardTurnStarted,
+      emit: (v) => this.subTurnLifecycle.emit(v as TurnStartedEvent),
+    },
+    [METHODS.TURN_COMPLETED]: {
+      guard: guardTurnCompleted,
+      emit: (v) => this.subTurnLifecycle.emit(v as TurnCompletedEvent),
+    },
+    [METHODS.TURN_ERROR]: {
+      guard: guardTurnError,
+      emit: (v) => this.subTurnLifecycle.emit(v as TurnErrorEvent),
+    },
+    [METHODS.APPROVAL_REQUESTED]: {
+      guard: guardApprovalRequested,
+      emit: (v) => this.subApprovalRequested.emit(v as ApprovalRequestedEvent),
+    },
+    [METHODS.WARNING]: {
+      guard: guardWarning,
+      emit: (v) => this.subWarning.emit(v as WarningEvent),
+    },
+  };
+
+  constructor(config: BridgeConfig | undefined) {
+    const cfg = config ?? {};
+    this.cfg = {
+      origin: cfg.origin ?? null,
+      getToken: cfg.getToken ?? getToken,
+      getProfileId: cfg.getProfileId ?? (() => getSelectedProfileId()),
+      webSocketImpl: cfg.webSocketImpl ?? (globalThis.WebSocket as typeof WebSocket),
+      generateId:
+        cfg.generateId ??
+        (() => {
+          if (typeof crypto !== "undefined" && typeof crypto.randomUUID === "function") {
+            return crypto.randomUUID();
+          }
+          return `rpc-${Date.now()}-${Math.random().toString(36).slice(2)}`;
+        }),
+      setTimeout:
+        cfg.setTimeout ??
+        ((fn, ms) => globalThis.setTimeout(fn, ms) as unknown),
+      clearTimeout:
+        cfg.clearTimeout ??
+        ((handle) => globalThis.clearTimeout(handle as ReturnType<typeof setTimeout>)),
+      now: cfg.now ?? (() => Date.now()),
+      features: cfg.features ?? UI_PROTOCOL_FEATURES,
+      rpcTimeoutMs: cfg.rpcTimeoutMs ?? DEFAULT_RPC_TIMEOUT_MS,
+      sendQueueLimit: cfg.sendQueueLimit ?? DEFAULT_SEND_QUEUE_LIMIT,
+      maxReconnectAttempts:
+        cfg.maxReconnectAttempts ?? DEFAULT_MAX_RECONNECT_ATTEMPTS,
+      keepaliveIntervalMs: cfg.keepaliveIntervalMs ?? DEFAULT_KEEPALIVE_MS,
+      keepaliveTimeoutMs:
+        cfg.keepaliveTimeoutMs ?? DEFAULT_KEEPALIVE_TIMEOUT_MS,
+    };
+  }
+
+  // ----- public API --------------------------------------------------------
+
+  async start(opts: { sessionId: string; profileId?: string }): Promise<void> {
+    if (!opts || !isString(opts.sessionId)) {
+      throw new Error("ui-protocol-bridge: start requires sessionId");
+    }
+    this.stopped = false;
+    this.sessionId = opts.sessionId;
+    this.profileId = opts.profileId ?? this.cfg.getProfileId();
+    this.reconnectAttempts = 0;
+    await this.openSocket();
+  }
+
+  async stop(): Promise<void> {
+    if (this.stopped) return;
+    this.stopped = true;
+    this.cancelReconnectTimer();
+    this.cancelKeepalive();
+    this.setState("closed");
+    const ws = this.ws;
+    this.ws = null;
+    if (ws) {
+      try {
+        ws.close(NORMAL_CLOSURE, "client_stop");
+      } catch {
+        // ignore — close errors don't affect the rejection sweep below.
+      }
+    }
+    this.rejectAllPending(new BridgeStoppedError());
+    this.sendQueue.length = 0;
+    this.subMessageDelta.clear();
+    this.subMessagePersisted.clear();
+    this.subTaskUpdated.clear();
+    this.subTaskOutputDelta.clear();
+    this.subTurnLifecycle.clear();
+    this.subApprovalRequested.clear();
+    this.subWarning.clear();
+    this.subState.clear();
+  }
+
+  sendTurn(turn_id: string, input: TurnStartInput[]): Promise<TurnStartResult> {
+    if (!isString(turn_id)) {
+      return Promise.reject(new Error("ui-protocol-bridge: sendTurn requires turn_id"));
+    }
+    return this.request<TurnStartResult>(METHODS.TURN_START, {
+      session_id: this.requireSessionId(),
+      turn_id,
+      input,
+    });
+  }
+
+  interruptTurn(
+    turn_id: string,
+    reason?: string,
+  ): Promise<TurnInterruptResult> {
+    if (!isString(turn_id)) {
+      return Promise.reject(
+        new Error("ui-protocol-bridge: interruptTurn requires turn_id"),
+      );
+    }
+    const params: Record<string, unknown> = {
+      session_id: this.requireSessionId(),
+      turn_id,
+    };
+    if (reason !== undefined) params.reason = reason;
+    return this.request<TurnInterruptResult>(METHODS.TURN_INTERRUPT, params);
+  }
+
+  respondToApproval(
+    approval_id: string,
+    decision: ApprovalDecision,
+    scope?: ApprovalScope,
+    client_note?: string,
+  ): Promise<ApprovalRespondResult> {
+    if (!isString(approval_id)) {
+      return Promise.reject(
+        new Error("ui-protocol-bridge: respondToApproval requires approval_id"),
+      );
+    }
+    const params: Record<string, unknown> = {
+      session_id: this.requireSessionId(),
+      approval_id,
+      decision,
+    };
+    if (scope !== undefined) params.approval_scope = scope;
+    if (client_note !== undefined) params.client_note = client_note;
+    return this.request<ApprovalRespondResult>(
+      METHODS.APPROVAL_RESPOND,
+      params,
+    );
+  }
+
+  onMessageDelta(handler: Listener<MessageDeltaEvent>): () => void {
+    return this.subMessageDelta.add(handler);
+  }
+  onMessagePersisted(handler: Listener<MessagePersistedEvent>): () => void {
+    return this.subMessagePersisted.add(handler);
+  }
+  onTaskUpdated(handler: Listener<TaskUpdatedEvent>): () => void {
+    return this.subTaskUpdated.add(handler);
+  }
+  onTaskOutputDelta(handler: Listener<TaskOutputDeltaEvent>): () => void {
+    return this.subTaskOutputDelta.add(handler);
+  }
+  onTurnLifecycle(
+    handler: Listener<TurnStartedEvent | TurnCompletedEvent | TurnErrorEvent>,
+  ): () => void {
+    return this.subTurnLifecycle.add(handler);
+  }
+  onApprovalRequested(handler: Listener<ApprovalRequestedEvent>): () => void {
+    return this.subApprovalRequested.add(handler);
+  }
+  onConnectionStateChange(handler: Listener<ConnectionState>): () => void {
+    return this.subState.add(handler);
+  }
+  onWarning(handler: Listener<WarningEvent>): () => void {
+    return this.subWarning.add(handler);
+  }
+
+  // ----- internals ---------------------------------------------------------
+
+  private requireSessionId(): string {
+    if (!this.sessionId) {
+      throw new Error("ui-protocol-bridge: bridge not started");
+    }
+    return this.sessionId;
+  }
+
+  private setState(next: ConnectionState): void {
+    if (this.state === next) return;
+    this.state = next;
+    this.subState.emit(next);
+  }
+
+  private buildUrl(): string {
+    const origin =
+      this.cfg.origin ??
+      (typeof window !== "undefined" && window.location
+        ? window.location.origin
+        : "");
+    const base = origin.replace(/^http:/, "ws:").replace(/^https:/, "wss:");
+    const params = new URLSearchParams();
+    const token = this.cfg.getToken();
+    // ?token= falls back into Caddy access logs but is the only path that
+    // works in browsers (which forbid setting Authorization on WS).
+    if (token) params.append("token", token);
+    for (const feature of this.cfg.features) {
+      params.append("ui_feature", feature);
+    }
+    const qs = params.toString();
+    return `${base}${UI_PROTOCOL_WS_PATH}${qs ? `?${qs}` : ""}`;
+  }
+
+  private async openSocket(): Promise<void> {
+    if (this.stopped) return;
+    if (!this.cfg.webSocketImpl) {
+      throw new Error("ui-protocol-bridge: WebSocket implementation unavailable");
+    }
+    this.cancelReconnectTimer();
+    this.setState("connecting");
+
+    let ws: WebSocket;
+    try {
+      // Some browsers may permit setting the bearer via the WS subprotocol;
+      // we offer it AND the ?token= fallback so the server can pick whichever
+      // path made it through.
+      const token = this.cfg.getToken();
+      const protocols = token ? [`octos.bearer.${token}`] : undefined;
+      ws = new this.cfg.webSocketImpl(this.buildUrl(), protocols);
+    } catch (err) {
+      this.setState("error");
+      throw err instanceof Error ? err : new Error(String(err));
+    }
+
+    this.ws = ws;
+    ws.onopen = () => {
+      void this.onWsOpen();
+    };
+    ws.onmessage = (ev) => {
+      this.onWsMessage(ev);
+    };
+    ws.onerror = () => {
+      this.onWsError();
+    };
+    ws.onclose = (ev) => {
+      this.onWsClose(ev);
+    };
+  }
+
+  private async onWsOpen(): Promise<void> {
+    if (this.stopped) return;
+    this.lastInboundAt = this.cfg.now();
+    try {
+      const params: Record<string, unknown> = {
+        session_id: this.requireSessionId(),
+      };
+      if (this.profileId) params.profile_id = this.profileId;
+      // session/open is the lifecycle gate: state stays at `connecting`
+      // until the server acks. Failure here forces a reconnect so the next
+      // attempt re-runs the handshake with a fresh socket.
+      await this.request<SessionOpenResult>(METHODS.SESSION_OPEN, params, {
+        bypassQueue: true,
+      });
+      if (this.stopped) return;
+      this.reconnectAttempts = 0;
+      this.setState("connected");
+      this.startKeepalive();
+      this.flushSendQueue();
+    } catch (err) {
+      if (this.stopped) return;
+      this.subWarning.emit({
+        reason: "session_open_failed",
+        context: err instanceof Error ? err.message : err,
+      });
+      this.scheduleReconnect();
+    }
+  }
+
+  private onWsMessage(ev: MessageEvent): void {
+    if (this.stopped) return;
+    if (typeof ev.data !== "string") {
+      this.subWarning.emit({
+        reason: "non_text_frame",
+        context: typeof ev.data,
+      });
+      return;
+    }
+    this.lastInboundAt = this.cfg.now();
+    let parsed: unknown;
+    try {
+      parsed = JSON.parse(ev.data);
+    } catch {
+      this.subWarning.emit({ reason: "json_parse_error" });
+      return;
+    }
+    if (!isPlainObject(parsed)) {
+      this.subWarning.emit({ reason: "envelope_not_object" });
+      return;
+    }
+    if (parsed.jsonrpc !== JSON_RPC_VERSION) {
+      this.subWarning.emit({
+        reason: "envelope_jsonrpc_mismatch",
+        context: parsed.jsonrpc,
+      });
+      return;
+    }
+    if (typeof parsed.id === "string") {
+      this.dispatchResponse(parsed as unknown as JsonRpcResponse);
+      return;
+    }
+    if (typeof parsed.method === "string") {
+      this.dispatchNotification(parsed as unknown as JsonRpcNotification);
+      return;
+    }
+    this.subWarning.emit({ reason: "envelope_unrecognized" });
+  }
+
+  private dispatchResponse(resp: JsonRpcResponse): void {
+    const pending = this.pending.get(resp.id);
+    if (!pending) {
+      this.subWarning.emit({ reason: "rpc_id_unmatched", context: resp.id });
+      return;
+    }
+    this.pending.delete(resp.id);
+    this.cfg.clearTimeout(pending.timer);
+    if (resp.error) {
+      pending.reject(
+        new BridgeRpcError(
+          resp.error.code,
+          resp.error.message,
+          resp.error.data,
+        ),
+      );
+      return;
+    }
+    pending.resolve(resp.result);
+  }
+
+  private dispatchNotification(note: JsonRpcNotification): void {
+    const params = note.params;
+    const handler = this.notificationTable[note.method];
+    if (!handler) return;
+    const result = handler.guard(params);
+    if (!result) {
+      this.subWarning.emit({
+        reason: `invalid_event:${note.method}`,
+        context: params,
+      });
+      return;
+    }
+    handler.emit(result);
+  }
+
+  private onWsError(): void {
+    if (this.stopped) return;
+    // `onerror` always pairs with `onclose`; we just reflect transport state
+    // and leave reconnect scheduling to onclose so the timing is consistent.
+    this.setState("error");
+  }
+
+  private onWsClose(ev: CloseEvent): void {
+    this.cancelKeepalive();
+    if (this.stopped) return;
+    this.ws = null;
+    if (ev?.code === NORMAL_CLOSURE) {
+      this.setState("closed");
+      this.rejectAllPending(new BridgeStoppedError("connection closed"));
+      return;
+    }
+    this.scheduleReconnect();
+  }
+
+  private scheduleReconnect(): void {
+    if (this.stopped) return;
+    if (this.reconnectAttempts >= this.cfg.maxReconnectAttempts) {
+      this.setState("error");
+      this.rejectAllPending(new BridgeStoppedError("max reconnect attempts"));
+      return;
+    }
+    this.setState("reconnecting");
+    const delay =
+      RECONNECT_BACKOFF_MS[this.reconnectAttempts] ?? RECONNECT_BACKOFF_CAP_MS;
+    this.reconnectAttempts += 1;
+    this.cancelReconnectTimer();
+    this.reconnectTimer = this.cfg.setTimeout(() => {
+      this.reconnectTimer = null;
+      void this.openSocket();
+    }, delay);
+  }
+
+  private cancelReconnectTimer(): void {
+    if (this.reconnectTimer != null) {
+      this.cfg.clearTimeout(this.reconnectTimer);
+      this.reconnectTimer = null;
+    }
+  }
+
+  private startKeepalive(): void {
+    this.cancelKeepalive();
+    this.lastInboundAt = this.cfg.now();
+    const tick = () => {
+      if (this.stopped || this.state !== "connected") return;
+      const now = this.cfg.now();
+      const silence = now - this.lastInboundAt;
+      if (silence >= this.cfg.keepaliveTimeoutMs) {
+        const ws = this.ws;
+        this.ws = null;
+        try {
+          ws?.close(4000, "keepalive_timeout");
+        } catch {
+          // ignore
+        }
+        this.scheduleReconnect();
+        return;
+      }
+      this.sendNotification(METHODS.PING, { ts: now });
+      this.keepaliveTimer = this.cfg.setTimeout(tick, this.cfg.keepaliveIntervalMs);
+    };
+    this.keepaliveTimer = this.cfg.setTimeout(
+      tick,
+      this.cfg.keepaliveIntervalMs,
+    );
+  }
+
+  private cancelKeepalive(): void {
+    if (this.keepaliveTimer != null) {
+      this.cfg.clearTimeout(this.keepaliveTimer);
+      this.keepaliveTimer = null;
+    }
+  }
+
+  private rejectAllPending(err: Error): void {
+    for (const [id, p] of this.pending) {
+      this.cfg.clearTimeout(p.timer);
+      p.reject(err);
+      this.pending.delete(id);
+    }
+  }
+
+  private request<T>(
+    method: string,
+    params: unknown,
+    opts?: { bypassQueue?: boolean; timeoutMs?: number },
+  ): Promise<T> {
+    if (this.stopped) {
+      return Promise.reject(new BridgeStoppedError());
+    }
+    const id = this.cfg.generateId();
+    const frame: JsonRpcRequest = {
+      jsonrpc: JSON_RPC_VERSION,
+      id,
+      method,
+      params,
+    };
+    const text = JSON.stringify(frame);
+    const timeoutMs = opts?.timeoutMs ?? this.cfg.rpcTimeoutMs;
+
+    return new Promise<T>((resolve, reject) => {
+      const timer = this.cfg.setTimeout(() => {
+        if (!this.pending.delete(id)) return;
+        reject(new BridgeTimeoutError(method, timeoutMs));
+      }, timeoutMs);
+      this.pending.set(id, {
+        method,
+        resolve: resolve as (v: unknown) => void,
+        reject,
+        timer,
+      });
+
+      if (opts?.bypassQueue) {
+        // session/open during onopen needs to bypass the queue — at that
+        // moment state is still `connecting` so the queue path would defer
+        // it forever, blocking the handshake completion.
+        const sent = this.rawSend(text);
+        if (!sent) {
+          this.pending.delete(id);
+          this.cfg.clearTimeout(timer);
+          reject(new BridgeStoppedError("socket not open for handshake"));
+        }
+        return;
+      }
+
+      if (this.state === "connected") {
+        if (!this.rawSend(text)) {
+          this.enqueueFrame(text);
+        }
+        return;
+      }
+      this.enqueueFrame(text);
+    });
+  }
+
+  private sendNotification(method: string, params: unknown): void {
+    const frame: JsonRpcNotification = {
+      jsonrpc: JSON_RPC_VERSION,
+      method,
+      params,
+    };
+    const text = JSON.stringify(frame);
+    if (this.state === "connected") {
+      if (!this.rawSend(text)) this.enqueueFrame(text);
+      return;
+    }
+    this.enqueueFrame(text);
+  }
+
+  private rawSend(text: string): boolean {
+    const ws = this.ws;
+    if (!ws) return false;
+    if (ws.readyState !== ws.OPEN) return false;
+    try {
+      ws.send(text);
+      return true;
+    } catch {
+      return false;
+    }
+  }
+
+  private enqueueFrame(text: string): void {
+    if (this.sendQueue.length >= this.cfg.sendQueueLimit) {
+      const dropped = this.sendQueue.shift();
+      this.subWarning.emit({
+        reason: "send_queue_overflow",
+        context: { dropped_bytes: dropped?.length ?? 0 },
+      });
+    }
+    this.sendQueue.push(text);
+  }
+
+  private flushSendQueue(): void {
+    while (this.state === "connected" && this.sendQueue.length > 0) {
+      const next = this.sendQueue[0];
+      if (!this.rawSend(next)) return;
+      this.sendQueue.shift();
+    }
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Factory
+// ---------------------------------------------------------------------------
+
+export function createUiProtocolBridge(
+  config?: BridgeConfig,
+): UiProtocolBridge {
+  return new UiProtocolBridgeImpl(config);
+}
+
+// Test-only export so the unit tests can drive guard logic directly without
+// rebuilding the WS scaffolding for every shape variation.
+export const __INTERNAL_GUARDS_FOR_TEST__ = {
+  guardMessageDelta,
+  guardMessagePersisted,
+  guardTaskUpdated,
+  guardTaskOutputDelta,
+  guardTurnStarted,
+  guardTurnCompleted,
+  guardTurnError,
+  guardApprovalRequested,
+  guardWarning,
+};

--- a/src/runtime/ui-protocol-types.ts
+++ b/src/runtime/ui-protocol-types.ts
@@ -1,0 +1,163 @@
+/**
+ * UI Protocol v1 typed event/result shapes used by the strict client bridge.
+ *
+ * Required fields are non-optional `string` — runtime guards in the bridge
+ * reject events missing them and emit a `warning` rather than synthesizing
+ * defaults. This is the fail-closed property called out in PR #63 review.
+ */
+
+export type ConnectionState =
+  | "idle"
+  | "connecting"
+  | "connected"
+  | "reconnecting"
+  | "closed"
+  | "error";
+
+export type ApprovalDecision = "approve" | "deny";
+
+export type ApprovalScope = "request" | "turn" | "session";
+
+export interface UiCursor {
+  stream: string;
+  seq: number;
+}
+
+export interface TurnStartInput {
+  kind: "text";
+  text: string;
+}
+
+export interface SessionOpenedResult {
+  session_id: string;
+  active_profile_id?: string;
+  cursor?: UiCursor;
+  workspace_root?: string;
+  panes?: unknown;
+}
+
+export interface SessionOpenResult {
+  opened: SessionOpenedResult;
+}
+
+export interface TurnStartResult {
+  accepted: boolean;
+}
+
+export interface TurnInterruptResult {
+  interrupted: boolean;
+}
+
+export interface ApprovalRespondResult {
+  approval_id: string;
+  accepted: boolean;
+  status: string;
+  runtime_resumed?: boolean;
+}
+
+export interface MessageDeltaEvent {
+  session_id: string;
+  turn_id: string;
+  delta: string;
+  message_id?: string;
+}
+
+export interface PersistedMessageFile {
+  path: string;
+  size?: number;
+  mime?: string;
+}
+
+export interface PersistedMessage {
+  id: string;
+  thread_id: string;
+  role: "assistant" | "user" | "tool";
+  content: string;
+  files?: PersistedMessageFile[];
+  history_seq?: number;
+  intra_thread_seq?: number;
+  client_message_id?: string;
+  response_to_client_message_id?: string;
+  source_tool_call_id?: string;
+  tool_calls?: Array<unknown>;
+  timestamp?: string;
+}
+
+export interface MessagePersistedEvent {
+  session_id: string;
+  turn_id: string;
+  message: PersistedMessage;
+}
+
+export interface TaskUpdatedEvent {
+  session_id: string;
+  turn_id: string;
+  task_id: string;
+  state: string;
+  title?: string;
+  runtime_detail?: string;
+  output_tail?: string;
+}
+
+export interface TaskOutputDeltaEvent {
+  session_id: string;
+  turn_id: string;
+  task_id: string;
+  chunk: string;
+  cursor?: { offset: number };
+}
+
+export interface TurnStartedEvent {
+  session_id: string;
+  turn_id: string;
+}
+
+export interface TurnCompletedEvent {
+  session_id: string;
+  turn_id: string;
+  reason?: string;
+}
+
+export interface TurnErrorEvent {
+  session_id: string;
+  turn_id: string;
+  error: { code: number; message: string; data?: unknown };
+}
+
+export interface ApprovalRenderHints {
+  default_decision?: ApprovalDecision;
+  primary_label?: string;
+  secondary_label?: string;
+  danger?: boolean;
+  monospace_fields?: string[];
+}
+
+export interface ApprovalTypedDetails {
+  kind?: string;
+  [field: string]: unknown;
+}
+
+export interface ApprovalRequestedEvent {
+  session_id: string;
+  approval_id: string;
+  turn_id: string;
+  tool_name: string;
+  title: string;
+  body: string;
+  approval_kind?: string;
+  approval_scope?: ApprovalScope;
+  risk?: string;
+  typed_details?: ApprovalTypedDetails;
+  render_hints?: ApprovalRenderHints;
+}
+
+export interface WarningEvent {
+  reason: string;
+  context?: unknown;
+}
+
+export interface RpcErrorPayload {
+  code: number;
+  message: string;
+  data?: unknown;
+}


### PR DESCRIPTION
## Summary

Phase C-1 of the /chat → UI Protocol v1 migration. Adds a strict, fail-closed
client adapter at `src/runtime/ui-protocol-bridge.ts` that wraps the JSON-RPC
over WebSocket transport at `/api/ui-protocol/ws`. Pure adapter — no
rendering, no store mutations. Phase C-2 wires it into the existing runtime;
this PR only lands the surface plus unit tests.

- Strict typed events: required fields are non-optional `string`. Runtime
  guards reject events missing required fields and emit a `warning` instead
  of synthesizing UUIDs. This is the structural fix for the M8.10
  thread-binding bug class flagged by codex in PR #63 review
  (`MessageDeltaEvent.turn_id?: string` → `turn_id: string`).
- Connection lifecycle: `idle` → `connecting` → `connected` →
  `reconnecting` / `closed` / `error`, with re-startable `start()` after
  `stop()`.
- Reconnect: exponential backoff 1s / 2s / 4s / 8s / 16s / 30s capped, with
  configurable `maxReconnectAttempts` (default 8). Re-runs `session/open`
  on each attempt.
- Send queue: bounded FIFO (default 64) drops the oldest entry with a
  `warning` on overflow; drains in order on `connected`. Closes the
  thread-safety + thrash issues from #758.
- RPC correlation: UUIDv7 per-request, response routes back via
  pending-id map, configurable timeout (default 30s) rejects with
  `BridgeTimeoutError`. Mismatched ids surface a `warning`.
- Keepalive: 30s `ping` notification while `connected`; reconnect if no
  inbound frame for 60s.

## Closes / tracks

- Closes #67
- Tracks master #66

## Test plan

- [x] `npx tsc -b --noEmit` clean
- [x] `npx vitest run src/runtime/ui-protocol-bridge.test.ts` — 30 tests
      passing across 8 categories (guards, lifecycle, reconnect, send queue,
      notification dispatch, RPC correlation, RPC timeout, keepalive,
      subscriber unsubscribe)
- [x] Full unit suite still green (84 tests across 3 files)
- [x] eslint clean on the new files
- [ ] Manual integration deferred to Phase C-2 — this PR is a pure adapter,
      no behavior change yet