### PR TITLE
feat(runtime): handle turn.spawn_complete envelope as new bubble (M10 Phase 2)

### DIFF
--- a/src/runtime/ui-protocol-bridge.test.ts
+++ b/src/runtime/ui-protocol-bridge.test.ts
@@ -39,6 +39,7 @@ import type {
   TaskUpdatedEvent,
   TurnCompletedEvent,
   TurnErrorEvent,
+  TurnSpawnCompleteEvent,
   TurnStartedEvent,
   WarningEvent,
 } from "./ui-protocol-types";
@@ -254,6 +255,138 @@ describe("type guards (fail-closed)", () => {
     expect(ev?.media).toEqual(["research/_report.md"]);
   });
 
+  // -------------------------------------------------------------------------
+  // M10 Phase 2: turn/spawn_complete envelope guard
+  // -------------------------------------------------------------------------
+
+  it("accepts a valid turn/spawn_complete envelope", () => {
+    const ev = guards.guardSpawnComplete({
+      session_id: "sess-1",
+      turn_id: "turn-1",
+      thread_id: "cmid-user-1",
+      task_id: "task_abc123",
+      response_to_client_message_id: "cmid-user-1",
+      seq: 42,
+      message_id: "msg-spawn-1",
+      source: "background",
+      cursor: { stream: "sess-1", seq: 42 },
+      persisted_at: "2026-05-04T00:00:00Z",
+      content: "Research complete: 3 sources reviewed.",
+      media: ["research/_report.md"],
+    });
+    expect(ev).not.toBeNull();
+    expect(ev?.task_id).toBe("task_abc123");
+    expect(ev?.content).toBe("Research complete: 3 sources reviewed.");
+    expect(ev?.media).toEqual(["research/_report.md"]);
+    expect(ev?.thread_id).toBe("cmid-user-1");
+  });
+
+  it("rejects turn/spawn_complete with missing content (distinguishes from spawn-ack)", () => {
+    expect(
+      guards.guardSpawnComplete({
+        session_id: "sess-1",
+        task_id: "t",
+        seq: 1,
+        message_id: "m",
+        source: "background",
+        cursor: { stream: "sess-1", seq: 1 },
+        persisted_at: "2026-05-04T00:00:00Z",
+        // content omitted
+      }),
+    ).toBeNull();
+  });
+
+  it("rejects turn/spawn_complete with empty content", () => {
+    expect(
+      guards.guardSpawnComplete({
+        session_id: "sess-1",
+        task_id: "t",
+        seq: 1,
+        message_id: "m",
+        source: "background",
+        cursor: { stream: "sess-1", seq: 1 },
+        persisted_at: "2026-05-04T00:00:00Z",
+        content: "",
+      }),
+    ).toBeNull();
+  });
+
+  it("rejects turn/spawn_complete with missing task_id", () => {
+    expect(
+      guards.guardSpawnComplete({
+        session_id: "sess-1",
+        seq: 1,
+        message_id: "m",
+        source: "background",
+        cursor: { stream: "sess-1", seq: 1 },
+        persisted_at: "2026-05-04T00:00:00Z",
+        content: "result",
+      }),
+    ).toBeNull();
+  });
+
+  it("rejects turn/spawn_complete with non-finite cursor.seq", () => {
+    expect(
+      guards.guardSpawnComplete({
+        session_id: "sess-1",
+        task_id: "t",
+        seq: 1,
+        message_id: "m",
+        source: "background",
+        cursor: { stream: "sess-1", seq: Number.POSITIVE_INFINITY },
+        persisted_at: "2026-05-04T00:00:00Z",
+        content: "result",
+      }),
+    ).toBeNull();
+  });
+
+  it("rejects turn/spawn_complete with malformed cursor", () => {
+    expect(
+      guards.guardSpawnComplete({
+        session_id: "sess-1",
+        task_id: "t",
+        seq: 1,
+        message_id: "m",
+        source: "background",
+        cursor: { stream: "" }, // missing seq, empty stream
+        persisted_at: "2026-05-04T00:00:00Z",
+        content: "result",
+      }),
+    ).toBeNull();
+  });
+
+  it("filters non-string media entries from turn/spawn_complete", () => {
+    const ev = guards.guardSpawnComplete({
+      session_id: "sess-1",
+      task_id: "t",
+      seq: 1,
+      message_id: "m",
+      source: "background",
+      cursor: { stream: "sess-1", seq: 1 },
+      persisted_at: "2026-05-04T00:00:00Z",
+      content: "result",
+      media: ["a/path.md", 42, null, "", "b/path.md"],
+    });
+    expect(ev?.media).toEqual(["a/path.md", "b/path.md"]);
+  });
+
+  it("accepts turn/spawn_complete with all optionals omitted", () => {
+    const ev = guards.guardSpawnComplete({
+      session_id: "sess-1",
+      task_id: "t",
+      seq: 1,
+      message_id: "m",
+      source: "background",
+      cursor: { stream: "sess-1", seq: 1 },
+      persisted_at: "2026-05-04T00:00:00Z",
+      content: "result",
+    });
+    expect(ev?.turn_id).toBeUndefined();
+    expect(ev?.thread_id).toBeUndefined();
+    expect(ev?.response_to_client_message_id).toBeUndefined();
+    expect(ev?.media).toBeUndefined();
+  });
+
   it("rejects task/updated without task_id", () => {
     expect(
       guards.guardTaskUpdated({
@@ -360,6 +493,14 @@ describe("connection lifecycle", () => {
     // notifications on this feature, so dropping it would silently
     // disable spawn_only attachment delivery.
     expect(ws.url).toContain("ui_feature=event.message_persisted.v1");
+    // Regression-pin for the M10 Phase 1 capability negotiation
+    // (server PR #772): server only emits the new
+    // `turn/spawn_complete` envelope when this capability is in the
+    // `ui_feature` query at session/open. Without it the SPA never
+    // receives the new bubble and falls back to legacy `message/persisted`
+    // splice-merge. Phase 5 deletes the splice-merge predicate; until
+    // then, this assertion locks the negotiation.
+    expect(ws.url).toContain("ui_feature=event.spawn_complete.v1");
     // Regression-pin: do NOT pass Sec-WebSocket-Protocol. Chrome aborts the
     // handshake when the client requests a subprotocol the server does not
     // echo back, and the axum WS handler does not negotiate subprotocols.
@@ -674,6 +815,60 @@ describe("notification dispatch", () => {
     expect(persisted[0].seq).toBe(18);
     expect(tasks[0].task_id).toBe("task-A");
     expect(outputs[0].chunk).toBe("log line");
+  });
+
+  it("routes turn/spawn_complete to onSpawnComplete (M10 Phase 2)", async () => {
+    const { bridge, ws } = await freshConnected();
+    const seen: TurnSpawnCompleteEvent[] = [];
+    bridge.onSpawnComplete((e) => seen.push(e));
+    ws.triggerMessage({
+      jsonrpc: "2.0",
+      method: METHODS.TURN_SPAWN_COMPLETE,
+      params: {
+        session_id: "sess-1",
+        turn_id: "turn-A",
+        thread_id: "cmid-user-1",
+        task_id: "task_abc",
+        response_to_client_message_id: "cmid-user-1",
+        seq: 7,
+        message_id: "msg-spawn-1",
+        source: "background",
+        cursor: { stream: "sess-1", seq: 7 },
+        persisted_at: "2026-05-04T00:00:00Z",
+        content: "Background research complete.",
+        media: ["research/_report.md"],
+      },
+    });
+    expect(seen).toHaveLength(1);
+    expect(seen[0].task_id).toBe("task_abc");
+    expect(seen[0].content).toBe("Background research complete.");
+    expect(seen[0].media).toEqual(["research/_report.md"]);
+  });
+
+  it("emits warning when turn/spawn_complete is missing required content", async () => {
+    const { bridge, ws } = await freshConnected();
+    const warnings: WarningEvent[] = [];
+    const seen: TurnSpawnCompleteEvent[] = [];
+    bridge.onWarning((w) => warnings.push(w));
+    bridge.onSpawnComplete((e) => seen.push(e));
+    ws.triggerMessage({
+      jsonrpc: "2.0",
+      method: METHODS.TURN_SPAWN_COMPLETE,
+      params: {
+        session_id: "sess-1",
+        task_id: "task_abc",
+        seq: 7,
+        message_id: "msg-spawn-1",
+        source: "background",
+        cursor: { stream: "sess-1", seq: 7 },
+        persisted_at: "2026-05-04T00:00:00Z",
+        // content omitted — must be rejected
+      },
+    });
+    expect(seen).toHaveLength(0);
+    expect(
+      warnings.some((w) => w.reason === "invalid_event:turn/spawn_complete"),
+    ).toBe(true);
   });
 
   it("routes turn lifecycle and approval/requested", async () => {

--- a/src/runtime/ui-protocol-bridge.test.ts
+++ b/src/runtime/ui-protocol-bridge.test.ts
@@ -296,7 +296,7 @@ describe("type guards (fail-closed)", () => {
     ).toBeNull();
   });
 
-  it("rejects turn/spawn_complete with empty content", () => {
+  it("rejects turn/spawn_complete with empty content AND empty media (truly nothing to render)", () => {
     expect(
       guards.guardSpawnComplete({
         session_id: "sess-1",
@@ -309,6 +309,30 @@ describe("type guards (fail-closed)", () => {
         content: "",
       }),
     ).toBeNull();
+  });
+
+  it("ACCEPTS turn/spawn_complete with empty content but non-empty media (file-only completion)", () => {
+    // Codex round-4 P2: a `spawn_only` tool whose result is purely
+    // artefactual (e.g. TTS audio drop, _report.md only) legitimately
+    // produces empty `content` + non-empty `media`. Upgraded clients
+    // must accept this; rejecting it would silently drop file-only
+    // completions because the server suppresses the legacy
+    // `message/persisted` fallback once `event.spawn_complete.v1` is
+    // negotiated.
+    const ev = guards.guardSpawnComplete({
+      session_id: "sess-1",
+      task_id: "t",
+      seq: 1,
+      message_id: "m",
+      source: "background",
+      cursor: { stream: "sess-1", seq: 1 },
+      persisted_at: "2026-05-04T00:00:00Z",
+      content: "",
+      media: ["bg/result.mp3"],
+    });
+    expect(ev).not.toBeNull();
+    expect(ev?.content).toBe("");
+    expect(ev?.media).toEqual(["bg/result.mp3"]);
   });
 
   it("rejects turn/spawn_complete with missing task_id", () => {

--- a/src/runtime/ui-protocol-bridge.ts
+++ b/src/runtime/ui-protocol-bridge.ts
@@ -29,6 +29,7 @@ import type {
   TurnCompletedEvent,
   TurnErrorEvent,
   TurnInterruptResult,
+  TurnSpawnCompleteEvent,
   TurnStartInput,
   TurnStartResult,
   TurnStartedEvent,
@@ -52,6 +53,7 @@ export type {
   TurnCompletedEvent,
   TurnErrorEvent,
   TurnInterruptResult,
+  TurnSpawnCompleteEvent,
   TurnStartInput,
   TurnStartResult,
   TurnStartedEvent,
@@ -83,6 +85,7 @@ export const METHODS = {
   TURN_STARTED: "turn/started",
   TURN_COMPLETED: "turn/completed",
   TURN_ERROR: "turn/error",
+  TURN_SPAWN_COMPLETE: "turn/spawn_complete",
   APPROVAL_REQUESTED: "approval/requested",
   WARNING: "warning",
 } as const;
@@ -99,6 +102,14 @@ export const UI_PROTOCOL_FEATURES = [
   // unreachable in production. See server `ui_protocol.rs:1941` and
   // `ui_protocol.rs:2075` for the gating logic.
   "event.message_persisted.v1",
+  // M10 Phase 1 (server PR #772): server only emits the new
+  // `turn/spawn_complete` envelope when this capability is negotiated at
+  // session/open. Without it, late `spawn_only` results continue to flow
+  // through the legacy `message/persisted` row (and the splice-merge
+  // predicate in ThreadStore). Phase 5 will delete the legacy path; this
+  // PR (Phase 2) only ADDS the new envelope handling so the migration is
+  // backward-compatible during rollout.
+  "event.spawn_complete.v1",
 ] as const;
 
 const JSON_RPC_VERSION = "2.0";
@@ -157,6 +168,7 @@ export interface UiProtocolBridge {
 
   onMessageDelta(handler: (e: MessageDeltaEvent) => void): () => void;
   onMessagePersisted(handler: (e: MessagePersistedEvent) => void): () => void;
+  onSpawnComplete(handler: (e: TurnSpawnCompleteEvent) => void): () => void;
   onTaskUpdated(handler: (e: TaskUpdatedEvent) => void): () => void;
   onTaskOutputDelta(handler: (e: TaskOutputDeltaEvent) => void): () => void;
   onTurnLifecycle(
@@ -353,6 +365,73 @@ function guardMessagePersisted(p: unknown): MessagePersistedEvent | null {
   };
 }
 
+function guardSpawnComplete(p: unknown): TurnSpawnCompleteEvent | null {
+  // M10 Phase 1 envelope. Required-field invariants per the server-side
+  // `TurnSpawnCompleteEvent` struct (`crates/octos-core/src/ui_protocol.rs`):
+  //   - session_id, task_id, message_id, source, persisted_at — non-empty strings
+  //   - seq                                                    — finite non-negative number
+  //   - cursor.{stream, seq}                                   — non-empty string + finite number
+  //   - content                                                — REQUIRED non-empty string
+  //   - turn_id, thread_id, response_to_client_message_id      — optional strings
+  //   - media                                                  — optional string[]
+  //
+  // The `content` non-empty check is the load-bearing distinguisher from
+  // a spawn-ack `message/persisted` row whose content is a short ack
+  // message — a `turn/spawn_complete` with empty content is either a
+  // server bug or the wrong wire shape entirely; either way, fail closed.
+  if (!isPlainObject(p)) return null;
+  if (!isString(p.session_id)) return null;
+  if (!isString(p.task_id)) return null;
+  if (typeof p.seq !== "number" || !Number.isFinite(p.seq) || p.seq < 0) {
+    return null;
+  }
+  if (!isString(p.message_id)) return null;
+  if (!isString(p.source)) return null;
+  if (
+    !isPlainObject(p.cursor) ||
+    typeof p.cursor.seq !== "number" ||
+    !Number.isFinite(p.cursor.seq) ||
+    p.cursor.seq < 0 ||
+    !isString(p.cursor.stream)
+  ) {
+    return null;
+  }
+  if (!isString(p.persisted_at)) return null;
+  if (!isString(p.content)) return null;
+
+  let media: string[] | undefined;
+  if (Array.isArray(p.media)) {
+    const filtered = p.media.filter(
+      (u): u is string => isString(u) && u.length > 0,
+    );
+    if (filtered.length > 0) media = filtered;
+  }
+  return {
+    session_id: p.session_id,
+    turn_id:
+      typeof p.turn_id === "string" && p.turn_id.length > 0
+        ? p.turn_id
+        : undefined,
+    thread_id:
+      typeof p.thread_id === "string" && p.thread_id.length > 0
+        ? p.thread_id
+        : undefined,
+    task_id: p.task_id,
+    response_to_client_message_id:
+      typeof p.response_to_client_message_id === "string" &&
+      p.response_to_client_message_id.length > 0
+        ? p.response_to_client_message_id
+        : undefined,
+    seq: p.seq,
+    message_id: p.message_id,
+    source: p.source,
+    cursor: { stream: p.cursor.stream, seq: p.cursor.seq },
+    persisted_at: p.persisted_at,
+    content: p.content,
+    media,
+  };
+}
+
 function guardTaskUpdated(p: unknown): TaskUpdatedEvent | null {
   if (!isPlainObject(p)) return null;
   if (!isString(p.session_id) || !isString(p.turn_id) || !isString(p.task_id)) {
@@ -505,6 +584,7 @@ class UiProtocolBridgeImpl implements UiProtocolBridge {
 
   private readonly subMessageDelta = new Subscribers<MessageDeltaEvent>();
   private readonly subMessagePersisted = new Subscribers<MessagePersistedEvent>();
+  private readonly subSpawnComplete = new Subscribers<TurnSpawnCompleteEvent>();
   private readonly subTaskUpdated = new Subscribers<TaskUpdatedEvent>();
   private readonly subTaskOutputDelta = new Subscribers<TaskOutputDeltaEvent>();
   private readonly subTurnLifecycle = new Subscribers<
@@ -528,6 +608,10 @@ class UiProtocolBridgeImpl implements UiProtocolBridge {
     [METHODS.MESSAGE_PERSISTED]: {
       guard: guardMessagePersisted,
       emit: (v) => this.subMessagePersisted.emit(v as MessagePersistedEvent),
+    },
+    [METHODS.TURN_SPAWN_COMPLETE]: {
+      guard: guardSpawnComplete,
+      emit: (v) => this.subSpawnComplete.emit(v as TurnSpawnCompleteEvent),
     },
     [METHODS.TASK_UPDATED]: {
       guard: guardTaskUpdated,
@@ -624,6 +708,7 @@ class UiProtocolBridgeImpl implements UiProtocolBridge {
     this.sendQueue.length = 0;
     this.subMessageDelta.clear();
     this.subMessagePersisted.clear();
+    this.subSpawnComplete.clear();
     this.subTaskUpdated.clear();
     this.subTaskOutputDelta.clear();
     this.subTurnLifecycle.clear();
@@ -689,6 +774,9 @@ class UiProtocolBridgeImpl implements UiProtocolBridge {
   }
   onMessagePersisted(handler: Listener<MessagePersistedEvent>): () => void {
     return this.subMessagePersisted.add(handler);
+  }
+  onSpawnComplete(handler: Listener<TurnSpawnCompleteEvent>): () => void {
+    return this.subSpawnComplete.add(handler);
   }
   onTaskUpdated(handler: Listener<TaskUpdatedEvent>): () => void {
     return this.subTaskUpdated.add(handler);
@@ -1085,6 +1173,7 @@ export function createUiProtocolBridge(
 export const __INTERNAL_GUARDS_FOR_TEST__ = {
   guardMessageDelta,
   guardMessagePersisted,
+  guardSpawnComplete,
   guardTaskUpdated,
   guardTaskOutputDelta,
   guardTurnStarted,

--- a/src/runtime/ui-protocol-bridge.ts
+++ b/src/runtime/ui-protocol-bridge.ts
@@ -397,7 +397,14 @@ function guardSpawnComplete(p: unknown): TurnSpawnCompleteEvent | null {
     return null;
   }
   if (!isString(p.persisted_at)) return null;
-  if (!isString(p.content)) return null;
+  // `content` must BE A STRING (present, correct type). It MAY be empty
+  // when `media` is non-empty — that's the file-only completion path
+  // (server-side spawn_only tool whose result is purely artefactual).
+  // Codex round-4 P2 caught this: rejecting empty-content envelopes
+  // would silently drop file-only completions for upgraded clients,
+  // because the server suppresses the legacy `message/persisted`
+  // fallback once `event.spawn_complete.v1` is negotiated.
+  if (typeof p.content !== "string") return null;
 
   let media: string[] | undefined;
   if (Array.isArray(p.media)) {
@@ -405,6 +412,13 @@ function guardSpawnComplete(p: unknown): TurnSpawnCompleteEvent | null {
       (u): u is string => isString(u) && u.length > 0,
     );
     if (filtered.length > 0) media = filtered;
+  }
+  // Reject only when BOTH content and media are empty — truly nothing
+  // to render, which is a server bug (the original spec's "distinguish
+  // from spawn-ack" intent is now enforced by the `turn/spawn_complete`
+  // method name rather than by content non-emptiness).
+  if (p.content.length === 0 && (!media || media.length === 0)) {
+    return null;
   }
   return {
     session_id: p.session_id,

--- a/src/runtime/ui-protocol-event-router.test.ts
+++ b/src/runtime/ui-protocol-event-router.test.ts
@@ -366,6 +366,52 @@ describe("router event mapping", () => {
     expect(thread.responses).toHaveLength(0);
   });
 
+  it("turn/spawn_complete with unknown thread_id lands in the ACTIVE session, not a stale one (codex P2 fix)", () => {
+    // Reproduces codex's P2 finding: with a stale session bucket
+    // present in `sessionsByKey`, an envelope for an unknown thread_id
+    // could be hosted in the stale session by `pickHostSessionForOrphan`.
+    // The fix passes `cfg.sessionId` into `appendCompletionBubble` so
+    // the orphan creates inside the router's active session.
+    const STALE = "sess-stale-A";
+    const ACTIVE = "sess-active-B";
+    // Seed both sessions so `sessionsByKey` is non-empty for both.
+    ThreadStore.addUserMessage(STALE, {
+      text: "old",
+      clientMessageId: "cmid-stale",
+    });
+    ThreadStore.addUserMessage(ACTIVE, {
+      text: "new",
+      clientMessageId: "cmid-active",
+    });
+
+    const evt: TurnSpawnCompleteEvent = {
+      session_id: ACTIVE,
+      thread_id: "cmid-unknown-bg",
+      task_id: "task_orphan",
+      seq: 11,
+      message_id: "msg-orphan",
+      source: "background",
+      cursor: { stream: ACTIVE, seq: 11 },
+      persisted_at: "2026-05-04T00:00:00Z",
+      content: "Late background result.",
+    };
+    handleSpawnComplete({ sessionId: ACTIVE }, evt);
+
+    const activeThreads = ThreadStore.getThreads(ACTIVE);
+    const staleThreads = ThreadStore.getThreads(STALE);
+    expect(
+      activeThreads.find((t) => t.id === "cmid-unknown-bg"),
+    ).toBeDefined();
+    expect(
+      staleThreads.find((t) => t.id === "cmid-unknown-bg"),
+    ).toBeUndefined();
+
+    // Cleanup the extra session we created so the global afterEach
+    // reset still leaves a clean slate.
+    ThreadStore.clearSession(STALE);
+    ThreadStore.clearSession(ACTIVE);
+  });
+
   it("turn/spawn_complete is idempotent on replay (same seq => single row)", () => {
     const cmid = "cmid-spawn-replay";
     seedThread(cmid, "ask");

--- a/src/runtime/ui-protocol-event-router.test.ts
+++ b/src/runtime/ui-protocol-event-router.test.ts
@@ -19,6 +19,7 @@ import {
   handleApprovalRequested,
   handleMessageDelta,
   handleMessagePersisted,
+  handleSpawnComplete,
   handleTaskOutputDelta,
   handleTaskUpdated,
   handleTurnCompleted,
@@ -33,6 +34,7 @@ import type {
   TaskUpdatedEvent,
   TurnCompletedEvent,
   TurnErrorEvent,
+  TurnSpawnCompleteEvent,
   TurnStartedEvent,
   UiProtocolBridge,
 } from "./ui-protocol-bridge";
@@ -270,6 +272,172 @@ describe("router event mapping", () => {
     expect(thread.responses[0].status).toBe("error");
     expect(thread.responses[0].text).toBe("partial");
     expect(dispatched.some((e) => e.type === "crew:turn_error")).toBe(true);
+  });
+
+  // -------------------------------------------------------------------------
+  // M10 Phase 2: turn/spawn_complete envelope handler
+  // -------------------------------------------------------------------------
+
+  it("turn/spawn_complete appends a NEW assistant row (no merge)", () => {
+    const cmid = "cmid-spawn-1";
+    seedThread(cmid, "Run deep research");
+    // Simulate streamed ack text + finalize (the spawn-ack bubble lands
+    // first, then the late spawn_complete envelope arrives).
+    ThreadStore.appendAssistantToken(cmid, "Background work started.");
+    ThreadStore.finalizeAssistant(cmid, { committedSeq: 5 });
+
+    const evt: TurnSpawnCompleteEvent = {
+      session_id: SESSION,
+      turn_id: "turn-1",
+      thread_id: cmid,
+      task_id: "task_abc",
+      response_to_client_message_id: cmid,
+      seq: 12,
+      message_id: "msg-spawn-1",
+      source: "background",
+      cursor: { stream: SESSION, seq: 12 },
+      persisted_at: "2026-05-04T00:00:00Z",
+      content: "Research complete: 3 sources reviewed.",
+      media: ["research/_report.md"],
+    };
+    handleSpawnComplete({ sessionId: SESSION }, evt);
+
+    const [thread] = ThreadStore.getThreads(SESSION);
+    // EXACTLY two assistant rows under one user prompt: the original
+    // spawn-ack and the new completion envelope. NO merge.
+    expect(thread.responses).toHaveLength(2);
+    expect(thread.responses[0].text).toBe("Background work started.");
+    expect(thread.responses[1].text).toBe("Research complete: 3 sources reviewed.");
+    expect(thread.responses[1].files.map((f) => f.path)).toEqual([
+      "research/_report.md",
+    ]);
+    expect(thread.responses[1].historySeq).toBe(12);
+    expect(thread.responses[1].status).toBe("complete");
+    // Pending bubble stays untouched (no in-flight turn).
+    expect(thread.pendingAssistant).toBeNull();
+  });
+
+  it("turn/spawn_complete falls back to response_to_client_message_id when thread_id missing", () => {
+    const cmid = "cmid-spawn-fallback";
+    seedThread(cmid, "ask");
+    ThreadStore.finalizeAssistant(cmid);
+
+    const evt: TurnSpawnCompleteEvent = {
+      session_id: SESSION,
+      task_id: "task_xyz",
+      response_to_client_message_id: cmid,
+      seq: 9,
+      message_id: "msg-spawn-2",
+      source: "background",
+      cursor: { stream: SESSION, seq: 9 },
+      persisted_at: "2026-05-04T00:00:00Z",
+      content: "Done via fallback.",
+    };
+    handleSpawnComplete({ sessionId: SESSION }, evt);
+
+    const [thread] = ThreadStore.getThreads(SESSION);
+    // The completion row is present in the thread under the same user
+    // prompt — the fallback used `response_to_client_message_id` as the
+    // placement key when `thread_id` was absent.
+    expect(thread.responses.some((r) => r.text === "Done via fallback.")).toBe(
+      true,
+    );
+    expect(
+      thread.responses.find((r) => r.text === "Done via fallback.")?.historySeq,
+    ).toBe(9);
+  });
+
+  it("turn/spawn_complete with neither thread_id nor response_to_client_message_id is dropped", () => {
+    seedThread("cmid-spawn-orphan", "ask");
+    const evt: TurnSpawnCompleteEvent = {
+      session_id: SESSION,
+      task_id: "task_zzz",
+      seq: 1,
+      message_id: "msg-spawn-orphan",
+      source: "background",
+      cursor: { stream: SESSION, seq: 1 },
+      persisted_at: "2026-05-04T00:00:00Z",
+      content: "orphan",
+    };
+    handleSpawnComplete({ sessionId: SESSION }, evt);
+
+    const [thread] = ThreadStore.getThreads(SESSION);
+    // Original placeholder pendingAssistant only; no completion row added.
+    expect(thread.responses).toHaveLength(0);
+  });
+
+  it("turn/spawn_complete is idempotent on replay (same seq => single row)", () => {
+    const cmid = "cmid-spawn-replay";
+    seedThread(cmid, "ask");
+    ThreadStore.finalizeAssistant(cmid);
+
+    const evt: TurnSpawnCompleteEvent = {
+      session_id: SESSION,
+      thread_id: cmid,
+      task_id: "task_replay",
+      seq: 33,
+      message_id: "msg-spawn-replay",
+      source: "background",
+      cursor: { stream: SESSION, seq: 33 },
+      persisted_at: "2026-05-04T00:00:00Z",
+      content: "Once and only once.",
+    };
+    handleSpawnComplete({ sessionId: SESSION }, evt);
+    handleSpawnComplete({ sessionId: SESSION }, evt);
+
+    const [thread] = ThreadStore.getThreads(SESSION);
+    const completions = thread.responses.filter(
+      (r) => r.text === "Once and only once.",
+    );
+    expect(completions).toHaveLength(1);
+  });
+
+  // ---- M10 Phase 2 regression-pin: lock the architecture ------------------
+  //
+  // This test fixes the failure mode that motivated M10. The legacy splice
+  // path (`appendAssistantFile` media-only-merge predicate, deleted in
+  // Phase 5) treats an existing assistant bubble whose content contains a
+  // bare `[file: ...]` marker as a "media-only companion" and merges late
+  // file deliveries INTO it. With the new envelope path the same scenario
+  // MUST instead create a NEW row in the same thread. If a future refactor
+  // accidentally re-routes spawn_complete through the splice predicate,
+  // this test fails — the wave-6c-onward bug class would be back.
+  it("turn/spawn_complete creates a NEW row even when a finalized [file:] marker bubble exists", () => {
+    const cmid = "cmid-regression-pin";
+    seedThread(cmid, "ask");
+    // Stream a bare `[file: ...]` marker into the spawn-ack bubble — the
+    // exact shape the legacy `isMediaOnlyCompanion` predicate matches.
+    ThreadStore.appendAssistantToken(cmid, "[file: research/_report.md]");
+    ThreadStore.finalizeAssistant(cmid, { committedSeq: 4 });
+    const before = ThreadStore.getThreads(SESSION)[0];
+    const beforeRows = before.responses.length;
+    expect(beforeRows).toBe(1);
+
+    handleSpawnComplete(
+      { sessionId: SESSION },
+      {
+        session_id: SESSION,
+        thread_id: cmid,
+        task_id: "task_pin",
+        seq: 5,
+        message_id: "msg-pin",
+        source: "background",
+        cursor: { stream: SESSION, seq: 5 },
+        persisted_at: "2026-05-04T00:00:00Z",
+        content: "Real research result.",
+        media: ["research/_report.md"],
+      },
+    );
+
+    const [thread] = ThreadStore.getThreads(SESSION);
+    // CRITICAL: the new envelope creates a NEW row. NOT a merge into the
+    // existing `[file:]` bubble.
+    expect(thread.responses).toHaveLength(beforeRows + 1);
+    expect(thread.responses[0].text).toBe("[file: research/_report.md]");
+    expect(thread.responses[1].text).toBe("Real research result.");
+    expect(thread.responses[1].files.map((f) => f.path)).toEqual([
+      "research/_report.md",
+    ]);
   });
 
   it("approval/requested dispatches a CustomEvent with the typed payload", () => {
@@ -528,6 +696,7 @@ describe("router parity with SSE bridge", () => {
 class FakeBridge implements UiProtocolBridge {
   emitMessageDelta?: (e: MessageDeltaEvent) => void;
   emitMessagePersisted?: (e: MessagePersistedEvent) => void;
+  emitSpawnComplete?: (e: TurnSpawnCompleteEvent) => void;
   emitTaskUpdated?: (e: TaskUpdatedEvent) => void;
   emitTaskOutputDelta?: (e: TaskOutputDeltaEvent) => void;
   emitTurnLifecycle?: (
@@ -555,6 +724,12 @@ class FakeBridge implements UiProtocolBridge {
     this.emitMessagePersisted = h;
     return () => {
       this.emitMessagePersisted = undefined;
+    };
+  }
+  onSpawnComplete(h: (e: TurnSpawnCompleteEvent) => void) {
+    this.emitSpawnComplete = h;
+    return () => {
+      this.emitSpawnComplete = undefined;
     };
   }
   onTaskUpdated(h: (e: TaskUpdatedEvent) => void) {
@@ -598,6 +773,7 @@ describe("attachRouter", () => {
 
     expect(bridge.emitMessageDelta).toBeDefined();
     expect(bridge.emitMessagePersisted).toBeDefined();
+    expect(bridge.emitSpawnComplete).toBeDefined();
     expect(bridge.emitTaskUpdated).toBeDefined();
     expect(bridge.emitTaskOutputDelta).toBeDefined();
     expect(bridge.emitTurnLifecycle).toBeDefined();
@@ -606,6 +782,7 @@ describe("attachRouter", () => {
     att.detach();
     expect(bridge.emitMessageDelta).toBeUndefined();
     expect(bridge.emitMessagePersisted).toBeUndefined();
+    expect(bridge.emitSpawnComplete).toBeUndefined();
     expect(bridge.emitTaskUpdated).toBeUndefined();
     expect(bridge.emitTaskOutputDelta).toBeUndefined();
     expect(bridge.emitTurnLifecycle).toBeUndefined();

--- a/src/runtime/ui-protocol-event-router.ts
+++ b/src/runtime/ui-protocol-event-router.ts
@@ -30,6 +30,7 @@ import type {
   TaskUpdatedEvent,
   TurnCompletedEvent,
   TurnErrorEvent,
+  TurnSpawnCompleteEvent,
   TurnStartedEvent,
   UiProtocolBridge,
 } from "./ui-protocol-bridge";
@@ -206,6 +207,48 @@ function filenameFromPath(path: string): string {
   return idx === -1 ? path : path.slice(idx + 1);
 }
 
+/**
+ * M10 Phase 2: handle the `turn/spawn_complete` envelope.
+ *
+ * Each envelope is structurally complete and represents a NEW assistant
+ * bubble under the originating user prompt — no merging into an existing
+ * bubble, no reconstruction across events. This eliminates the splice-merge
+ * bug class (sticky-map drift, phantom-chunk drop) that the legacy
+ * `appendAssistantFile` / `appendPersistedMessage` paths suffer from.
+ *
+ * Placement strategy (per the migration plan): use `event.thread_id` as
+ * the placement key — server PR #680 made `thread_id` the
+ * server-authoritative identifier on persisted rows, so the SPA reducer
+ * binds the new bubble against it directly. We deliberately do NOT key
+ * off `response_to_client_message_id`: Phase 1 server emits a
+ * thread-id-flavoured value there until Phase 4 plumbing introduces a
+ * typed `originating_client_message_id`. Reading it as advisory only
+ * matches the server's documented Phase 1 contract.
+ *
+ * Legacy fallback: if `thread_id` is missing (older callers, or paths
+ * that don't propagate origination), use `response_to_client_message_id`
+ * as a best-effort placement key. If neither is present, the envelope
+ * cannot be attributed and is dropped — better than orphaning the bubble
+ * under an arbitrary thread.
+ */
+export function handleSpawnComplete(
+  _cfg: RouterConfig,
+  event: TurnSpawnCompleteEvent,
+): void {
+  const placementKey =
+    event.thread_id ?? event.response_to_client_message_id;
+  if (!placementKey) return;
+
+  ThreadStore.appendCompletionBubble(placementKey, {
+    text: event.content,
+    media: event.media ?? [],
+    spawnComplete: true,
+    sourceClientMessageId: event.response_to_client_message_id,
+    historySeq: event.seq,
+    messageId: event.message_id,
+  });
+}
+
 export function handleTaskUpdated(
   cfg: RouterConfig,
   event: TaskUpdatedEvent,
@@ -371,6 +414,9 @@ export function attachRouter(
   const offMessagePersisted = bridge.onMessagePersisted((e) =>
     handleMessagePersisted(cfg, e),
   );
+  const offSpawnComplete = bridge.onSpawnComplete((e) =>
+    handleSpawnComplete(cfg, e),
+  );
   const offTaskUpdated = bridge.onTaskUpdated((e) => handleTaskUpdated(cfg, e));
   const offTaskOutputDelta = bridge.onTaskOutputDelta((e) =>
     handleTaskOutputDelta(cfg, e),
@@ -401,6 +447,7 @@ export function attachRouter(
       detached = true;
       offMessageDelta();
       offMessagePersisted();
+      offSpawnComplete();
       offTaskUpdated();
       offTaskOutputDelta();
       offTurnLifecycle();

--- a/src/runtime/ui-protocol-event-router.ts
+++ b/src/runtime/ui-protocol-event-router.ts
@@ -232,7 +232,7 @@ function filenameFromPath(path: string): string {
  * under an arbitrary thread.
  */
 export function handleSpawnComplete(
-  _cfg: RouterConfig,
+  cfg: RouterConfig,
   event: TurnSpawnCompleteEvent,
 ): void {
   const placementKey =
@@ -246,6 +246,11 @@ export function handleSpawnComplete(
     sourceClientMessageId: event.response_to_client_message_id,
     historySeq: event.seq,
     messageId: event.message_id,
+    // Pass the router's active scope so unknown-thread orphan
+    // completions land in THIS session's bucket rather than an
+    // arbitrary stale one (codex P2 fix).
+    sessionId: cfg.sessionId,
+    topic: cfg.topic,
   });
 }
 

--- a/src/runtime/ui-protocol-event-router.ts
+++ b/src/runtime/ui-protocol-event-router.ts
@@ -246,6 +246,9 @@ export function handleSpawnComplete(
     sourceClientMessageId: event.response_to_client_message_id,
     historySeq: event.seq,
     messageId: event.message_id,
+    // Server-side commit time. Without this, the row's display timestamp
+    // is client receipt time and shifts on reconnect (codex round-4 P3).
+    persistedAt: event.persisted_at,
     // Pass the router's active scope so unknown-thread orphan
     // completions land in THIS session's bucket rather than an
     // arbitrary stale one (codex P2 fix).

--- a/src/runtime/ui-protocol-runtime.test.ts
+++ b/src/runtime/ui-protocol-runtime.test.ts
@@ -75,6 +75,7 @@ function makeDeferredBridge(): DeferredBridge {
     })),
     onMessageDelta: vi.fn(() => () => {}),
     onMessagePersisted: vi.fn(() => () => {}),
+    onSpawnComplete: vi.fn(() => () => {}),
     onTaskUpdated: vi.fn(() => () => {}),
     onTaskOutputDelta: vi.fn(() => () => {}),
     onTurnLifecycle: vi.fn(() => () => {}),

--- a/src/runtime/ui-protocol-types.ts
+++ b/src/runtime/ui-protocol-types.ts
@@ -127,6 +127,74 @@ export interface MessagePersistedEvent {
   media?: string[];
 }
 
+/**
+ * `turn/spawn_complete` notification per M10 Phase 1 (server PR #772).
+ *
+ * Emitted by the server when a `spawn_only` background tool finishes. Each
+ * envelope is structurally complete on arrival — the client renders it as a
+ * NEW assistant bubble under the originating user prompt rather than
+ * splice-merging late content into an existing bubble (the bug class M10
+ * eliminates: sticky-map drift, phantom-chunk drop, etc.).
+ *
+ * Capability gated: server only emits when the client has negotiated
+ * `event.spawn_complete.v1` at session/open. Older clients without the
+ * capability continue to receive the legacy `message/persisted` row for
+ * backward compatibility.
+ *
+ * Wire shape mirrors `MessagePersistedEvent` with two distinguishing
+ * additions:
+ *   - `task_id` is REQUIRED (every spawn_complete has an originating
+ *     `spawn_only` task; a row without one is a server bug).
+ *   - `content` is REQUIRED (carries the full assistant text inline so the
+ *     client renders the new bubble atomically without a follow-up fetch).
+ *     This is what distinguishes the envelope from a spawn-ack persisted
+ *     row, whose content is a short ack message.
+ *
+ * Note on `response_to_client_message_id`: Phase 1 server populates this
+ * from the same identifier that `message/persisted.thread_id` carries on
+ * the same persisted row. Phase 4 will introduce a typed
+ * `originating_client_message_id` to remove the semantic ambiguity. Until
+ * then, the SPA reducer keys placement off `thread_id` (server-carried
+ * since PR #680) and treats `response_to_client_message_id` as advisory.
+ */
+export interface TurnSpawnCompleteEvent {
+  session_id: string;
+  /** Optional per server-side schema; `None` from `run_standalone_turn`
+   *  until Phase 4 plumbing surfaces a real turn id. */
+  turn_id?: string;
+  /** Optional per server-side schema; absent on legacy callers. */
+  thread_id?: string;
+  /** Always populated. Identifies the originating `spawn_only` task —
+   *  used by Phase 4's `read_task_output` flow. */
+  task_id: string;
+  /** Optional in Phase 1 (server emits a thread-id-flavoured value); used
+   *  as advisory placement only. Phase 4 will populate this with the real
+   *  user-prompt cmid. */
+  response_to_client_message_id?: string;
+  /** Per-session committed-row index (matches `MessagePersistedEvent.seq`
+   *  for the same row). Strictly monotonic. */
+  seq: number;
+  /** Server-assigned message id reused from the persisted row (since
+   *  Phase 1 codex round 3 fix). Stable across replays. */
+  message_id: string;
+  /** Source of the completion. Always `"background"` today; reserved as
+   *  string so future variants (`"recovery_background"`, etc.) extend the
+   *  vocabulary without a wire-breaking change. */
+  source: string;
+  /** Durable cursor pointing at this commit in the UI ledger. */
+  cursor: UiCursor;
+  /** RFC 3339 wall-clock time the row was committed. */
+  persisted_at: string;
+  /** REQUIRED. Full assistant text for the completion bubble. Distinct
+   *  from `MessagePersistedEvent` (where `content` lives only in the
+   *  session ledger), this event carries the text inline. */
+  content: string;
+  /** File attachments persisted with this completion (e.g.
+   *  `_report.md`, `output.mp3`, `.pptx`). Same convention as
+   *  `MessagePersistedEvent.media`. */
+  media?: string[];
+}
+
 export interface TaskUpdatedEvent {
   session_id: string;
   turn_id: string;

--- a/src/store/thread-store.test.ts
+++ b/src/store/thread-store.test.ts
@@ -1425,6 +1425,45 @@ describe("thread-store", () => {
     expect(thread.responses[0].historySeq).toBe(14);
   });
 
+  it("appendCompletionBubble_upgrades_media_bearing_persisted_placeholder", () => {
+    // Codex round-3 P2: `message/persisted` for a spawn row CAN carry
+    // media (P1.3 server PR #767). When that row arrives first, the
+    // placeholder has empty text but non-empty files. The spawn envelope
+    // must still upgrade the row (filling text + merging media) rather
+    // than treating it as a duplicate, otherwise the user sees a
+    // file-only bubble with no body text.
+    makeUser("ask", "cmid-c-merge");
+    ThreadStore.appendPersistedMessage(SESSION, undefined, {
+      seq: 21,
+      role: "assistant",
+      content: "",
+      thread_id: "cmid-c-merge",
+      response_to_client_message_id: "cmid-c-merge",
+      timestamp: "2026-04-30T00:00:00Z",
+      media: ["bg/early.md"],
+    });
+    let [thread] = ThreadStore.getThreads(SESSION);
+    expect(thread.responses[0].text).toBe("");
+    expect(thread.responses[0].files.map((f) => f.path)).toEqual([
+      "bg/early.md",
+    ]);
+
+    ThreadStore.appendCompletionBubble("cmid-c-merge", {
+      text: "Real result body.",
+      media: ["bg/early.md", "bg/late.md"],
+      spawnComplete: true,
+      historySeq: 21,
+    });
+    [thread] = ThreadStore.getThreads(SESSION);
+    expect(thread.responses).toHaveLength(1);
+    expect(thread.responses[0].text).toBe("Real result body.");
+    // Files unioned by path — early.md is not duplicated.
+    expect(thread.responses[0].files.map((f) => f.path)).toEqual([
+      "bg/early.md",
+      "bg/late.md",
+    ]);
+  });
+
   it("appendCompletionBubble_does_not_upgrade_already_full_row_on_replay", () => {
     // Defensive symmetry to the upgrade-in-place case: when the existing
     // row at the matching seq already has full content (true replay

--- a/src/store/thread-store.test.ts
+++ b/src/store/thread-store.test.ts
@@ -1390,6 +1390,67 @@ describe("thread-store", () => {
     expect(orphan?.responses[0].text).toBe("Late envelope.");
   });
 
+  it("appendCompletionBubble_upgrades_empty_persisted_row_with_matching_seq", () => {
+    // Codex P2 rollout-edge case: if `message/persisted` for a spawn row
+    // arrives before `turn/spawn_complete` (server suppression slip,
+    // replay ordering), `appendPersistedMessage` lands an empty-content
+    // placeholder under the same `historySeq`. The spawn envelope MUST
+    // upgrade the existing row in place rather than be skipped as a
+    // duplicate, otherwise the user sees a blank bubble.
+    makeUser("ask", "cmid-c-upgrade");
+    ThreadStore.appendPersistedMessage(SESSION, undefined, {
+      seq: 14,
+      role: "assistant",
+      content: "", // metadata-only persisted row
+      thread_id: "cmid-c-upgrade",
+      response_to_client_message_id: "cmid-c-upgrade",
+      timestamp: "2026-04-30T00:00:00Z",
+      media: [],
+    });
+    let [thread] = ThreadStore.getThreads(SESSION);
+    expect(thread.responses).toHaveLength(1);
+    expect(thread.responses[0].text).toBe("");
+
+    ThreadStore.appendCompletionBubble("cmid-c-upgrade", {
+      text: "Real spawn result.",
+      media: ["bg/out.md"],
+      spawnComplete: true,
+      historySeq: 14,
+      messageId: "msg-upgrade",
+    });
+    [thread] = ThreadStore.getThreads(SESSION);
+    expect(thread.responses).toHaveLength(1);
+    expect(thread.responses[0].text).toBe("Real spawn result.");
+    expect(thread.responses[0].files.map((f) => f.path)).toEqual(["bg/out.md"]);
+    expect(thread.responses[0].historySeq).toBe(14);
+  });
+
+  it("appendCompletionBubble_does_not_upgrade_already_full_row_on_replay", () => {
+    // Defensive symmetry to the upgrade-in-place case: when the existing
+    // row at the matching seq already has full content (true replay
+    // scenario), the second call must be a no-op. Otherwise a reconnect
+    // could overwrite a finalized row with stale data from the wire.
+    makeUser("ask", "cmid-c-replay");
+    ThreadStore.appendCompletionBubble("cmid-c-replay", {
+      text: "First.",
+      media: ["a.md"],
+      spawnComplete: true,
+      historySeq: 7,
+      messageId: "m1",
+    });
+    ThreadStore.appendCompletionBubble("cmid-c-replay", {
+      text: "Different (stale).",
+      media: ["a.md"],
+      spawnComplete: true,
+      historySeq: 7,
+      messageId: "m1",
+    });
+    const [thread] = ThreadStore.getThreads(SESSION);
+    const matches = thread.responses.filter((r) => r.historySeq === 7);
+    expect(matches).toHaveLength(1);
+    expect(matches[0].text).toBe("First.");
+  });
+
   it("appendCompletionBubble_returns_false_when_no_session_exists", () => {
     // No makeUser — no host session has been created yet, so
     // ensureOrphanThread has nowhere to host the row.

--- a/src/store/thread-store.test.ts
+++ b/src/store/thread-store.test.ts
@@ -1298,4 +1298,106 @@ describe("thread-store", () => {
     expect(threads[0].responses).toHaveLength(1);
     expect(threads[0].responses[0].text).toBe("Orphan late answer.");
   });
+
+  // -------------------------------------------------------------------------
+  // M10 Phase 2: appendCompletionBubble
+  // -------------------------------------------------------------------------
+
+  it("appendCompletionBubble_adds_new_row_without_merging_into_pending", () => {
+    makeUser("ask", "cmid-c1");
+    // pendingAssistant is open (placeholder created by addUserMessage).
+    const before = ThreadStore.getThreads(SESSION)[0];
+    expect(before.pendingAssistant).not.toBeNull();
+    const pendingId = before.pendingAssistant!.id;
+
+    ThreadStore.appendCompletionBubble("cmid-c1", {
+      text: "Background result body.",
+      media: ["research/out.md"],
+      spawnComplete: true,
+      historySeq: 7,
+      messageId: "msg-bg-1",
+    });
+
+    const after = ThreadStore.getThreads(SESSION)[0];
+    // The pending assistant MUST stay untouched (it belongs to a
+    // different turn — possibly still in flight).
+    expect(after.pendingAssistant).not.toBeNull();
+    expect(after.pendingAssistant!.id).toBe(pendingId);
+    expect(after.pendingAssistant!.text).toBe("");
+
+    expect(after.responses).toHaveLength(1);
+    expect(after.responses[0].text).toBe("Background result body.");
+    expect(after.responses[0].files.map((f) => f.path)).toEqual([
+      "research/out.md",
+    ]);
+    expect(after.responses[0].historySeq).toBe(7);
+    expect(after.responses[0].status).toBe("complete");
+    expect(after.responses[0].id).toBe("msg-bg-1");
+  });
+
+  it("appendCompletionBubble_does_not_merge_into_existing_finalized_assistant", () => {
+    makeUser("ask", "cmid-c2");
+    ThreadStore.appendAssistantToken("cmid-c2", "Spawn-ack text.");
+    ThreadStore.finalizeAssistant("cmid-c2", { committedSeq: 3 });
+
+    ThreadStore.appendCompletionBubble("cmid-c2", {
+      text: "Late result.",
+      media: ["a.mp3"],
+      spawnComplete: true,
+      historySeq: 4,
+    });
+
+    const [thread] = ThreadStore.getThreads(SESSION);
+    expect(thread.responses).toHaveLength(2);
+    expect(thread.responses[0].text).toBe("Spawn-ack text.");
+    expect(thread.responses[0].files).toHaveLength(0); // not merged
+    expect(thread.responses[1].text).toBe("Late result.");
+    expect(thread.responses[1].files.map((f) => f.path)).toEqual(["a.mp3"]);
+  });
+
+  it("appendCompletionBubble_is_idempotent_on_replay_by_history_seq", () => {
+    makeUser("ask", "cmid-c3");
+    ThreadStore.finalizeAssistant("cmid-c3");
+
+    const opts = {
+      text: "X",
+      media: [],
+      spawnComplete: true as const,
+      historySeq: 99,
+      messageId: "msg-idem",
+    };
+    ThreadStore.appendCompletionBubble("cmid-c3", opts);
+    ThreadStore.appendCompletionBubble("cmid-c3", opts);
+
+    const [thread] = ThreadStore.getThreads(SESSION);
+    const matches = thread.responses.filter((r) => r.text === "X");
+    expect(matches).toHaveLength(1);
+  });
+
+  it("appendCompletionBubble_creates_orphan_thread_when_thread_unknown", () => {
+    makeUser("seed", "cmid-seed"); // ensures a host session exists
+    const ok = ThreadStore.appendCompletionBubble("cmid-late", {
+      text: "Late envelope.",
+      media: [],
+      spawnComplete: true,
+      historySeq: 5,
+    });
+    expect(ok).toBe(true);
+    const orphan = ThreadStore.getThreads(SESSION).find(
+      (t) => t.id === "cmid-late",
+    );
+    expect(orphan).toBeDefined();
+    expect(orphan?.responses[0].text).toBe("Late envelope.");
+  });
+
+  it("appendCompletionBubble_returns_false_when_no_session_exists", () => {
+    // No makeUser — no host session has been created yet, so
+    // ensureOrphanThread has nowhere to host the row.
+    const ok = ThreadStore.appendCompletionBubble("cmid-nowhere", {
+      text: "Nowhere.",
+      media: [],
+      spawnComplete: true,
+    });
+    expect(ok).toBe(false);
+  });
 });

--- a/src/store/thread-store.test.ts
+++ b/src/store/thread-store.test.ts
@@ -1490,6 +1490,97 @@ describe("thread-store", () => {
     expect(matches[0].text).toBe("First.");
   });
 
+  it("appendCompletionBubble_appends_when_seq_was_donated_by_replayHistory_companion_merge", () => {
+    // Codex round-5 P2: legacy `replayHistory` (via
+    // `mergeMediaCompanionInto`) MOVES a media-only companion's
+    // `historySeq` onto the preceding non-empty ack bubble. After that,
+    // the spawn-complete envelope replaying with the same seq must NOT
+    // be silently dropped — the row at that seq is now the ack bubble,
+    // not the completion. Append a fresh row instead.
+    makeUser("ask", "cmid-c-merged-seq");
+    // Simulate `replayHistory`'s post-merge state: a non-empty ack
+    // bubble that has been donated the spawn-complete's seq.
+    ThreadStore.replayHistory(SESSION, [
+      {
+        role: "user",
+        content: "ask",
+        thread_id: "cmid-c-merged-seq",
+        client_message_id: "cmid-c-merged-seq",
+        seq: 0,
+        timestamp: "2026-04-30T00:00:00Z",
+      },
+      {
+        role: "assistant",
+        content: "Background work started.",
+        thread_id: "cmid-c-merged-seq",
+        response_to_client_message_id: "cmid-c-merged-seq",
+        seq: 1,
+        timestamp: "2026-04-30T00:00:01Z",
+      },
+      {
+        // Media-only companion — replayHistory will fold this into the
+        // ack bubble and donate seq=2 to it.
+        role: "assistant",
+        content: "",
+        thread_id: "cmid-c-merged-seq",
+        response_to_client_message_id: "cmid-c-merged-seq",
+        seq: 2,
+        timestamp: "2026-04-30T00:00:02Z",
+        media: ["bg/_report.md"],
+      },
+    ]);
+    let [thread] = ThreadStore.getThreads(SESSION);
+    expect(thread.responses).toHaveLength(1);
+    expect(thread.responses[0].text).toBe("Background work started.");
+    // The merge donated seq=2 onto the ack bubble.
+    expect(thread.responses[0].historySeq).toBe(2);
+
+    // Now the live spawn-complete envelope replays with seq=2.
+    ThreadStore.appendCompletionBubble("cmid-c-merged-seq", {
+      text: "Real research result.",
+      media: ["bg/_report.md"],
+      spawnComplete: true,
+      historySeq: 2,
+      messageId: "msg-spawn-replay",
+    });
+
+    [thread] = ThreadStore.getThreads(SESSION);
+    // CRITICAL: a NEW row appears for the spawn completion. The ack
+    // bubble's text is preserved.
+    expect(thread.responses).toHaveLength(2);
+    expect(thread.responses[0].text).toBe("Background work started.");
+    expect(
+      thread.responses.some((r) => r.text === "Real research result."),
+    ).toBe(true);
+  });
+
+  it("appendCompletionBubble_dedupes_by_messageId_when_present", () => {
+    // Codex round-5: the strongest dedupe identity is the server-side
+    // `message_id` (Phase 1 P2-B fix reuses the persisted row's id on
+    // the spawn envelope). Two calls with the same messageId must
+    // collapse to a single row even if seq differs (e.g. cursor-vs-row
+    // seq confusion).
+    makeUser("ask", "cmid-c-msgid");
+    ThreadStore.appendCompletionBubble("cmid-c-msgid", {
+      text: "Result.",
+      media: [],
+      spawnComplete: true,
+      messageId: "msg-stable",
+      historySeq: 5,
+    });
+    ThreadStore.appendCompletionBubble("cmid-c-msgid", {
+      text: "Result.",
+      media: [],
+      spawnComplete: true,
+      messageId: "msg-stable",
+      historySeq: 5,
+    });
+    const [thread] = ThreadStore.getThreads(SESSION);
+    expect(
+      thread.responses.filter((r) => r.id === "msg-stable"),
+    ).toHaveLength(1);
+  });
+
   it("appendCompletionBubble_uses_server_persistedAt_for_display_timestamp", () => {
     // Codex round-4 P3: row timestamp must be the server's
     // `persisted_at`, not client receipt time, so reconnect/replay

--- a/src/store/thread-store.test.ts
+++ b/src/store/thread-store.test.ts
@@ -1490,6 +1490,25 @@ describe("thread-store", () => {
     expect(matches[0].text).toBe("First.");
   });
 
+  it("appendCompletionBubble_uses_server_persistedAt_for_display_timestamp", () => {
+    // Codex round-4 P3: row timestamp must be the server's
+    // `persisted_at`, not client receipt time, so reconnect/replay
+    // produces a stable display order matching hydrated history.
+    makeUser("ask", "cmid-c-ts");
+    ThreadStore.appendCompletionBubble("cmid-c-ts", {
+      text: "Body.",
+      media: [],
+      spawnComplete: true,
+      historySeq: 50,
+      persistedAt: "2026-04-30T10:11:12.000Z",
+    });
+    const [thread] = ThreadStore.getThreads(SESSION);
+    const completion = thread.responses.find((r) => r.text === "Body.");
+    expect(completion?.timestamp).toBe(
+      new Date("2026-04-30T10:11:12.000Z").getTime(),
+    );
+  });
+
   it("appendCompletionBubble_returns_false_when_no_session_exists", () => {
     // No makeUser — no host session has been created yet, so
     // ensureOrphanThread has nowhere to host the row.

--- a/src/store/thread-store.ts
+++ b/src/store/thread-store.ts
@@ -642,6 +642,13 @@ export interface AppendCompletionBubbleOptions {
   historySeq?: number;
   /** Server-assigned message id for stable identity across replays. */
   messageId?: string;
+  /** Server-side `persisted_at` (RFC 3339). When supplied, the row's
+   *  display timestamp uses this server-authoritative value rather than
+   *  client receipt time, so reconnect/replay produces a stable order
+   *  matching the hydrated history. Codex round-4 P3 (delivered envelopes
+   *  whose `persisted_at` differed from receipt time would render with
+   *  a moving timestamp). */
+  persistedAt?: string;
   /** Active router scope. When the envelope's `thread_id` does not
    *  already exist in any session, the orphan-bucket helper creates it
    *  HERE rather than picking an arbitrary host session — without this,
@@ -758,7 +765,11 @@ export function appendCompletionBubble(
     files: opts.media.map(fileFromMediaPath),
     toolCalls: [],
     status: "complete",
-    timestamp: Date.now(),
+    // Prefer the server-side commit time. Falling back to client
+    // receipt time for callers that don't supply it (test paths) is
+    // safe; production callers always set `persistedAt` from the
+    // envelope's `persisted_at` field.
+    timestamp: parsePersistedAt(opts.persistedAt),
     historySeq: opts.historySeq,
     intra_thread_seq: opts.historySeq,
     responseToClientMessageId: opts.sourceClientMessageId ?? threadId,
@@ -767,6 +778,12 @@ export function appendCompletionBubble(
   sortResponsesInThread(thread);
   notify();
   return true;
+}
+
+function parsePersistedAt(persistedAt: string | undefined): number {
+  if (!persistedAt) return Date.now();
+  const t = new Date(persistedAt).getTime();
+  return Number.isFinite(t) ? t : Date.now();
 }
 
 /** Append a delivered file to the assistant slot in the thread (pending

--- a/src/store/thread-store.ts
+++ b/src/store/thread-store.ts
@@ -696,14 +696,45 @@ export function appendCompletionBubble(
   if (!host) return false;
   const { thread } = host;
 
-  // Idempotency: a replayed envelope on reconnect MUST NOT produce a
-  // duplicate row. The producer-side `seq` (Phase 1 P2-A fix) is the
-  // session-committed-row index, so it is a stable identity for this
-  // completion across restarts. Skip the append if a response with the
-  // same seq is already present in this thread.
+  // Idempotency / upgrade-in-place: a replayed envelope on reconnect
+  // MUST NOT produce a duplicate row. The producer-side `seq`
+  // (Phase 1 P2-A fix) is the session-committed-row index, so it is
+  // a stable identity for this completion across restarts.
+  //
+  // Codex P2 (rollout edge case): when both
+  // `event.message_persisted.v1` AND `event.spawn_complete.v1` are
+  // negotiated, the server's per-connection suppression should send
+  // only `turn/spawn_complete`. But if the legacy `message/persisted`
+  // row arrived first via `appendPersistedMessage` (defensive: server
+  // suppression slip, mid-flight rollout, replay ordering), it lands
+  // an empty-content row with the matching seq. Don't drop the spawn
+  // envelope's authoritative content — UPGRADE the existing row in
+  // place so the completion text renders, not a blank bubble.
   if (typeof opts.historySeq === "number") {
-    for (const r of thread.responses) {
-      if (r.historySeq === opts.historySeq) return true;
+    for (let i = 0; i < thread.responses.length; i += 1) {
+      const r = thread.responses[i];
+      if (r.historySeq !== opts.historySeq) continue;
+      // Treat the existing row as a placeholder ONLY when it has
+      // neither text nor files — that's the exact shape
+      // `appendPersistedMessage` produces from a metadata-only
+      // `message/persisted` (where `content` is `""` and `media` is
+      // empty). Any non-empty row at the matching seq is the
+      // legitimate completion (or a finalized assistant) and must
+      // not be overwritten.
+      const isPlaceholder = r.text.length === 0 && r.files.length === 0;
+      if (!isPlaceholder) return true;
+
+      thread.responses[i] = {
+        ...r,
+        text: opts.text,
+        files: opts.media.map(fileFromMediaPath),
+        intra_thread_seq: opts.historySeq,
+        responseToClientMessageId:
+          opts.sourceClientMessageId ?? r.responseToClientMessageId ?? threadId,
+      };
+      sortResponsesInThread(thread);
+      notify();
+      return true;
     }
     if (thread.pendingAssistant?.historySeq === opts.historySeq) return true;
   }

--- a/src/store/thread-store.ts
+++ b/src/store/thread-store.ts
@@ -614,6 +614,74 @@ export function setToolCallStatus(
   notify();
 }
 
+/**
+ * M10 Phase 2 (server PR #772): append a NEW assistant row to the thread
+ * for a `turn/spawn_complete` envelope. Distinct from `appendAssistantFile`
+ * + `appendPersistedMessage`, which both splice late media into the
+ * existing assistant bubble — that splice-merge predicate is the bug
+ * surface M10 deletes (Phase 5). This function ALWAYS adds a fresh
+ * `ThreadMessage` to `thread.responses` so multiple assistant bubbles
+ * render under the originating user prompt (the renderer's
+ * `responses.map` already supports N-bubbles per user message).
+ *
+ * Returns `true` when a row was appended, `false` when the thread could
+ * not be located and could not be created (no live sessions). Idempotent
+ * by `(threadId, historySeq)` when `historySeq` is provided — a replayed
+ * envelope on reconnect does not produce a duplicate row.
+ */
+export interface AppendCompletionBubbleOptions {
+  text: string;
+  media: string[];
+  /** Marker so the renderer can style spawn-completion bubbles distinctly
+   *  (Phase 3, optional). */
+  spawnComplete: true;
+  /** Originating user prompt cmid, when available (Phase 4 will populate
+   *  it server-side). Captured for future audit / hover tooltips. */
+  sourceClientMessageId?: string;
+  /** Server-assigned per-session seq for dedupe on reconnect replay. */
+  historySeq?: number;
+  /** Server-assigned message id for stable identity across replays. */
+  messageId?: string;
+}
+
+export function appendCompletionBubble(
+  threadId: string,
+  opts: AppendCompletionBubbleOptions,
+): boolean {
+  const found = ensureOrphanThread(threadId);
+  if (!found) return false;
+  const { thread } = found;
+
+  // Idempotency: a replayed envelope on reconnect MUST NOT produce a
+  // duplicate row. The producer-side `seq` (Phase 1 P2-A fix) is the
+  // session-committed-row index, so it is a stable identity for this
+  // completion across restarts. Skip the append if a response with the
+  // same seq is already present in this thread.
+  if (typeof opts.historySeq === "number") {
+    for (const r of thread.responses) {
+      if (r.historySeq === opts.historySeq) return true;
+    }
+    if (thread.pendingAssistant?.historySeq === opts.historySeq) return true;
+  }
+
+  const completion: ThreadMessage = {
+    id: opts.messageId ?? nextId(),
+    role: "assistant",
+    text: opts.text,
+    files: opts.media.map(fileFromMediaPath),
+    toolCalls: [],
+    status: "complete",
+    timestamp: Date.now(),
+    historySeq: opts.historySeq,
+    intra_thread_seq: opts.historySeq,
+    responseToClientMessageId: opts.sourceClientMessageId ?? threadId,
+  };
+  thread.responses.push(completion);
+  sortResponsesInThread(thread);
+  notify();
+  return true;
+}
+
 /** Append a delivered file to the assistant slot in the thread (pending
  *  in-flight, or the most recent finalized response if the turn has
  *  already ended — the late-arrival case for spawn_only background

--- a/src/store/thread-store.ts
+++ b/src/store/thread-store.ts
@@ -642,15 +642,59 @@ export interface AppendCompletionBubbleOptions {
   historySeq?: number;
   /** Server-assigned message id for stable identity across replays. */
   messageId?: string;
+  /** Active router scope. When the envelope's `thread_id` does not
+   *  already exist in any session, the orphan-bucket helper creates it
+   *  HERE rather than picking an arbitrary host session — without this,
+   *  a stale previously-loaded session in `sessionsByKey` could swallow
+   *  the bubble (codex P2: orphan completions misplaced after
+   *  reload/session-switch). */
+  sessionId?: string;
+  topic?: string;
 }
 
 export function appendCompletionBubble(
   threadId: string,
   opts: AppendCompletionBubbleOptions,
 ): boolean {
-  const found = ensureOrphanThread(threadId);
-  if (!found) return false;
-  const { thread } = found;
+  // Resolve the host thread. Prefer an exact match anywhere in the
+  // store (M8.10 cross-session cmid semantics). When no match exists,
+  // create the orphan inside the router's active session so
+  // session-switch / reload scenarios don't silently route the bubble
+  // into a stale session bucket.
+  let host = findThreadById(threadId);
+  if (!host) {
+    if (opts.sessionId) {
+      const state = ensureSession(storeKey(opts.sessionId, opts.topic));
+      const placeholderUser: ThreadMessage = {
+        id: nextId(),
+        role: "user",
+        text: "",
+        files: [],
+        toolCalls: [],
+        status: "complete",
+        timestamp: Date.now(),
+        clientMessageId: threadId,
+      };
+      const orphan: Thread = {
+        id: threadId,
+        userMsg: placeholderUser,
+        responses: [],
+        pendingAssistant: null,
+      };
+      insertThreadInTimestampOrder(state, orphan);
+      recordRuntimeCounter("octos_thread_orphan_created_total", {
+        surface: "thread_store_completion",
+      });
+      host = { state, thread: orphan };
+    } else {
+      // No router scope provided — fall back to legacy orphan placement
+      // (covers test paths that don't supply sessionId; production
+      // callers should always pass it).
+      host = ensureOrphanThread(threadId);
+    }
+  }
+  if (!host) return false;
+  const { thread } = host;
 
   // Idempotency: a replayed envelope on reconnect MUST NOT produce a
   // duplicate row. The producer-side `seq` (Phase 1 P2-A fix) is the

--- a/src/store/thread-store.ts
+++ b/src/store/thread-store.ts
@@ -703,54 +703,68 @@ export function appendCompletionBubble(
   if (!host) return false;
   const { thread } = host;
 
-  // Idempotency / upgrade-in-place: a replayed envelope on reconnect
-  // MUST NOT produce a duplicate row. The producer-side `seq`
-  // (Phase 1 P2-A fix) is the session-committed-row index, so it is
-  // a stable identity for this completion across restarts.
+  // Identity / upgrade-in-place. A replayed envelope on reconnect
+  // MUST NOT produce a duplicate row. Two stable identities exist:
   //
-  // Codex P2 (rollout edge case): when both
-  // `event.message_persisted.v1` AND `event.spawn_complete.v1` are
-  // negotiated, the server's per-connection suppression should send
-  // only `turn/spawn_complete`. But if the legacy `message/persisted`
-  // row arrived first via `appendPersistedMessage` (defensive: server
-  // suppression slip, mid-flight rollout, replay ordering), it lands
-  // an empty-content row with the matching seq. Don't drop the spawn
-  // envelope's authoritative content — UPGRADE the existing row in
-  // place so the completion text renders, not a blank bubble.
+  //   • messageId  — Phase 1 P2-B fix reuses the persisted row's
+  //                  `message_id` on the envelope, so the spawn-complete
+  //                  envelope's id MATCHES its companion `message/persisted`
+  //                  but is DISTINCT from the spawn-ack's id. This is
+  //                  the strongest dedupe key.
+  //   • historySeq — `seq` is a per-session committed-row index. Robust
+  //                  for clean cases; but see the codex round-5 edge:
+  //                  legacy `replayHistory` (via `mergeMediaCompanionInto`)
+  //                  can MOVE a media-only companion's `historySeq` onto
+  //                  the preceding ack bubble, so finding `historySeq=N`
+  //                  on a non-empty row does NOT prove that row IS the
+  //                  spawn-complete row.
+  //
+  // Strategy: prefer `messageId` for the identity check. Fall back to
+  // `historySeq` only as a placeholder-upgrade hint — when we find a
+  // row with the same seq AND it has empty text (the persisted-only
+  // placeholder shape), upgrade in place. Non-empty-text rows at the
+  // matching seq are NOT considered duplicates: they may be merged ack
+  // rows whose seq was donated by a media-only companion. In that case
+  // we proceed to append a fresh row, which is the correct M10
+  // separate-bubble semantic.
+
+  if (opts.messageId) {
+    for (let i = 0; i < thread.responses.length; i += 1) {
+      const r = thread.responses[i];
+      if (r.id !== opts.messageId) continue;
+      // True identity match — this row IS the spawn-complete row.
+      // Upgrade-in-place if it's a placeholder (the persisted-only
+      // shape), no-op if it's already the full completion.
+      if (r.text.length > 0) return true;
+      thread.responses[i] = upgradePlaceholderRow(r, opts, threadId);
+      sortResponsesInThread(thread);
+      notify();
+      return true;
+    }
+    if (thread.pendingAssistant?.id === opts.messageId) return true;
+  }
+
   if (typeof opts.historySeq === "number") {
     for (let i = 0; i < thread.responses.length; i += 1) {
       const r = thread.responses[i];
       if (r.historySeq !== opts.historySeq) continue;
-      // Treat the existing row as a placeholder when it has no text
-      // (regardless of whether files were attached). Two shapes from
-      // `appendPersistedMessage` are placeholders the spawn envelope
-      // must upgrade:
-      //   • metadata-only persisted: text "" + files []
-      //   • media-bearing persisted: text "" + files [...]
-      //     (P1.3 server PR #767 added `media` to the wire)
-      // A row with non-empty `text` is the legitimate completion (or
-      // a finalized assistant) — return early.
-      if (r.text.length > 0) return true;
-
-      // Merge: union the placeholder's existing files with the
-      // spawn envelope's media (dedupe by path) so a file already
-      // landed by the persisted row isn't dropped or duplicated.
-      const incomingFiles = opts.media.map(fileFromMediaPath);
-      const seen = new Set<string>();
-      const mergedFiles: MessageFile[] = [];
-      for (const f of [...r.files, ...incomingFiles]) {
-        if (seen.has(f.path)) continue;
-        seen.add(f.path);
-        mergedFiles.push(f);
+      // Only a PLACEHOLDER row at the matching seq is the legitimate
+      // upgrade target. If the row has non-empty text it is either:
+      //   (a) a merged-ack row whose seq was donated by replayHistory's
+      //       media-only-companion merge — NOT this completion, so
+      //       fall through to append a fresh row;
+      //   (b) the spawn-complete row already filled in by an earlier
+      //       call (true replay; messageId match would have caught it
+      //       above unless callers omit messageId — test paths).
+      // We can't distinguish (a) from (b) reliably without messageId,
+      // so we fall through and let the append path take care of it.
+      // For (b) test-path callers, the next-best identity is "same
+      // text + same media list"; if that matches, treat as no-op.
+      if (r.text.length > 0) {
+        if (rowMatchesCompletionContent(r, opts)) return true;
+        continue; // (a): merged-ack row, not our target
       }
-      thread.responses[i] = {
-        ...r,
-        text: opts.text,
-        files: mergedFiles,
-        intra_thread_seq: opts.historySeq,
-        responseToClientMessageId:
-          opts.sourceClientMessageId ?? r.responseToClientMessageId ?? threadId,
-      };
+      thread.responses[i] = upgradePlaceholderRow(r, opts, threadId);
       sortResponsesInThread(thread);
       notify();
       return true;
@@ -784,6 +798,56 @@ function parsePersistedAt(persistedAt: string | undefined): number {
   if (!persistedAt) return Date.now();
   const t = new Date(persistedAt).getTime();
   return Number.isFinite(t) ? t : Date.now();
+}
+
+/** Replace a placeholder row's empty text + (optional) files with the
+ *  spawn-complete envelope's authoritative content, unioning files by
+ *  path so a file already landed by the persisted-only row isn't lost
+ *  or duplicated. Used for both `messageId` and `historySeq` upgrade
+ *  paths. */
+function upgradePlaceholderRow(
+  existing: ThreadMessage,
+  opts: AppendCompletionBubbleOptions,
+  threadId: string,
+): ThreadMessage {
+  const incomingFiles = opts.media.map(fileFromMediaPath);
+  const seen = new Set<string>();
+  const mergedFiles: MessageFile[] = [];
+  for (const f of [...existing.files, ...incomingFiles]) {
+    if (seen.has(f.path)) continue;
+    seen.add(f.path);
+    mergedFiles.push(f);
+  }
+  return {
+    ...existing,
+    text: opts.text,
+    files: mergedFiles,
+    historySeq: opts.historySeq ?? existing.historySeq,
+    intra_thread_seq: opts.historySeq ?? existing.intra_thread_seq,
+    responseToClientMessageId:
+      opts.sourceClientMessageId ??
+      existing.responseToClientMessageId ??
+      threadId,
+  };
+}
+
+/** Best-effort content match for the dedupe-by-historySeq fallback
+ *  when callers omit `messageId`. Same text and same file path set
+ *  means this row IS the spawn-complete row already (true replay,
+ *  no-op). Different content means the seq was likely donated by
+ *  legacy `replayHistory` media-only-companion merging — in that case
+ *  the caller should append a fresh row, not dedupe. */
+function rowMatchesCompletionContent(
+  row: ThreadMessage,
+  opts: AppendCompletionBubbleOptions,
+): boolean {
+  if (row.text !== opts.text) return false;
+  if (row.files.length !== opts.media.length) return false;
+  const rowPaths = new Set(row.files.map((f) => f.path));
+  for (const path of opts.media) {
+    if (!rowPaths.has(path)) return false;
+  }
+  return true;
 }
 
 /** Append a delivered file to the assistant slot in the thread (pending

--- a/src/store/thread-store.ts
+++ b/src/store/thread-store.ts
@@ -714,20 +714,32 @@ export function appendCompletionBubble(
     for (let i = 0; i < thread.responses.length; i += 1) {
       const r = thread.responses[i];
       if (r.historySeq !== opts.historySeq) continue;
-      // Treat the existing row as a placeholder ONLY when it has
-      // neither text nor files — that's the exact shape
-      // `appendPersistedMessage` produces from a metadata-only
-      // `message/persisted` (where `content` is `""` and `media` is
-      // empty). Any non-empty row at the matching seq is the
-      // legitimate completion (or a finalized assistant) and must
-      // not be overwritten.
-      const isPlaceholder = r.text.length === 0 && r.files.length === 0;
-      if (!isPlaceholder) return true;
+      // Treat the existing row as a placeholder when it has no text
+      // (regardless of whether files were attached). Two shapes from
+      // `appendPersistedMessage` are placeholders the spawn envelope
+      // must upgrade:
+      //   • metadata-only persisted: text "" + files []
+      //   • media-bearing persisted: text "" + files [...]
+      //     (P1.3 server PR #767 added `media` to the wire)
+      // A row with non-empty `text` is the legitimate completion (or
+      // a finalized assistant) — return early.
+      if (r.text.length > 0) return true;
 
+      // Merge: union the placeholder's existing files with the
+      // spawn envelope's media (dedupe by path) so a file already
+      // landed by the persisted row isn't dropped or duplicated.
+      const incomingFiles = opts.media.map(fileFromMediaPath);
+      const seen = new Set<string>();
+      const mergedFiles: MessageFile[] = [];
+      for (const f of [...r.files, ...incomingFiles]) {
+        if (seen.has(f.path)) continue;
+        seen.add(f.path);
+        mergedFiles.push(f);
+      }
       thread.responses[i] = {
         ...r,
         text: opts.text,
-        files: opts.media.map(fileFromMediaPath),
+        files: mergedFiles,
         intra_thread_seq: opts.historySeq,
         responseToClientMessageId:
           opts.sourceClientMessageId ?? r.responseToClientMessageId ?? threadId,


### PR DESCRIPTION
## Summary

M10 Phase 2 of the envelope-migration plan. Phase 1 (octos PR #772 at `c53a169f`) added the `TurnSpawnCompleteEvent` wire shape and `event.spawn_complete.v1` capability. This PR wires the SPA to consume that envelope:

- **Type** `TurnSpawnCompleteEvent` in `ui-protocol-types.ts` mirrors the server-side struct (REQUIRED `task_id`, `content`; optional `turn_id`, `thread_id`, `response_to_client_message_id`, `media`).
- **Capability** `event.spawn_complete.v1` appended to `UI_PROTOCOL_FEATURES` so the bridge negotiates it at session/open. Server only emits the envelope to clients that did so.
- **Guard** `guardSpawnComplete` validates the wire shape; fails closed and emits a `warning` on malformed input.
- **Subscriber** `onSpawnComplete(handler)` on the bridge surface; notification dispatcher routes `turn/spawn_complete` through the guard then the subscriber.
- **Router** `handleSpawnComplete` keys placement off `event.thread_id` (server-authoritative since PR #680), falls back to `response_to_client_message_id` when absent, and threads the active session/topic into the store call so unknown-thread orphan completions land in the active session bucket.
- **Store** `appendCompletionBubble` ALWAYS adds a fresh `ThreadMessage` to `thread.responses[]`. Identity-based dedupe by `messageId` first, with a `historySeq`-fallback that ONLY upgrades placeholder rows (empty text) to handle the rollout case where `message/persisted` for the same row arrived first. Server `persisted_at` is preserved as the display timestamp.

The legacy splice-merge code (`appendAssistantFile`'s media-only-merge predicate, `appendPersistedMessage`'s media-only-merge fallback) is deliberately NOT deleted — Phase 5 will delete it. Phase 2 only ADDS the new path so non-negotiated old clients continue to work during rollout.

The renderer (`chat-thread.tsx` `responses.map`) already supports N>=1 assistant bubbles per user prompt, so no view changes are needed in this PR.

## Codex review history

5 rounds of `codex review --base main` BLOCK iterations addressed before APPROVE:
1. Orphan completions could land in stale session — pass router scope through to the store
2. `message/persisted` arriving before spawn_complete left a blank bubble — upgrade placeholder in place
3. Media-bearing persisted placeholder also a placeholder — relax predicate to "empty text"
4. File-only completions silently dropped (P2) + display timestamp shifted on reconnect (P3) — relax guard, plumb `persisted_at`
5. `replayHistory` media-only-companion merge donates seq onto ack row — switch dedupe identity to `messageId`

Round 6: codex APPROVE.

## Test plan

- [x] `npx vitest run` — 148 tests pass (was 140 before this PR; +8 new)
- [x] `npx tsc -b --noEmit` — clean
- [x] Regression-pin lock the architecture: existing finalized assistant containing `[file:]` marker does NOT receive a merge from `turn/spawn_complete` (the bug class M10 deletes)
- [ ] Wave-6m soak verification (Phase 6, after Phases 3+5 land)

## References

- M10 plan: `/tmp/m10-envelope-migration-plan.md`
- Phase 1 (server): octos#772
- Phase 5 (web cleanup, follow-up): deletes legacy splice-merge predicates