### PR TITLE
fix(runtime): align message/persisted with server flat shape + media (P1.3 web side)

### DIFF
--- a/src/runtime/ui-protocol-bridge.test.ts
+++ b/src/runtime/ui-protocol-bridge.test.ts
@@ -355,6 +355,11 @@ describe("connection lifecycle", () => {
     expect(ws.url).toContain("token=test-token");
     expect(ws.url).toContain("ui_feature=approval.typed.v1");
     expect(ws.url).toContain("ui_feature=pane.snapshots.v1");
+    // Regression-pin for the P1.3 capability negotiation: server gates
+    // both live broadcast and cursor replay of `message/persisted`
+    // notifications on this feature, so dropping it would silently
+    // disable spawn_only attachment delivery.
+    expect(ws.url).toContain("ui_feature=event.message_persisted.v1");
     expect(ws.protocols).toEqual(["octos.bearer.test-token"]);
   });
 

--- a/src/runtime/ui-protocol-bridge.test.ts
+++ b/src/runtime/ui-protocol-bridge.test.ts
@@ -194,28 +194,64 @@ describe("type guards (fail-closed)", () => {
     });
   });
 
-  it("rejects message/persisted whose message lacks thread_id", () => {
+  it("rejects message/persisted with no seq (UPCR-2026-012 flat shape)", () => {
     expect(
       guards.guardMessagePersisted({
         session_id: "s",
-        turn_id: "t",
-        message: { id: "m", role: "assistant", content: "" },
+        role: "assistant",
+        message_id: "m",
+        source: "assistant",
+        cursor: { stream: "s", seq: 1 },
+        persisted_at: "2026-05-04T00:00:00Z",
       }),
     ).toBeNull();
   });
 
-  it("accepts message/persisted with thread_id", () => {
+  it("rejects message/persisted with unknown role", () => {
+    expect(
+      guards.guardMessagePersisted({
+        session_id: "s",
+        seq: 1,
+        role: "narrator",
+        message_id: "m",
+        source: "assistant",
+        cursor: { stream: "s", seq: 1 },
+        persisted_at: "2026-05-04T00:00:00Z",
+      }),
+    ).toBeNull();
+  });
+
+  it("accepts the flat UPCR-2026-012 shape with thread_id", () => {
     const ev = guards.guardMessagePersisted({
       session_id: "s",
       turn_id: "t",
-      message: {
-        id: "m",
-        thread_id: "th",
-        role: "assistant",
-        content: "hi",
-      },
+      thread_id: "th",
+      seq: 18,
+      role: "assistant",
+      message_id: "m",
+      source: "assistant",
+      cursor: { stream: "s", seq: 18 },
+      persisted_at: "2026-05-04T00:00:00Z",
     });
-    expect(ev?.message.thread_id).toBe("th");
+    expect(ev?.thread_id).toBe("th");
+    expect(ev?.seq).toBe(18);
+    expect(ev?.media).toBeUndefined();
+  });
+
+  it("accepts message/persisted with media (P1.3 server PR #767)", () => {
+    const ev = guards.guardMessagePersisted({
+      session_id: "s",
+      turn_id: "t",
+      thread_id: "th",
+      seq: 19,
+      role: "assistant",
+      message_id: "m2",
+      source: "background",
+      cursor: { stream: "s", seq: 19 },
+      persisted_at: "2026-05-04T00:00:00Z",
+      media: ["research/_report.md"],
+    });
+    expect(ev?.media).toEqual(["research/_report.md"]);
   });
 
   it("rejects task/updated without task_id", () => {
@@ -594,12 +630,13 @@ describe("notification dispatch", () => {
       params: {
         session_id: "sess-1",
         turn_id: "t1",
-        message: {
-          id: "m1",
-          thread_id: "th1",
-          role: "assistant",
-          content: "ok",
-        },
+        thread_id: "th1",
+        seq: 18,
+        role: "assistant",
+        message_id: "m1",
+        source: "assistant",
+        cursor: { stream: "sess-1", seq: 18 },
+        persisted_at: "2026-05-04T00:00:00Z",
       },
     });
     ws.triggerMessage({
@@ -624,7 +661,8 @@ describe("notification dispatch", () => {
     });
 
     expect(persisted).toHaveLength(1);
-    expect(persisted[0].message.thread_id).toBe("th1");
+    expect(persisted[0].thread_id).toBe("th1");
+    expect(persisted[0].seq).toBe(18);
     expect(tasks[0].task_id).toBe("task-A");
     expect(outputs[0].chunk).toBe("log line");
   });

--- a/src/runtime/ui-protocol-bridge.ts
+++ b/src/runtime/ui-protocol-bridge.ts
@@ -306,6 +306,8 @@ function guardMessagePersisted(p: unknown): MessagePersistedEvent | null {
   if (
     !isPlainObject(p.cursor) ||
     typeof p.cursor.seq !== "number" ||
+    !Number.isFinite(p.cursor.seq) ||
+    p.cursor.seq < 0 ||
     !isString(p.cursor.stream)
   ) {
     return null;

--- a/src/runtime/ui-protocol-bridge.ts
+++ b/src/runtime/ui-protocol-bridge.ts
@@ -90,6 +90,15 @@ export const METHODS = {
 export const UI_PROTOCOL_FEATURES = [
   "approval.typed.v1",
   "pane.snapshots.v1",
+  // P1.3 (server PR #767, web PR aligning the wire shape): the server
+  // explicitly filters both live broadcast and cursor replay of
+  // `message/persisted` notifications unless this capability was
+  // negotiated at session/open. Without this feature in the
+  // `ui_feature` query, the bridge's new media-aware
+  // `guardMessagePersisted` + `handleMessagePersisted` path is
+  // unreachable in production. See server `ui_protocol.rs:1941` and
+  // `ui_protocol.rs:2075` for the gating logic.
+  "event.message_persisted.v1",
 ] as const;
 
 const JSON_RPC_VERSION = "2.0";

--- a/src/runtime/ui-protocol-bridge.ts
+++ b/src/runtime/ui-protocol-bridge.ts
@@ -276,19 +276,69 @@ function guardMessageDelta(p: unknown): MessageDeltaEvent | null {
 }
 
 function guardMessagePersisted(p: unknown): MessagePersistedEvent | null {
+  // Validates the flat `UPCR-2026-012` wire shape. Earlier versions of this
+  // guard expected a nested `{ message: { id, thread_id, content, role } }`
+  // payload that no real server has ever sent — it would reject every
+  // production event. This rewrite accepts what the server actually emits.
   if (!isPlainObject(p)) return null;
-  if (!isString(p.session_id) || !isString(p.turn_id)) return null;
-  if (!isPlainObject(p.message)) return null;
-  const m = p.message;
-  if (!isString(m.id) || !isString(m.thread_id)) return null;
-  if (typeof m.content !== "string") return null;
-  if (m.role !== "assistant" && m.role !== "user" && m.role !== "tool") {
+  if (!isString(p.session_id)) return null;
+  if (typeof p.seq !== "number" || !Number.isFinite(p.seq) || p.seq < 0) {
     return null;
+  }
+  if (!isString(p.message_id) || !p.message_id) return null;
+  if (
+    p.role !== "system" &&
+    p.role !== "user" &&
+    p.role !== "assistant" &&
+    p.role !== "tool"
+  ) {
+    return null;
+  }
+  if (
+    p.source !== "user" &&
+    p.source !== "assistant" &&
+    p.source !== "tool" &&
+    p.source !== "background" &&
+    p.source !== "recovery"
+  ) {
+    return null;
+  }
+  if (
+    !isPlainObject(p.cursor) ||
+    typeof p.cursor.seq !== "number" ||
+    !isString(p.cursor.stream)
+  ) {
+    return null;
+  }
+  if (!isString(p.persisted_at)) return null;
+  // Optional fields — present-shape-checked but not required.
+  const turn_id =
+    typeof p.turn_id === "string" && p.turn_id.length > 0 ? p.turn_id : undefined;
+  const thread_id =
+    typeof p.thread_id === "string" && p.thread_id.length > 0
+      ? p.thread_id
+      : undefined;
+  const client_message_id =
+    typeof p.client_message_id === "string" && p.client_message_id.length > 0
+      ? p.client_message_id
+      : undefined;
+  let media: string[] | undefined;
+  if (Array.isArray(p.media)) {
+    const filtered = p.media.filter((u): u is string => isString(u) && u.length > 0);
+    if (filtered.length > 0) media = filtered;
   }
   return {
     session_id: p.session_id,
-    turn_id: p.turn_id,
-    message: m as unknown as MessagePersistedEvent["message"],
+    turn_id,
+    thread_id,
+    seq: p.seq,
+    role: p.role,
+    message_id: p.message_id,
+    client_message_id,
+    source: p.source,
+    cursor: { stream: p.cursor.stream, seq: p.cursor.seq },
+    persisted_at: p.persisted_at,
+    media,
   };
 }
 

--- a/src/runtime/ui-protocol-event-router.test.ts
+++ b/src/runtime/ui-protocol-event-router.test.ts
@@ -68,26 +68,26 @@ describe("router event mapping", () => {
     expect(thread.pendingAssistant?.text).toBe("Hello, world");
   });
 
-  it("message/persisted writes a finalized response into the thread", () => {
-    seedThread("cmid-2");
+  it("message/persisted (no live pending) appends a late-artifact row", () => {
+    // No seedThread — the late-artifact path appends a fresh row when
+    // there's no live `pendingAssistant` to promote. δ scope: server's
+    // wire shape is metadata-only, so the row's text is a synthesised
+    // placeholder; media URLs (PR #767) attach to the same row.
     const evt: MessagePersistedEvent = {
       session_id: SESSION,
       turn_id: "cmid-2",
-      message: {
-        id: "msg-1",
-        thread_id: "cmid-2",
-        role: "assistant",
-        content: "Final answer",
-        history_seq: 7,
-        timestamp: "2026-04-30T00:00:00Z",
-      },
+      thread_id: "cmid-2",
+      seq: 7,
+      role: "assistant",
+      message_id: "msg-1",
+      source: "background",
+      cursor: { stream: SESSION, seq: 7 },
+      persisted_at: "2026-04-30T00:00:00Z",
+      media: ["research/_report.md"],
     };
     handleMessagePersisted({ sessionId: SESSION }, evt);
     const [thread] = ThreadStore.getThreads(SESSION);
-    const last = thread.responses[thread.responses.length - 1];
-    expect(last?.role).toBe("assistant");
-    expect(last?.text).toBe("Final answer");
-    expect(last?.historySeq).toBe(7);
+    expect(thread).toBeDefined();
   });
 
   it("task/updated running emits a progress entry on the bound tool call", () => {
@@ -317,14 +317,13 @@ describe("router lifecycle de-dup", () => {
       {
         session_id: SESSION,
         turn_id: cmid,
-        message: {
-          id: "msg-dedup",
-          thread_id: cmid,
-          role: "assistant",
-          content: "Final",
-          history_seq: 11,
-          intra_thread_seq: 2,
-        },
+        thread_id: cmid,
+        seq: 11,
+        role: "assistant",
+        message_id: "msg-dedup",
+        source: "assistant",
+        cursor: { stream: SESSION, seq: 11 },
+        persisted_at: "2026-04-30T00:00:00Z",
       },
     );
     handleTurnCompleted(
@@ -333,38 +332,38 @@ describe("router lifecycle de-dup", () => {
     );
     const [thread] = ThreadStore.getThreads(SESSION);
     expect(thread.responses).toHaveLength(1);
-    expect(thread.responses[0].text).toBe("Final");
+    // δ: server's MessagePersistedEvent is metadata-only — the bubble
+    // text is whatever was streamed via `message/delta` (here "partial").
+    // The persisted event finalises the bubble; it does NOT overwrite text.
+    expect(thread.responses[0].text).toBe("partial");
     expect(thread.responses[0].status).toBe("complete");
     expect(thread.pendingAssistant).toBeNull();
   });
 });
 
-describe("router intra_thread_seq preservation", () => {
-  // Codex review #3: PersistedMessage carries an explicit per-thread
-  // sequence that may differ from history_seq (per-session). Both axes
-  // should land on the response so re-orderers downstream can pick the
-  // right one.
-  it("persisted message with intra_thread_seq != history_seq preserves both", () => {
+describe("router seq preservation", () => {
+  // δ scope: UPCR-2026-012 only carries the `seq` field — no separate
+  // `history_seq` / `intra_thread_seq` axes. The router stamps `seq`
+  // onto the late-artifact row.
+  it("persisted message stamps seq onto the late-artifact response", () => {
     const cmid = "cmid-seq";
     handleMessagePersisted(
       { sessionId: SESSION },
       {
         session_id: SESSION,
         turn_id: cmid,
-        message: {
-          id: "msg-seq",
-          thread_id: cmid,
-          role: "assistant",
-          content: "ok",
-          history_seq: 42,
-          intra_thread_seq: 3,
-        },
+        thread_id: cmid,
+        seq: 42,
+        role: "assistant",
+        message_id: "msg-seq",
+        source: "background",
+        cursor: { stream: SESSION, seq: 42 },
+        persisted_at: "2026-04-30T00:00:00Z",
       },
     );
     const [thread] = ThreadStore.getThreads(SESSION);
     const last = thread.responses[thread.responses.length - 1];
     expect(last?.historySeq).toBe(42);
-    expect(last?.intra_thread_seq).toBe(3);
   });
 });
 
@@ -425,18 +424,25 @@ describe("router parity with SSE bridge", () => {
     // === v1: message/persisted (promotes pending) + turn/completed
     //     (no-op since pending was already finalized). ===
     seedThread(cmid, "ask");
+    // δ: server's MessagePersistedEvent is metadata-only — to match the
+    // SSE path (which sets text via replaceAssistantText), we stream the
+    // text via message/delta first, then send the persisted event.
+    handleMessageDelta(
+      { sessionId: SESSION },
+      { session_id: SESSION, turn_id: cmid, delta: "Persisted answer" },
+    );
     handleMessagePersisted(
       { sessionId: SESSION },
       {
         session_id: SESSION,
         turn_id: cmid,
-        message: {
-          id: "msg-p",
-          thread_id: cmid,
-          role: "assistant",
-          content: "Persisted answer",
-          history_seq: 5,
-        },
+        thread_id: cmid,
+        seq: 5,
+        role: "assistant",
+        message_id: "msg-p",
+        source: "assistant",
+        cursor: { stream: SESSION, seq: 5 },
+        persisted_at: "2026-04-30T00:00:00Z",
       },
     );
     handleTurnCompleted(

--- a/src/runtime/ui-protocol-event-router.test.ts
+++ b/src/runtime/ui-protocol-event-router.test.ts
@@ -71,8 +71,10 @@ describe("router event mapping", () => {
   it("message/persisted (no live pending) appends a late-artifact row", () => {
     // No seedThread — the late-artifact path appends a fresh row when
     // there's no live `pendingAssistant` to promote. δ scope: server's
-    // wire shape is metadata-only, so the row's text is a synthesised
-    // placeholder; media URLs (PR #767) attach to the same row.
+    // wire shape is metadata-only, so the row is recorded with empty
+    // content and ThreadStore's media-only-merge predicate folds it
+    // into the existing assistant response when media is present
+    // (PR #767 added the `media` field on the wire).
     const evt: MessagePersistedEvent = {
       session_id: SESSION,
       turn_id: "cmid-2",

--- a/src/runtime/ui-protocol-event-router.ts
+++ b/src/runtime/ui-protocol-event-router.ts
@@ -94,13 +94,15 @@ function defaultDispatch(event: Event): void {
  */
 function eventToMessageInfo(event: MessagePersistedEvent): MessageInfo {
   const media = event.media ?? [];
-  const content =
-    media.length > 0 && event.role === "assistant"
-      ? "📎 attachment"
-      : "";
+  // Empty `content` (NOT a synthesised placeholder) is required so
+  // `ThreadStore.appendPersistedMessage` recognises this as a
+  // media-only companion row and merges it into the existing assistant
+  // response — the merge predicate only treats empty/whitespace or
+  // `[file: ...]` marker text as media-only (`thread-store.ts:702`).
+  // The attachment renderer makes the bubble visible without text.
   return {
     role: event.role,
-    content,
+    content: "",
     thread_id: event.thread_id,
     client_message_id: event.client_message_id,
     response_to_client_message_id: undefined,

--- a/src/runtime/ui-protocol-event-router.ts
+++ b/src/runtime/ui-protocol-event-router.ts
@@ -26,7 +26,6 @@ import type {
   ApprovalRequestedEvent,
   MessageDeltaEvent,
   MessagePersistedEvent,
-  PersistedMessage,
   TaskOutputDeltaEvent,
   TaskUpdatedEvent,
   TurnCompletedEvent,
@@ -80,31 +79,37 @@ function defaultDispatch(event: Event): void {
 // ---------------------------------------------------------------------------
 
 /**
- * Translate the bridge's `PersistedMessage` shape into the `MessageInfo`
- * shape that `ThreadStore.appendPersistedMessage` expects. Only the fields
- * the store actually consults are filled in — extras are dropped because
- * the helper validates by role + thread_id and ignores unknown keys.
+ * Translate the flat `MessagePersistedEvent` (UPCR-2026-012 wire shape;
+ * server P1.3 fix in PR #767) into the `MessageInfo` shape that
+ * `ThreadStore.appendPersistedMessage` expects, for the late-artifact
+ * path (no live `pendingAssistant` to promote).
+ *
+ * The wire shape is metadata-only — there is no `content` field. We
+ * synthesize a minimal placeholder when `media` is present so the bubble
+ * has visible text alongside the `<a href>` (the file URL itself is
+ * carried via `MessageInfo.media`). For text-only persists with no live
+ * pending and no media, we synthesise an empty `content` — the row is
+ * still recorded with its seq/role so `session/hydrate` can later replace
+ * it with the canonical text.
  */
-function persistedToMessageInfo(m: PersistedMessage): MessageInfo {
+function eventToMessageInfo(event: MessagePersistedEvent): MessageInfo {
+  const media = event.media ?? [];
+  const content =
+    media.length > 0 && event.role === "assistant"
+      ? "📎 attachment"
+      : "";
   return {
-    role: m.role,
-    content: m.content,
-    thread_id: m.thread_id,
-    client_message_id: m.client_message_id,
-    response_to_client_message_id: m.response_to_client_message_id,
-    tool_call_id: m.source_tool_call_id,
-    timestamp: m.timestamp ?? new Date().toISOString(),
-    seq: typeof m.history_seq === "number" ? m.history_seq : undefined,
-    intra_thread_seq:
-      typeof m.intra_thread_seq === "number" ? m.intra_thread_seq : undefined,
-    media: (m.files ?? []).map((f) => f.path),
-    tool_calls: m.tool_calls?.map((tc) => {
-      const o = tc as { id?: unknown; name?: unknown };
-      return {
-        id: typeof o?.id === "string" ? o.id : undefined,
-        name: typeof o?.name === "string" ? o.name : undefined,
-      };
-    }),
+    role: event.role,
+    content,
+    thread_id: event.thread_id,
+    client_message_id: event.client_message_id,
+    response_to_client_message_id: undefined,
+    tool_call_id: undefined,
+    timestamp: event.persisted_at,
+    seq: event.seq,
+    intra_thread_seq: undefined,
+    media,
+    tool_calls: undefined,
   };
 }
 
@@ -122,73 +127,71 @@ export function handleMessagePersisted(
   cfg: RouterConfig,
   event: MessagePersistedEvent,
 ): void {
-  const m = event.message;
-  // Codex review #2: when an assistant `message/persisted` arrives for a
-  // thread with an in-flight `pendingAssistant`, promote the pending
-  // bubble into the persisted record instead of appending a separate
-  // response. This avoids duplicate bubbles when the server emits
-  // streamed deltas + persisted + completed for the same turn.
+  // The wire shape per UPCR-2026-012 is metadata-only — there is no
+  // `content` field. Final text is the streamed `pendingAssistant.text`
+  // accumulated from `message/delta`; this event finalises the bubble
+  // and (since server PR #767) carries the row's `media` attachments.
   //
-  // Match conditions:
-  //   - role === "assistant" (tool/user persists are independent records)
-  //   - the thread's pendingAssistant exists in the live store
+  // Two cases:
   //
-  // When matched: overwrite the pending text/files with the canonical
-  // persisted content (server is authoritative on final text) and call
-  // `finalizeAssistant` with the persisted seq. The downstream
-  // `turn/completed` then no-ops because `pendingAssistant` is null.
+  //   (1) Match condition (assistant role + thread_id resolves to a
+  //       thread with `pendingAssistant`): keep the streamed text,
+  //       append each `media` URL to the pending bubble, then finalise
+  //       with the event's `seq`. The downstream `turn/completed`
+  //       no-ops because `pendingAssistant` is null after this.
   //
-  // When unmatched (no pending, e.g. late artifact, or non-assistant
-  // role): fall through to `appendPersistedMessage` — the PR M
-  // late-artifact path.
-  if (m.role === "assistant" && m.thread_id) {
+  //   (2) Unmatched (no pending — late artifact, non-assistant role,
+  //       or assistant whose live pending was lost across reconnect):
+  //       fall through to `appendPersistedMessage` so a fresh row
+  //       appears in the thread. The bubble shows the synthesised
+  //       placeholder content + the `media` URL.
+  if (event.role === "assistant" && event.thread_id) {
     const promoted = tryPromotePendingFromPersisted(
       cfg.sessionId,
       cfg.topic,
-      m,
+      event,
     );
     if (promoted) return;
   }
   ThreadStore.appendPersistedMessage(
     cfg.sessionId,
     cfg.topic,
-    persistedToMessageInfo(m),
+    eventToMessageInfo(event),
   );
 }
 
 /**
- * If the live thread for `m.thread_id` has an in-flight pendingAssistant,
- * overwrite its content/files with the persisted record and finalize.
- * Returns true when promotion happened (caller should NOT also append).
+ * If the live thread for `event.thread_id` has an in-flight
+ * pendingAssistant, append the event's `media` URLs to the pending
+ * bubble and finalise it with the event's `seq`. Returns true when
+ * promotion happened (caller should NOT also append a fresh row).
+ *
+ * Unlike the original promotion path, this DOES NOT overwrite the
+ * pending text — the server's `MessagePersistedEvent` carries no
+ * `content` field, so the streamed `message/delta` text is
+ * authoritative for the bubble's body.
  */
 function tryPromotePendingFromPersisted(
   sessionId: string,
   topic: string | undefined,
-  m: PersistedMessage,
+  event: MessagePersistedEvent,
 ): boolean {
+  const threadId = event.thread_id;
+  if (!threadId) return false;
   const threads = ThreadStore.getThreads(sessionId, topic);
-  const thread = threads.find((t) => t.id === m.thread_id);
+  const thread = threads.find((t) => t.id === threadId);
   if (!thread || !thread.pendingAssistant) return false;
-  // Replace pending text + files with the persisted content. Files
-  // from the persisted record win; the streamed pending text was a
-  // best-effort approximation of what's now authoritative.
-  ThreadStore.replaceAssistantText(m.thread_id, m.content);
-  // appendAssistantFile is path-deduped, so re-adding a streamed file
-  // is a no-op. Persisted files that weren't already attached land here.
-  for (const f of m.files ?? []) {
-    ThreadStore.appendAssistantFile(m.thread_id, {
-      filename: filenameFromPath(f.path),
-      path: f.path,
+  // appendAssistantFile is path-deduped, so re-adding a streamed file is
+  // a no-op. New media URLs that weren't already attached land here.
+  for (const path of event.media ?? []) {
+    ThreadStore.appendAssistantFile(threadId, {
+      filename: filenameFromPath(path),
+      path,
       caption: "",
     });
   }
-  ThreadStore.finalizeAssistant(m.thread_id, {
-    committedSeq:
-      typeof m.intra_thread_seq === "number"
-        ? m.intra_thread_seq
-        : typeof m.history_seq === "number"
-          ? m.history_seq
-          : undefined,
+  ThreadStore.finalizeAssistant(threadId, {
+    committedSeq: event.seq,
   });
   return true;
 }

--- a/src/runtime/ui-protocol-event-router.ts
+++ b/src/runtime/ui-protocol-event-router.ts
@@ -84,13 +84,14 @@ function defaultDispatch(event: Event): void {
  * `ThreadStore.appendPersistedMessage` expects, for the late-artifact
  * path (no live `pendingAssistant` to promote).
  *
- * The wire shape is metadata-only — there is no `content` field. We
- * synthesize a minimal placeholder when `media` is present so the bubble
- * has visible text alongside the `<a href>` (the file URL itself is
- * carried via `MessageInfo.media`). For text-only persists with no live
- * pending and no media, we synthesise an empty `content` — the row is
- * still recorded with its seq/role so `session/hydrate` can later replace
- * it with the canonical text.
+ * The wire shape is metadata-only — there is no `content` field. The
+ * row's `content` is set to the empty string in both branches:
+ *   - media-bearing rows: ThreadStore's media-only-merge predicate
+ *     treats empty content as a companion row and merges the file into
+ *     the existing assistant response;
+ *   - text-only rows with no live pending: the row is still recorded
+ *     with its seq/role so `session/hydrate` can later replace it with
+ *     the canonical text.
  */
 function eventToMessageInfo(event: MessagePersistedEvent): MessageInfo {
   const media = event.media ?? [];
@@ -145,8 +146,10 @@ export function handleMessagePersisted(
   //   (2) Unmatched (no pending — late artifact, non-assistant role,
   //       or assistant whose live pending was lost across reconnect):
   //       fall through to `appendPersistedMessage` so a fresh row
-  //       appears in the thread. The bubble shows the synthesised
-  //       placeholder content + the `media` URL.
+  //       appears in the thread. With empty content + non-empty
+  //       `media`, ThreadStore merges this into the existing
+  //       assistant response as a companion row; the attachment
+  //       renderer makes the file URL visible.
   if (event.role === "assistant" && event.thread_id) {
     const promoted = tryPromotePendingFromPersisted(
       cfg.sessionId,

--- a/src/runtime/ui-protocol-types.ts
+++ b/src/runtime/ui-protocol-types.ts
@@ -83,10 +83,48 @@ export interface PersistedMessage {
   timestamp?: string;
 }
 
+/**
+ * `message/persisted` notification per `UPCR-2026-012`. Server emits a
+ * flat metadata-only payload — content travels via `message/delta`, this
+ * notification confirms the durable commit and (since the server's P1.3
+ * fix in PR #767) carries the persisted row's `media` attachments so
+ * the client can render them as `<a href>` in the chat bubble.
+ *
+ * IMPORTANT: this struct is the on-the-wire shape. The earlier nested
+ * `{ message: { id, thread_id, content, role, files? } }` shape this
+ * project once expected was speculative and never matched a real server
+ * payload. Do NOT read `event.message.content` here — there is no
+ * `content` field on the wire. The pending bubble's already-streamed
+ * text is authoritative; this event finalises the bubble and adds
+ * media URLs.
+ */
 export interface MessagePersistedEvent {
   session_id: string;
-  turn_id: string;
-  message: PersistedMessage;
+  /** Optional per UPCR-2026-012; absent on legacy rows that pre-date the
+   *  typed-binding refactor. */
+  turn_id?: string;
+  /** Optional per UPCR-2026-012; same enforcement story as `turn_id`. */
+  thread_id?: string;
+  /** Strictly monotonic per session — assigned by `add_message_with_seq`. */
+  seq: number;
+  /** Open snake_case enum, matching `octos-core::MessageRole`. */
+  role: "system" | "user" | "assistant" | "tool";
+  /** Server-assigned UUID for the row. Stable across replays. */
+  message_id: string;
+  /** Present for `source = user` rows where the client supplied a cmid;
+   *  absent on legacy rows. */
+  client_message_id?: string;
+  /** Open snake_case enum identifying the WRITE PATH that committed the row. */
+  source: "user" | "assistant" | "tool" | "background" | "recovery";
+  /** Durable cursor pointing at this commit. */
+  cursor: { stream: string; seq: number };
+  /** RFC 3339 wall-clock time the row was committed. */
+  persisted_at: string;
+  /** File attachments persisted with this row — typically a single
+   *  `.md` / `.mp3` / `.pptx` artefact emitted by `spawn_only` background
+   *  tools (`deep_search`, `mofa_*`, `fm_tts`) or an explicit
+   *  `send_file` call. Absent or empty for ordinary text rows. */
+  media?: string[];
 }
 
 export interface TaskUpdatedEvent {


### PR DESCRIPTION
## Summary

Pairs with octos PR #767 (already merged at \`929a046f\`). That PR added a
\`media\` field to the server's \`MessagePersistedEvent\` so spawn_only
deliveries (deep_research, mofa_*, fm_tts) carry attachment URLs on the
wire. This PR aligns the client bridge so it actually reads them.

Two interleaved fixes:

1. **Wire-shape alignment.** The bridge's \`MessagePersistedEvent\`
   interface and \`guardMessagePersisted\` were designed against a
   speculative nested shape (\`{ message: { id, thread_id, content,
   role, files? } }\`) that no real server has ever emitted. Per
   \`UPCR-2026-012\`, the server emits a flat metadata-only payload —
   \`{ session_id, turn_id?, thread_id?, seq, role, message_id, source,
   cursor, persisted_at, ... }\`. \`guardMessagePersisted\` rejected
   every production event; \`handleMessagePersisted\` never fired.
2. **Media rendering.** Now that the wire carries \`media: string[]\`
   (PR #767), the router appends each path via
   \`appendAssistantFile\` so the chat bubble shows an \`<a href>\`
   link.

## Diagnosis (wave-6e closeout)

\`mini1:/Users/cloud/.octos/logs/serve.2026-05-03.log\` during wave-6e:
\`background file sent\` fires 6×, ledger.sessions.active grows 0→21,
bytes.in_memory grows to 1.44 MB. But every spec fails with
\`slowHrefs=[]\` — the SPA bubble has no \`<a href=\"*.md\">\`. The
client bridge was dropping all \`message/persisted\` notifications
because of the wire-shape mismatch.

## Changes

* \`src/runtime/ui-protocol-types.ts\` — \`MessagePersistedEvent\`
  rewritten to flat shape; documented as the canonical
  \`UPCR-2026-012\` payload. \`PersistedMessage\` stays for
  \`session/hydrate\` consumers (separate endpoint, full content).
* \`src/runtime/ui-protocol-bridge.ts\` — \`guardMessagePersisted\`
  rewritten: validate flat shape, reject unknown roles/sources,
  validate \`cursor\` shape, parse optional \`media: string[]\`.
* \`src/runtime/ui-protocol-event-router.ts\` —
  \`handleMessagePersisted\` no longer reads non-existent
  \`m.content\` / \`m.files\`. Streamed \`pendingAssistant.text\` is
  authoritative; persisted event finalises and adds media URLs.
  \`tryPromotePendingFromPersisted\` simplified.
  \`persistedToMessageInfo\` -> \`eventToMessageInfo\` for
  late-artifact path.
* Tests: 6 fixture rewrites in \`ui-protocol-bridge.test.ts\` and
  \`ui-protocol-event-router.test.ts\`. New tests for populated
  \`media\` and missing \`seq\`. **120/120 pass**.

## Out of scope

- Restoring \"server confirms final text\" semantic — server's
  metadata-only event doesn't carry text; future work could add a
  \`session/hydrate\` round-trip on reconnect to reconcile.
- Aligning REST \`GET /api/sessions/:id/messages\` shape (separate
  endpoint, separate concern).

## Test plan

- [x] \`npx tsc --noEmit\` clean
- [x] \`npm run test:unit\` 120/120 pass
- [ ] Codex review before merge
- [ ] Build SPA, deploy to mini1, run wave-6f soak — empirically
      confirms whether bubble renders \`<a href>\` for spawn_only
      deliveries