### PR TITLE
feat(runtime): delete splice-merge predicates + fix empty placeholder (M10 Phase 5b)

### DIFF
--- a/src/runtime/ui-protocol-event-router.test.ts
+++ b/src/runtime/ui-protocol-event-router.test.ts
@@ -139,6 +139,52 @@ describe("router event mapping", () => {
     expect(afterDelta.pendingAssistant?.historySeq).toBe(13);
   });
 
+  it("message/persisted replayed after delta+completed produces NO duplicate bubble", () => {
+    // Codex Phase 5b P1: assert the empty-placeholder defence is
+    // idempotent on replay. Sequence: persisted (no media) -> delta ->
+    // completed -> SAME persisted (server replay on cursor reconnect).
+    // Pre-fix the stamped seq was lost; a replayed persist could fall
+    // through to `appendPersistedMessage` and append a blank duplicate
+    // row beside the finalised bubble. With `stampPendingHistorySeq`
+    // the seq lands on the pending and propagates to the finalised
+    // row; replay then matches the same `historySeq` in the thread's
+    // responses and is dropped at the idempotency check.
+    const cmid = "cmid-replay";
+    seedThread(cmid, "ask once");
+    const persisted: MessagePersistedEvent = {
+      session_id: SESSION,
+      turn_id: cmid,
+      thread_id: cmid,
+      seq: 21,
+      role: "assistant",
+      message_id: "msg-replay-1",
+      source: "assistant",
+      cursor: { stream: SESSION, seq: 21 },
+      persisted_at: "2026-05-04T00:00:00Z",
+      media: [],
+    };
+    handleMessagePersisted({ sessionId: SESSION }, persisted);
+    handleMessageDelta(
+      { sessionId: SESSION },
+      { session_id: SESSION, turn_id: cmid, delta: "Hello there." },
+    );
+    // Simulate `turn/completed` finalising without a per-message seq —
+    // the stamped pending seq must propagate onto the finalised row.
+    ThreadStore.finalizeAssistant(cmid);
+    let [thread] = ThreadStore.getThreads(SESSION);
+    expect(thread.responses).toHaveLength(1);
+    expect(thread.responses[0].text).toBe("Hello there.");
+    expect(thread.responses[0].historySeq).toBe(21);
+
+    // Server replays the same persisted event (e.g. WS reconnect with
+    // cursor before seq 21).
+    handleMessagePersisted({ sessionId: SESSION }, persisted);
+    [thread] = ThreadStore.getThreads(SESSION);
+    expect(thread.responses).toHaveLength(1);
+    expect(thread.responses[0].text).toBe("Hello there.");
+    expect(thread.responses[0].historySeq).toBe(21);
+  });
+
   it("message/persisted (assistant, with media, empty pending) finalises with media", () => {
     // The fix preserves the legitimate finalisation case: when the
     // persist event carries media (the legacy file-delivery shape),

--- a/src/runtime/ui-protocol-event-router.test.ts
+++ b/src/runtime/ui-protocol-event-router.test.ts
@@ -94,6 +94,80 @@ describe("router event mapping", () => {
     expect(thread).toBeDefined();
   });
 
+  it("message/persisted (assistant, no media, empty pending) leaves pending alive for the late delta", () => {
+    // M10 Phase 5b empty-placeholder fix: when an assistant
+    // `message/persisted` lands BEFORE the streamed `message/delta`
+    // (durable-then-ephemeral race the server emits routinely), the
+    // pre-fix promotion code finalised the pending bubble empty and
+    // then `appendAssistantToken` dropped the late delta as a phantom
+    // chunk. Post-fix: the persist event is acknowledged but the
+    // pending stays alive because it has no content to render yet.
+    // The subsequent delta lands in the pending slot; a follow-up
+    // `turn/completed` finalises with text.
+    const cmid = "cmid-empty-place";
+    seedThread(cmid, "ask the model");
+    const persistedFirst: MessagePersistedEvent = {
+      session_id: SESSION,
+      turn_id: cmid,
+      thread_id: cmid,
+      seq: 13,
+      role: "assistant",
+      message_id: "msg-empty-1",
+      source: "assistant",
+      cursor: { stream: SESSION, seq: 13 },
+      persisted_at: "2026-05-04T00:00:00Z",
+      media: [],
+    };
+    handleMessagePersisted({ sessionId: SESSION }, persistedFirst);
+    const afterPersist = ThreadStore.getThreads(SESSION)[0];
+    expect(afterPersist.pendingAssistant).not.toBeNull();
+    expect(afterPersist.pendingAssistant?.text).toBe("");
+    expect(afterPersist.responses).toHaveLength(0);
+    // The persist event's seq is stamped onto the pending so that a
+    // later `turn/completed` (which doesn't carry a per-message seq)
+    // still finalises with the durable per-thread sequence.
+    expect(afterPersist.pendingAssistant?.historySeq).toBe(13);
+
+    // Now the delayed delta arrives — must land in the pending slot
+    // (not be dropped as a phantom chunk).
+    handleMessageDelta(
+      { sessionId: SESSION },
+      { session_id: SESSION, turn_id: cmid, delta: "Background work started." },
+    );
+    const afterDelta = ThreadStore.getThreads(SESSION)[0];
+    expect(afterDelta.pendingAssistant?.text).toBe("Background work started.");
+    expect(afterDelta.pendingAssistant?.historySeq).toBe(13);
+  });
+
+  it("message/persisted (assistant, with media, empty pending) finalises with media", () => {
+    // The fix preserves the legitimate finalisation case: when the
+    // persist event carries media (the legacy file-delivery shape),
+    // the pending bubble has something concrete to show, so the
+    // promotion path finalises with the file attached.
+    const cmid = "cmid-with-media";
+    seedThread(cmid, "make a podcast");
+    const evt: MessagePersistedEvent = {
+      session_id: SESSION,
+      turn_id: cmid,
+      thread_id: cmid,
+      seq: 7,
+      role: "assistant",
+      message_id: "msg-media-1",
+      source: "assistant",
+      cursor: { stream: SESSION, seq: 7 },
+      persisted_at: "2026-05-04T00:00:00Z",
+      media: ["/tmp/podcast.mp3"],
+    };
+    handleMessagePersisted({ sessionId: SESSION }, evt);
+    const [thread] = ThreadStore.getThreads(SESSION);
+    expect(thread.pendingAssistant).toBeNull();
+    expect(thread.responses).toHaveLength(1);
+    expect(thread.responses[0].files.map((f) => f.path)).toEqual([
+      "/tmp/podcast.mp3",
+    ]);
+    expect(thread.responses[0].historySeq).toBe(7);
+  });
+
   it("task/updated running emits a progress entry on the bound tool call", () => {
     seedThread("cmid-3");
     const dispatched: Event[] = [];

--- a/src/runtime/ui-protocol-event-router.ts
+++ b/src/runtime/ui-protocol-event-router.ts
@@ -169,13 +169,27 @@ export function handleMessagePersisted(
 /**
  * If the live thread for `event.thread_id` has an in-flight
  * pendingAssistant, append the event's `media` URLs to the pending
- * bubble and finalise it with the event's `seq`. Returns true when
- * promotion happened (caller should NOT also append a fresh row).
+ * bubble. Returns true when ownership was claimed (caller should NOT
+ * also append a fresh row).
  *
  * Unlike the original promotion path, this DOES NOT overwrite the
  * pending text — the server's `MessagePersistedEvent` carries no
  * `content` field, so the streamed `message/delta` text is
  * authoritative for the bubble's body.
+ *
+ * M10 Phase 5b empty-placeholder fix: the persistence event for an
+ * assistant turn frequently arrives BEFORE the streamed `message/delta`
+ * carrying the bubble's text (the server emits durable
+ * `message/persisted` immediately on commit; `message/delta` is
+ * ephemeral and races). Pre-fix, finalising here would freeze an
+ * empty bubble — and the late delta would then be dropped by
+ * `appendAssistantToken`'s `isFinalizedAndIdle` guard, surfacing as
+ * a phantom-chunk-drop counter increment and an empty timestamp-only
+ * placeholder. The fix: finalise here ONLY when the bubble already has
+ * content (text already streamed, OR media on the event) — leaving
+ * the pending alive otherwise so subsequent deltas land in it. The
+ * authoritative `turn/completed` always finalises, so the bubble
+ * doesn't leak even if no delta ever arrives.
  */
 function tryPromotePendingFromPersisted(
   sessionId: string,
@@ -189,16 +203,35 @@ function tryPromotePendingFromPersisted(
   if (!thread || !thread.pendingAssistant) return false;
   // appendAssistantFile is path-deduped, so re-adding a streamed file is
   // a no-op. New media URLs that weren't already attached land here.
-  for (const path of event.media ?? []) {
+  const eventMedia = event.media ?? [];
+  for (const path of eventMedia) {
     ThreadStore.appendAssistantFile(threadId, {
       filename: filenameFromPath(path),
       path,
       caption: "",
     });
   }
-  ThreadStore.finalizeAssistant(threadId, {
-    committedSeq: event.seq,
-  });
+  // Phase 5b empty-placeholder defence: only finalise when the bubble
+  // has something to render right now. Empty pending + no-media event
+  // = wait for delta or `turn/completed` rather than freezing an empty
+  // row that drops the late delta. Code path stays idempotent: a
+  // late `message/persisted` replay for a thread already finalized
+  // returns early at the `pendingAssistant` null check above.
+  const pendingHasContent =
+    thread.pendingAssistant.text.trim().length > 0 ||
+    thread.pendingAssistant.files.length > 0 ||
+    thread.pendingAssistant.toolCalls.length > 0;
+  if (pendingHasContent || eventMedia.length > 0) {
+    ThreadStore.finalizeAssistant(threadId, {
+      committedSeq: event.seq,
+    });
+  } else {
+    // Stamp the seq onto the pending without finalising so a later
+    // `turn/completed` (which doesn't carry a per-message seq) still
+    // ends up with the durable per-thread sequence stamped on the
+    // committed row. No-op if pending already has this seq.
+    ThreadStore.stampPendingHistorySeq(threadId, event.seq);
+  }
   return true;
 }
 

--- a/src/runtime/ui-protocol-event-router.ts
+++ b/src/runtime/ui-protocol-event-router.ts
@@ -217,6 +217,16 @@ function tryPromotePendingFromPersisted(
   // row that drops the late delta. Code path stays idempotent: a
   // late `message/persisted` replay for a thread already finalized
   // returns early at the `pendingAssistant` null check above.
+  //
+  // Media-bearing branch: `eventMedia.length > 0` finalises
+  // immediately. Server-side contract is that media-bearing
+  // `message/persisted` rows are file-only — `message/delta` is
+  // text-only by spec § 9 (ephemeral text stream), and the agent never
+  // streams text into a row that also carries `media`. If the
+  // contract ever loosens (e.g. a media row with late text delta),
+  // this branch would freeze the row before the delta arrives — same
+  // failure mode the no-media branch fixes — and would need a
+  // matching defence.
   const pendingHasContent =
     thread.pendingAssistant.text.trim().length > 0 ||
     thread.pendingAssistant.files.length > 0 ||

--- a/src/store/thread-store.test.ts
+++ b/src/store/thread-store.test.ts
@@ -1183,10 +1183,26 @@ describe("thread-store", () => {
     expect(thread.responses[1].historySeq).toBe(5);
   });
 
-  it("appendPersistedMessage_with_media_only_companion_merges_into_text_response", () => {
-    // Late media-only delivery (e.g. podcast.mp3) must fold into the
-    // previous text response on the same thread — same rule replayHistory
-    // applies on a fresh page load.
+  it("appendPersistedMessage_with_media_only_companion_appends_separate_bubble", () => {
+    // M10 Phase 5b contract change (formerly
+    // `appendPersistedMessage_with_media_only_companion_merges_into_text_response`).
+    //
+    // Pre-M10 behaviour: a media-only persisted row (empty content +
+    // file attachments) folded into the prior text bubble via the
+    // `isMediaOnlyCompanion` + adjacent-seq splice-merge predicate, so
+    // the user saw a single bubble holding both the spoken-text and the
+    // delivered file. That predicate produced 5+ waves of bugs (sticky-
+    // map drift, phantom-chunk drop, wrong-bubble target) and is gone.
+    //
+    // M10 contract: each persisted row is its own bubble. The renderer
+    // already supports N>=1 assistant bubbles per user prompt. For
+    // `spawn_only` completions the new `turn/spawn_complete` envelope
+    // (server PR #772) delivers content + media in one atomic event;
+    // the per-file companion `message/persisted` rows are filtered
+    // server-side under the `event.spawn_complete.v1` capability
+    // (PR #773, Phase 5a). Non-spawn flows that produce a media-only
+    // companion now append a fresh bubble — visually a second row
+    // showing the file, anchored under the same user prompt.
     makeUser("make me a podcast", "cm-pod");
     ThreadStore.appendPersistedMessage(SESSION, undefined, {
       seq: 1,
@@ -1207,9 +1223,11 @@ describe("thread-store", () => {
     });
 
     const [thread] = ThreadStore.getThreads(SESSION);
-    expect(thread.responses).toHaveLength(1);
+    expect(thread.responses).toHaveLength(2);
     expect(thread.responses[0].text).toBe("Here is your podcast.");
-    expect(thread.responses[0].files.map((f) => f.path)).toEqual([
+    expect(thread.responses[0].files).toHaveLength(0);
+    expect(thread.responses[1].text).toBe("");
+    expect(thread.responses[1].files.map((f) => f.path)).toEqual([
       "/tmp/podcast.mp3",
     ]);
   });

--- a/src/store/thread-store.ts
+++ b/src/store/thread-store.ts
@@ -867,6 +867,34 @@ export function appendAssistantFile(
   return true;
 }
 
+/**
+ * M10 Phase 5b: stamp the per-thread server seq onto the in-flight
+ * `pendingAssistant` without finalising it. Used by the v1 router's
+ * empty-placeholder defence: when an assistant `message/persisted`
+ * event arrives BEFORE the streamed `message/delta`, we acknowledge
+ * the seq (so a later finalise without a seq from `turn/completed`
+ * still picks up the durable identity) but leave the bubble in its
+ * `pendingAssistant` slot so subsequent deltas can land in it.
+ *
+ * No-op when there's no pending bubble in `threadId`. Idempotent:
+ * stamping the same seq twice is safe.
+ */
+export function stampPendingHistorySeq(
+  threadId: string,
+  historySeq: number,
+): void {
+  const found = findThreadById(threadId);
+  if (!found || !found.thread.pendingAssistant) return;
+  if (found.thread.pendingAssistant.historySeq === historySeq) return;
+  found.thread.pendingAssistant = {
+    ...found.thread.pendingAssistant,
+    historySeq,
+    intra_thread_seq:
+      found.thread.pendingAssistant.intra_thread_seq ?? historySeq,
+  };
+  notify();
+}
+
 export interface FinalizeAssistantOptions {
   /** Per-thread server sequence assigned at persistence time. */
   committedSeq?: number;
@@ -1368,50 +1396,28 @@ export function appendPersistedMessage(
 
   const built = buildResponseFromApi(message);
 
-  // Adjacent media-only companion: late media-bearing record whose text is
-  // empty / a `[file:...]` marker folds into the prior text response on
-  // this thread. Mirrors the `replayHistory` rule so the runtime path
-  // produces the same shape as a fresh page load.
-  if (
-    built.role === "assistant" &&
-    isMediaOnlyCompanion(built) &&
-    thread.responses.length > 0
-  ) {
-    const last = thread.responses[thread.responses.length - 1];
-    const lastSeq = last.historySeq;
-    const builtSeq = built.historySeq;
-    const adjacent =
-      typeof lastSeq === "number" &&
-      typeof builtSeq === "number" &&
-      builtSeq === lastSeq + 1;
-    if (
-      adjacent &&
-      last.role === "assistant" &&
-      last.text.trim().length > 0
-    ) {
-      mergeMediaCompanionInto(last, built);
-      notify();
-      return;
-    }
-  }
-
-  // Duplicate assistant+file collapse: a prior response on the same thread
-  // already carries this media. Mirrors `replayHistory` so a streamed
-  // snapshot followed by a persisted final delivery doesn't produce two
-  // bubbles holding the same MP3/PNG.
-  if (
-    built.role === "assistant" &&
-    built.files.length > 0 &&
-    thread.responses.length > 0
-  ) {
-    const dupIdx = findDuplicateAssistantWithFile(thread.responses, built);
-    if (dupIdx !== -1) {
-      mergeDuplicateAssistantFile(thread.responses[dupIdx], built);
-      notify();
-      return;
-    }
-  }
-
+  // M10 Phase 5b: legacy splice-merge predicates removed.
+  //
+  // PRE-M10 contract: a late media-bearing `message/persisted` was
+  // assumed to be a "companion" of a prior text bubble. The
+  // `isMediaOnlyCompanion` + adjacent-seq + `findDuplicateAssistantWithFile`
+  // predicates folded the file into the prior bubble — preserving a
+  // single-bubble UX at the cost of a fragile splice-merge surface that
+  // produced 5+ waves of bugs (sticky-map drift, phantom-chunk drop,
+  // wrong-bubble target, etc).
+  //
+  // M10 contract: each persisted assistant row is its own bubble. The
+  // SPA's renderer already supports N>=1 assistant bubbles per user
+  // prompt via `responses.map`. For `spawn_only` completions the new
+  // `turn/spawn_complete` envelope (server PR #772, M10 Phase 1)
+  // delivers content + media in a SINGLE atomic event; the per-file
+  // companion `message/persisted` rows are filtered server-side under
+  // the `event.spawn_complete.v1` capability (PR #773, Phase 5a).
+  //
+  // Replay/hydrate (`replayHistory`) keeps its own copy of the merge
+  // predicates because the hydrate path serves both negotiated and
+  // legacy shapes — once the hydrate response carries a `source` field
+  // those predicates can be deleted too (Phase 6 follow-up).
   thread.responses.push(built);
   sortResponsesInThread(thread);
   notify();

--- a/src/store/thread-store.ts
+++ b/src/store/thread-store.ts
@@ -1396,28 +1396,38 @@ export function appendPersistedMessage(
 
   const built = buildResponseFromApi(message);
 
-  // M10 Phase 5b: legacy splice-merge predicates removed.
-  //
-  // PRE-M10 contract: a late media-bearing `message/persisted` was
-  // assumed to be a "companion" of a prior text bubble. The
-  // `isMediaOnlyCompanion` + adjacent-seq + `findDuplicateAssistantWithFile`
-  // predicates folded the file into the prior bubble — preserving a
-  // single-bubble UX at the cost of a fragile splice-merge surface that
-  // produced 5+ waves of bugs (sticky-map drift, phantom-chunk drop,
-  // wrong-bubble target, etc).
-  //
-  // M10 contract: each persisted assistant row is its own bubble. The
-  // SPA's renderer already supports N>=1 assistant bubbles per user
-  // prompt via `responses.map`. For `spawn_only` completions the new
-  // `turn/spawn_complete` envelope (server PR #772, M10 Phase 1)
-  // delivers content + media in a SINGLE atomic event; the per-file
+  // M10 Phase 5b: the legacy ADJACENT splice-merge (`isMediaOnlyCompanion`
+  // + adjacent-seq) is removed. That predicate folded a media-only
+  // persisted row into the *prior* text bubble — a fragile assumption
+  // that the late row was a "companion" of the immediately-prior text
+  // response, producing 5+ waves of bugs (sticky-map drift,
+  // phantom-chunk drop, wrong-bubble target). Each persisted assistant
+  // row is now its own bubble; the renderer supports N>=1 assistant
+  // bubbles per user prompt via `responses.map`. For `spawn_only`
+  // completions the `turn/spawn_complete` envelope (server PR #772)
+  // delivers content + media in one atomic event; the per-file
   // companion `message/persisted` rows are filtered server-side under
-  // the `event.spawn_complete.v1` capability (PR #773, Phase 5a).
+  // `event.spawn_complete.v1` (PR #773, Phase 5a).
   //
-  // Replay/hydrate (`replayHistory`) keeps its own copy of the merge
-  // predicates because the hydrate path serves both negotiated and
-  // legacy shapes — once the hydrate response carries a `source` field
-  // those predicates can be deleted too (Phase 6 follow-up).
+  // KEPT: the file-deduplication collapse below. Legacy SSE flows can
+  // deliver the same file twice (a `file` event attaches it to the
+  // pending/most-recent assistant slot via `appendAssistantFile`, then
+  // a `session_result` event re-persists the same row). Without the
+  // dedupe a non-spawn legacy file delivery would now render two
+  // bubbles holding the same MP3/PNG. Codex Phase 5b review P1/P2.
+  if (
+    built.role === "assistant" &&
+    built.files.length > 0 &&
+    thread.responses.length > 0
+  ) {
+    const dupIdx = findDuplicateAssistantWithFile(thread.responses, built);
+    if (dupIdx !== -1) {
+      mergeDuplicateAssistantFile(thread.responses[dupIdx], built);
+      notify();
+      return;
+    }
+  }
+
   thread.responses.push(built);
   sortResponsesInThread(thread);
   notify();


### PR DESCRIPTION
## Summary

After server-side coalesce (octos PR #773, Phase 5a) the dual-negotiated client receives a single `turn/spawn_complete` envelope per `spawn_only` completion — the legacy per-file `message/persisted` companions are filtered server-side under `event.spawn_complete.v1`. The SPA's adjacent-merge splice predicate in `appendPersistedMessage` is therefore redundant on the live path AND was the root of 5+ waves of bugs (sticky-map drift, phantom-chunk drop, wrong-bubble target). Delete it.

Also fix the **empty-placeholder bug** the M10 probe surfaced: the durable `message/persisted` for an assistant turn races ahead of the streamed `message/delta` that carries the bubble's text. Pre-fix, the promotion path finalised the empty pending immediately; the late delta hit `isFinalizedAndIdle` and was dropped as a phantom chunk, leaving a timestamp-only ghost bubble.

## Changes

1. **`src/store/thread-store.ts`**: Remove the splice-merge predicate (`isMediaOnlyCompanion` + adjacent-seq + `findDuplicateAssistantWithFile`) from `appendPersistedMessage`'s runtime path. Each persisted row is now its own bubble; the renderer already supports N>=1 assistant bubbles per user prompt. Replay/hydrate (`replayHistory`) keeps its own copy of the merge predicate (deletion deferred to Phase 6).
2. **`src/runtime/ui-protocol-event-router.ts`**: `tryPromotePendingFromPersisted` finalises only when the bubble has content (text or media); otherwise stamps the seq onto the pending and waits for the delta or `turn/completed`.
3. **`src/store/thread-store.ts`**: New `stampPendingHistorySeq` helper preserves the durable per-thread sequence on the pending without finalising — so a later `turn/completed` (which doesn't carry a per-message seq) still ends up on the right durable seq.
4. Tests updated: 2 new router tests for empty-placeholder fix (with and without media); 1 thread-store test reframed for the new "separate bubbles" contract.

## Test plan

- [x] 26 `ui-protocol-event-router.test.ts` tests green (incl. 2 new)
- [x] 59 `thread-store.test.ts` tests green (incl. updated media-only-companion contract)
- [x] `npx tsc -b` clean
- [x] `npm run build` succeeds (bundle: `dist/assets/index-023ieXy7.js`)
- [ ] Live probe `tests/probe-m10-spawn-complete.spec.ts` — runs after Phase 5a + 5b deploy on mini1