### PR TITLE
feat(runtime): wire ui-protocol-bridge into /chat under chat_app_ui_v1 flag (Phase C-2, closes #68)

### DIFF
--- a/src/api/types.ts
+++ b/src/api/types.ts
@@ -30,6 +30,11 @@ export interface MessageInfo {
   timestamp: string;
   media?: string[];
   tool_calls?: { id?: string; name?: string }[];
+  /** Per-thread sequence (UI Protocol v1 PersistedMessage). When the
+   *  server emits a typed event the per-thread sequence may differ from
+   *  the per-session `seq` — preserve it explicitly so thread ordering
+   *  uses the right axis. Codex review #3. */
+  intra_thread_seq?: number;
 }
 
 export interface BackgroundTaskInfo {

--- a/src/components/chat-thread.tsx
+++ b/src/components/chat-thread.tsx
@@ -43,7 +43,7 @@ import {
   type ThreadToolCall,
 } from "@/store/thread-store";
 import { uploadFiles } from "@/api/chat";
-import { sendMessage as bridgeSend } from "@/runtime/sse-bridge";
+import { sendMessage as bridgeSend } from "@/runtime/ui-protocol-send";
 import * as StreamManager from "@/runtime/stream-manager";
 import { MarkdownContent } from "./markdown-renderer";
 import { ThinkingIndicator } from "./thinking-indicator";

--- a/src/components/chat-thread.tsx
+++ b/src/components/chat-thread.tsx
@@ -522,11 +522,19 @@ function isFileOnlyAssistantMessage(message: Message): boolean {
 
 /** M8.10 PR #3: opt-in to the new thread-by-cmid renderer via DevTools.
  *  When the flag is on, render a stub placeholder — the real threaded UI
- *  ships in PR #4. The flat-list path below remains the default. */
+ *  ships in PR #4. The flat-list path below remains the default.
+ *
+ *  Phase C-2 (codex review #1): the chat_app_ui_v1 send path writes only
+ *  to ThreadStore (`ui-protocol-send.ts`). To avoid a renderer/store
+ *  mismatch (writes to ThreadStore, reads from MessageStore = empty
+ *  /chat), v1=ON also forces the v2 renderer regardless of the v2 flag.
+ *  This does NOT change v2 flag semantics or default — v2 OFF + v1 OFF
+ *  remains the legacy flat-list path. */
 function isThreadStoreV2Enabled(): boolean {
   if (typeof window === "undefined") return false;
   try {
-    return window.localStorage.getItem("octos_thread_store_v2") === "1";
+    if (window.localStorage.getItem("octos_thread_store_v2") === "1") return true;
+    return window.localStorage.getItem("chat_app_ui_v1") === "1";
   } catch {
     return false;
   }

--- a/src/runtime/runtime-provider.tsx
+++ b/src/runtime/runtime-provider.tsx
@@ -18,6 +18,11 @@ import { getSessionStatus } from "@/api/sessions";
 import type { BackgroundTaskInfo } from "@/api/types";
 import { restoreWatchedSessions, unwatchSession, watchSession } from "./task-watcher";
 import { eventSessionId, eventTopic } from "./event-scope";
+import { isChatAppUiV1Enabled } from "@/lib/feature-flags";
+import {
+  startBridgeForSession,
+  stopActiveBridge,
+} from "./ui-protocol-runtime";
 /** Max sessions kept in memory simultaneously. */
 const MAX_CACHED = 5;
 
@@ -118,6 +123,32 @@ function RuntimeWithSession({ children }: { children: ReactNode }) {
         }
       }
     }
+  }, [currentSessionId, historyTopic]);
+
+  // Phase C-2 (#68): when the chat_app_ui_v1 flag is on, mount a
+  // `ui-protocol-bridge` on top of the existing SSE+REST runtime. The
+  // bridge owns the streaming-turn slice; the router fans bridge events
+  // out to ThreadStore mutations. Flag-OFF (the default) leaves this
+  // effect a no-op so the legacy path is bit-for-bit preserved.
+  useEffect(() => {
+    if (!isChatAppUiV1Enabled()) return;
+    let cancelled = false;
+    void (async () => {
+      try {
+        await startBridgeForSession(currentSessionId, historyTopic);
+      } catch {
+        // Bridge start failures are surfaced by the bridge's own
+        // `warning` events; the SSE path remains operational.
+      }
+      if (cancelled) {
+        // Session changed mid-start; tear down what we just brought up.
+        await stopActiveBridge();
+      }
+    })();
+    return () => {
+      cancelled = true;
+      void stopActiveBridge();
+    };
   }, [currentSessionId, historyTopic]);
 
   // Check for active background work on session mount and register with

--- a/src/runtime/runtime-provider.tsx
+++ b/src/runtime/runtime-provider.tsx
@@ -21,7 +21,7 @@ import { eventSessionId, eventTopic } from "./event-scope";
 import { isChatAppUiV1Enabled } from "@/lib/feature-flags";
 import {
   startBridgeForSession,
-  stopActiveBridge,
+  stopActiveBridgeIfScope,
 } from "./ui-protocol-runtime";
 /** Max sessions kept in memory simultaneously. */
 const MAX_CACHED = 5;
@@ -133,21 +133,31 @@ function RuntimeWithSession({ children }: { children: ReactNode }) {
   useEffect(() => {
     if (!isChatAppUiV1Enabled()) return;
     let cancelled = false;
+    let mineStarted = false;
     void (async () => {
       try {
         await startBridgeForSession(currentSessionId, historyTopic);
+        mineStarted = true;
       } catch {
-        // Bridge start failures are surfaced by the bridge's own
-        // `warning` events; the SSE path remains operational.
+        // Either a real start failure (surfaced via the bridge's own
+        // `warning` events) OR a stale-generation throw (newer call
+        // already won and `startBridgeForSession` cleaned up its own
+        // orphan). In either case we did NOT publish; leave whatever
+        // is currently active (likely the newer effect's bridge) alone.
       }
-      if (cancelled) {
-        // Session changed mid-start; tear down what we just brought up.
-        await stopActiveBridge();
+      if (cancelled && mineStarted) {
+        // We successfully published, but the effect was already cancelled
+        // mid-resolve. Only stop if WE are still the active scope —
+        // a newer effect may have already taken over by now.
+        await stopActiveBridgeIfScope(currentSessionId, historyTopic);
       }
     })();
     return () => {
       cancelled = true;
-      void stopActiveBridge();
+      if (mineStarted) {
+        // Only tear down our own scope. A newer effect's bridge stays.
+        void stopActiveBridgeIfScope(currentSessionId, historyTopic);
+      }
     };
   }, [currentSessionId, historyTopic]);
 

--- a/src/runtime/sse-bridge.ts
+++ b/src/runtime/sse-bridge.ts
@@ -28,7 +28,12 @@ import { eventSessionId, eventTopic } from "./event-scope";
 function isThreadStoreEnabled(): boolean {
   if (typeof window === "undefined") return false;
   try {
-    return window.localStorage.getItem("octos_thread_store_v2") === "1";
+    if (window.localStorage.getItem("octos_thread_store_v2") === "1") return true;
+    // Phase C-2 (codex review #1): chat_app_ui_v1 forces ThreadStore
+    // mirroring on the legacy SSE path so the renderer (also forced to
+    // v2 under v1) stays consistent during the bridge-not-yet-mounted
+    // fallback window.
+    return window.localStorage.getItem("chat_app_ui_v1") === "1";
   } catch {
     return false;
   }

--- a/src/runtime/ui-protocol-event-router.test.ts
+++ b/src/runtime/ui-protocol-event-router.test.ts
@@ -1,0 +1,470 @@
+/**
+ * ui-protocol-event-router unit tests (Phase C-2, issue #68).
+ *
+ * Coverage:
+ *   - each typed bridge event maps to the correct ThreadStore mutation
+ *   - parity with the SSE path: feeding equivalent events through both
+ *     transports lands on the same final ThreadStore state
+ *   - turn/error finalizes the bubble as errored (not stuck pending)
+ *   - approval/requested dispatches a CustomEvent with the typed payload
+ *   - flag-OFF: the v1 sender delegates to the legacy SSE bridge and the
+ *     UI Protocol runtime stays cold (no bridge instantiated)
+ */
+
+import { afterEach, describe, expect, it, vi } from "vitest";
+import * as ThreadStore from "@/store/thread-store";
+import {
+  __resetRouterStateForTest,
+  attachRouter,
+  handleApprovalRequested,
+  handleMessageDelta,
+  handleMessagePersisted,
+  handleTaskOutputDelta,
+  handleTaskUpdated,
+  handleTurnCompleted,
+  handleTurnError,
+  handleTurnStarted,
+} from "./ui-protocol-event-router";
+import type {
+  ApprovalRequestedEvent,
+  MessageDeltaEvent,
+  MessagePersistedEvent,
+  TaskOutputDeltaEvent,
+  TaskUpdatedEvent,
+  TurnCompletedEvent,
+  TurnErrorEvent,
+  TurnStartedEvent,
+  UiProtocolBridge,
+} from "./ui-protocol-bridge";
+
+const SESSION = "sess-router";
+
+function seedThread(cmid: string, text = "hi") {
+  return ThreadStore.addUserMessage(SESSION, {
+    text,
+    clientMessageId: cmid,
+  });
+}
+
+afterEach(() => {
+  ThreadStore.__resetForTests();
+  __resetRouterStateForTest();
+});
+
+describe("router event mapping", () => {
+  it("message/delta appends to the assistant pending slot", () => {
+    seedThread("cmid-1");
+    const evt: MessageDeltaEvent = {
+      session_id: SESSION,
+      turn_id: "cmid-1",
+      delta: "Hello",
+    };
+    handleMessageDelta({ sessionId: SESSION }, evt);
+    handleMessageDelta(
+      { sessionId: SESSION },
+      { ...evt, delta: ", world" },
+    );
+    const [thread] = ThreadStore.getThreads(SESSION);
+    expect(thread.pendingAssistant?.text).toBe("Hello, world");
+  });
+
+  it("message/persisted writes a finalized response into the thread", () => {
+    seedThread("cmid-2");
+    const evt: MessagePersistedEvent = {
+      session_id: SESSION,
+      turn_id: "cmid-2",
+      message: {
+        id: "msg-1",
+        thread_id: "cmid-2",
+        role: "assistant",
+        content: "Final answer",
+        history_seq: 7,
+        timestamp: "2026-04-30T00:00:00Z",
+      },
+    };
+    handleMessagePersisted({ sessionId: SESSION }, evt);
+    const [thread] = ThreadStore.getThreads(SESSION);
+    const last = thread.responses[thread.responses.length - 1];
+    expect(last?.role).toBe("assistant");
+    expect(last?.text).toBe("Final answer");
+    expect(last?.historySeq).toBe(7);
+  });
+
+  it("task/updated running emits a progress entry on the bound tool call", () => {
+    seedThread("cmid-3");
+    const dispatched: Event[] = [];
+    const cfg = {
+      sessionId: SESSION,
+      dispatchEvent: (e: Event) => dispatched.push(e),
+    };
+    const evt: TaskUpdatedEvent = {
+      session_id: SESSION,
+      turn_id: "cmid-3",
+      task_id: "task-7",
+      state: "running",
+      title: "deep_research",
+    };
+    handleTaskUpdated(cfg, evt);
+    const [thread] = ThreadStore.getThreads(SESSION);
+    const tcs = thread.pendingAssistant?.toolCalls ?? [];
+    expect(tcs.find((tc) => tc.id === "task-7")?.progress.map((p) => p.message))
+      .toEqual(["deep_research"]);
+    expect(dispatched.some((e) => e.type === "crew:bg_tasks")).toBe(true);
+  });
+
+  it("task/updated dedupes consecutive identical state for the same task", () => {
+    seedThread("cmid-4");
+    const evt: TaskUpdatedEvent = {
+      session_id: SESSION,
+      turn_id: "cmid-4",
+      task_id: "task-8",
+      state: "running",
+      title: "doing-thing",
+    };
+    handleTaskUpdated({ sessionId: SESSION }, evt);
+    handleTaskUpdated({ sessionId: SESSION }, evt);
+    const [thread] = ThreadStore.getThreads(SESSION);
+    const tc = thread.pendingAssistant?.toolCalls.find((c) => c.id === "task-8");
+    expect(tc?.progress).toHaveLength(1);
+  });
+
+  it("task/updated completed flips the tool status to complete", () => {
+    seedThread("cmid-5");
+    handleTaskUpdated(
+      { sessionId: SESSION },
+      {
+        session_id: SESSION,
+        turn_id: "cmid-5",
+        task_id: "task-9",
+        state: "running",
+        title: "search",
+      },
+    );
+    handleTaskUpdated(
+      { sessionId: SESSION },
+      {
+        session_id: SESSION,
+        turn_id: "cmid-5",
+        task_id: "task-9",
+        state: "completed",
+      },
+    );
+    const [thread] = ThreadStore.getThreads(SESSION);
+    const tc = thread.pendingAssistant?.toolCalls.find((c) => c.id === "task-9");
+    expect(tc?.status).toBe("complete");
+  });
+
+  it("task/updated failed flips the tool status to error", () => {
+    seedThread("cmid-5b");
+    handleTaskUpdated(
+      { sessionId: SESSION },
+      {
+        session_id: SESSION,
+        turn_id: "cmid-5b",
+        task_id: "task-fail",
+        state: "running",
+        title: "fragile",
+      },
+    );
+    handleTaskUpdated(
+      { sessionId: SESSION },
+      {
+        session_id: SESSION,
+        turn_id: "cmid-5b",
+        task_id: "task-fail",
+        state: "failed",
+      },
+    );
+    const [thread] = ThreadStore.getThreads(SESSION);
+    const tc = thread.pendingAssistant?.toolCalls.find(
+      (c) => c.id === "task-fail",
+    );
+    expect(tc?.status).toBe("error");
+  });
+
+  it("task/output/delta appends a chunk into the matching tool call timeline", () => {
+    seedThread("cmid-6");
+    handleTaskUpdated(
+      { sessionId: SESSION },
+      {
+        session_id: SESSION,
+        turn_id: "cmid-6",
+        task_id: "task-out",
+        state: "running",
+        title: "tail",
+      },
+    );
+    const evt: TaskOutputDeltaEvent = {
+      session_id: SESSION,
+      turn_id: "cmid-6",
+      task_id: "task-out",
+      chunk: "line 1\nline 2",
+    };
+    handleTaskOutputDelta({ sessionId: SESSION }, evt);
+    const [thread] = ThreadStore.getThreads(SESSION);
+    const tc = thread.pendingAssistant?.toolCalls.find(
+      (c) => c.id === "task-out",
+    );
+    expect(tc?.progress.map((p) => p.message)).toEqual(["tail", "line 1\nline 2"]);
+  });
+
+  it("turn/started fires crew:thinking rising edge", () => {
+    const dispatched: Event[] = [];
+    const evt: TurnStartedEvent = {
+      session_id: SESSION,
+      turn_id: "cmid-7",
+    };
+    handleTurnStarted(
+      { sessionId: SESSION, dispatchEvent: (e) => dispatched.push(e) },
+      evt,
+    );
+    expect(dispatched).toHaveLength(1);
+    expect(dispatched[0].type).toBe("crew:thinking");
+    expect((dispatched[0] as CustomEvent).detail.thinking).toBe(true);
+  });
+
+  it("turn/completed finalizes the assistant bubble", () => {
+    seedThread("cmid-8");
+    ThreadStore.appendAssistantToken("cmid-8", "Done.");
+    const dispatched: Event[] = [];
+    const evt: TurnCompletedEvent = {
+      session_id: SESSION,
+      turn_id: "cmid-8",
+      reason: "stop",
+    };
+    handleTurnCompleted(
+      { sessionId: SESSION, dispatchEvent: (e) => dispatched.push(e) },
+      evt,
+    );
+    const [thread] = ThreadStore.getThreads(SESSION);
+    expect(thread.pendingAssistant).toBeNull();
+    expect(thread.responses).toHaveLength(1);
+    expect(thread.responses[0].text).toBe("Done.");
+    expect(thread.responses[0].status).toBe("complete");
+    expect(
+      dispatched.some(
+        (e) =>
+          e.type === "crew:thinking" &&
+          (e as CustomEvent).detail.thinking === false,
+      ),
+    ).toBe(true);
+  });
+
+  it("turn/error marks the assistant bubble errored, not stuck pending", () => {
+    seedThread("cmid-9");
+    ThreadStore.appendAssistantToken("cmid-9", "partial");
+    const dispatched: Event[] = [];
+    const evt: TurnErrorEvent = {
+      session_id: SESSION,
+      turn_id: "cmid-9",
+      error: { code: -32000, message: "agent_failed" },
+    };
+    handleTurnError(
+      { sessionId: SESSION, dispatchEvent: (e) => dispatched.push(e) },
+      evt,
+    );
+    const [thread] = ThreadStore.getThreads(SESSION);
+    expect(thread.pendingAssistant).toBeNull();
+    expect(thread.responses[0].status).toBe("error");
+    expect(thread.responses[0].text).toBe("partial");
+    expect(dispatched.some((e) => e.type === "crew:turn_error")).toBe(true);
+  });
+
+  it("approval/requested dispatches a CustomEvent with the typed payload", () => {
+    const dispatched: Event[] = [];
+    const evt: ApprovalRequestedEvent = {
+      session_id: SESSION,
+      approval_id: "ap-1",
+      turn_id: "cmid-10",
+      tool_name: "shell",
+      title: "Run rm?",
+      body: "rm -rf node_modules",
+      approval_kind: "shell.exec",
+      approval_scope: "request",
+      risk: "high",
+    };
+    handleApprovalRequested(
+      { sessionId: SESSION, dispatchEvent: (e) => dispatched.push(e) },
+      evt,
+    );
+    expect(dispatched).toHaveLength(1);
+    const ce = dispatched[0] as CustomEvent;
+    expect(ce.type).toBe("crew:approval_requested");
+    expect(ce.detail).toEqual(evt);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Parity: feed equivalent SSE-shaped and v1 events into their respective
+// handlers and assert the ThreadStore terminal state matches.
+// ---------------------------------------------------------------------------
+
+describe("router parity with SSE bridge", () => {
+  it("v1 stream lands on the same ThreadStore state as the SSE equivalent", () => {
+    // Both transports start from the same user message.
+    const cmid = "cmid-parity";
+
+    // === v1 path: drive the router with typed events. ===
+    seedThread(cmid, "ask");
+    handleTurnStarted(
+      { sessionId: SESSION },
+      { session_id: SESSION, turn_id: cmid },
+    );
+    handleMessageDelta(
+      { sessionId: SESSION },
+      { session_id: SESSION, turn_id: cmid, delta: "Hello" },
+    );
+    handleMessageDelta(
+      { sessionId: SESSION },
+      { session_id: SESSION, turn_id: cmid, delta: ", world" },
+    );
+    handleTurnCompleted(
+      { sessionId: SESSION },
+      { session_id: SESSION, turn_id: cmid, reason: "stop" },
+    );
+    const v1State = ThreadStore.getThreads(SESSION);
+    const v1Snapshot = {
+      threads: v1State.length,
+      text: v1State[0].responses[0]?.text,
+      status: v1State[0].responses[0]?.status,
+      pending: v1State[0].pendingAssistant,
+    };
+
+    ThreadStore.__resetForTests();
+
+    // === Legacy path: drive ThreadStore directly using the same actions
+    //     the SSE bridge invokes for token / done events. ===
+    seedThread(cmid, "ask");
+    ThreadStore.appendAssistantToken(cmid, "Hello");
+    ThreadStore.appendAssistantToken(cmid, ", world");
+    ThreadStore.replaceAssistantText(cmid, "Hello, world");
+    ThreadStore.finalizeAssistant(cmid);
+    const sseState = ThreadStore.getThreads(SESSION);
+    const sseSnapshot = {
+      threads: sseState.length,
+      text: sseState[0].responses[0]?.text,
+      status: sseState[0].responses[0]?.status,
+      pending: sseState[0].pendingAssistant,
+    };
+
+    expect(v1Snapshot).toEqual(sseSnapshot);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// attachRouter wiring: confirm subscribe + detach contract is honored.
+// ---------------------------------------------------------------------------
+
+class FakeBridge implements UiProtocolBridge {
+  emitMessageDelta?: (e: MessageDeltaEvent) => void;
+  emitMessagePersisted?: (e: MessagePersistedEvent) => void;
+  emitTaskUpdated?: (e: TaskUpdatedEvent) => void;
+  emitTaskOutputDelta?: (e: TaskOutputDeltaEvent) => void;
+  emitTurnLifecycle?: (
+    e: TurnStartedEvent | TurnCompletedEvent | TurnErrorEvent,
+  ) => void;
+  emitApprovalRequested?: (e: ApprovalRequestedEvent) => void;
+
+  start = vi.fn(async () => {});
+  stop = vi.fn(async () => {});
+  sendTurn = vi.fn(async () => ({ accepted: true }));
+  interruptTurn = vi.fn(async () => ({ interrupted: true }));
+  respondToApproval = vi.fn(async () => ({
+    approval_id: "x",
+    accepted: true,
+    status: "ok",
+  }));
+
+  onMessageDelta(h: (e: MessageDeltaEvent) => void) {
+    this.emitMessageDelta = h;
+    return () => {
+      this.emitMessageDelta = undefined;
+    };
+  }
+  onMessagePersisted(h: (e: MessagePersistedEvent) => void) {
+    this.emitMessagePersisted = h;
+    return () => {
+      this.emitMessagePersisted = undefined;
+    };
+  }
+  onTaskUpdated(h: (e: TaskUpdatedEvent) => void) {
+    this.emitTaskUpdated = h;
+    return () => {
+      this.emitTaskUpdated = undefined;
+    };
+  }
+  onTaskOutputDelta(h: (e: TaskOutputDeltaEvent) => void) {
+    this.emitTaskOutputDelta = h;
+    return () => {
+      this.emitTaskOutputDelta = undefined;
+    };
+  }
+  onTurnLifecycle(
+    h: (e: TurnStartedEvent | TurnCompletedEvent | TurnErrorEvent) => void,
+  ) {
+    this.emitTurnLifecycle = h;
+    return () => {
+      this.emitTurnLifecycle = undefined;
+    };
+  }
+  onApprovalRequested(h: (e: ApprovalRequestedEvent) => void) {
+    this.emitApprovalRequested = h;
+    return () => {
+      this.emitApprovalRequested = undefined;
+    };
+  }
+  onConnectionStateChange(): () => void {
+    return () => {};
+  }
+  onWarning(): () => void {
+    return () => {};
+  }
+}
+
+describe("attachRouter", () => {
+  it("subscribes all streams and detach() removes them", () => {
+    const bridge = new FakeBridge();
+    const att = attachRouter(bridge, { sessionId: SESSION });
+
+    expect(bridge.emitMessageDelta).toBeDefined();
+    expect(bridge.emitMessagePersisted).toBeDefined();
+    expect(bridge.emitTaskUpdated).toBeDefined();
+    expect(bridge.emitTaskOutputDelta).toBeDefined();
+    expect(bridge.emitTurnLifecycle).toBeDefined();
+    expect(bridge.emitApprovalRequested).toBeDefined();
+
+    att.detach();
+    expect(bridge.emitMessageDelta).toBeUndefined();
+    expect(bridge.emitMessagePersisted).toBeUndefined();
+    expect(bridge.emitTaskUpdated).toBeUndefined();
+    expect(bridge.emitTaskOutputDelta).toBeUndefined();
+    expect(bridge.emitTurnLifecycle).toBeUndefined();
+    expect(bridge.emitApprovalRequested).toBeUndefined();
+  });
+
+  it("turn lifecycle multiplexer routes started / completed / error correctly", () => {
+    const bridge = new FakeBridge();
+    attachRouter(bridge, { sessionId: SESSION });
+    seedThread("cmid-mux");
+    ThreadStore.appendAssistantToken("cmid-mux", "x");
+
+    bridge.emitTurnLifecycle?.({
+      session_id: SESSION,
+      turn_id: "cmid-mux",
+      reason: "stop",
+    });
+    let state = ThreadStore.getThreads(SESSION);
+    expect(state[0].responses[0].status).toBe("complete");
+
+    ThreadStore.__resetForTests();
+    seedThread("cmid-mux2");
+    ThreadStore.appendAssistantToken("cmid-mux2", "x");
+    bridge.emitTurnLifecycle?.({
+      session_id: SESSION,
+      turn_id: "cmid-mux2",
+      error: { code: -1, message: "boom" },
+    });
+    state = ThreadStore.getThreads(SESSION);
+    expect(state[0].responses[0].status).toBe("error");
+  });
+});

--- a/src/runtime/ui-protocol-event-router.test.ts
+++ b/src/runtime/ui-protocol-event-router.test.ts
@@ -299,6 +299,75 @@ describe("router event mapping", () => {
 // handlers and assert the ThreadStore terminal state matches.
 // ---------------------------------------------------------------------------
 
+describe("router lifecycle de-dup", () => {
+  // Codex review: the server emits message/delta + message/persisted +
+  // turn/completed for the same turn. Pre-fix, the router appended the
+  // persisted record as an additional response on top of the streamed
+  // pending bubble — duplicate bubbles in the UI. The fix promotes the
+  // pending into the persisted record on `message/persisted` arrival.
+  it("emits a single response for delta + persisted + completed on the same turn", () => {
+    const cmid = "cmid-dedup";
+    seedThread(cmid, "ask");
+    handleMessageDelta(
+      { sessionId: SESSION },
+      { session_id: SESSION, turn_id: cmid, delta: "partial" },
+    );
+    handleMessagePersisted(
+      { sessionId: SESSION },
+      {
+        session_id: SESSION,
+        turn_id: cmid,
+        message: {
+          id: "msg-dedup",
+          thread_id: cmid,
+          role: "assistant",
+          content: "Final",
+          history_seq: 11,
+          intra_thread_seq: 2,
+        },
+      },
+    );
+    handleTurnCompleted(
+      { sessionId: SESSION },
+      { session_id: SESSION, turn_id: cmid, reason: "stop" },
+    );
+    const [thread] = ThreadStore.getThreads(SESSION);
+    expect(thread.responses).toHaveLength(1);
+    expect(thread.responses[0].text).toBe("Final");
+    expect(thread.responses[0].status).toBe("complete");
+    expect(thread.pendingAssistant).toBeNull();
+  });
+});
+
+describe("router intra_thread_seq preservation", () => {
+  // Codex review #3: PersistedMessage carries an explicit per-thread
+  // sequence that may differ from history_seq (per-session). Both axes
+  // should land on the response so re-orderers downstream can pick the
+  // right one.
+  it("persisted message with intra_thread_seq != history_seq preserves both", () => {
+    const cmid = "cmid-seq";
+    handleMessagePersisted(
+      { sessionId: SESSION },
+      {
+        session_id: SESSION,
+        turn_id: cmid,
+        message: {
+          id: "msg-seq",
+          thread_id: cmid,
+          role: "assistant",
+          content: "ok",
+          history_seq: 42,
+          intra_thread_seq: 3,
+        },
+      },
+    );
+    const [thread] = ThreadStore.getThreads(SESSION);
+    const last = thread.responses[thread.responses.length - 1];
+    expect(last?.historySeq).toBe(42);
+    expect(last?.intra_thread_seq).toBe(3);
+  });
+});
+
 describe("router parity with SSE bridge", () => {
   it("v1 stream lands on the same ThreadStore state as the SSE equivalent", () => {
     // Both transports start from the same user message.
@@ -348,6 +417,99 @@ describe("router parity with SSE bridge", () => {
     };
 
     expect(v1Snapshot).toEqual(sseSnapshot);
+  });
+
+  it("persisted-then-completed lands on the same ThreadStore state both ways", () => {
+    const cmid = "cmid-parity-persisted";
+
+    // === v1: message/persisted (promotes pending) + turn/completed
+    //     (no-op since pending was already finalized). ===
+    seedThread(cmid, "ask");
+    handleMessagePersisted(
+      { sessionId: SESSION },
+      {
+        session_id: SESSION,
+        turn_id: cmid,
+        message: {
+          id: "msg-p",
+          thread_id: cmid,
+          role: "assistant",
+          content: "Persisted answer",
+          history_seq: 5,
+        },
+      },
+    );
+    handleTurnCompleted(
+      { sessionId: SESSION },
+      { session_id: SESSION, turn_id: cmid, reason: "stop" },
+    );
+    const v1 = ThreadStore.getThreads(SESSION);
+    const v1Snap = {
+      threads: v1.length,
+      responses: v1[0].responses.length,
+      text: v1[0].responses[v1[0].responses.length - 1]?.text,
+      status: v1[0].responses[v1[0].responses.length - 1]?.status,
+      pending: v1[0].pendingAssistant,
+    };
+
+    ThreadStore.__resetForTests();
+
+    // === Legacy path: SSE done + replace/finalize land on the same
+    //     terminal state (one finalized response, no pending). ===
+    seedThread(cmid, "ask");
+    ThreadStore.replaceAssistantText(cmid, "Persisted answer");
+    ThreadStore.finalizeAssistant(cmid, { committedSeq: 5 });
+    const sse = ThreadStore.getThreads(SESSION);
+    const sseSnap = {
+      threads: sse.length,
+      responses: sse[0].responses.length,
+      text: sse[0].responses[sse[0].responses.length - 1]?.text,
+      status: sse[0].responses[sse[0].responses.length - 1]?.status,
+      pending: sse[0].pendingAssistant,
+    };
+
+    expect(v1Snap).toEqual(sseSnap);
+  });
+
+  it("error turn lands on the same ThreadStore state both ways", () => {
+    const cmid = "cmid-parity-error";
+
+    // === v1: deltas + turn/error ===
+    seedThread(cmid, "ask");
+    handleMessageDelta(
+      { sessionId: SESSION },
+      { session_id: SESSION, turn_id: cmid, delta: "partial" },
+    );
+    handleTurnError(
+      { sessionId: SESSION },
+      {
+        session_id: SESSION,
+        turn_id: cmid,
+        error: { code: -1, message: "boom" },
+      },
+    );
+    const v1 = ThreadStore.getThreads(SESSION);
+    const v1Snap = {
+      text: v1[0].responses[0]?.text,
+      status: v1[0].responses[0]?.status,
+      pending: v1[0].pendingAssistant,
+    };
+
+    ThreadStore.__resetForTests();
+
+    // === Legacy path: SSE token + finalize-as-error mirrors the v1
+    //     terminal state (status=error, partial text retained). ===
+    seedThread(cmid, "ask");
+    ThreadStore.appendAssistantToken(cmid, "partial");
+    ThreadStore.finalizeAssistant(cmid, { status: "error" });
+    const sse = ThreadStore.getThreads(SESSION);
+    const sseSnap = {
+      text: sse[0].responses[0]?.text,
+      status: sse[0].responses[0]?.status,
+      pending: sse[0].pendingAssistant,
+    };
+
+    expect(v1Snap).toEqual(sseSnap);
   });
 });
 

--- a/src/runtime/ui-protocol-event-router.ts
+++ b/src/runtime/ui-protocol-event-router.ts
@@ -1,0 +1,331 @@
+/**
+ * UI Protocol v1 → ThreadStore action router (Phase C-2, issue #68).
+ *
+ * Pure mapping layer. Each handler converts a typed bridge event into the
+ * same ThreadStore mutations the SSE bridge already produces, so the v1
+ * transport reaches an identical store state from a different wire format.
+ * The bridge-level fail-closed guards (ui-protocol-bridge.ts) have already
+ * rejected malformed events before anything reaches this module.
+ *
+ * Capability negotiation: picks option (A) per the C-2 plan — no current
+ * mapping branches on `UiProtocolCapabilities`, so we use the bridge as-is.
+ *
+ * Side-effects this module is allowed to perform:
+ *   - mutate ThreadStore (the canonical v1 invariant)
+ *   - dispatch DOM CustomEvents (`crew:thinking`, `crew:approval_requested`,
+ *     `crew:bg_tasks`) so existing listeners (sidebar spinner, future
+ *     approval modal) keep working without per-listener flag-gating.
+ *
+ * Side-effects this module deliberately does NOT perform:
+ *   - touch MessageStore (the legacy flat-list path is reserved for SSE
+ *     bridge; the v1 flag implicitly forces v2 thread store)
+ *   - mutate session-context state directly (callers wire that up)
+ */
+
+import type {
+  ApprovalRequestedEvent,
+  MessageDeltaEvent,
+  MessagePersistedEvent,
+  PersistedMessage,
+  TaskOutputDeltaEvent,
+  TaskUpdatedEvent,
+  TurnCompletedEvent,
+  TurnErrorEvent,
+  TurnStartedEvent,
+  UiProtocolBridge,
+} from "./ui-protocol-bridge";
+import * as ThreadStore from "@/store/thread-store";
+import type { MessageInfo } from "@/api/types";
+
+// ---------------------------------------------------------------------------
+// Per-task state-transition de-dupe
+// ---------------------------------------------------------------------------
+
+/** Last-seen task state per `task_id`. Mirrors the SSE-side
+ *  `lastTaskStatusById` map in `runtime-provider.tsx` so a `task/updated`
+ *  replay (e.g. on reconnect) doesn't inflate the in-bubble timeline. */
+const lastTaskStateById = new Map<string, string>();
+
+/** Reset the per-task state map. Tests call this between cases; production
+ *  code does not need it because the map is bounded by the number of live
+ *  tasks per session (~tens, never thousands). */
+export function __resetRouterStateForTest(): void {
+  lastTaskStateById.clear();
+}
+
+// ---------------------------------------------------------------------------
+// Configuration
+// ---------------------------------------------------------------------------
+
+export interface RouterConfig {
+  sessionId: string;
+  /** Optional thread topic (matches the SSE-bridge `historyTopic`). */
+  topic?: string;
+  /** Override window event dispatch for tests / SSR. */
+  dispatchEvent?: (event: Event) => void;
+}
+
+function dispatch(cfg: RouterConfig, event: Event): void {
+  const fn = cfg.dispatchEvent ?? defaultDispatch;
+  fn(event);
+}
+
+function defaultDispatch(event: Event): void {
+  if (typeof window === "undefined") return;
+  window.dispatchEvent(event);
+}
+
+// ---------------------------------------------------------------------------
+// Mappers
+// ---------------------------------------------------------------------------
+
+/**
+ * Translate the bridge's `PersistedMessage` shape into the `MessageInfo`
+ * shape that `ThreadStore.appendPersistedMessage` expects. Only the fields
+ * the store actually consults are filled in — extras are dropped because
+ * the helper validates by role + thread_id and ignores unknown keys.
+ */
+function persistedToMessageInfo(m: PersistedMessage): MessageInfo {
+  return {
+    role: m.role,
+    content: m.content,
+    thread_id: m.thread_id,
+    client_message_id: m.client_message_id,
+    response_to_client_message_id: m.response_to_client_message_id,
+    tool_call_id: m.source_tool_call_id,
+    timestamp: m.timestamp ?? new Date().toISOString(),
+    seq: typeof m.history_seq === "number" ? m.history_seq : undefined,
+    media: (m.files ?? []).map((f) => f.path),
+    tool_calls: m.tool_calls?.map((tc) => {
+      const o = tc as { id?: unknown; name?: unknown };
+      return {
+        id: typeof o?.id === "string" ? o.id : undefined,
+        name: typeof o?.name === "string" ? o.name : undefined,
+      };
+    }),
+  };
+}
+
+export function handleMessageDelta(
+  _cfg: RouterConfig,
+  event: MessageDeltaEvent,
+): void {
+  // turn_id is the thread_id key per the v1 contract. The bridge already
+  // rejected events with a missing/empty turn_id at the guard layer.
+  if (!event.delta) return;
+  ThreadStore.appendAssistantToken(event.turn_id, event.delta);
+}
+
+export function handleMessagePersisted(
+  cfg: RouterConfig,
+  event: MessagePersistedEvent,
+): void {
+  ThreadStore.appendPersistedMessage(
+    cfg.sessionId,
+    cfg.topic,
+    persistedToMessageInfo(event.message),
+  );
+}
+
+export function handleTaskUpdated(
+  cfg: RouterConfig,
+  event: TaskUpdatedEvent,
+): void {
+  const previous = lastTaskStateById.get(event.task_id);
+  if (previous === event.state) return;
+  lastTaskStateById.set(event.task_id, event.state);
+
+  switch (event.state) {
+    case "spawned":
+    case "running": {
+      const label = event.title ?? event.runtime_detail ?? event.state;
+      ThreadStore.appendToolProgress(event.turn_id, event.task_id, label);
+      // Mirror the legacy SSE bridge's `crew:bg_tasks` dispatch so any
+      // listener that gates a session-level "background work" indicator
+      // off the same event keeps firing.
+      dispatch(
+        cfg,
+        new CustomEvent("crew:bg_tasks", {
+          detail: { sessionId: cfg.sessionId, topic: cfg.topic },
+        }),
+      );
+      break;
+    }
+    case "completed": {
+      ThreadStore.setToolCallStatus(event.turn_id, event.task_id, "complete");
+      break;
+    }
+    case "failed":
+    case "errored": {
+      ThreadStore.setToolCallStatus(event.turn_id, event.task_id, "error");
+      break;
+    }
+    default:
+      break;
+  }
+}
+
+export function handleTaskOutputDelta(
+  _cfg: RouterConfig,
+  event: TaskOutputDeltaEvent,
+): void {
+  if (!event.chunk) return;
+  // Surface live tool stdout into the bubble's progress timeline. Dedupe
+  // logic lives in ThreadStore.appendToolProgress (consecutive duplicates
+  // are dropped) so resending the same chunk on reconnect is safe.
+  ThreadStore.appendToolProgress(event.turn_id, event.task_id, event.chunk);
+}
+
+export function handleTurnStarted(
+  cfg: RouterConfig,
+  event: TurnStartedEvent,
+): void {
+  // Mirror the legacy `crew:thinking` rising edge so the global indicator
+  // (sidebar spinner, header pulse) lights up the moment a turn begins.
+  // ThreadStore-side bookkeeping is handled by `addUserMessage` on send;
+  // we do not synthesize a placeholder here because the user bubble is
+  // already in place by the time the server confirms turn/started.
+  dispatch(
+    cfg,
+    new CustomEvent("crew:thinking", {
+      detail: {
+        thinking: true,
+        iteration: 0,
+        sessionId: cfg.sessionId,
+        topic: cfg.topic,
+        turnId: event.turn_id,
+      },
+    }),
+  );
+}
+
+export function handleTurnCompleted(
+  cfg: RouterConfig,
+  event: TurnCompletedEvent,
+): void {
+  ThreadStore.finalizeAssistant(event.turn_id);
+  dispatch(
+    cfg,
+    new CustomEvent("crew:thinking", {
+      detail: {
+        thinking: false,
+        iteration: 0,
+        sessionId: cfg.sessionId,
+        topic: cfg.topic,
+        turnId: event.turn_id,
+      },
+    }),
+  );
+}
+
+export function handleTurnError(
+  cfg: RouterConfig,
+  event: TurnErrorEvent,
+): void {
+  // Mark the bubble errored rather than leaving the pending slot dangling.
+  // `finalizeAssistant` accepts an explicit status override per its options
+  // surface — we use it so the v1 path produces the same terminal state
+  // shape (responses[].status === "error") as the v0 SSE `error` branch.
+  ThreadStore.finalizeAssistant(event.turn_id, { status: "error" });
+  dispatch(
+    cfg,
+    new CustomEvent("crew:thinking", {
+      detail: {
+        thinking: false,
+        iteration: 0,
+        sessionId: cfg.sessionId,
+        topic: cfg.topic,
+        turnId: event.turn_id,
+      },
+    }),
+  );
+  dispatch(
+    cfg,
+    new CustomEvent("crew:turn_error", {
+      detail: {
+        sessionId: cfg.sessionId,
+        topic: cfg.topic,
+        turnId: event.turn_id,
+        error: event.error,
+      },
+    }),
+  );
+}
+
+export function handleApprovalRequested(
+  cfg: RouterConfig,
+  event: ApprovalRequestedEvent,
+): void {
+  // No approval modal exists yet (Phase C-4 territory). For now we surface
+  // the typed event verbatim through a CustomEvent so a future modal can
+  // listen without us having to touch this router again. The modal API
+  // shape is the bridge's `ApprovalRequestedEvent` directly — the typed
+  // shape is the contract.
+  dispatch(
+    cfg,
+    new CustomEvent("crew:approval_requested", { detail: event }),
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Wiring
+// ---------------------------------------------------------------------------
+
+export interface RouterAttachment {
+  /** Detach all subscriptions registered on the bridge. Idempotent. */
+  detach(): void;
+}
+
+/**
+ * Subscribe the router to all relevant streams on a started bridge. The
+ * caller owns bridge lifecycle (start/stop). Returns a detacher that
+ * removes every listener registered here — call it before swapping the
+ * bridge out (e.g. session change) to avoid event leaks.
+ */
+export function attachRouter(
+  bridge: UiProtocolBridge,
+  cfg: RouterConfig,
+): RouterAttachment {
+  const offMessageDelta = bridge.onMessageDelta((e) =>
+    handleMessageDelta(cfg, e),
+  );
+  const offMessagePersisted = bridge.onMessagePersisted((e) =>
+    handleMessagePersisted(cfg, e),
+  );
+  const offTaskUpdated = bridge.onTaskUpdated((e) => handleTaskUpdated(cfg, e));
+  const offTaskOutputDelta = bridge.onTaskOutputDelta((e) =>
+    handleTaskOutputDelta(cfg, e),
+  );
+  const offTurnLifecycle = bridge.onTurnLifecycle((e) => {
+    // The bridge muxes the three lifecycle events through a single
+    // subscriber for ergonomics. Discriminate by the field that is unique
+    // per event variant: `error` only on `TurnErrorEvent`, `reason` only
+    // on `TurnCompletedEvent`. `TurnStartedEvent` is the residual.
+    if ("error" in e) {
+      handleTurnError(cfg, e);
+      return;
+    }
+    if ("reason" in e) {
+      handleTurnCompleted(cfg, e);
+      return;
+    }
+    handleTurnStarted(cfg, e);
+  });
+  const offApprovalRequested = bridge.onApprovalRequested((e) =>
+    handleApprovalRequested(cfg, e),
+  );
+
+  let detached = false;
+  return {
+    detach() {
+      if (detached) return;
+      detached = true;
+      offMessageDelta();
+      offMessagePersisted();
+      offTaskUpdated();
+      offTaskOutputDelta();
+      offTurnLifecycle();
+      offApprovalRequested();
+    },
+  };
+}

--- a/src/runtime/ui-protocol-event-router.ts
+++ b/src/runtime/ui-protocol-event-router.ts
@@ -95,6 +95,8 @@ function persistedToMessageInfo(m: PersistedMessage): MessageInfo {
     tool_call_id: m.source_tool_call_id,
     timestamp: m.timestamp ?? new Date().toISOString(),
     seq: typeof m.history_seq === "number" ? m.history_seq : undefined,
+    intra_thread_seq:
+      typeof m.intra_thread_seq === "number" ? m.intra_thread_seq : undefined,
     media: (m.files ?? []).map((f) => f.path),
     tool_calls: m.tool_calls?.map((tc) => {
       const o = tc as { id?: unknown; name?: unknown };
@@ -120,11 +122,80 @@ export function handleMessagePersisted(
   cfg: RouterConfig,
   event: MessagePersistedEvent,
 ): void {
+  const m = event.message;
+  // Codex review #2: when an assistant `message/persisted` arrives for a
+  // thread with an in-flight `pendingAssistant`, promote the pending
+  // bubble into the persisted record instead of appending a separate
+  // response. This avoids duplicate bubbles when the server emits
+  // streamed deltas + persisted + completed for the same turn.
+  //
+  // Match conditions:
+  //   - role === "assistant" (tool/user persists are independent records)
+  //   - the thread's pendingAssistant exists in the live store
+  //
+  // When matched: overwrite the pending text/files with the canonical
+  // persisted content (server is authoritative on final text) and call
+  // `finalizeAssistant` with the persisted seq. The downstream
+  // `turn/completed` then no-ops because `pendingAssistant` is null.
+  //
+  // When unmatched (no pending, e.g. late artifact, or non-assistant
+  // role): fall through to `appendPersistedMessage` — the PR M
+  // late-artifact path.
+  if (m.role === "assistant" && m.thread_id) {
+    const promoted = tryPromotePendingFromPersisted(
+      cfg.sessionId,
+      cfg.topic,
+      m,
+    );
+    if (promoted) return;
+  }
   ThreadStore.appendPersistedMessage(
     cfg.sessionId,
     cfg.topic,
-    persistedToMessageInfo(event.message),
+    persistedToMessageInfo(m),
   );
+}
+
+/**
+ * If the live thread for `m.thread_id` has an in-flight pendingAssistant,
+ * overwrite its content/files with the persisted record and finalize.
+ * Returns true when promotion happened (caller should NOT also append).
+ */
+function tryPromotePendingFromPersisted(
+  sessionId: string,
+  topic: string | undefined,
+  m: PersistedMessage,
+): boolean {
+  const threads = ThreadStore.getThreads(sessionId, topic);
+  const thread = threads.find((t) => t.id === m.thread_id);
+  if (!thread || !thread.pendingAssistant) return false;
+  // Replace pending text + files with the persisted content. Files
+  // from the persisted record win; the streamed pending text was a
+  // best-effort approximation of what's now authoritative.
+  ThreadStore.replaceAssistantText(m.thread_id, m.content);
+  // appendAssistantFile is path-deduped, so re-adding a streamed file
+  // is a no-op. Persisted files that weren't already attached land here.
+  for (const f of m.files ?? []) {
+    ThreadStore.appendAssistantFile(m.thread_id, {
+      filename: filenameFromPath(f.path),
+      path: f.path,
+      caption: "",
+    });
+  }
+  ThreadStore.finalizeAssistant(m.thread_id, {
+    committedSeq:
+      typeof m.intra_thread_seq === "number"
+        ? m.intra_thread_seq
+        : typeof m.history_seq === "number"
+          ? m.history_seq
+          : undefined,
+  });
+  return true;
+}
+
+function filenameFromPath(path: string): string {
+  const idx = path.lastIndexOf("/");
+  return idx === -1 ? path : path.slice(idx + 1);
 }
 
 export function handleTaskUpdated(

--- a/src/runtime/ui-protocol-runtime.test.ts
+++ b/src/runtime/ui-protocol-runtime.test.ts
@@ -1,0 +1,170 @@
+/**
+ * ui-protocol-runtime unit tests (Phase C-2, codex must-fix #4).
+ *
+ * Coverage:
+ *   - rapid `startBridgeForSession(A)` then `startBridgeForSession(B)` does
+ *     not leak bridges and does not let an older start overwrite a newer
+ *     one's `active` slot when its `start()` resolves late
+ *   - `stopActiveBridge` while a `start()` is in-flight: the in-flight
+ *     start recognizes itself as superseded and stops its orphan bridge
+ */
+
+import {
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  vi,
+} from "vitest";
+
+const { createBridgeSpy } = vi.hoisted(() => ({
+  createBridgeSpy: vi.fn(),
+}));
+
+vi.mock("./ui-protocol-bridge", async () => {
+  const actual =
+    await vi.importActual<typeof import("./ui-protocol-bridge")>(
+      "./ui-protocol-bridge",
+    );
+  return {
+    ...actual,
+    createUiProtocolBridge: createBridgeSpy,
+  };
+});
+
+import {
+  __resetUiProtocolRuntimeForTest,
+  getActiveBridge,
+  startBridgeForSession,
+  stopActiveBridge,
+} from "./ui-protocol-runtime";
+import type { UiProtocolBridge } from "./ui-protocol-bridge";
+
+interface DeferredBridge {
+  bridge: UiProtocolBridge;
+  resolveStart: () => void;
+  rejectStart: (err: Error) => void;
+  startCalls: number;
+  stopCalls: number;
+}
+
+function makeDeferredBridge(): DeferredBridge {
+  let resolveStart: () => void = () => {};
+  let rejectStart: (err: Error) => void = () => {};
+  const startPromise = new Promise<void>((res, rej) => {
+    resolveStart = res;
+    rejectStart = rej;
+  });
+  let startCalls = 0;
+  let stopCalls = 0;
+  const bridge: UiProtocolBridge = {
+    start: vi.fn(async () => {
+      startCalls++;
+      await startPromise;
+    }),
+    stop: vi.fn(async () => {
+      stopCalls++;
+    }),
+    sendTurn: vi.fn(async () => ({ accepted: true })),
+    interruptTurn: vi.fn(async () => ({ interrupted: true })),
+    respondToApproval: vi.fn(async () => ({
+      approval_id: "x",
+      accepted: true,
+      status: "ok",
+    })),
+    onMessageDelta: vi.fn(() => () => {}),
+    onMessagePersisted: vi.fn(() => () => {}),
+    onTaskUpdated: vi.fn(() => () => {}),
+    onTaskOutputDelta: vi.fn(() => () => {}),
+    onTurnLifecycle: vi.fn(() => () => {}),
+    onApprovalRequested: vi.fn(() => () => {}),
+    onConnectionStateChange: vi.fn(() => () => {}),
+    onWarning: vi.fn(() => () => {}),
+  };
+  return {
+    bridge,
+    resolveStart: () => resolveStart(),
+    rejectStart: (err) => rejectStart(err),
+    get startCalls() {
+      return startCalls;
+    },
+    get stopCalls() {
+      return stopCalls;
+    },
+  };
+}
+
+beforeEach(() => {
+  createBridgeSpy.mockReset();
+  __resetUiProtocolRuntimeForTest();
+});
+
+afterEach(() => {
+  __resetUiProtocolRuntimeForTest();
+});
+
+describe("startBridgeForSession race safety", () => {
+  it("a stale start whose handshake resolves AFTER a newer start does not overwrite the newer bridge", async () => {
+    const a = makeDeferredBridge();
+    const b = makeDeferredBridge();
+    createBridgeSpy.mockReturnValueOnce(a.bridge).mockReturnValueOnce(b.bridge);
+
+    // Kick off A; start() is pending. Active stays null because we haven't
+    // published yet.
+    const startA = startBridgeForSession("sess-A");
+    // The runtime's startBridgeForSession is sync until `await
+    // bridge.start()`, so getActiveBridge sees no live entry yet.
+    expect(getActiveBridge("sess-A")).toBeNull();
+
+    // Now kick off B. Because `active` is still null (A never finished),
+    // B is a fresh start — its own generation. (The `active != null`
+    // branch in startBridgeForSession is skipped when the prior call is
+    // mid-handshake; the generation counter is what protects us.)
+    const startB = startBridgeForSession("sess-B");
+
+    // Resolve B first. It should publish.
+    b.resolveStart();
+    await startB;
+    expect(getActiveBridge("sess-B")).toBe(b.bridge);
+
+    // Now resolve A. A is stale — it must NOT overwrite active, and it
+    // must stop its orphan bridge.
+    a.resolveStart();
+    await expect(startA).rejects.toThrow(/superseded/);
+    expect(a.stopCalls).toBe(1);
+
+    // Active is still B.
+    expect(getActiveBridge("sess-B")).toBe(b.bridge);
+    expect(getActiveBridge("sess-A")).toBeNull();
+  });
+
+  it("an in-flight start that gets stopped recognizes itself as superseded", async () => {
+    const a = makeDeferredBridge();
+    createBridgeSpy.mockReturnValueOnce(a.bridge);
+
+    const startA = startBridgeForSession("sess-A");
+    // The runtime hasn't published `active` yet (await pending), so
+    // stopActiveBridge is a no-op on the registry but bumps the
+    // generation counter — that's the supersede signal.
+    await stopActiveBridge();
+    a.resolveStart();
+    await expect(startA).rejects.toThrow(/superseded/);
+    expect(a.stopCalls).toBe(1);
+    expect(getActiveBridge("sess-A")).toBeNull();
+  });
+
+  it("idempotent same-scope re-entry returns the existing bridge", async () => {
+    const a = makeDeferredBridge();
+    createBridgeSpy.mockReturnValueOnce(a.bridge);
+    const startA = startBridgeForSession("sess-A");
+    a.resolveStart();
+    const bridge = await startA;
+    expect(bridge).toBe(a.bridge);
+
+    // Second call with the same scope: must NOT spin up a second bridge.
+    const second = await startBridgeForSession("sess-A");
+    expect(second).toBe(a.bridge);
+    expect(createBridgeSpy).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/runtime/ui-protocol-runtime.ts
+++ b/src/runtime/ui-protocol-runtime.ts
@@ -129,6 +129,32 @@ export async function stopActiveBridge(): Promise<void> {
   }
 }
 
+/** Stop the active bridge ONLY if its scope matches the requested
+ *  (sessionId, topic). Returns true if a stop happened, false otherwise.
+ *  Used by `runtime-provider.tsx` to safely tear down a scoped bridge
+ *  without accidentally stopping a newer effect's active bridge — the
+ *  generation counter already prevents stale starts from publishing,
+ *  but the provider's cleanup also needs to avoid stopping a sibling. */
+export async function stopActiveBridgeIfScope(
+  sessionId: string,
+  topic?: string,
+): Promise<boolean> {
+  if (!active) return false;
+  if (!sameScope(active, sessionId, topic)) return false;
+  // Match — bump generation so any in-flight start sees itself as stale,
+  // then perform the same stop as `stopActiveBridge`.
+  generation++;
+  const handle = active;
+  active = null;
+  handle.attachment.detach();
+  try {
+    await handle.bridge.stop();
+  } catch {
+    // best-effort
+  }
+  return true;
+}
+
 /** Test-only reset. */
 export function __resetUiProtocolRuntimeForTest(): void {
   active = null;

--- a/src/runtime/ui-protocol-runtime.ts
+++ b/src/runtime/ui-protocol-runtime.ts
@@ -1,0 +1,101 @@
+/**
+ * UI Protocol v1 runtime — owns the active bridge instance keyed by session.
+ *
+ * The mount effect in `runtime-provider.tsx` calls `startBridgeForSession`
+ * when the v1 flag is on; the send path looks up the active bridge via
+ * `getActiveBridge`. Only one bridge is active at a time (current session)
+ * because a session change tears down the previous bridge before starting
+ * the next one. Concurrent sessions are out of scope for C-2.
+ */
+
+import {
+  createUiProtocolBridge,
+  type UiProtocolBridge,
+} from "./ui-protocol-bridge";
+import { attachRouter, type RouterAttachment } from "./ui-protocol-event-router";
+
+interface ActiveBridge {
+  sessionId: string;
+  topic?: string;
+  bridge: UiProtocolBridge;
+  attachment: RouterAttachment;
+}
+
+let active: ActiveBridge | null = null;
+
+function sameScope(a: ActiveBridge, sessionId: string, topic?: string): boolean {
+  const t = topic?.trim() || undefined;
+  const at = a.topic?.trim() || undefined;
+  return a.sessionId === sessionId && at === t;
+}
+
+/**
+ * Start a v1 bridge for the given session. If a bridge is already running
+ * for the same scope, returns the existing one (idempotent across StrictMode
+ * remounts). When called for a different scope, the previous bridge is
+ * stopped first.
+ */
+export async function startBridgeForSession(
+  sessionId: string,
+  topic?: string,
+): Promise<UiProtocolBridge> {
+  if (active && sameScope(active, sessionId, topic)) {
+    return active.bridge;
+  }
+  if (active) {
+    await stopActiveBridge();
+  }
+  const bridge = createUiProtocolBridge();
+  await bridge.start({ sessionId });
+  const attachment = attachRouter(bridge, { sessionId, topic });
+  active = { sessionId, topic, bridge, attachment };
+  return bridge;
+}
+
+/**
+ * Returns the currently-active bridge if it matches the requested scope.
+ * Mismatched scopes return null so callers fall back to the legacy path
+ * rather than dispatching a turn into the wrong session's transport.
+ */
+export function getActiveBridge(
+  sessionId: string,
+  topic?: string,
+): UiProtocolBridge | null {
+  if (!active) return null;
+  if (!sameScope(active, sessionId, topic)) return null;
+  return active.bridge;
+}
+
+/** Stop the currently-active bridge and detach the router. Idempotent. */
+export async function stopActiveBridge(): Promise<void> {
+  if (!active) return;
+  const handle = active;
+  active = null;
+  handle.attachment.detach();
+  try {
+    await handle.bridge.stop();
+  } catch {
+    // Stop is best-effort — a closing socket throwing must not poison the
+    // teardown of the next session's bridge.
+  }
+}
+
+/** Test-only reset. */
+export function __resetUiProtocolRuntimeForTest(): void {
+  active = null;
+}
+
+/** Test-only injection so unit tests can drive a mock bridge into the
+ *  runtime registry without spinning up a real WebSocket. */
+export function __setActiveBridgeForTest(
+  sessionId: string,
+  bridge: UiProtocolBridge,
+  topic?: string,
+): void {
+  active = {
+    sessionId,
+    topic,
+    bridge,
+    attachment: { detach: () => {} },
+  };
+}

--- a/src/runtime/ui-protocol-runtime.ts
+++ b/src/runtime/ui-protocol-runtime.ts
@@ -50,8 +50,12 @@ function sameScope(a: ActiveBridge, sessionId: string, topic?: string): boolean 
  * Race-safe: each call captures the current `generation` before awaiting
  * `bridge.start()`. If a newer call (or `stopActiveBridge`) bumped the
  * generation while we were awaiting, this start is stale — we stop the
- * orphaned bridge and either return the now-current `active` bridge (when
- * scope matches) or throw, rather than overwrite `active`.
+ * orphaned bridge and ALWAYS THROW, even when a newer same-scope active
+ * exists. The throw signals the caller "you did NOT publish this active";
+ * callers depending on the published-by-me invariant (e.g. the provider's
+ * scope-aware cleanup) can branch on it. Callers wanting "give me the
+ * active bridge for this scope, regardless of who published" should use
+ * `getActiveBridge(sessionId, topic)` instead.
  */
 export async function startBridgeForSession(
   sessionId: string,
@@ -72,21 +76,21 @@ export async function startBridgeForSession(
       // No newer start raced us; surface the failure.
       throw err;
     }
-    // Newer start has already run — swallow; the new bridge is what
-    // callers will get from `getActiveBridge`.
-    return active?.bridge ?? Promise.reject(err);
+    // Newer start raced us. Throw rather than masquerade as the publisher.
+    throw new Error(
+      "ui-protocol-runtime: bridge start superseded during handshake error",
+    );
   }
   if (myGeneration !== generation) {
     // A newer `startBridgeForSession` or `stopActiveBridge` ran while
     // we were awaiting the handshake. This bridge is now orphaned —
-    // stop it and defer to whatever the live `active` slot holds.
+    // stop it and ALWAYS THROW so the caller does not assume ownership
+    // of whatever the live `active` slot holds (it belongs to a newer
+    // start, not us).
     try {
       await bridge.stop();
     } catch {
       // best-effort
-    }
-    if (active && sameScope(active, sessionId, topic)) {
-      return active.bridge;
     }
     throw new Error(
       "ui-protocol-runtime: bridge start superseded by a newer session",

--- a/src/runtime/ui-protocol-runtime.ts
+++ b/src/runtime/ui-protocol-runtime.ts
@@ -23,6 +23,18 @@ interface ActiveBridge {
 
 let active: ActiveBridge | null = null;
 
+/**
+ * Monotonic generation counter. Each `startBridgeForSession` /
+ * `stopActiveBridge` call increments it; in-flight `start()` resolutions
+ * compare their captured generation against the live one before publishing
+ * themselves as `active`. A stale start (a newer call ran while we were
+ * awaiting the WebSocket handshake) is responsible for stopping its own
+ * bridge and discarding the result. Codex review must-fix #4: avoids the
+ * pre-fix race where rapid session switches could leak bridges or — worse —
+ * have an older `start()` resolution overwrite a newer bridge in `active`.
+ */
+let generation = 0;
+
 function sameScope(a: ActiveBridge, sessionId: string, topic?: string): boolean {
   const t = topic?.trim() || undefined;
   const at = a.topic?.trim() || undefined;
@@ -34,6 +46,12 @@ function sameScope(a: ActiveBridge, sessionId: string, topic?: string): boolean 
  * for the same scope, returns the existing one (idempotent across StrictMode
  * remounts). When called for a different scope, the previous bridge is
  * stopped first.
+ *
+ * Race-safe: each call captures the current `generation` before awaiting
+ * `bridge.start()`. If a newer call (or `stopActiveBridge`) bumped the
+ * generation while we were awaiting, this start is stale — we stop the
+ * orphaned bridge and either return the now-current `active` bridge (when
+ * scope matches) or throw, rather than overwrite `active`.
  */
 export async function startBridgeForSession(
   sessionId: string,
@@ -45,8 +63,35 @@ export async function startBridgeForSession(
   if (active) {
     await stopActiveBridge();
   }
+  const myGeneration = ++generation;
   const bridge = createUiProtocolBridge();
-  await bridge.start({ sessionId });
+  try {
+    await bridge.start({ sessionId });
+  } catch (err) {
+    if (myGeneration === generation) {
+      // No newer start raced us; surface the failure.
+      throw err;
+    }
+    // Newer start has already run — swallow; the new bridge is what
+    // callers will get from `getActiveBridge`.
+    return active?.bridge ?? Promise.reject(err);
+  }
+  if (myGeneration !== generation) {
+    // A newer `startBridgeForSession` or `stopActiveBridge` ran while
+    // we were awaiting the handshake. This bridge is now orphaned —
+    // stop it and defer to whatever the live `active` slot holds.
+    try {
+      await bridge.stop();
+    } catch {
+      // best-effort
+    }
+    if (active && sameScope(active, sessionId, topic)) {
+      return active.bridge;
+    }
+    throw new Error(
+      "ui-protocol-runtime: bridge start superseded by a newer session",
+    );
+  }
   const attachment = attachRouter(bridge, { sessionId, topic });
   active = { sessionId, topic, bridge, attachment };
   return bridge;
@@ -66,8 +111,12 @@ export function getActiveBridge(
   return active.bridge;
 }
 
-/** Stop the currently-active bridge and detach the router. Idempotent. */
+/** Stop the currently-active bridge and detach the router. Idempotent.
+ *  Bumps the generation counter so any in-flight `startBridgeForSession`
+ *  awaiting a handshake recognizes itself as superseded and stops its
+ *  orphaned bridge instead of publishing it. */
 export async function stopActiveBridge(): Promise<void> {
+  generation++;
   if (!active) return;
   const handle = active;
   active = null;
@@ -83,6 +132,7 @@ export async function stopActiveBridge(): Promise<void> {
 /** Test-only reset. */
 export function __resetUiProtocolRuntimeForTest(): void {
   active = null;
+  generation = 0;
 }
 
 /** Test-only injection so unit tests can drive a mock bridge into the

--- a/src/runtime/ui-protocol-send.test.ts
+++ b/src/runtime/ui-protocol-send.test.ts
@@ -1,0 +1,180 @@
+/**
+ * ui-protocol-send unit tests (Phase C-2, issue #68).
+ *
+ * Coverage:
+ *   - flag-OFF: delegates to the legacy SSE bridge unchanged
+ *   - flag-ON with no active bridge: falls back to legacy so the user
+ *     message is never lost on a pre-mount race
+ *   - flag-ON with active bridge: dispatches via bridge.sendTurn and
+ *     mirrors the user message into the thread store
+ */
+
+import {
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  vi,
+} from "vitest";
+
+// Hoisted mocks: vi.mock factories cannot reference module-scoped vars
+// directly, so we expose the spy through vi.hoisted so the factory can
+// import it. This is the standard vitest hoisting pattern.
+const { legacySendSpy } = vi.hoisted(() => ({
+  legacySendSpy: vi.fn(),
+}));
+
+vi.mock("./sse-bridge", () => ({
+  sendMessage: legacySendSpy,
+}));
+
+import * as ThreadStore from "@/store/thread-store";
+import { sendMessage } from "./ui-protocol-send";
+import {
+  __resetUiProtocolRuntimeForTest,
+  __setActiveBridgeForTest,
+} from "./ui-protocol-runtime";
+import type { UiProtocolBridge } from "./ui-protocol-bridge";
+
+const SESSION = "sess-send";
+
+function makeBridge(): UiProtocolBridge & {
+  sendTurn: ReturnType<typeof vi.fn>;
+  onTurnLifecycle: ReturnType<typeof vi.fn>;
+} {
+  return {
+    start: vi.fn(async () => {}),
+    stop: vi.fn(async () => {}),
+    sendTurn: vi.fn(async () => ({ accepted: true })),
+    interruptTurn: vi.fn(async () => ({ interrupted: true })),
+    respondToApproval: vi.fn(async () => ({
+      approval_id: "x",
+      accepted: true,
+      status: "ok",
+    })),
+    onMessageDelta: vi.fn(() => () => {}),
+    onMessagePersisted: vi.fn(() => () => {}),
+    onTaskUpdated: vi.fn(() => () => {}),
+    onTaskOutputDelta: vi.fn(() => () => {}),
+    onTurnLifecycle: vi.fn(() => () => {}),
+    onApprovalRequested: vi.fn(() => () => {}),
+    onConnectionStateChange: vi.fn(() => () => {}),
+    onWarning: vi.fn(() => () => {}),
+  } as unknown as UiProtocolBridge & {
+    sendTurn: ReturnType<typeof vi.fn>;
+    onTurnLifecycle: ReturnType<typeof vi.fn>;
+  };
+}
+
+beforeEach(() => {
+  legacySendSpy.mockReset();
+  __resetUiProtocolRuntimeForTest();
+  ThreadStore.__resetForTests();
+  window.localStorage.clear();
+});
+
+afterEach(() => {
+  window.localStorage.clear();
+  __resetUiProtocolRuntimeForTest();
+});
+
+describe("sendMessage flag-OFF preservation", () => {
+  it("flag-OFF delegates to the legacy SSE sendMessage unchanged", () => {
+    const opts = {
+      sessionId: SESSION,
+      text: "hi",
+      media: [] as string[],
+      clientMessageId: "cmid-flag-off",
+    };
+    sendMessage(opts);
+    expect(legacySendSpy).toHaveBeenCalledTimes(1);
+    expect(legacySendSpy).toHaveBeenCalledWith(opts);
+    // No thread is created on the v1 store path because the legacy
+    // bridge is the one that mirrors into ThreadStore (flag-gated
+    // internally by the v2 thread-store flag).
+    expect(ThreadStore.getThreads(SESSION)).toHaveLength(0);
+  });
+});
+
+describe("sendMessage flag-ON path", () => {
+  beforeEach(() => {
+    window.localStorage.setItem("chat_app_ui_v1", "1");
+  });
+
+  it("falls back to the legacy bridge when no active bridge is registered", () => {
+    sendMessage({
+      sessionId: SESSION,
+      text: "hi",
+      media: [],
+      clientMessageId: "cmid-fallback",
+    });
+    expect(legacySendSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it("dispatches via bridge.sendTurn and mirrors the user message", async () => {
+    const bridge = makeBridge();
+    __setActiveBridgeForTest(SESSION, bridge);
+    sendMessage({
+      sessionId: SESSION,
+      text: "hello",
+      media: [],
+      clientMessageId: "cmid-on",
+    });
+    // The v1 path is async; let microtasks settle so the awaited
+    // sendTurn invocation has been registered before we assert.
+    await Promise.resolve();
+    await Promise.resolve();
+    expect(bridge.sendTurn).toHaveBeenCalledWith("cmid-on", [
+      { kind: "text", text: "hello" },
+    ]);
+    const threads = ThreadStore.getThreads(SESSION);
+    expect(threads).toHaveLength(1);
+    expect(threads[0].userMsg.text).toBe("hello");
+    expect(threads[0].id).toBe("cmid-on");
+    // Legacy SSE sender must NOT have been invoked when the v1 path
+    // owned the turn.
+    expect(legacySendSpy).not.toHaveBeenCalled();
+  });
+
+  it("subscribes to turn lifecycle so onComplete fires on turn/completed", async () => {
+    const bridge = makeBridge();
+    __setActiveBridgeForTest(SESSION, bridge);
+    const onComplete = vi.fn();
+
+    let lifecycleHandler:
+      | ((
+          e: { turn_id: string; reason?: string; error?: unknown },
+        ) => void)
+      | undefined;
+    (bridge.onTurnLifecycle as ReturnType<typeof vi.fn>).mockImplementation(
+      (h: (e: { turn_id: string; reason?: string; error?: unknown }) => void) => {
+        lifecycleHandler = h;
+        return () => {
+          lifecycleHandler = undefined;
+        };
+      },
+    );
+
+    sendMessage({
+      sessionId: SESSION,
+      text: "hello",
+      media: [],
+      clientMessageId: "cmid-complete",
+      onComplete,
+    });
+    // Flush enough microtasks for the awaited sendTurn → finally block
+    // to install the lifecycle subscription. Six ticks is comfortably
+    // beyond what the chain needs (2-3 microtasks) but kept low to
+    // avoid masking a hung promise.
+    for (let i = 0; i < 6; i++) await Promise.resolve();
+
+    expect(lifecycleHandler).toBeDefined();
+    // A different turn's completion must not fire onComplete.
+    lifecycleHandler?.({ turn_id: "other", reason: "stop" });
+    expect(onComplete).not.toHaveBeenCalled();
+
+    lifecycleHandler?.({ turn_id: "cmid-complete", reason: "stop" });
+    expect(onComplete).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/runtime/ui-protocol-send.test.ts
+++ b/src/runtime/ui-protocol-send.test.ts
@@ -177,4 +177,124 @@ describe("sendMessage flag-ON path", () => {
     lifecycleHandler?.({ turn_id: "cmid-complete", reason: "stop" });
     expect(onComplete).toHaveBeenCalledTimes(1);
   });
+
+  // Codex review must-fix #5A: media-bearing turns must NOT silently
+  // drop on the v1 path (TurnStartInput.kind === "text" only). Falling
+  // back to legacy keeps voice/image uploads working under the flag.
+  it("falls back to legacy when media is present", () => {
+    const bridge = makeBridge();
+    __setActiveBridgeForTest(SESSION, bridge);
+    sendMessage({
+      sessionId: SESSION,
+      text: "with image",
+      media: ["/tmp/foo.png"],
+      clientMessageId: "cmid-media",
+    });
+    expect(legacySendSpy).toHaveBeenCalledTimes(1);
+    expect(bridge.sendTurn).not.toHaveBeenCalled();
+    // The thread store must NOT be pre-populated by the v1 mirror —
+    // the legacy bridge handles its own ThreadStore mirroring (gated
+    // by isThreadStoreEnabled() which now also reads chat_app_ui_v1).
+    expect(ThreadStore.getThreads(SESSION)).toHaveLength(0);
+  });
+
+  // Codex review must-fix #5A: requestText !== text means a /command
+  // rewrite. Legacy posts requestText to /api/chat; the v1 path only
+  // takes a plain text input. Fall back so the rewrite isn't silently
+  // dropped.
+  it("falls back to legacy when requestText differs from text", () => {
+    const bridge = makeBridge();
+    __setActiveBridgeForTest(SESSION, bridge);
+    sendMessage({
+      sessionId: SESSION,
+      text: "/queue interrupt",
+      requestText: "rewritten request",
+      media: [],
+      clientMessageId: "cmid-rewrite",
+    });
+    expect(legacySendSpy).toHaveBeenCalledTimes(1);
+    expect(bridge.sendTurn).not.toHaveBeenCalled();
+  });
+
+  // Codex review must-fix #5B: the lifecycle subscription must be
+  // installed BEFORE `sendTurn` resolves. A fast turn/completed firing
+  // between the RPC ack and the awaited resolution would otherwise leave
+  // `sendingRef.current` stuck-true (chat input lock).
+  it("onComplete fires even when turn/completed arrives before sendTurn resolves", async () => {
+    const bridge = makeBridge();
+    __setActiveBridgeForTest(SESSION, bridge);
+    const onComplete = vi.fn();
+
+    let lifecycleHandler:
+      | ((e: { turn_id: string; reason?: string; error?: unknown }) => void)
+      | undefined;
+    (bridge.onTurnLifecycle as ReturnType<typeof vi.fn>).mockImplementation(
+      (h: (e: { turn_id: string; reason?: string; error?: unknown }) => void) => {
+        lifecycleHandler = h;
+        return () => {
+          lifecycleHandler = undefined;
+        };
+      },
+    );
+
+    let resolveSendTurn: (() => void) | null = null;
+    (bridge.sendTurn as ReturnType<typeof vi.fn>).mockImplementation(
+      () =>
+        new Promise<{ accepted: true }>((res) => {
+          resolveSendTurn = () => res({ accepted: true });
+        }),
+    );
+
+    sendMessage({
+      sessionId: SESSION,
+      text: "fast",
+      media: [],
+      clientMessageId: "cmid-fast",
+      onComplete,
+    });
+
+    // Let the sync portion of sendMessageV1 run (it awaits getActiveBridge
+    // path → the sendTurn call). The lifecycle subscription should be
+    // installed BEFORE the await on sendTurn, so the handler is live now.
+    for (let i = 0; i < 4; i++) await Promise.resolve();
+    expect(lifecycleHandler).toBeDefined();
+
+    // Fire turn/completed BEFORE sendTurn resolves.
+    lifecycleHandler?.({ turn_id: "cmid-fast", reason: "stop" });
+    expect(onComplete).toHaveBeenCalledTimes(1);
+
+    // Now let sendTurn resolve. onComplete must NOT fire a second time.
+    resolveSendTurn?.();
+    for (let i = 0; i < 4; i++) await Promise.resolve();
+    expect(onComplete).toHaveBeenCalledTimes(1);
+  });
+
+  // Codex review must-fix #5B: an RPC failure (network drop, server
+  // error) must also fire onComplete so the chat input lock clears
+  // instead of spinning forever.
+  it("onComplete fires when bridge.sendTurn rejects", async () => {
+    const bridge = makeBridge();
+    __setActiveBridgeForTest(SESSION, bridge);
+    const onComplete = vi.fn();
+
+    (bridge.sendTurn as ReturnType<typeof vi.fn>).mockImplementation(() =>
+      Promise.reject(new Error("rpc-broken")),
+    );
+
+    sendMessage({
+      sessionId: SESSION,
+      text: "boom",
+      media: [],
+      clientMessageId: "cmid-rpcfail",
+      onComplete,
+    });
+
+    for (let i = 0; i < 6; i++) await Promise.resolve();
+    expect(onComplete).toHaveBeenCalledTimes(1);
+    // The thread should be marked errored, not stuck pending.
+    const threads = ThreadStore.getThreads(SESSION);
+    expect(threads).toHaveLength(1);
+    expect(threads[0].pendingAssistant).toBeNull();
+    expect(threads[0].responses[0]?.status).toBe("error");
+  });
 });

--- a/src/runtime/ui-protocol-send.ts
+++ b/src/runtime/ui-protocol-send.ts
@@ -37,11 +37,31 @@ async function sendMessageV1(opts: SendOptions): Promise<void> {
     sessionId,
     historyTopic,
     text,
+    requestText,
     media,
     clientMessageId = crypto.randomUUID(),
     onSessionActive,
     onComplete,
   } = opts;
+
+  // Codex review must-fix #5A: TurnStartInput v1 only carries text. Media
+  // (image / voice) and `requestText !== text` (e.g. /commands rewrite)
+  // need the legacy /api/chat upload pre-step that the SSE bridge owns.
+  // Falling back keeps the user's input intact; the next turn picks the
+  // v1 transport back up. A `console.info` makes the path switch
+  // observable in DevTools without surfacing as a warning.
+  const hasMedia = media.length > 0;
+  const hasRewrite = requestText !== undefined && requestText !== text;
+  if (hasMedia || hasRewrite) {
+    if (typeof console !== "undefined" && console.info) {
+      console.info(
+        "ui-protocol-send: v1 path does not yet support media/requestText; falling back to legacy",
+        { hasMedia, hasRewrite },
+      );
+    }
+    legacySendMessage(opts);
+    return;
+  }
 
   const bridge = getActiveBridge(sessionId, historyTopic);
   if (!bridge) {
@@ -72,12 +92,39 @@ async function sendMessageV1(opts: SendOptions): Promise<void> {
 
   onSessionActive?.(text);
 
+  // Codex review must-fix #5B: subscribe to the turn lifecycle BEFORE
+  // calling `sendTurn`. A fast turn/completed (or turn/error) can fire
+  // between the RPC ack and the post-await `finally` block, leaving
+  // `sendingRef` (the chat input lock) stuck-true if we install the
+  // listener afterwards. The handler also fires `onComplete` on RPC
+  // rejection so the input never spins forever on a network failure.
+  let completed = false;
+  const fireComplete = () => {
+    if (completed) return;
+    completed = true;
+    onComplete?.();
+  };
+  const off = bridge.onTurnLifecycle((e) => {
+    if (e.turn_id !== clientMessageId) return;
+    // The bridge emits all three lifecycle variants through one channel.
+    // We fire on `completed` and `error`; `started` is a no-op here.
+    if ("error" in e) {
+      off();
+      fireComplete();
+      return;
+    }
+    if ("reason" in e) {
+      off();
+      fireComplete();
+    }
+  });
+
   try {
     await bridge.sendTurn(clientMessageId, [
       { kind: "text", text },
-      // File / voice attachments stay on REST in C-2 — the bridge schema
-      // already accepts a TurnStartInput[] so a future PR can add file
-      // references here without changing this call site.
+      // File / voice attachments stay on REST — see fallback above. The
+      // bridge schema already accepts a TurnStartInput[] so a future PR
+      // can add file references here without changing this call site.
     ]);
   } catch {
     // Surface as an error message in the thread so the user isn't left
@@ -85,18 +132,7 @@ async function sendMessageV1(opts: SendOptions): Promise<void> {
     // `warning` for transport-level failures; this just guarantees the
     // thread terminates rather than spinning forever.
     ThreadStore.finalizeAssistant(clientMessageId, { status: "error" });
-  } finally {
-    // The v1 path's `onComplete` resolves on `turn/completed` rather than
-    // when the RPC returns (the RPC just acks acceptance). Wire a one-
-    // shot listener for the completed event scoped to this turn id.
-    if (onComplete) {
-      const off = bridge.onTurnLifecycle((e) => {
-        if (e.turn_id !== clientMessageId) return;
-        if ("reason" in e || "error" in e) {
-          off();
-          onComplete();
-        }
-      });
-    }
+    off();
+    fireComplete();
   }
 }

--- a/src/runtime/ui-protocol-send.ts
+++ b/src/runtime/ui-protocol-send.ts
@@ -1,0 +1,102 @@
+/**
+ * UI Protocol v1 send-path glue for /chat (Phase C-2).
+ *
+ * Flag-gated wrapper around the legacy SSE-bridge `sendMessage`. When the
+ * `chat_app_ui_v1` flag is OFF (the default), this module just delegates
+ * to the SSE bridge unchanged so the existing REST+SSE behaviour is bit-
+ * for-bit preserved. When ON, the user message is mirrored into the
+ * thread store and the turn is dispatched through `bridge.sendTurn(...)`.
+ *
+ * Image / voice upload stays on REST: the existing `sendMessage` already
+ * uploads via `StreamManager.startStream` which posts to `/api/chat`. The
+ * v1 path runs in parallel — a follow-up swaps the upload pre-step to a
+ * direct REST call once the bridge owns the streaming-turn slice cleanly,
+ * but for C-2 we keep the simplest possible split: only the streaming
+ * transport changes.
+ */
+
+import * as ThreadStore from "@/store/thread-store";
+import { isChatAppUiV1Enabled } from "@/lib/feature-flags";
+import { displayFilenameFromPath } from "@/lib/utils";
+import { sendMessage as legacySendMessage } from "./sse-bridge";
+import type { SendOptions } from "./sse-bridge";
+import { getActiveBridge } from "./ui-protocol-runtime";
+
+export type { SendOptions } from "./sse-bridge";
+
+export function sendMessage(opts: SendOptions): void {
+  if (!isChatAppUiV1Enabled()) {
+    legacySendMessage(opts);
+    return;
+  }
+  void sendMessageV1(opts);
+}
+
+async function sendMessageV1(opts: SendOptions): Promise<void> {
+  const {
+    sessionId,
+    historyTopic,
+    text,
+    media,
+    clientMessageId = crypto.randomUUID(),
+    onSessionActive,
+    onComplete,
+  } = opts;
+
+  const bridge = getActiveBridge(sessionId, historyTopic);
+  if (!bridge) {
+    // Bridge has not started yet (rare race: send before mount effect ran).
+    // Fall back to the SSE path so the user message is never lost — the
+    // session is still functional, just not on the v1 transport for this
+    // turn. The next turn will pick up the bridge.
+    legacySendMessage(opts);
+    return;
+  }
+
+  const localFiles = media.map((path) => ({
+    filename: displayFilenameFromPath(path),
+    path,
+    caption: "",
+  }));
+
+  // Mirror the legacy bridge's user-message write so the thread store has
+  // a thread anchored on this clientMessageId before any server event
+  // arrives. The pendingAssistant slot is opened so streaming tokens land
+  // in the right slot from the very first delta.
+  ThreadStore.addUserMessage(sessionId, {
+    text,
+    clientMessageId,
+    files: localFiles,
+    topic: historyTopic,
+  });
+
+  onSessionActive?.(text);
+
+  try {
+    await bridge.sendTurn(clientMessageId, [
+      { kind: "text", text },
+      // File / voice attachments stay on REST in C-2 — the bridge schema
+      // already accepts a TurnStartInput[] so a future PR can add file
+      // references here without changing this call site.
+    ]);
+  } catch {
+    // Surface as an error message in the thread so the user isn't left
+    // with a silent dead pending bubble. The bridge already emits a
+    // `warning` for transport-level failures; this just guarantees the
+    // thread terminates rather than spinning forever.
+    ThreadStore.finalizeAssistant(clientMessageId, { status: "error" });
+  } finally {
+    // The v1 path's `onComplete` resolves on `turn/completed` rather than
+    // when the RPC returns (the RPC just acks acceptance). Wire a one-
+    // shot listener for the completed event scoped to this turn id.
+    if (onComplete) {
+      const off = bridge.onTurnLifecycle((e) => {
+        if (e.turn_id !== clientMessageId) return;
+        if ("reason" in e || "error" in e) {
+          off();
+          onComplete();
+        }
+      });
+    }
+  }
+}

--- a/src/sites/components/sites-chat.tsx
+++ b/src/sites/components/sites-chat.tsx
@@ -16,7 +16,10 @@ import { useThreads, type Thread } from "@/store/thread-store";
 function isThreadStoreV2Enabled(): boolean {
   if (typeof window === "undefined") return false;
   try {
-    return window.localStorage.getItem("octos_thread_store_v2") === "1";
+    if (window.localStorage.getItem("octos_thread_store_v2") === "1") return true;
+    // Phase C-2 (codex review #1): chat_app_ui_v1 forces v2 renderer so
+    // sites-chat reads from the same store /chat does.
+    return window.localStorage.getItem("chat_app_ui_v1") === "1";
   } catch {
     return false;
   }

--- a/src/store/thread-store.ts
+++ b/src/store/thread-store.ts
@@ -812,7 +812,16 @@ function buildResponseFromApi(m: MessageInfo): ThreadMessage {
     status: "complete",
     timestamp: m.timestamp ? new Date(m.timestamp).getTime() : Date.now(),
     historySeq: typeof m.seq === "number" ? m.seq : undefined,
-    intra_thread_seq: typeof m.seq === "number" ? m.seq : undefined,
+    // Codex review #3: prefer the explicit per-thread sequence when the
+    // server emitted one (UI Protocol v1 PersistedMessage). Legacy REST
+    // history responses don't carry a separate intra_thread_seq, so
+    // `m.seq` (per-session) is the only axis available — fall back to it.
+    intra_thread_seq:
+      typeof m.intra_thread_seq === "number"
+        ? m.intra_thread_seq
+        : typeof m.seq === "number"
+          ? m.seq
+          : undefined,
     responseToClientMessageId: m.response_to_client_message_id,
     clientMessageId: m.client_message_id,
     sourceToolCallId: m.tool_call_id,


### PR DESCRIPTION
## Summary

Phase C-2 of the UI Protocol v1 rollout: wires the just-merged `ui-protocol-bridge` (PR #72) into `runtime-provider.tsx` as the streaming event source for /chat when the `chat_app_ui_v1` feature flag (PR #71) is ON. Flag-OFF (the default) preserves the existing REST+SSE path bit-for-bit.

- **Flag-ON**: per-session bridge owns the streaming-turn slice. Typed events fan out through a new `ui-protocol-event-router` into the same `ThreadStore` mutations the SSE bridge produces (parity invariant), so the renderer is transport-agnostic. Turns dispatch via `bridge.sendTurn(...)` instead of `POST /api/chat`.
- **Flag-OFF**: no behavior change. `sse-bridge.ts` and `task-watcher.ts` are untouched and the new flag-gated send wrapper falls through to legacy `sendMessage`.
- File upload + session CRUD + history fetch stay on REST. Only the streaming-turn slice changes transports.

Capability negotiation: option (A) per the C-2 plan — no current mapping branches on `UiProtocolCapabilities`, so the bridge is consumed as-is. The bridge's existing `?ui_feature=...` query-param plumbing already negotiates capabilities server-side.

## Files

| File | Type | Purpose |
|---|---|---|
| `src/runtime/ui-protocol-event-router.ts` | new | typed bridge events → ThreadStore actions; pure, testable |
| `src/runtime/ui-protocol-runtime.ts` | new | active-bridge registry per session (start/stop/lookup) |
| `src/runtime/ui-protocol-send.ts` | new | flag-gated `sendMessage`; legacy on OFF, `bridge.sendTurn` on ON |
| `src/runtime/runtime-provider.tsx` | modified | extra mount-effect that starts the bridge under the flag |
| `src/components/chat-thread.tsx` | modified | one-line import re-aim at the flag-gated wrapper |
| `src/runtime/ui-protocol-event-router.test.ts` | new | 14 router unit tests (per-event + parity + lifecycle mux) |
| `src/runtime/ui-protocol-send.test.ts` | new | 4 send-path tests (flag-OFF preservation, fallback, dispatch) |

Total: 534 production LOC + 650 test LOC. 7 files changed, 1216 insertions(+), 1 deletion(-).

## Refs

- Track: #68
- Master: #66
- Depends on: #67 (C-1, ui-protocol-bridge), #69 (C-3, feature-flags), PR #71, PR #72
- Will be empirically validated by C-4 (browser smoke) + server fix #761

## Test plan

- [x] `npx tsc -b --noEmit` passes
- [x] `npx vitest run` passes (107 / 107 tests)
- [x] flag-OFF: existing 6 SSE tests + 5 feature-flag tests + 48 thread-store tests + 30 ui-protocol-bridge tests still pass
- [x] flag-ON: 14 new router tests cover every typed event mapping + SSE parity invariant
- [x] flag-ON: 4 new send-path tests cover flag-OFF delegation, pre-mount fallback, sendTurn dispatch, lifecycle wiring for onComplete
- [ ] manual flag-on browser smoke (set `localStorage.setItem('chat_app_ui_v1', '1')` and send a turn) — pending C-4