### PR TITLE
fix(runtime): render generic file attachments as <a href> anchors

### DIFF
--- a/src/components/chat-thread.tsx
+++ b/src/components/chat-thread.tsx
@@ -48,7 +48,7 @@ import * as StreamManager from "@/runtime/stream-manager";
 import { MarkdownContent } from "./markdown-renderer";
 import { ThinkingIndicator } from "./thinking-indicator";
 import { ToolProgressIndicator } from "./tool-progress-indicator";
-import { buildFileUrl } from "@/api/files";
+import { buildAuthenticatedFileUrl, buildFileUrl } from "@/api/files";
 import { displayFilenameFromPath } from "@/lib/utils";
 import { nextTopicForCommand } from "@/lib/slash-commands";
 import { getToken } from "@/api/client";
@@ -303,11 +303,41 @@ function FileAttachment({ file }: { file: MessageFile }) {
     );
   }
 
-  // Generic download button
-  return (
+  // Generic file attachment — render as a real `<a href>` anchor pointing at
+  // the authenticated `/api/files/...` URL (with `?token=` query param). This
+  // gives the bubble a clickable, downloadable link whose URL preserves the
+  // file extension (so e.g. `.md` reports remain matchable by harness link
+  // predicates) while still flowing through the standard auth path. We keep
+  // the blob preflight (`useBlobUrl`) as a liveness check: if the auth or
+  // path resolution would fail, we surface that as a disabled state rather
+  // than rendering a link that 403s when clicked.
+  //
+  // External URLs (`https://…`, `http://…`) bypass `/api/files` entirely —
+  // `useBlobUrl` already short-circuits the fetch for them, and wrapping
+  // them through `buildAuthenticatedFileUrl` would point the anchor at our
+  // local file endpoint with the literal URL as the path component, which
+  // 403s. Pass the original path through untouched so legacy
+  // `[file:https://…]` deliveries keep opening.
+  const isExternalUrl = /^https?:\/\//i.test(file.path);
+  const directHref = isExternalUrl
+    ? file.path
+    : buildAuthenticatedFileUrl(file.path);
+  return blobUrl ? (
+    <a
+      href={directHref}
+      download={file.filename}
+      target="_blank"
+      rel="noopener noreferrer"
+      className="glass-pill inline-flex max-w-full items-center gap-1.5 overflow-hidden rounded-[10px] px-3 py-2 text-xs text-link hover:text-accent"
+      data-file-attachment="true"
+    >
+      <Download size={14} className="shrink-0" />
+      <span className="truncate">{file.filename}</span>
+    </a>
+  ) : (
     <button
       onClick={handleDownload}
-      disabled={!blobUrl}
+      disabled
       className="glass-pill inline-flex max-w-full items-center gap-1.5 overflow-hidden rounded-[10px] px-3 py-2 text-xs text-link hover:text-accent disabled:opacity-50"
     >
       <Download size={14} className="shrink-0" />


### PR DESCRIPTION
## Summary

The deep_research / mofa / fm_tts spawn_only flow delivers `.md` / `.mp3` / `.pptx` artefacts that fall outside the audio/video/image type detectors. Those rendered as a `<button>` whose enabled state hinged on a successful blob fetch — when the file URL 403s for any reason (path scoping mismatch, expired token), the user saw a disabled button with no signal as to why and no clickable URL.

Switch the generic branch to a real `<a href>` once the blob preflight resolves, with the href pointing at `buildAuthenticatedFileUrl(file.path)` — the standard `/api/files/...?token=...` URL. That gives the bubble:
- a clickable, downloadable link whose URL preserves the file extension (so `.md` stays matchable by harness predicates that gate on `<a[href]>` matching `\\.md(?:$|[?#])`, e.g. `live-thread-interleave`'s `slowHrefs` check);
- right-click → "Save link as" works without bouncing through the in-page blob fetch.

External URLs (`https?://…`) bypass `/api/files` entirely — wrapping them through `buildAuthenticatedFileUrl` would point the anchor at our local file endpoint with the literal URL as the path component, which 403s. Pass them through untouched so legacy `[file:https://...]` deliveries keep opening.

When the preflight fails we still render a disabled button (visually unchanged from before) so the broken state stays distinguishable from the loaded one, matching the existing UX for media types.

## Test plan

- [x] `npx tsc -b --noEmit` passes
- [x] Full vitest suite (120 tests across 7 files) passes unchanged
- [x] `codex review --base origin/main` returned no correctness findings on the final pass
- [ ] Manual verification on `dspfac.crew.ominix.io` paired with the server-side fix (`octos-org/octos#769`).