### PR TITLE
fix(runtime): render spawn-ack delta text into the assistant bubble (M10 Phase 6.2)

### DIFF
--- a/src/runtime/ui-protocol-bridge.test.ts
+++ b/src/runtime/ui-protocol-bridge.test.ts
@@ -176,6 +176,21 @@ describe("type guards (fail-closed)", () => {
     expect(
       guards.guardMessageDelta({
         session_id: "s",
+        text: "hi",
+      }),
+    ).toBeNull();
+  });
+
+  it("rejects message/delta whose text-bearing field is the legacy `delta` name (M10 Phase 6.2)", () => {
+    // The wire field is `text` (see `octos_core::ui_protocol::MessageDeltaEvent`).
+    // A payload that uses `delta:` is not what the server emits; reject it
+    // explicitly so a future regression that re-introduces the wrong name
+    // fails this guard at parse time instead of silently dropping every
+    // spawn-ack and surfacing as an empty timestamp-only bubble.
+    expect(
+      guards.guardMessageDelta({
+        session_id: "s",
+        turn_id: "t",
         delta: "hi",
       }),
     ).toBeNull();
@@ -185,12 +200,12 @@ describe("type guards (fail-closed)", () => {
     const ev = guards.guardMessageDelta({
       session_id: "s",
       turn_id: "t",
-      delta: "hi",
+      text: "hi",
     });
     expect(ev).toEqual({
       session_id: "s",
       turn_id: "t",
-      delta: "hi",
+      text: "hi",
       message_id: undefined,
     });
   });
@@ -766,7 +781,7 @@ describe("notification dispatch", () => {
     ws.triggerMessage({
       jsonrpc: "2.0",
       method: METHODS.MESSAGE_DELTA,
-      params: { session_id: "sess-1", turn_id: "t1", delta: "hi" },
+      params: { session_id: "sess-1", turn_id: "t1", text: "hi" },
     });
     expect(seen).toHaveLength(1);
     expect(seen[0].turn_id).toBe("t1");
@@ -781,7 +796,7 @@ describe("notification dispatch", () => {
     ws.triggerMessage({
       jsonrpc: "2.0",
       method: METHODS.MESSAGE_DELTA,
-      params: { session_id: "sess-1", delta: "hi" },
+      params: { session_id: "sess-1", text: "hi" },
     });
     expect(deltas).toHaveLength(0);
     expect(warnings.some((w) => w.reason === "invalid_event:message/delta")).toBe(
@@ -963,16 +978,16 @@ describe("notification dispatch", () => {
     ws.triggerMessage({
       jsonrpc: "2.0",
       method: METHODS.MESSAGE_DELTA,
-      params: { session_id: "sess-1", turn_id: "t1", delta: "a" },
+      params: { session_id: "sess-1", turn_id: "t1", text: "a" },
     });
     unsub();
     ws.triggerMessage({
       jsonrpc: "2.0",
       method: METHODS.MESSAGE_DELTA,
-      params: { session_id: "sess-1", turn_id: "t1", delta: "b" },
+      params: { session_id: "sess-1", turn_id: "t1", text: "b" },
     });
     expect(seen).toHaveLength(1);
-    expect(seen[0].delta).toBe("a");
+    expect(seen[0].text).toBe("a");
   });
 });
 

--- a/src/runtime/ui-protocol-bridge.ts
+++ b/src/runtime/ui-protocol-bridge.ts
@@ -287,11 +287,16 @@ function isPlainObject(v: unknown): v is Record<string, unknown> {
 function guardMessageDelta(p: unknown): MessageDeltaEvent | null {
   if (!isPlainObject(p)) return null;
   if (!isString(p.session_id) || !isString(p.turn_id)) return null;
-  if (typeof p.delta !== "string") return null;
+  // Server-side wire field is `text` (see
+  // `octos_core::ui_protocol::MessageDeltaEvent`). The previous guard
+  // required `params.delta` and silently rejected every real frame —
+  // the M10 Phase 6.2 root cause that left the spawn-ack pending
+  // empty. Accept `text` and surface it as `event.text` to the router.
+  if (typeof p.text !== "string") return null;
   return {
     session_id: p.session_id,
     turn_id: p.turn_id,
-    delta: p.delta,
+    text: p.text,
     message_id: typeof p.message_id === "string" ? p.message_id : undefined,
   };
 }

--- a/src/runtime/ui-protocol-event-router.test.ts
+++ b/src/runtime/ui-protocol-event-router.test.ts
@@ -59,12 +59,12 @@ describe("router event mapping", () => {
     const evt: MessageDeltaEvent = {
       session_id: SESSION,
       turn_id: "cmid-1",
-      delta: "Hello",
+      text: "Hello",
     };
     handleMessageDelta({ sessionId: SESSION }, evt);
     handleMessageDelta(
       { sessionId: SESSION },
-      { ...evt, delta: ", world" },
+      { ...evt, text: ", world" },
     );
     const [thread] = ThreadStore.getThreads(SESSION);
     expect(thread.pendingAssistant?.text).toBe("Hello, world");
@@ -132,7 +132,7 @@ describe("router event mapping", () => {
     // (not be dropped as a phantom chunk).
     handleMessageDelta(
       { sessionId: SESSION },
-      { session_id: SESSION, turn_id: cmid, delta: "Background work started." },
+      { session_id: SESSION, turn_id: cmid, text: "Background work started." },
     );
     const afterDelta = ThreadStore.getThreads(SESSION)[0];
     expect(afterDelta.pendingAssistant?.text).toBe("Background work started.");
@@ -166,7 +166,7 @@ describe("router event mapping", () => {
     handleMessagePersisted({ sessionId: SESSION }, persisted);
     handleMessageDelta(
       { sessionId: SESSION },
-      { session_id: SESSION, turn_id: cmid, delta: "Hello there." },
+      { session_id: SESSION, turn_id: cmid, text: "Hello there." },
     );
     // Simulate `turn/completed` finalising without a per-message seq —
     // the stamped pending seq must propagate onto the finalised row.
@@ -606,6 +606,100 @@ describe("router event mapping", () => {
     ]);
   });
 
+  // -------------------------------------------------------------------------
+  // M10 Phase 6.2: spawn-ack rendering regression test
+  // -------------------------------------------------------------------------
+  //
+  // Pre-fix (M10 Phase 6.1 probe): the bridge guard expected `params.delta`
+  // but the server emits `params.text` (see
+  // `octos_core::ui_protocol::MessageDeltaEvent`), so the spawn-ack
+  // `message/delta` was rejected silently at the guard layer. The
+  // pendingAssistant stayed empty; subsequent finalization produced a
+  // timestamp-only ghost assistant bubble in the SPA. This test pins the
+  // corrected behaviour: the streamed text lands in the bubble, and the
+  // spawn_complete envelope appends a second bubble — two assistant rows
+  // total (the user prompt is the third), not the three observed in the
+  // wave-6m probe.
+  it(
+    "spawn-ack delta + persisted + spawn_complete renders 2 assistant bubbles (1 ack, 1 completion)",
+    () => {
+      const cmid = "cmid-spawn-ack-render";
+      seedThread(cmid, "Use deep_search to find Rust news");
+
+      // (1) message/delta — spawn-ack text streams in. With the pre-fix
+      //     guard this frame was silently rejected; with the fix the text
+      //     lands on `pendingAssistant.text`.
+      handleMessageDelta(
+        { sessionId: SESSION },
+        {
+          session_id: SESSION,
+          turn_id: cmid,
+          text: "Background work started for `deep_search`.",
+        },
+      );
+
+      // (2) message/persisted — assistant ack row (no media). Promotion
+      //     finalises the pending bubble because it now has content.
+      handleMessagePersisted(
+        { sessionId: SESSION },
+        {
+          session_id: SESSION,
+          turn_id: cmid,
+          thread_id: cmid,
+          seq: 4,
+          role: "assistant",
+          message_id: "msg-ack",
+          source: "assistant",
+          cursor: { stream: SESSION, seq: 4 },
+          persisted_at: "2026-05-04T00:00:00Z",
+        },
+      );
+
+      // (3) turn/spawn_complete — atomic completion envelope. Appends a
+      //     fresh bubble under the same user prompt.
+      handleSpawnComplete(
+        { sessionId: SESSION },
+        {
+          session_id: SESSION,
+          turn_id: cmid,
+          thread_id: cmid,
+          task_id: "task_deep_search_1",
+          response_to_client_message_id: cmid,
+          seq: 6,
+          message_id: "msg-spawn-complete",
+          source: "background",
+          cursor: { stream: SESSION, seq: 6 },
+          persisted_at: "2026-05-04T00:00:02Z",
+          content: "✓ deep_search completed (research/_report.md)",
+          media: ["research/_report.md"],
+        },
+      );
+
+      const [thread] = ThreadStore.getThreads(SESSION);
+      expect(thread.pendingAssistant).toBeNull();
+      // Exactly TWO assistant rows: the ack bubble (with the streamed
+      // delta text) and the spawn_complete bubble.
+      expect(thread.responses).toHaveLength(2);
+
+      // Ack bubble carries the spawn-ack text — NOT empty. This is the
+      // load-bearing assertion for Phase 6.2.
+      expect(thread.responses[0].text).toBe(
+        "Background work started for `deep_search`.",
+      );
+      expect(thread.responses[0].status).toBe("complete");
+      expect(thread.responses[0].files).toHaveLength(0);
+
+      // Completion bubble carries the spawn_complete envelope's atomic
+      // content + media list.
+      expect(thread.responses[1].text).toBe(
+        "✓ deep_search completed (research/_report.md)",
+      );
+      expect(thread.responses[1].files.map((f) => f.path)).toEqual([
+        "research/_report.md",
+      ]);
+    },
+  );
+
   it("approval/requested dispatches a CustomEvent with the typed payload", () => {
     const dispatched: Event[] = [];
     const evt: ApprovalRequestedEvent = {
@@ -646,7 +740,7 @@ describe("router lifecycle de-dup", () => {
     seedThread(cmid, "ask");
     handleMessageDelta(
       { sessionId: SESSION },
-      { session_id: SESSION, turn_id: cmid, delta: "partial" },
+      { session_id: SESSION, turn_id: cmid, text: "partial" },
     );
     handleMessagePersisted(
       { sessionId: SESSION },
@@ -716,11 +810,11 @@ describe("router parity with SSE bridge", () => {
     );
     handleMessageDelta(
       { sessionId: SESSION },
-      { session_id: SESSION, turn_id: cmid, delta: "Hello" },
+      { session_id: SESSION, turn_id: cmid, text: "Hello" },
     );
     handleMessageDelta(
       { sessionId: SESSION },
-      { session_id: SESSION, turn_id: cmid, delta: ", world" },
+      { session_id: SESSION, turn_id: cmid, text: ", world" },
     );
     handleTurnCompleted(
       { sessionId: SESSION },
@@ -765,7 +859,7 @@ describe("router parity with SSE bridge", () => {
     // text via message/delta first, then send the persisted event.
     handleMessageDelta(
       { sessionId: SESSION },
-      { session_id: SESSION, turn_id: cmid, delta: "Persisted answer" },
+      { session_id: SESSION, turn_id: cmid, text: "Persisted answer" },
     );
     handleMessagePersisted(
       { sessionId: SESSION },
@@ -820,7 +914,7 @@ describe("router parity with SSE bridge", () => {
     seedThread(cmid, "ask");
     handleMessageDelta(
       { sessionId: SESSION },
-      { session_id: SESSION, turn_id: cmid, delta: "partial" },
+      { session_id: SESSION, turn_id: cmid, text: "partial" },
     );
     handleTurnError(
       { sessionId: SESSION },

--- a/src/runtime/ui-protocol-event-router.ts
+++ b/src/runtime/ui-protocol-event-router.ts
@@ -123,8 +123,11 @@ export function handleMessageDelta(
 ): void {
   // turn_id is the thread_id key per the v1 contract. The bridge already
   // rejected events with a missing/empty turn_id at the guard layer.
-  if (!event.delta) return;
-  ThreadStore.appendAssistantToken(event.turn_id, event.delta);
+  // The wire field is `text` (see `MessageDeltaEvent`) — using the wrong
+  // field name silently drops every spawn-ack delta and leaves an empty
+  // timestamp-only bubble (M10 Phase 6.2 regression).
+  if (!event.text) return;
+  ThreadStore.appendAssistantToken(event.turn_id, event.text);
 }
 
 export function handleMessagePersisted(

--- a/src/runtime/ui-protocol-types.ts
+++ b/src/runtime/ui-protocol-types.ts
@@ -55,10 +55,23 @@ export interface ApprovalRespondResult {
   runtime_resumed?: boolean;
 }
 
+/**
+ * `message/delta` notification per UI Protocol v1 spec § 6 / § 9.
+ *
+ * The wire payload's text-bearing field is named `text` to match
+ * `octos_core::ui_protocol::MessageDeltaEvent` (see
+ * `crates/octos-core/src/ui_protocol.rs`). An earlier version of this
+ * type called the field `delta`; the guard then required `params.delta:
+ * string` and silently rejected every real server frame, which left the
+ * spawn-ack `pendingAssistant` empty (the M10 Phase 6.2 root cause —
+ * empty-timestamp ghost bubble in the SPA). Keep this struct in lockstep
+ * with the server enum or the bridge will fail closed without a visible
+ * error.
+ */
 export interface MessageDeltaEvent {
   session_id: string;
   turn_id: string;
-  delta: string;
+  text: string;
   message_id?: string;
 }
 


### PR DESCRIPTION
## Summary

- **Root cause (Phase 6.2)**: the UI Protocol v1 bridge guard for `message/delta` required `params.delta: string`, but the server-side `octos_core::ui_protocol::MessageDeltaEvent` serialises the text field as `text`. Every spawn-ack `message/delta` was silently rejected at the bridge layer, leaving `pendingAssistant.text` empty. The empty pending then advanced through promotion + finalisation and rendered as a timestamp-only ghost assistant bubble in the SPA — the third bubble that the M10 Phase 6.1 probe pinned.
- **Fix**: rename `MessageDeltaEvent.delta` → `MessageDeltaEvent.text` in the typed contract, the bridge `guardMessageDelta` runtime check, and the router's `handleMessageDelta` mutation. The SSE bridge already used `text` semantics via the `token` event handler; this aligns the v1 transport with both the server enum and the legacy SSE path.
- **Tests**:
  - New regression-pin in `ui-protocol-bridge.test.ts` asserts that a payload using the legacy `delta:` field is rejected by the guard, so any future regression that re-introduces the wrong name fails loudly at parse time rather than silently dropping every spawn-ack.
  - New router-level test asserts the corrected sequence: `message/delta` (spawn-ack text) + `message/persisted` (assistant) + `turn/spawn_complete` ⇒ exactly 2 assistant bubbles — first carrying the streamed delta text, second carrying the spawn_complete envelope's atomic content + media list.

26 LOC of production code; 130 LOC of test scaffolding (regression + parity assertions). 0 server-side changes; SSE bridge untouched.

Codex `review --base main`: APPROVE on first pass — "The change consistently updates the message delta wire field from `delta` to `text` across types, guards, router handling, and tests. Targeted unit tests and the production build pass, and I did not find an introduced correctness issue."

## Test plan

- [x] `npx vitest run` — 153 / 153 passing
- [ ] Build with the `feature-flags.ts` flip + rsync to mini1
- [ ] Re-run `tests/probe-m10-spawn-complete.spec.ts`; assert EXACTLY 2 bubbles render (1 user + 1 assistant) and the empty placeholder is gone