### PR TITLE
fix(runtime): drop Sec-WebSocket-Protocol from /api/ui-protocol/ws handshake

### DIFF
--- a/src/runtime/ui-protocol-bridge.test.ts
+++ b/src/runtime/ui-protocol-bridge.test.ts
@@ -360,7 +360,11 @@ describe("connection lifecycle", () => {
     // notifications on this feature, so dropping it would silently
     // disable spawn_only attachment delivery.
     expect(ws.url).toContain("ui_feature=event.message_persisted.v1");
-    expect(ws.protocols).toEqual(["octos.bearer.test-token"]);
+    // Regression-pin: do NOT pass Sec-WebSocket-Protocol. Chrome aborts the
+    // handshake when the client requests a subprotocol the server does not
+    // echo back, and the axum WS handler does not negotiate subprotocols.
+    // Auth flows entirely via the `?token=` query param above.
+    expect(ws.protocols).toBeUndefined();
   });
 
   it("session/open params include profile_id when provided to start()", async () => {

--- a/src/runtime/ui-protocol-bridge.ts
+++ b/src/runtime/ui-protocol-bridge.ts
@@ -755,12 +755,12 @@ class UiProtocolBridgeImpl implements UiProtocolBridge {
 
     let ws: WebSocket;
     try {
-      // Some browsers may permit setting the bearer via the WS subprotocol;
-      // we offer it AND the ?token= fallback so the server can pick whichever
-      // path made it through.
-      const token = this.cfg.getToken();
-      const protocols = token ? [`octos.bearer.${token}`] : undefined;
-      ws = new this.cfg.webSocketImpl(this.buildUrl(), protocols);
+      // Auth flows via `?token=` query param (set by buildUrl). We do NOT
+      // pass a Sec-WebSocket-Protocol subprotocol: Chrome aborts the
+      // handshake when the client requests one and the server does not
+      // echo a chosen protocol in the response, and the axum handler at
+      // /api/ui-protocol/ws does not currently negotiate subprotocols.
+      ws = new this.cfg.webSocketImpl(this.buildUrl());
     } catch (err) {
       this.setState("error");
       throw err instanceof Error ? err : new Error(String(err));


### PR DESCRIPTION
## Summary

The UI Protocol v1 bridge passed `['octos.bearer.<token>']` as the second arg to `new WebSocket(url, protocols)`, which sets `Sec-WebSocket-Protocol: octos.bearer.<token>` in the handshake. Chrome aborts the handshake when the server does not echo a chosen protocol back in the response — and the axum handler at `/api/ui-protocol/ws` does not currently negotiate subprotocols. Result: every Chrome/Chromium client failed the WS handshake silently. Zero frames flowed; the SPA bubble rendered locally for the user message but never received the assistant response, so all wave-6f live specs showed `realContent=0/N`.

This PR removes the subprotocol from the constructor call. Auth still flows via the `?token=` query parameter (set by `buildUrl()`), which the server already accepts and which was already the production path.

## Empirical evidence (root-cause diagnosis)

Live inspection on `https://dspfac.crew.ominix.io` after the wave-6f deploy:

```
[error] WebSocket connection to 'wss://dspfac.crew.ominix.io/api/ui-protocol/ws?...' failed:
Error during WebSocket handshake: Sent non-empty 'Sec-WebSocket-Protocol' header but no resp[onse]
```

Direct curl to the daemon (port 50080) and through Caddy on HTTP/1.1: WS upgrade returns `101 Switching Protocols` BUT no `Sec-WebSocket-Protocol:` response header even when the client requests one. Confirmed both paths.

## Why this only surfaced in wave-6f

`chat_app_ui_v1` was opt-in for waves 6c–6e (default off). Wave-6f flipped it permanently ON for the test build to drive 100% of traffic through the new WS path — exposing this bug for the first time. That also explains the `media-mix-soak-five-skills` regression from 3/5 (wave-6c) to 0/5 (wave-6d onward, where the wave-6d agent enabled the flag in its build).

## Test plan

- [x] `npx vitest run src/runtime/ui-protocol-bridge.test.ts` — 32/32 pass
- [x] `npx vitest run` (full octos-web) — 120/120 pass
- [x] Updated `expect(ws.protocols).toEqual([...])` regression-pin → `expect(ws.protocols).toBeUndefined()` so future regressions don't silently re-enable the subprotocol path
- [ ] Build + deploy SPA to mini1; re-run inspection spec to confirm WS opens, frames flow, bubble fills
- [ ] Re-run wave-6f soak (`live-thread-interleave` + `live-overflow-stress`) — pass criterion: `slowHrefs` non-empty in `live-thread-interleave`

## Risks

- None to the legacy SSE path (untouched).
- The query-param token path was already production for every prior soak run; this PR just removes the unused subprotocol fallback. If a future client-side environment _can_ only use WS subprotocols for auth (not browsers we ship to), it will need a separate server-side fix to negotiate `octos.bearer.*`.