### PR TITLE
fix(runtime): serialise WS turn/start sends per session (Bug B)

### DIFF
--- a/src/runtime/ui-protocol-bridge.ts
+++ b/src/runtime/ui-protocol-bridge.ts
@@ -247,6 +247,27 @@ interface PendingRpc {
 
 type Listener<T> = (value: T) => void;
 
+// Bug B diagnostic instrumentation. Gated on
+// `localStorage.octos_debug_envelope === '1'`. NEVER logs in production
+// by default; toggled on per test run only. See M10 follow-up Bug B —
+// the goal is to capture every `turn/spawn_complete` envelope the bridge
+// SEES so we can diff against what ThreadStore actually appends. Cheap
+// no-op when the flag is off (single localStorage read on each call).
+function debugEnvelopeEnabled(): boolean {
+  if (typeof window === "undefined") return false;
+  try {
+    return window.localStorage.getItem("octos_debug_envelope") === "1";
+  } catch {
+    return false;
+  }
+}
+
+export function debugEnvelopeLog(tag: string, payload: unknown): void {
+  if (!debugEnvelopeEnabled()) return;
+  // eslint-disable-next-line no-console
+  console.log(`[bug-b] ${tag}`, payload);
+}
+
 class Subscribers<T> {
   private readonly handlers: Set<Listener<T>> = new Set();
 
@@ -1005,14 +1026,40 @@ class UiProtocolBridgeImpl implements UiProtocolBridge {
   private dispatchNotification(note: JsonRpcNotification): void {
     const params = note.params;
     const handler = this.notificationTable[note.method];
-    if (!handler) return;
+    if (!handler) {
+      // Bug B diagnostic: surface unhandled methods to the debug log
+      // so a server-side rename (or capability negotiation gap) shows
+      // up immediately instead of silently dropping events.
+      debugEnvelopeLog("notif:unhandled-method", { method: note.method });
+      return;
+    }
     const result = handler.guard(params);
     if (!result) {
+      // Bug B diagnostic: spawn_complete envelopes that fail the guard
+      // produce no DOM bubble. Surface the rejected method + raw params
+      // so we can spot wire-shape regressions on the failing path.
+      debugEnvelopeLog("notif:guard-rejected", {
+        method: note.method,
+        params,
+      });
       this.subWarning.emit({
         reason: `invalid_event:${note.method}`,
         context: params,
       });
       return;
+    }
+    if (note.method === METHODS.TURN_SPAWN_COMPLETE) {
+      const r = result as TurnSpawnCompleteEvent;
+      debugEnvelopeLog("notif:spawn_complete", {
+        task_id: r.task_id,
+        thread_id: r.thread_id,
+        turn_id: r.turn_id,
+        seq: r.seq,
+        message_id: r.message_id,
+        content_len: r.content.length,
+        media_count: r.media?.length ?? 0,
+        rcm: r.response_to_client_message_id,
+      });
     }
     handler.emit(result);
   }

--- a/src/runtime/ui-protocol-event-router.ts
+++ b/src/runtime/ui-protocol-event-router.ts
@@ -53,6 +53,20 @@ export function __resetRouterStateForTest(): void {
   lastTaskStateById.clear();
 }
 
+// Bug B diagnostic. Gated on `localStorage.octos_debug_envelope === '1'`.
+// Mirrors the bridge/store loggers so a single flag flip turns on the
+// full router → bridge → store breadcrumb trail.
+function debugRouterLog(tag: string, payload: unknown): void {
+  if (typeof window === "undefined") return;
+  try {
+    if (window.localStorage.getItem("octos_debug_envelope") !== "1") return;
+  } catch {
+    return;
+  }
+  // eslint-disable-next-line no-console
+  console.log(`[bug-b:router] ${tag}`, payload);
+}
+
 // ---------------------------------------------------------------------------
 // Configuration
 // ---------------------------------------------------------------------------
@@ -283,7 +297,23 @@ export function handleSpawnComplete(
 ): void {
   const placementKey =
     event.thread_id ?? event.response_to_client_message_id;
-  if (!placementKey) return;
+  if (!placementKey) {
+    debugRouterLog("spawn_complete:drop-no-placement-key", {
+      task_id: event.task_id,
+      seq: event.seq,
+      message_id: event.message_id,
+    });
+    return;
+  }
+
+  debugRouterLog("spawn_complete:forward", {
+    placementKey,
+    cfg_session: cfg.sessionId,
+    task_id: event.task_id,
+    seq: event.seq,
+    thread_id: event.thread_id,
+    rcm: event.response_to_client_message_id,
+  });
 
   ThreadStore.appendCompletionBubble(placementKey, {
     text: event.content,

--- a/src/runtime/ui-protocol-send.test.ts
+++ b/src/runtime/ui-protocol-send.test.ts
@@ -381,6 +381,66 @@ describe("sendMessage flag-ON path", () => {
     ]);
   });
 
+  // Codex P2 round 3 (M10 follow-up Bug B): a throwing `onComplete`
+  // callback must NOT wedge the per-session queue. Pre-fix, the
+  // lifecycle promise never resolved because the throw unwound past
+  // `releaseLifecycleGate` and every subsequent send blocked on the
+  // 15-min safety timer.
+  it("releases the queue even when the onComplete callback throws", async () => {
+    const bridge = makeBridge();
+    __setActiveBridgeForTest(SESSION, bridge);
+
+    let lifecycleHandler:
+      | ((e: { turn_id: string; reason?: string; error?: unknown }) => void)
+      | undefined;
+    (bridge.onTurnLifecycle as ReturnType<typeof vi.fn>).mockImplementation(
+      (h: (e: { turn_id: string; reason?: string; error?: unknown }) => void) => {
+        lifecycleHandler = h;
+        return () => {
+          lifecycleHandler = undefined;
+        };
+      },
+    );
+
+    const onCompleteThrowing = vi.fn(() => {
+      throw new Error("subscriber blew up");
+    });
+    const onCompleteFollowup = vi.fn();
+
+    sendMessage({
+      sessionId: SESSION,
+      text: "Q1",
+      media: [],
+      clientMessageId: "cmid-Q1",
+      onComplete: onCompleteThrowing,
+    });
+    sendMessage({
+      sessionId: SESSION,
+      text: "Q2",
+      media: [],
+      clientMessageId: "cmid-Q2",
+      onComplete: onCompleteFollowup,
+    });
+
+    for (let i = 0; i < 12; i++) await Promise.resolve();
+    expect(bridge.sendTurn).toHaveBeenCalledTimes(1);
+
+    // Q1's lifecycle fires; its onComplete throws. The chain MUST still
+    // advance — Q2's sendTurn must follow. The real bridge swallows
+    // subscriber exceptions inside its `Subscribers.emit`; this mock
+    // calls the handler directly so we catch the throw at the call
+    // site to mirror the real-world contract.
+    expect(() =>
+      lifecycleHandler?.({ turn_id: "cmid-Q1", reason: "stop" }),
+    ).toThrow("subscriber blew up");
+    expect(onCompleteThrowing).toHaveBeenCalledTimes(1);
+    for (let i = 0; i < 12; i++) await Promise.resolve();
+    expect(bridge.sendTurn).toHaveBeenCalledTimes(2);
+    expect(bridge.sendTurn).toHaveBeenLastCalledWith("cmid-Q2", [
+      { kind: "text", text: "Q2" },
+    ]);
+  });
+
   // Codex P2 round 2 (M10 follow-up Bug B): when the bridge is torn down
   // (user navigates away from the session/topic, runtime calls
   // `stopActiveBridge`), `bridge.stop()` clears `subTurnLifecycle`. The

--- a/src/runtime/ui-protocol-send.test.ts
+++ b/src/runtime/ui-protocol-send.test.ts
@@ -30,7 +30,10 @@ vi.mock("./sse-bridge", () => ({
 }));
 
 import * as ThreadStore from "@/store/thread-store";
-import { sendMessage } from "./ui-protocol-send";
+import {
+  sendMessage,
+  __resetSendQueueForTest,
+} from "./ui-protocol-send";
 import {
   __resetUiProtocolRuntimeForTest,
   __setActiveBridgeForTest,
@@ -70,6 +73,7 @@ function makeBridge(): UiProtocolBridge & {
 beforeEach(() => {
   legacySendSpy.mockReset();
   __resetUiProtocolRuntimeForTest();
+  __resetSendQueueForTest();
   ThreadStore.__resetForTests();
   window.localStorage.clear();
 });
@@ -77,6 +81,7 @@ beforeEach(() => {
 afterEach(() => {
   window.localStorage.clear();
   __resetUiProtocolRuntimeForTest();
+  __resetSendQueueForTest();
 });
 
 describe("sendMessage flag-OFF preservation", () => {
@@ -123,8 +128,9 @@ describe("sendMessage flag-ON path", () => {
     });
     // The v1 path is async; let microtasks settle so the awaited
     // sendTurn invocation has been registered before we assert.
-    await Promise.resolve();
-    await Promise.resolve();
+    // Bug B's per-session turn queue adds 2-3 microtask ticks (await
+    // prev → await sendMessageV1 entry) on top of the legacy chain.
+    for (let i = 0; i < 12; i++) await Promise.resolve();
     expect(bridge.sendTurn).toHaveBeenCalledWith("cmid-on", [
       { kind: "text", text: "hello" },
     ]);
@@ -163,11 +169,13 @@ describe("sendMessage flag-ON path", () => {
       clientMessageId: "cmid-complete",
       onComplete,
     });
-    // Flush enough microtasks for the awaited sendTurn → finally block
-    // to install the lifecycle subscription. Six ticks is comfortably
-    // beyond what the chain needs (2-3 microtasks) but kept low to
-    // avoid masking a hung promise.
-    for (let i = 0; i < 6; i++) await Promise.resolve();
+    // Flush enough microtasks for the per-session queue tail to settle,
+    // then for the awaited sendTurn → finally block to install the
+    // lifecycle subscription. The Bug B turn-queue adds 2-3 ticks on top
+    // of the original chain (await prev, await sendMessageV1), so we
+    // bumped from 6 to 12 — still tightly bounded so a hung promise still
+    // surfaces as a failure.
+    for (let i = 0; i < 12; i++) await Promise.resolve();
 
     expect(lifecycleHandler).toBeDefined();
     // A different turn's completion must not fire onComplete.
@@ -253,10 +261,11 @@ describe("sendMessage flag-ON path", () => {
       onComplete,
     });
 
-    // Let the sync portion of sendMessageV1 run (it awaits getActiveBridge
-    // path → the sendTurn call). The lifecycle subscription should be
-    // installed BEFORE the await on sendTurn, so the handler is live now.
-    for (let i = 0; i < 4; i++) await Promise.resolve();
+    // Let the sync portion of sendMessageV1 run. The lifecycle
+    // subscription must be installed BEFORE the await on sendTurn so the
+    // handler is live now. Bug B's turn-queue adds 2-3 microtask ticks
+    // on top of the original chain.
+    for (let i = 0; i < 12; i++) await Promise.resolve();
     expect(lifecycleHandler).toBeDefined();
 
     // Fire turn/completed BEFORE sendTurn resolves.
@@ -265,7 +274,7 @@ describe("sendMessage flag-ON path", () => {
 
     // Now let sendTurn resolve. onComplete must NOT fire a second time.
     resolveSendTurn?.();
-    for (let i = 0; i < 4; i++) await Promise.resolve();
+    for (let i = 0; i < 8; i++) await Promise.resolve();
     expect(onComplete).toHaveBeenCalledTimes(1);
   });
 
@@ -289,12 +298,86 @@ describe("sendMessage flag-ON path", () => {
       onComplete,
     });
 
-    for (let i = 0; i < 6; i++) await Promise.resolve();
+    // Bug B turn-queue adds extra ticks on top of the original chain.
+    for (let i = 0; i < 12; i++) await Promise.resolve();
     expect(onComplete).toHaveBeenCalledTimes(1);
     // The thread should be marked errored, not stuck pending.
     const threads = ThreadStore.getThreads(SESSION);
     expect(threads).toHaveLength(1);
     expect(threads[0].pendingAssistant).toBeNull();
     expect(threads[0].responses[0]?.status).toBe("error");
+  });
+
+  // M10 follow-up Bug B: the WS `turn/start` handler enforces "one turn at
+  // a time" per session — a second `turn/start` arriving while the
+  // previous turn's foreground phase is still running is REJECTED with
+  // `"a turn is already running for this session"`. The legacy SSE path
+  // hid this from the SPA because `/api/chat` queues server-side; the v1
+  // path doesn't, so the client must serialise sends per session.
+  //
+  // This test asserts that 3 rapid `sendMessage` calls (the
+  // `live-overflow-stress` failure shape) issue `bridge.sendTurn`
+  // serially: each call waits for the prior turn's
+  // `turn/completed`/`turn/error` lifecycle event before its own RPC
+  // fires. Without serialisation, all 3 issue concurrently and the
+  // server rejects 2 of them, dropping 2 of 3 user prompts on the floor.
+  it("serialises 3 rapid sends per session, awaiting prior turn lifecycle", async () => {
+    const bridge = makeBridge();
+    __setActiveBridgeForTest(SESSION, bridge);
+
+    let lifecycleHandler:
+      | ((e: { turn_id: string; reason?: string; error?: unknown }) => void)
+      | undefined;
+    (bridge.onTurnLifecycle as ReturnType<typeof vi.fn>).mockImplementation(
+      (h: (e: { turn_id: string; reason?: string; error?: unknown }) => void) => {
+        lifecycleHandler = h;
+        return () => {
+          lifecycleHandler = undefined;
+        };
+      },
+    );
+
+    sendMessage({
+      sessionId: SESSION,
+      text: "Q1",
+      media: [],
+      clientMessageId: "cmid-Q1",
+    });
+    sendMessage({
+      sessionId: SESSION,
+      text: "Q2",
+      media: [],
+      clientMessageId: "cmid-Q2",
+    });
+    sendMessage({
+      sessionId: SESSION,
+      text: "Q3",
+      media: [],
+      clientMessageId: "cmid-Q3",
+    });
+
+    // After the queue settles, only ONE bridge.sendTurn (Q1) must have
+    // fired. Q2 and Q3 are blocked waiting for Q1's turn/completed.
+    for (let i = 0; i < 12; i++) await Promise.resolve();
+    expect(bridge.sendTurn).toHaveBeenCalledTimes(1);
+    expect(bridge.sendTurn).toHaveBeenLastCalledWith("cmid-Q1", [
+      { kind: "text", text: "Q1" },
+    ]);
+
+    // Fire turn/completed for Q1. Q2's sendTurn must follow.
+    lifecycleHandler?.({ turn_id: "cmid-Q1", reason: "stop" });
+    for (let i = 0; i < 12; i++) await Promise.resolve();
+    expect(bridge.sendTurn).toHaveBeenCalledTimes(2);
+    expect(bridge.sendTurn).toHaveBeenLastCalledWith("cmid-Q2", [
+      { kind: "text", text: "Q2" },
+    ]);
+
+    // Q2 lifecycle → Q3 fires.
+    lifecycleHandler?.({ turn_id: "cmid-Q2", reason: "stop" });
+    for (let i = 0; i < 12; i++) await Promise.resolve();
+    expect(bridge.sendTurn).toHaveBeenCalledTimes(3);
+    expect(bridge.sendTurn).toHaveBeenLastCalledWith("cmid-Q3", [
+      { kind: "text", text: "Q3" },
+    ]);
   });
 });

--- a/src/runtime/ui-protocol-send.test.ts
+++ b/src/runtime/ui-protocol-send.test.ts
@@ -390,6 +390,48 @@ describe("sendMessage flag-ON path", () => {
     ]);
   });
 
+  // Codex P2 round 7 (M10 follow-up Bug B): a `bridge.sendTurn`
+  // resolution of `{ accepted: false }` (the protocol type allows it)
+  // means no `turn/started` lifecycle will ever fire. Pre-fix the
+  // queue would wait the full 15-min safety timer and the mirrored
+  // bubble would stay pending. Treat it as an inline error so the
+  // chain advances immediately and the bubble shows errored status.
+  it("releases the queue when bridge.sendTurn resolves accepted: false", async () => {
+    const bridge = makeBridge();
+    __setActiveBridgeForTest(SESSION, bridge);
+
+    (bridge.sendTurn as ReturnType<typeof vi.fn>).mockImplementation(() =>
+      Promise.resolve({ accepted: false }),
+    );
+
+    const onComplete1 = vi.fn();
+    const onComplete2 = vi.fn();
+
+    sendMessage({
+      sessionId: SESSION,
+      text: "Q1 server-rejects",
+      media: [],
+      clientMessageId: "cmid-rejected",
+      onComplete: onComplete1,
+    });
+    sendMessage({
+      sessionId: SESSION,
+      text: "Q2 follow-up",
+      media: [],
+      clientMessageId: "cmid-followup",
+      onComplete: onComplete2,
+    });
+
+    for (let i = 0; i < 12; i++) await Promise.resolve();
+    // Q1 finishes inline (accepted: false → finalizeAssistant + release).
+    expect(onComplete1).toHaveBeenCalledTimes(1);
+    expect(bridge.sendTurn).toHaveBeenCalledTimes(2);
+    const threads = ThreadStore.getThreads(SESSION);
+    expect(threads.find((t) => t.id === "cmid-rejected")?.responses[0].status).toBe(
+      "error",
+    );
+  });
+
   // Codex P2 round 4 (M10 follow-up Bug B): the user message must be
   // mirrored into ThreadStore SYNCHRONOUSLY, before the per-session
   // queue gate. Pre-fix, `addUserMessage` ran inside `sendMessageV1`

--- a/src/runtime/ui-protocol-send.test.ts
+++ b/src/runtime/ui-protocol-send.test.ts
@@ -608,22 +608,28 @@ describe("sendMessage flag-ON path", () => {
     expect(onComplete1).toHaveBeenCalledTimes(1);
 
     // Q2 must now proceed. With the bridge already torn down /
-    // unregistered, the v1 path falls back to legacy — so we just
-    // verify that Q2's onComplete eventually fires (the queue
-    // unblocked) and we did NOT issue a second `bridge.sendTurn`
-    // against a stopped bridge.
+    // unregistered, the v1 path falls back to legacy. The real legacy
+    // SSE bridge fires `onComplete` on stream done — mirror that with
+    // the spy mock so the queue-release tied to legacy completion
+    // (codex round 5 P2) actually fires in the test, allowing a Q3
+    // follow-up to proceed instead of parking on the 15-min safety
+    // timer.
+    legacySendSpy.mockImplementation((opts: SendOptions) => {
+      // Microtask-defer onComplete so the queue advances after the
+      // current await Promise.resolve() loop, not synchronously.
+      Promise.resolve().then(() => opts.onComplete?.());
+    });
     __resetUiProtocolRuntimeForTest(); // mirrors runtime stopping the bridge
     for (let i = 0; i < 12; i++) await Promise.resolve();
     // sendTurn count is unchanged — Q2 fell to legacy because the bridge
     // is no longer registered when its turn at the queue head arrived.
     expect(bridge.sendTurn).toHaveBeenCalledTimes(1);
-    // Q2's onComplete fires from the legacy fallback path's
-    // releaseLifecycleGate; the legacy SSE bridge is mocked here so it
-    // doesn't call onComplete itself. The minimal correctness signal is
-    // that the QUEUE drained (a follow-up send would proceed); assert
-    // by issuing a third send and confirming it lands in the legacy
-    // mock too rather than parking forever.
+    // Q3 follow-up: lands on legacy too (still no bridge). The queue
+    // must have drained for this to fire.
     legacySendSpy.mockClear();
+    legacySendSpy.mockImplementation((opts: SendOptions) => {
+      Promise.resolve().then(() => opts.onComplete?.());
+    });
     sendMessage({
       sessionId: SESSION,
       text: "Q3",

--- a/src/runtime/ui-protocol-send.test.ts
+++ b/src/runtime/ui-protocol-send.test.ts
@@ -107,13 +107,16 @@ describe("sendMessage flag-ON path", () => {
     window.localStorage.setItem("chat_app_ui_v1", "1");
   });
 
-  it("falls back to the legacy bridge when no active bridge is registered", () => {
+  it("falls back to the legacy bridge when no active bridge is registered", async () => {
     sendMessage({
       sessionId: SESSION,
       text: "hi",
       media: [],
       clientMessageId: "cmid-fallback",
     });
+    // Bug B per-session queue: legacy fallback runs after `await prev`
+    // so the synchronous spy assertion gains 2-3 microtask ticks.
+    for (let i = 0; i < 12; i++) await Promise.resolve();
     expect(legacySendSpy).toHaveBeenCalledTimes(1);
   });
 
@@ -189,7 +192,7 @@ describe("sendMessage flag-ON path", () => {
   // Codex review must-fix #5A: media-bearing turns must NOT silently
   // drop on the v1 path (TurnStartInput.kind === "text" only). Falling
   // back to legacy keeps voice/image uploads working under the flag.
-  it("falls back to legacy when media is present", () => {
+  it("falls back to legacy when media is present", async () => {
     const bridge = makeBridge();
     __setActiveBridgeForTest(SESSION, bridge);
     sendMessage({
@@ -198,11 +201,14 @@ describe("sendMessage flag-ON path", () => {
       media: ["/tmp/foo.png"],
       clientMessageId: "cmid-media",
     });
+    // Bug B per-session queue: legacy fallback runs after `await prev`.
+    for (let i = 0; i < 12; i++) await Promise.resolve();
     expect(legacySendSpy).toHaveBeenCalledTimes(1);
     expect(bridge.sendTurn).not.toHaveBeenCalled();
-    // The thread store must NOT be pre-populated by the v1 mirror —
-    // the legacy bridge handles its own ThreadStore mirroring (gated
-    // by isThreadStoreEnabled() which now also reads chat_app_ui_v1).
+    // The thread store must NOT be pre-populated by the v1 sync mirror —
+    // the legacy bridge handles its own ThreadStore mirroring for
+    // media (gated by isThreadStoreEnabled()), and duplicating it here
+    // would double-thread.
     expect(ThreadStore.getThreads(SESSION)).toHaveLength(0);
   });
 
@@ -210,7 +216,7 @@ describe("sendMessage flag-ON path", () => {
   // rewrite. Legacy posts requestText to /api/chat; the v1 path only
   // takes a plain text input. Fall back so the rewrite isn't silently
   // dropped.
-  it("falls back to legacy when requestText differs from text", () => {
+  it("falls back to legacy when requestText differs from text", async () => {
     const bridge = makeBridge();
     __setActiveBridgeForTest(SESSION, bridge);
     sendMessage({
@@ -220,6 +226,7 @@ describe("sendMessage flag-ON path", () => {
       media: [],
       clientMessageId: "cmid-rewrite",
     });
+    for (let i = 0; i < 12; i++) await Promise.resolve();
     expect(legacySendSpy).toHaveBeenCalledTimes(1);
     expect(bridge.sendTurn).not.toHaveBeenCalled();
   });
@@ -379,6 +386,110 @@ describe("sendMessage flag-ON path", () => {
     expect(bridge.sendTurn).toHaveBeenLastCalledWith("cmid-Q3", [
       { kind: "text", text: "Q3" },
     ]);
+  });
+
+  // Codex P2 round 4 (M10 follow-up Bug B): the user message must be
+  // mirrored into ThreadStore SYNCHRONOUSLY, before the per-session
+  // queue gate. Pre-fix, `addUserMessage` ran inside `sendMessageV1`
+  // AFTER `await prev`, so a queued prompt was invisible until the
+  // prior turn drained — and the user's input field had already
+  // cleared, making the prompt feel lost.
+  it("mirrors a queued v1 user message synchronously, before the gate clears", async () => {
+    const bridge = makeBridge();
+    __setActiveBridgeForTest(SESSION, bridge);
+
+    let lifecycleHandler:
+      | ((e: { turn_id: string; reason?: string; error?: unknown }) => void)
+      | undefined;
+    (bridge.onTurnLifecycle as ReturnType<typeof vi.fn>).mockImplementation(
+      (h: (e: { turn_id: string; reason?: string; error?: unknown }) => void) => {
+        lifecycleHandler = h;
+        return () => {
+          lifecycleHandler = undefined;
+        };
+      },
+    );
+
+    sendMessage({
+      sessionId: SESSION,
+      text: "Q1",
+      media: [],
+      clientMessageId: "cmid-Q1",
+    });
+    sendMessage({
+      sessionId: SESSION,
+      text: "Q2",
+      media: [],
+      clientMessageId: "cmid-Q2",
+    });
+
+    // After exactly one microtask tick — well before Q1's lifecycle
+    // would unblock Q2's `bridge.sendTurn` — both user bubbles must
+    // already be in the thread store.
+    await Promise.resolve();
+    const threads = ThreadStore.getThreads(SESSION);
+    expect(threads.map((t) => t.id)).toEqual(["cmid-Q1", "cmid-Q2"]);
+    expect(threads[0].userMsg.text).toBe("Q1");
+    expect(threads[1].userMsg.text).toBe("Q2");
+    // Only Q1's bridge.sendTurn fired so far — Q2 is still queued.
+    for (let i = 0; i < 12; i++) await Promise.resolve();
+    expect(bridge.sendTurn).toHaveBeenCalledTimes(1);
+    expect(bridge.sendTurn).toHaveBeenLastCalledWith("cmid-Q1", [
+      { kind: "text", text: "Q1" },
+    ]);
+
+    lifecycleHandler?.({ turn_id: "cmid-Q1", reason: "stop" });
+    for (let i = 0; i < 12; i++) await Promise.resolve();
+    expect(bridge.sendTurn).toHaveBeenCalledTimes(2);
+  });
+
+  // Codex P2 round 4 (M10 follow-up Bug B): a media-bearing prompt
+  // queued behind an in-flight v1 turn must not overtake the v1 turn at
+  // the server. Pre-fix, `sendMessage` short-circuited media sends to
+  // the synchronous `legacySendMessage` path, so a "Q1 text → Q2
+  // image" pair could arrive on the server in reverse order. Now every
+  // v1 send (text, media, rewrite) funnels through `enqueueSendV1`,
+  // and the legacy `/api/chat` for a fallback only runs after the
+  // prior v1 turn's lifecycle.
+  it("orders mixed text + media sends through the same per-session queue", async () => {
+    const bridge = makeBridge();
+    __setActiveBridgeForTest(SESSION, bridge);
+
+    let lifecycleHandler:
+      | ((e: { turn_id: string; reason?: string; error?: unknown }) => void)
+      | undefined;
+    (bridge.onTurnLifecycle as ReturnType<typeof vi.fn>).mockImplementation(
+      (h: (e: { turn_id: string; reason?: string; error?: unknown }) => void) => {
+        lifecycleHandler = h;
+        return () => {
+          lifecycleHandler = undefined;
+        };
+      },
+    );
+
+    // Q1: pure text → v1 path. Q2: text + media → legacy fallback.
+    sendMessage({
+      sessionId: SESSION,
+      text: "Q1 text",
+      media: [],
+      clientMessageId: "cmid-Q1",
+    });
+    sendMessage({
+      sessionId: SESSION,
+      text: "Q2 with image",
+      media: ["/tmp/foo.png"],
+      clientMessageId: "cmid-Q2",
+    });
+
+    for (let i = 0; i < 12; i++) await Promise.resolve();
+    // Q1's v1 sendTurn fired first; Q2's legacy fallback is parked.
+    expect(bridge.sendTurn).toHaveBeenCalledTimes(1);
+    expect(legacySendSpy).not.toHaveBeenCalled();
+
+    // Q1 completes → Q2's legacy /api/chat runs.
+    lifecycleHandler?.({ turn_id: "cmid-Q1", reason: "stop" });
+    for (let i = 0; i < 12; i++) await Promise.resolve();
+    expect(legacySendSpy).toHaveBeenCalledTimes(1);
   });
 
   // Codex P2 round 3 (M10 follow-up Bug B): a throwing `onComplete`

--- a/src/runtime/ui-protocol-send.test.ts
+++ b/src/runtime/ui-protocol-send.test.ts
@@ -380,4 +380,86 @@ describe("sendMessage flag-ON path", () => {
       { kind: "text", text: "Q3" },
     ]);
   });
+
+  // Codex P2 round 2 (M10 follow-up Bug B): when the bridge is torn down
+  // (user navigates away from the session/topic, runtime calls
+  // `stopActiveBridge`), `bridge.stop()` clears `subTurnLifecycle`. The
+  // `onTurnLifecycle` handler installed by the in-flight `sendMessageV1`
+  // is dropped before the server ever emits `turn/completed`. Pre-fix,
+  // the per-session queue would block subsequent sends for the 15-min
+  // safety timer.
+  //
+  // The connection-state listener bridges this: as soon as the bridge
+  // transitions to `"closed"`, the in-flight send forces release of the
+  // lifecycle gate. Subsequent enqueued sends resume immediately
+  // (falling through to legacy if the bridge is gone).
+  it("releases the per-session queue when the bridge transitions to closed", async () => {
+    const bridge = makeBridge();
+    __setActiveBridgeForTest(SESSION, bridge);
+
+    let stateHandler: ((s: string) => void) | undefined;
+    (bridge.onConnectionStateChange as ReturnType<typeof vi.fn>).mockImplementation(
+      (h: (s: string) => void) => {
+        stateHandler = h;
+        return () => {
+          stateHandler = undefined;
+        };
+      },
+    );
+
+    const onComplete1 = vi.fn();
+    const onComplete2 = vi.fn();
+
+    // First send installs its lifecycle + state listeners.
+    sendMessage({
+      sessionId: SESSION,
+      text: "Q1",
+      media: [],
+      clientMessageId: "cmid-Q1",
+      onComplete: onComplete1,
+    });
+    // Second send queues behind Q1's lifecycle gate.
+    sendMessage({
+      sessionId: SESSION,
+      text: "Q2",
+      media: [],
+      clientMessageId: "cmid-Q2",
+      onComplete: onComplete2,
+    });
+
+    for (let i = 0; i < 12; i++) await Promise.resolve();
+    expect(bridge.sendTurn).toHaveBeenCalledTimes(1);
+    expect(stateHandler).toBeDefined();
+
+    // Bridge teardown: connection state goes to `closed`. The lifecycle
+    // gate must release WITHOUT waiting for `turn/completed`.
+    stateHandler?.("closed");
+    expect(onComplete1).toHaveBeenCalledTimes(1);
+
+    // Q2 must now proceed. With the bridge already torn down /
+    // unregistered, the v1 path falls back to legacy — so we just
+    // verify that Q2's onComplete eventually fires (the queue
+    // unblocked) and we did NOT issue a second `bridge.sendTurn`
+    // against a stopped bridge.
+    __resetUiProtocolRuntimeForTest(); // mirrors runtime stopping the bridge
+    for (let i = 0; i < 12; i++) await Promise.resolve();
+    // sendTurn count is unchanged — Q2 fell to legacy because the bridge
+    // is no longer registered when its turn at the queue head arrived.
+    expect(bridge.sendTurn).toHaveBeenCalledTimes(1);
+    // Q2's onComplete fires from the legacy fallback path's
+    // releaseLifecycleGate; the legacy SSE bridge is mocked here so it
+    // doesn't call onComplete itself. The minimal correctness signal is
+    // that the QUEUE drained (a follow-up send would proceed); assert
+    // by issuing a third send and confirming it lands in the legacy
+    // mock too rather than parking forever.
+    legacySendSpy.mockClear();
+    sendMessage({
+      sessionId: SESSION,
+      text: "Q3",
+      media: [],
+      clientMessageId: "cmid-Q3",
+    });
+    for (let i = 0; i < 12; i++) await Promise.resolve();
+    expect(legacySendSpy).toHaveBeenCalled();
+  });
 });

--- a/src/runtime/ui-protocol-send.test.ts
+++ b/src/runtime/ui-protocol-send.test.ts
@@ -201,15 +201,17 @@ describe("sendMessage flag-ON path", () => {
       media: ["/tmp/foo.png"],
       clientMessageId: "cmid-media",
     });
-    // Bug B per-session queue: legacy fallback runs after `await prev`.
+    // Codex round 6 P2: the user bubble must appear SYNCHRONOUSLY for
+    // every send (text, media, rewrite) so a queued prompt isn't
+    // invisible until the prior turn drains. After exactly one tick
+    // the thread is in the store; the legacy `legacySendMessage` itself
+    // runs after the queue gate (12 ticks here covers it).
+    await Promise.resolve();
+    expect(ThreadStore.getThreads(SESSION)).toHaveLength(1);
+    expect(ThreadStore.getThreads(SESSION)[0].id).toBe("cmid-media");
     for (let i = 0; i < 12; i++) await Promise.resolve();
     expect(legacySendSpy).toHaveBeenCalledTimes(1);
     expect(bridge.sendTurn).not.toHaveBeenCalled();
-    // The thread store must NOT be pre-populated by the v1 sync mirror —
-    // the legacy bridge handles its own ThreadStore mirroring for
-    // media (gated by isThreadStoreEnabled()), and duplicating it here
-    // would double-thread.
-    expect(ThreadStore.getThreads(SESSION)).toHaveLength(0);
   });
 
   // Codex review must-fix #5A: requestText !== text means a /command

--- a/src/runtime/ui-protocol-send.ts
+++ b/src/runtime/ui-protocol-send.ts
@@ -29,10 +29,133 @@ export function sendMessage(opts: SendOptions): void {
     legacySendMessage(opts);
     return;
   }
-  void sendMessageV1(opts);
+  // Fast-path the legacy fallbacks SYNCHRONOUSLY (no queue) — they don't
+  // issue a `bridge.sendTurn`, so they don't compete for the server's
+  // "one turn at a time" slot. Pulling them out of the queue path also
+  // preserves the original synchronous semantics of `sendMessage(opts);
+  // expect(legacySendSpy).toHaveBeenCalledTimes(1)` that the unit tests
+  // depend on (no `await` between call and assertion).
+  if (shouldFallbackToLegacy(opts)) {
+    legacySendMessage(opts);
+    return;
+  }
+  void enqueueSendV1(opts);
 }
 
-async function sendMessageV1(opts: SendOptions): Promise<void> {
+function shouldFallbackToLegacy(opts: SendOptions): boolean {
+  const hasMedia = opts.media.length > 0;
+  const hasRewrite =
+    opts.requestText !== undefined && opts.requestText !== opts.text;
+  if (hasMedia || hasRewrite) {
+    if (typeof console !== "undefined" && console.info) {
+      console.info(
+        "ui-protocol-send: v1 path does not yet support media/requestText; falling back to legacy",
+        { hasMedia, hasRewrite },
+      );
+    }
+    return true;
+  }
+  // No active bridge → legacy fallback (rare race: send before mount).
+  if (!getActiveBridge(opts.sessionId, opts.historyTopic)) {
+    return true;
+  }
+  return false;
+}
+
+// ---------------------------------------------------------------------------
+// Per-session turn-start queue (M10 follow-up Bug B)
+// ---------------------------------------------------------------------------
+//
+// Background: the WS `turn/start` handler enforces "one turn at a time" per
+// session — a second `turn/start` arriving while the previous turn's
+// foreground phase is still running is rejected with the error
+// `"a turn is already running for this session"`
+// (see `crates/octos-cli/src/api/ui_protocol.rs::handle_turn_start`).
+//
+// Pre-fix, `sendMessageV1` called `bridge.sendTurn(...)` immediately. When
+// the user (or a soak test) sent a second prompt before the first turn's
+// foreground phase finished, the SPA had already added a user bubble via
+// `ThreadStore.addUserMessage` but the server then rejected the RPC. The
+// bubble stayed on screen with no assistant pair — exactly the `live-
+// overflow-stress` failure mode (4 of 5 prompts orphaned at workers=1).
+//
+// The legacy SSE `/api/chat` path doesn't hit this because the chat backend
+// queues concurrent messages server-side (see `stream-manager.ts:191`
+// "The backend's queue mode … handles concurrent messages server-side").
+// The v1 WS protocol intentionally rejects rather than queues, so the
+// queueing has to live on the client.
+//
+// Implementation: a per-session promise chain. `enqueueSendV1` pushes the
+// next send onto the chain; each send awaits BOTH (a) the prior send's
+// completion AND (b) the prior turn's lifecycle event (`turn/completed`
+// or `turn/error`) before issuing `bridge.sendTurn`. The chain is keyed
+// by `(sessionId, historyTopic)` so distinct sessions don't block each
+// other.
+//
+// On falls-through to `legacySendMessage` (no bridge / has media /
+// rewrite), we DON'T inject the wait — the legacy path is independent.
+
+const turnQueues = new Map<string, Promise<void>>();
+
+function queueKey(sessionId: string, topic: string | undefined): string {
+  const t = topic?.trim();
+  return t ? `${sessionId}#${t}` : sessionId;
+}
+
+async function enqueueSendV1(opts: SendOptions): Promise<void> {
+  const key = queueKey(opts.sessionId, opts.historyTopic);
+  const prev = turnQueues.get(key) ?? Promise.resolve();
+
+  // The signal we hand to `sendMessageV1`. The lifecycle handler resolves
+  // it on `turn/completed` or `turn/error` (or on early failure inside
+  // `sendMessageV1`). The next chained call awaits this signal before
+  // issuing its own `bridge.sendTurn`.
+  let release!: () => void;
+  const lifecycleDone = new Promise<void>((resolve) => {
+    release = resolve;
+  });
+  // Build the chain entry as a fresh promise we keep a stable reference to,
+  // so the cleanup compare-and-delete is correct.
+  const chained = prev.then(() => lifecycleDone);
+  turnQueues.set(key, chained);
+
+  try {
+    await prev;
+    await sendMessageV1(opts, release);
+    // Wait for the lifecycle to complete before we let the chain advance.
+    // `sendMessageV1` always calls `release()` — on success via the
+    // `turn/completed`/`turn/error` listener, on early fallback or RPC
+    // failure inline — so this resolves promptly rather than parking the
+    // chain forever.
+    await lifecycleDone;
+  } catch {
+    // Defensive: if `sendMessageV1` ever rejects without calling release,
+    // unblock the chain so a transient failure doesn't wedge subsequent
+    // sends.
+    release();
+  } finally {
+    if (turnQueues.get(key) === chained) {
+      turnQueues.delete(key);
+    }
+  }
+}
+
+/** Test-only reset for the per-session queue map. */
+export function __resetSendQueueForTest(): void {
+  turnQueues.clear();
+}
+
+async function sendMessageV1(
+  opts: SendOptions,
+  // Bug B (M10 follow-up): per-session FIFO queue gate. Resolves on the
+  // server's `turn/completed`/`turn/error` for THIS turn so the next
+  // `enqueueSendV1` call can issue its own `bridge.sendTurn` without
+  // racing the server's "one turn at a time" rule. Always called exactly
+  // once on every code path (including the legacy fallbacks) so the chain
+  // never wedges. Defaults to a no-op for backward compatibility / direct
+  // test calls.
+  releaseLifecycleGate: () => void = () => {},
+): Promise<void> {
   const {
     sessionId,
     historyTopic,
@@ -60,6 +183,12 @@ async function sendMessageV1(opts: SendOptions): Promise<void> {
       );
     }
     legacySendMessage(opts);
+    // Legacy SSE path runs independently of the v1 turn-queue. Releasing
+    // immediately means the next v1 send won't be blocked behind a
+    // legacy-only turn — but that's the right semantic, because the
+    // legacy `/api/chat` route is the path that already queues
+    // server-side, so the WS turn-collision doesn't apply.
+    releaseLifecycleGate();
     return;
   }
 
@@ -70,6 +199,9 @@ async function sendMessageV1(opts: SendOptions): Promise<void> {
     // session is still functional, just not on the v1 transport for this
     // turn. The next turn will pick up the bridge.
     legacySendMessage(opts);
+    // Same reasoning as the media/rewrite fallback above — release so
+    // the v1 chain doesn't stall behind a non-v1 turn.
+    releaseLifecycleGate();
     return;
   }
 
@@ -99,10 +231,19 @@ async function sendMessageV1(opts: SendOptions): Promise<void> {
   // listener afterwards. The handler also fires `onComplete` on RPC
   // rejection so the input never spins forever on a network failure.
   let completed = false;
+  let lifecycleSafetyTimer: ReturnType<typeof setTimeout> | null = null;
   const fireComplete = () => {
     if (completed) return;
     completed = true;
+    if (lifecycleSafetyTimer !== null) {
+      clearTimeout(lifecycleSafetyTimer);
+      lifecycleSafetyTimer = null;
+    }
     onComplete?.();
+    // Bug B: also unblock the per-session turn queue so the next
+    // `enqueueSendV1` can issue its `bridge.sendTurn`. Calling release
+    // multiple times is a no-op.
+    releaseLifecycleGate();
   };
   const off = bridge.onTurnLifecycle((e) => {
     if (e.turn_id !== clientMessageId) return;
@@ -118,6 +259,26 @@ async function sendMessageV1(opts: SendOptions): Promise<void> {
       fireComplete();
     }
   });
+
+  // Bug B safety net: if the server never emits `turn/completed` /
+  // `turn/error` for this turn (server crash mid-turn, WS reconnect race
+  // that drops the lifecycle frame past the ledger replay window), the
+  // per-session queue would otherwise wedge — every subsequent
+  // `sendMessage` call sits forever waiting for `lifecycleDone`. Force a
+  // release after a generously long upper bound (15 min); long enough
+  // that legitimate slow turns (deep_research foreground, mofa-podcast
+  // generation) finish well within it, short enough that a wedged
+  // session recovers without a page reload. `fireComplete` is
+  // idempotent, so a late lifecycle frame after the timeout is a no-op.
+  lifecycleSafetyTimer = setTimeout(
+    () => {
+      if (!completed) {
+        off();
+        fireComplete();
+      }
+    },
+    15 * 60 * 1000,
+  );
 
   try {
     await bridge.sendTurn(clientMessageId, [

--- a/src/runtime/ui-protocol-send.ts
+++ b/src/runtime/ui-protocol-send.ts
@@ -357,12 +357,22 @@ async function sendMessageV1(
   );
 
   try {
-    await bridge.sendTurn(clientMessageId, [
+    const result = await bridge.sendTurn(clientMessageId, [
       { kind: "text", text },
       // File / voice attachments stay on REST — see fallback above. The
       // bridge schema already accepts a TurnStartInput[] so a future PR
       // can add file references here without changing this call site.
     ]);
+    // Codex round 7 P2: if the server's RPC reply is structurally
+    // valid but reports `{ accepted: false }`, no `turn/started` will
+    // ever fire — the lifecycle gate would otherwise wait the full
+    // 15-min safety timer. Mark the bubble errored and release
+    // immediately, mirroring the rejected-RPC catch branch below.
+    if (!result?.accepted) {
+      ThreadStore.finalizeAssistant(clientMessageId, { status: "error" });
+      off();
+      fireComplete();
+    }
   } catch {
     // Surface as an error message in the thread so the user isn't left
     // with a silent dead pending bubble. The bridge already emits a

--- a/src/runtime/ui-protocol-send.ts
+++ b/src/runtime/ui-protocol-send.ts
@@ -253,11 +253,20 @@ async function sendMessageV1(
       offState();
       offState = null;
     }
-    onComplete?.();
-    // Bug B: also unblock the per-session turn queue so the next
-    // `enqueueSendV1` can issue its `bridge.sendTurn`. Calling release
-    // multiple times is a no-op.
-    releaseLifecycleGate();
+    // Codex round 3 P2: invoke onComplete inside try/finally so a
+    // throwing callback cannot wedge the per-session queue. The bridge
+    // swallows subscriber exceptions inside its `Subscribers.emit`, so
+    // pre-fix a thrown callback unwound past `releaseLifecycleGate`
+    // here, the lifecycle promise never resolved, and every subsequent
+    // send for the session blocked on the 15-min safety timer.
+    try {
+      onComplete?.();
+    } finally {
+      // Bug B: unblock the per-session turn queue so the next
+      // `enqueueSendV1` can issue its `bridge.sendTurn`. Calling
+      // release multiple times is a no-op.
+      releaseLifecycleGate();
+    }
   };
   const off = bridge.onTurnLifecycle((e) => {
     if (e.turn_id !== clientMessageId) return;

--- a/src/runtime/ui-protocol-send.ts
+++ b/src/runtime/ui-protocol-send.ts
@@ -111,6 +111,16 @@ async function enqueueSendV1(opts: SendOptions): Promise<void> {
   const key = queueKey(opts.sessionId);
   const prev = turnQueues.get(key) ?? Promise.resolve();
 
+  // Codex round 5 P1: pin the clientMessageId ONCE so the synchronous
+  // ThreadStore mirror and the eventual `sendTurn`/lifecycle gate use
+  // the same value. Pre-fix, when a caller omitted `clientMessageId`
+  // (the chat-thread default), `enqueueSendV1` minted one for the
+  // mirror but `sendMessageV1` minted a different one for sendTurn —
+  // server events / errors would not attach to the mirrored pending
+  // bubble.
+  const clientMessageId = opts.clientMessageId ?? crypto.randomUUID();
+  const pinnedOpts: SendOptions = { ...opts, clientMessageId };
+
   // Codex round 4 P2: mirror the user message into ThreadStore
   // SYNCHRONOUSLY before the queue gate, so the bubble is visible the
   // instant the user clicks Send — even when a prior turn has not yet
@@ -132,19 +142,19 @@ async function enqueueSendV1(opts: SendOptions): Promise<void> {
   //     `requestText` to /api/chat but mirrors `text` into the store —
   //     we'd need to pre-compute that here and risk drifting from the
   //     legacy bridge's behaviour. Defer to legacy for these too.
-  if (shouldMirrorUserMessageSync(opts)) {
-    const localFiles = opts.media.map((path) => ({
+  if (shouldMirrorUserMessageSync(pinnedOpts)) {
+    const localFiles = pinnedOpts.media.map((path) => ({
       filename: displayFilenameFromPath(path),
       path,
       caption: "",
     }));
-    ThreadStore.addUserMessage(opts.sessionId, {
-      text: opts.text,
-      clientMessageId: opts.clientMessageId ?? crypto.randomUUID(),
+    ThreadStore.addUserMessage(pinnedOpts.sessionId, {
+      text: pinnedOpts.text,
+      clientMessageId,
       files: localFiles,
-      topic: opts.historyTopic,
+      topic: pinnedOpts.historyTopic,
     });
-    opts.onSessionActive?.(opts.text);
+    pinnedOpts.onSessionActive?.(pinnedOpts.text);
   }
 
   // The signal we hand to `sendMessageV1`. The lifecycle handler resolves
@@ -166,11 +176,44 @@ async function enqueueSendV1(opts: SendOptions): Promise<void> {
     // bridge availability HERE (rather than at sendMessage entry) so a
     // bridge that was torn down while we were parked correctly falls
     // through to legacy.
-    if (shouldFallbackToLegacy(opts)) {
-      legacySendMessage(opts);
-      release();
+    if (shouldFallbackToLegacy(pinnedOpts)) {
+      // Codex round 5 P2: tie the queue release to the legacy send's
+      // own completion callback. Pre-fix, the queue released
+      // immediately after `legacySendMessage` returned (which only
+      // schedules the SSE fetch — the actual /api/chat is still in
+      // flight). A subsequent v1 `bridge.sendTurn` could then race
+      // the legacy turn at the WS one-turn lock. Wrap the caller's
+      // `onComplete` so we hold the gate until the legacy stream's
+      // `done` (or error) fires.
+      const userOnComplete = pinnedOpts.onComplete;
+      let released = false;
+      legacySendMessage({
+        ...pinnedOpts,
+        onComplete: () => {
+          if (!released) {
+            released = true;
+            release();
+          }
+          userOnComplete?.();
+        },
+      });
+      // Defensive timeout: if the legacy bridge never calls
+      // `onComplete` (e.g. an unhandled fetch error), match the v1
+      // safety net's 15-minute upper bound so the chain still drains.
+      const legacySafetyTimer = setTimeout(
+        () => {
+          if (!released) {
+            released = true;
+            release();
+          }
+        },
+        15 * 60 * 1000,
+      );
+      // Don't keep the timer alive past resolution — once the chain
+      // advances we don't care about a late onComplete.
+      void lifecycleDone.then(() => clearTimeout(legacySafetyTimer));
     } else {
-      await sendMessageV1(opts, release);
+      await sendMessageV1(pinnedOpts, release);
     }
     // Wait for the lifecycle to complete before we let the chain advance.
     // `sendMessageV1` always calls `release()` — on success via the

--- a/src/runtime/ui-protocol-send.ts
+++ b/src/runtime/ui-protocol-send.ts
@@ -97,13 +97,20 @@ function shouldFallbackToLegacy(opts: SendOptions): boolean {
 
 const turnQueues = new Map<string, Promise<void>>();
 
-function queueKey(sessionId: string, topic: string | undefined): string {
-  const t = topic?.trim();
-  return t ? `${sessionId}#${t}` : sessionId;
+// Per-session lock scope. Codex P2: the server's
+// `handle_turn_start` "one turn at a time" lock is keyed by `session_id`
+// only — `bridge.sendTurn` doesn't carry the SPA-side `historyTopic`,
+// so switching topic mid-turn would not relax the server's rejection
+// rule. Key the queue on `sessionId` to match the server lock scope
+// exactly; otherwise a topic switch lets a fresh prompt through to the
+// same-session lock and reproduces the orphan-bubble shape this fix
+// targets.
+function queueKey(sessionId: string): string {
+  return sessionId;
 }
 
 async function enqueueSendV1(opts: SendOptions): Promise<void> {
-  const key = queueKey(opts.sessionId, opts.historyTopic);
+  const key = queueKey(opts.sessionId);
   const prev = turnQueues.get(key) ?? Promise.resolve();
 
   // The signal we hand to `sendMessageV1`. The lifecycle handler resolves

--- a/src/runtime/ui-protocol-send.ts
+++ b/src/runtime/ui-protocol-send.ts
@@ -29,16 +29,14 @@ export function sendMessage(opts: SendOptions): void {
     legacySendMessage(opts);
     return;
   }
-  // Fast-path the legacy fallbacks SYNCHRONOUSLY (no queue) — they don't
-  // issue a `bridge.sendTurn`, so they don't compete for the server's
-  // "one turn at a time" slot. Pulling them out of the queue path also
-  // preserves the original synchronous semantics of `sendMessage(opts);
-  // expect(legacySendSpy).toHaveBeenCalledTimes(1)` that the unit tests
-  // depend on (no `await` between call and assertion).
-  if (shouldFallbackToLegacy(opts)) {
-    legacySendMessage(opts);
-    return;
-  }
+  // Codex round 4 P2: every v1 send funnels through the per-session
+  // queue, including the legacy fallbacks (media/rewrite/no-bridge).
+  // Pre-fix, fallback sends bypassed the queue and could overtake an
+  // already-queued v1 prompt — the user submits "Q1" (text → queued
+  // behind a running turn) then "Q2 with image" (legacy fast-path) and
+  // the server sees Q2 first. Funnelling everything through
+  // `enqueueSendV1` preserves user submission order regardless of
+  // which transport each send eventually picks.
   void enqueueSendV1(opts);
 }
 
@@ -113,6 +111,42 @@ async function enqueueSendV1(opts: SendOptions): Promise<void> {
   const key = queueKey(opts.sessionId);
   const prev = turnQueues.get(key) ?? Promise.resolve();
 
+  // Codex round 4 P2: mirror the user message into ThreadStore
+  // SYNCHRONOUSLY before the queue gate, so the bubble is visible the
+  // instant the user clicks Send — even when a prior turn has not yet
+  // emitted `turn/completed`. Pre-fix, `addUserMessage` ran inside
+  // `sendMessageV1` AFTER `await prev`, so a queued prompt was
+  // invisible until the prior turn drained (and could be lost on
+  // reload during that window). The legacy-fallback path also benefits:
+  // a media-bearing prompt parked behind a v1 turn now shows its bubble
+  // immediately, and only the actual `legacySendMessage` (or
+  // `bridge.sendTurn`) is gated.
+  //
+  // Two callers skip the synchronous mirror:
+  //   - text + media: `legacySendMessage` runs the upload pipeline and
+  //     triggers its own ThreadStore mirror via the SSE bridge's hook;
+  //     duplicating it here would create two threads with the same
+  //     clientMessageId (the legacy mirror is gated on the v2-store
+  //     flag, but the v1 send path implies v2 is on).
+  //   - rewrite (`requestText !== text`): the legacy bridge sends
+  //     `requestText` to /api/chat but mirrors `text` into the store —
+  //     we'd need to pre-compute that here and risk drifting from the
+  //     legacy bridge's behaviour. Defer to legacy for these too.
+  if (shouldMirrorUserMessageSync(opts)) {
+    const localFiles = opts.media.map((path) => ({
+      filename: displayFilenameFromPath(path),
+      path,
+      caption: "",
+    }));
+    ThreadStore.addUserMessage(opts.sessionId, {
+      text: opts.text,
+      clientMessageId: opts.clientMessageId ?? crypto.randomUUID(),
+      files: localFiles,
+      topic: opts.historyTopic,
+    });
+    opts.onSessionActive?.(opts.text);
+  }
+
   // The signal we hand to `sendMessageV1`. The lifecycle handler resolves
   // it on `turn/completed` or `turn/error` (or on early failure inside
   // `sendMessageV1`). The next chained call awaits this signal before
@@ -128,7 +162,16 @@ async function enqueueSendV1(opts: SendOptions): Promise<void> {
 
   try {
     await prev;
-    await sendMessageV1(opts, release);
+    // After the gate clears, decide v1 vs legacy fallback. Re-check
+    // bridge availability HERE (rather than at sendMessage entry) so a
+    // bridge that was torn down while we were parked correctly falls
+    // through to legacy.
+    if (shouldFallbackToLegacy(opts)) {
+      legacySendMessage(opts);
+      release();
+    } else {
+      await sendMessageV1(opts, release);
+    }
     // Wait for the lifecycle to complete before we let the chain advance.
     // `sendMessageV1` always calls `release()` — on success via the
     // `turn/completed`/`turn/error` listener, on early fallback or RPC
@@ -147,6 +190,19 @@ async function enqueueSendV1(opts: SendOptions): Promise<void> {
       turnQueues.delete(key);
     }
   }
+}
+
+/** Whether `enqueueSendV1` should mirror the user message into the
+ *  ThreadStore SYNCHRONOUSLY (codex round 4 P2). Returns true only for
+ *  the pure-text v1 path; the media and rewrite legacy fallbacks have
+ *  their own ThreadStore mirroring inside the SSE bridge that we must
+ *  not duplicate. */
+function shouldMirrorUserMessageSync(opts: SendOptions): boolean {
+  if (opts.media.length > 0) return false;
+  if (opts.requestText !== undefined && opts.requestText !== opts.text) {
+    return false;
+  }
+  return true;
 }
 
 /** Test-only reset for the per-session queue map. */
@@ -169,69 +225,28 @@ async function sendMessageV1(
     sessionId,
     historyTopic,
     text,
-    requestText,
-    media,
     clientMessageId = crypto.randomUUID(),
-    onSessionActive,
     onComplete,
   } = opts;
 
-  // Codex review must-fix #5A: TurnStartInput v1 only carries text. Media
-  // (image / voice) and `requestText !== text` (e.g. /commands rewrite)
-  // need the legacy /api/chat upload pre-step that the SSE bridge owns.
-  // Falling back keeps the user's input intact; the next turn picks the
-  // v1 transport back up. A `console.info` makes the path switch
-  // observable in DevTools without surfacing as a warning.
-  const hasMedia = media.length > 0;
-  const hasRewrite = requestText !== undefined && requestText !== text;
-  if (hasMedia || hasRewrite) {
-    if (typeof console !== "undefined" && console.info) {
-      console.info(
-        "ui-protocol-send: v1 path does not yet support media/requestText; falling back to legacy",
-        { hasMedia, hasRewrite },
-      );
-    }
-    legacySendMessage(opts);
-    // Legacy SSE path runs independently of the v1 turn-queue. Releasing
-    // immediately means the next v1 send won't be blocked behind a
-    // legacy-only turn — but that's the right semantic, because the
-    // legacy `/api/chat` route is the path that already queues
-    // server-side, so the WS turn-collision doesn't apply.
-    releaseLifecycleGate();
-    return;
-  }
+  // The user message is mirrored into ThreadStore by `enqueueSendV1`
+  // BEFORE the queue gate (codex round 4 P2). All sendMessageV1 callers
+  // arrive here through `enqueueSendV1` for the v1 path, so the bubble
+  // already exists in the thread store. Direct test paths that call
+  // `sendMessageV1` without going through the queue must mirror their
+  // own user message — but the production export (`sendMessage`) goes
+  // through `enqueueSendV1` unconditionally.
 
   const bridge = getActiveBridge(sessionId, historyTopic);
   if (!bridge) {
-    // Bridge has not started yet (rare race: send before mount effect ran).
-    // Fall back to the SSE path so the user message is never lost — the
-    // session is still functional, just not on the v1 transport for this
-    // turn. The next turn will pick up the bridge.
+    // Bridge was torn down between the queue gate and now. Fall back to
+    // legacy. The user bubble is already in the store from
+    // `enqueueSendV1`'s synchronous mirror, so the legacy path's own
+    // mirror is a no-op (deduped by clientMessageId in ThreadStore).
     legacySendMessage(opts);
-    // Same reasoning as the media/rewrite fallback above — release so
-    // the v1 chain doesn't stall behind a non-v1 turn.
     releaseLifecycleGate();
     return;
   }
-
-  const localFiles = media.map((path) => ({
-    filename: displayFilenameFromPath(path),
-    path,
-    caption: "",
-  }));
-
-  // Mirror the legacy bridge's user-message write so the thread store has
-  // a thread anchored on this clientMessageId before any server event
-  // arrives. The pendingAssistant slot is opened so streaming tokens land
-  // in the right slot from the very first delta.
-  ThreadStore.addUserMessage(sessionId, {
-    text,
-    clientMessageId,
-    files: localFiles,
-    topic: historyTopic,
-  });
-
-  onSessionActive?.(text);
 
   // Codex review must-fix #5B: subscribe to the turn lifecycle BEFORE
   // calling `sendTurn`. A fast turn/completed (or turn/error) can fire

--- a/src/runtime/ui-protocol-send.ts
+++ b/src/runtime/ui-protocol-send.ts
@@ -121,41 +121,34 @@ async function enqueueSendV1(opts: SendOptions): Promise<void> {
   const clientMessageId = opts.clientMessageId ?? crypto.randomUUID();
   const pinnedOpts: SendOptions = { ...opts, clientMessageId };
 
-  // Codex round 4 P2: mirror the user message into ThreadStore
+  // Codex round 4-6 P2: mirror the user message into ThreadStore
   // SYNCHRONOUSLY before the queue gate, so the bubble is visible the
   // instant the user clicks Send — even when a prior turn has not yet
   // emitted `turn/completed`. Pre-fix, `addUserMessage` ran inside
   // `sendMessageV1` AFTER `await prev`, so a queued prompt was
-  // invisible until the prior turn drained (and could be lost on
-  // reload during that window). The legacy-fallback path also benefits:
-  // a media-bearing prompt parked behind a v1 turn now shows its bubble
-  // immediately, and only the actual `legacySendMessage` (or
-  // `bridge.sendTurn`) is gated.
+  // invisible until the prior turn drained.
   //
-  // Two callers skip the synchronous mirror:
-  //   - text + media: `legacySendMessage` runs the upload pipeline and
-  //     triggers its own ThreadStore mirror via the SSE bridge's hook;
-  //     duplicating it here would create two threads with the same
-  //     clientMessageId (the legacy mirror is gated on the v2-store
-  //     flag, but the v1 send path implies v2 is on).
-  //   - rewrite (`requestText !== text`): the legacy bridge sends
-  //     `requestText` to /api/chat but mirrors `text` into the store —
-  //     we'd need to pre-compute that here and risk drifting from the
-  //     legacy bridge's behaviour. Defer to legacy for these too.
-  if (shouldMirrorUserMessageSync(pinnedOpts)) {
-    const localFiles = pinnedOpts.media.map((path) => ({
-      filename: displayFilenameFromPath(path),
-      path,
-      caption: "",
-    }));
-    ThreadStore.addUserMessage(pinnedOpts.sessionId, {
-      text: pinnedOpts.text,
-      clientMessageId,
-      files: localFiles,
-      topic: pinnedOpts.historyTopic,
-    });
-    pinnedOpts.onSessionActive?.(pinnedOpts.text);
-  }
+  // This applies to EVERY transport path (v1 text, legacy media,
+  // legacy rewrite, no-bridge fallback). The legacy SSE bridge does
+  // its own `addUserMessage` mirror later in `legacySendMessage`, but
+  // `addUserMessage` is idempotent on an existing `clientMessageId`
+  // (`thread-store.ts:addUserMessage` "If a thread already exists with
+  // this id, adopt it instead of double-inserting"), so the second
+  // call is a no-op. By matching the legacy bridge's mirror semantics
+  // (`text` for the bubble even when `requestText` differs) the two
+  // paths produce identical store state.
+  const localFiles = pinnedOpts.media.map((path) => ({
+    filename: displayFilenameFromPath(path),
+    path,
+    caption: "",
+  }));
+  ThreadStore.addUserMessage(pinnedOpts.sessionId, {
+    text: pinnedOpts.text,
+    clientMessageId,
+    files: localFiles,
+    topic: pinnedOpts.historyTopic,
+  });
+  pinnedOpts.onSessionActive?.(pinnedOpts.text);
 
   // The signal we hand to `sendMessageV1`. The lifecycle handler resolves
   // it on `turn/completed` or `turn/error` (or on early failure inside
@@ -235,18 +228,6 @@ async function enqueueSendV1(opts: SendOptions): Promise<void> {
   }
 }
 
-/** Whether `enqueueSendV1` should mirror the user message into the
- *  ThreadStore SYNCHRONOUSLY (codex round 4 P2). Returns true only for
- *  the pure-text v1 path; the media and rewrite legacy fallbacks have
- *  their own ThreadStore mirroring inside the SSE bridge that we must
- *  not duplicate. */
-function shouldMirrorUserMessageSync(opts: SendOptions): boolean {
-  if (opts.media.length > 0) return false;
-  if (opts.requestText !== undefined && opts.requestText !== opts.text) {
-    return false;
-  }
-  return true;
-}
 
 /** Test-only reset for the per-session queue map. */
 export function __resetSendQueueForTest(): void {

--- a/src/runtime/ui-protocol-send.ts
+++ b/src/runtime/ui-protocol-send.ts
@@ -132,8 +132,10 @@ async function enqueueSendV1(opts: SendOptions): Promise<void> {
     // Wait for the lifecycle to complete before we let the chain advance.
     // `sendMessageV1` always calls `release()` — on success via the
     // `turn/completed`/`turn/error` listener, on early fallback or RPC
-    // failure inline — so this resolves promptly rather than parking the
-    // chain forever.
+    // failure inline (including the connection-state `closed` listener
+    // for codex P2 round 2: bridge teardown cascades release through
+    // every parked entry without the 15-min safety wait). So this
+    // resolves promptly rather than parking the chain forever.
     await lifecycleDone;
   } catch {
     // Defensive: if `sendMessageV1` ever rejects without calling release,
@@ -239,12 +241,17 @@ async function sendMessageV1(
   // rejection so the input never spins forever on a network failure.
   let completed = false;
   let lifecycleSafetyTimer: ReturnType<typeof setTimeout> | null = null;
+  let offState: (() => void) | null = null;
   const fireComplete = () => {
     if (completed) return;
     completed = true;
     if (lifecycleSafetyTimer !== null) {
       clearTimeout(lifecycleSafetyTimer);
       lifecycleSafetyTimer = null;
+    }
+    if (offState !== null) {
+      offState();
+      offState = null;
     }
     onComplete?.();
     // Bug B: also unblock the per-session turn queue so the next
@@ -262,6 +269,20 @@ async function sendMessageV1(
       return;
     }
     if ("reason" in e) {
+      off();
+      fireComplete();
+    }
+  });
+
+  // Codex P2 round 2: if the bridge stops (user navigates away from this
+  // session/topic, runtime tears down), `bridge.stop()` calls
+  // `subTurnLifecycle.clear()` and our `onTurnLifecycle` handler is gone
+  // forever — `releaseLifecycleGate` would otherwise wait on the 15-min
+  // safety timer. Subscribe to the bridge's connection state and force a
+  // release as soon as it transitions to `closed`. Idempotent via the
+  // `completed` guard inside `fireComplete`.
+  offState = bridge.onConnectionStateChange((s) => {
+    if (s === "closed") {
       off();
       fireComplete();
     }

--- a/src/store/thread-store.test.ts
+++ b/src/store/thread-store.test.ts
@@ -1628,4 +1628,88 @@ describe("thread-store", () => {
     });
     expect(ok).toBe(false);
   });
+
+  it("appendCompletionBubble_routes_burst_of_3_sibling_envelopes_to_distinct_threads", () => {
+    // M10 follow-up Bug B regression: under the wave-6m soak, 3+
+    // sibling user prompts (each with a spawn_only skill) sometimes
+    // fail to receive their `turn/spawn_complete` envelope when the
+    // envelopes arrive in rapid succession (parallel deep_search +
+    // mofa-podcast + tts can finish back-to-back).
+    //
+    // The synchronous routing path MUST land each envelope under its
+    // own user-prompt thread, regardless of dispatch order. Each thread
+    // has a finalized spawn-ack (the "Q1/Q2/Q3 user bubble + spawn-ack"
+    // shape from the failing soak DOM dump) so the upgrade-in-place
+    // codepath is NOT triggered — fresh rows are appended.
+    makeUser("Q1 deep research", "cmid-Q1");
+    makeUser("Q2 mofa podcast", "cmid-Q2");
+    makeUser("Q3 tts", "cmid-Q3");
+
+    // Each thread already has a finalized spawn-ack (mirrors the live
+    // sequence: spawn_only tool emits message/delta + message/persisted
+    // for the ack BEFORE the late spawn_complete envelope).
+    ThreadStore.appendAssistantToken("cmid-Q1", "深度研究已在后台启动…");
+    ThreadStore.finalizeAssistant("cmid-Q1", { committedSeq: 2 });
+    ThreadStore.appendAssistantToken("cmid-Q2", "Podcast generation started…");
+    ThreadStore.finalizeAssistant("cmid-Q2", { committedSeq: 3 });
+    ThreadStore.appendAssistantToken("cmid-Q3", "TTS synthesis started…");
+    ThreadStore.finalizeAssistant("cmid-Q3", { committedSeq: 4 });
+
+    // 3 turn/spawn_complete envelopes fire in the same JS tick (server
+    // emitted them within ms of each other; the WS frame loop drains
+    // them all before yielding). Each carries DISTINCT messageId,
+    // historySeq, and threadId.
+    ThreadStore.appendCompletionBubble("cmid-Q1", {
+      text: "Rust news: tokio 1.42 released.",
+      media: ["bg/research-Q1.md"],
+      spawnComplete: true,
+      messageId: "msg-Q1-result",
+      historySeq: 10,
+      sessionId: SESSION,
+    });
+    ThreadStore.appendCompletionBubble("cmid-Q2", {
+      text: "AI podcast episode generated.",
+      media: ["bg/podcast-Q2.mp3"],
+      spawnComplete: true,
+      messageId: "msg-Q2-result",
+      historySeq: 11,
+      sessionId: SESSION,
+    });
+    ThreadStore.appendCompletionBubble("cmid-Q3", {
+      text: "Voice synthesised.",
+      media: ["bg/tts-Q3.mp3"],
+      spawnComplete: true,
+      messageId: "msg-Q3-result",
+      historySeq: 12,
+      sessionId: SESSION,
+    });
+
+    const threads = ThreadStore.getThreads(SESSION);
+    expect(threads.map((t) => t.id)).toEqual([
+      "cmid-Q1",
+      "cmid-Q2",
+      "cmid-Q3",
+    ]);
+
+    const findCompletion = (threadId: string) =>
+      threads
+        .find((t) => t.id === threadId)
+        ?.responses.find((r) => r.id.startsWith("msg-"));
+
+    const c1 = findCompletion("cmid-Q1");
+    const c2 = findCompletion("cmid-Q2");
+    const c3 = findCompletion("cmid-Q3");
+    expect(c1?.text).toBe("Rust news: tokio 1.42 released.");
+    expect(c1?.files.map((f) => f.path)).toEqual(["bg/research-Q1.md"]);
+    expect(c2?.text).toBe("AI podcast episode generated.");
+    expect(c2?.files.map((f) => f.path)).toEqual(["bg/podcast-Q2.mp3"]);
+    expect(c3?.text).toBe("Voice synthesised.");
+    expect(c3?.files.map((f) => f.path)).toEqual(["bg/tts-Q3.mp3"]);
+
+    // Each thread MUST have exactly its own ack + completion (2 rows),
+    // not bleed into siblings — the splice-merge bug class M10 deletes.
+    for (const t of threads) {
+      expect(t.responses).toHaveLength(2);
+    }
+  });
 });

--- a/src/store/thread-store.ts
+++ b/src/store/thread-store.ts
@@ -99,6 +99,19 @@ interface SessionState {
   byId: Map<string, Thread>;
 }
 
+// Bug B diagnostic. Gated on `localStorage.octos_debug_envelope === '1'`.
+// See `ui-protocol-bridge.ts` `debugEnvelopeLog` for the full rationale.
+function debugCompletionLog(tag: string, payload: unknown): void {
+  if (typeof window === "undefined") return;
+  try {
+    if (window.localStorage.getItem("octos_debug_envelope") !== "1") return;
+  } catch {
+    return;
+  }
+  // eslint-disable-next-line no-console
+  console.log(`[bug-b:store:appendCompletion] ${tag}`, payload);
+}
+
 const sessionsByKey = new Map<string, SessionState>();
 const listeners = new Set<() => void>();
 const loadedSessions = new Set<string>();
@@ -663,6 +676,15 @@ export function appendCompletionBubble(
   threadId: string,
   opts: AppendCompletionBubbleOptions,
 ): boolean {
+  // Bug B diagnostic. See ui-protocol-bridge.ts `debugEnvelopeLog`.
+  debugCompletionLog("enter", {
+    threadId,
+    messageId: opts.messageId,
+    historySeq: opts.historySeq,
+    text_len: opts.text.length,
+    media_count: opts.media.length,
+    sessionId: opts.sessionId,
+  });
   // Resolve the host thread. Prefer an exact match anywhere in the
   // store (M8.10 cross-session cmid semantics). When no match exists,
   // create the orphan inside the router's active session so
@@ -700,8 +722,17 @@ export function appendCompletionBubble(
       host = ensureOrphanThread(threadId);
     }
   }
-  if (!host) return false;
+  if (!host) {
+    debugCompletionLog("drop:no-host", { threadId });
+    return false;
+  }
   const { thread } = host;
+  debugCompletionLog("host-resolved", {
+    threadId,
+    is_orphan: thread.userMsg.text === "",
+    existing_responses: thread.responses.length,
+    has_pending: thread.pendingAssistant !== null,
+  });
 
   // Identity / upgrade-in-place. A replayed envelope on reconnect
   // MUST NOT produce a duplicate row. Two stable identities exist:
@@ -735,13 +766,29 @@ export function appendCompletionBubble(
       // True identity match — this row IS the spawn-complete row.
       // Upgrade-in-place if it's a placeholder (the persisted-only
       // shape), no-op if it's already the full completion.
-      if (r.text.length > 0) return true;
+      if (r.text.length > 0) {
+        debugCompletionLog("dedupe:messageId-existing-text", {
+          threadId,
+          messageId: opts.messageId,
+        });
+        return true;
+      }
       thread.responses[i] = upgradePlaceholderRow(r, opts, threadId);
       sortResponsesInThread(thread);
       notify();
+      debugCompletionLog("upgrade:messageId-placeholder", {
+        threadId,
+        messageId: opts.messageId,
+      });
       return true;
     }
-    if (thread.pendingAssistant?.id === opts.messageId) return true;
+    if (thread.pendingAssistant?.id === opts.messageId) {
+      debugCompletionLog("dedupe:messageId-pending", {
+        threadId,
+        messageId: opts.messageId,
+      });
+      return true;
+    }
   }
 
   if (typeof opts.historySeq === "number") {
@@ -761,15 +808,31 @@ export function appendCompletionBubble(
       // For (b) test-path callers, the next-best identity is "same
       // text + same media list"; if that matches, treat as no-op.
       if (r.text.length > 0) {
-        if (rowMatchesCompletionContent(r, opts)) return true;
+        if (rowMatchesCompletionContent(r, opts)) {
+          debugCompletionLog("dedupe:historySeq-content-match", {
+            threadId,
+            historySeq: opts.historySeq,
+          });
+          return true;
+        }
         continue; // (a): merged-ack row, not our target
       }
       thread.responses[i] = upgradePlaceholderRow(r, opts, threadId);
       sortResponsesInThread(thread);
       notify();
+      debugCompletionLog("upgrade:historySeq-placeholder", {
+        threadId,
+        historySeq: opts.historySeq,
+      });
       return true;
     }
-    if (thread.pendingAssistant?.historySeq === opts.historySeq) return true;
+    if (thread.pendingAssistant?.historySeq === opts.historySeq) {
+      debugCompletionLog("dedupe:historySeq-pending", {
+        threadId,
+        historySeq: opts.historySeq,
+      });
+      return true;
+    }
   }
 
   const completion: ThreadMessage = {
@@ -791,6 +854,11 @@ export function appendCompletionBubble(
   thread.responses.push(completion);
   sortResponsesInThread(thread);
   notify();
+  debugCompletionLog("append:new-row", {
+    threadId,
+    messageId: completion.id,
+    responses_after: thread.responses.length,
+  });
   return true;
 }
 


### PR DESCRIPTION
## Summary

- Serialise WS `turn/start` sends per session via a per-session promise queue. The server's `handle_turn_start` enforces "one turn at a time" per session and rejects concurrent RPCs; the legacy SSE `/api/chat` path queues server-side, but the v1 WS protocol intentionally rejects rather than queues, so the client must serialise.
- Pre-fix soak showed 1 of 5 prompts paired in the wave-6m media-mix-soak-five-skills scenario at workers=1. Empirical confirmation via the server ledger: only 2 of 5 expected `turn/started` events landed; Q2/Q4/Q5 were RPC-rejected with `"a turn is already running for this session"`. The user bubbles were already mirrored into ThreadStore (so the test saw 5 user bubbles in the DOM) but the assistant turns never ran.
- Diagnostic instrumentation gated on `localStorage.octos_debug_envelope === '1'` lands across the bridge / router / store. Off in production by default; flip the flag in DevTools to capture every `turn/spawn_complete` envelope, every `appendCompletionBubble` invocation, every dedupe / upgrade / new-row path. Used to empirically rule out the bridge / router / store as the failure surface before localising the bug to the server's RPC reject.

## Root cause

`sendMessageV1` issued `bridge.sendTurn(...)` immediately. When prompts arrive in rapid succession (the `live-overflow-stress` 5-prompt soak shape), the SPA pre-populated user bubbles via `ThreadStore.addUserMessage` but the server then rejected the RPC for prompts 2..N. Bubbles stayed on screen with no assistant pair — the test pair-walk halted at the first orphan, masking the actual RPC-rejection shape.

## Implementation

Per-session promise chain in `ui-protocol-send.ts`. Each send awaits BOTH (a) the prior send's completion AND (b) the prior turn's lifecycle event (`turn/completed` or `turn/error`) before issuing `bridge.sendTurn`. The chain is keyed by `sessionId` (matching the server's lock scope — `bridge.sendTurn` does not carry `historyTopic`).

Defensive details (codex review iterated):

- 15-min safety timer force-releases the lifecycle gate if the server never emits a lifecycle event (server crash mid-turn, WS reconnect race that drops the lifecycle frame past the ledger replay window).
- `onConnectionStateChange("closed")` listener forces release on bridge teardown so navigation doesn't wedge the queue waiting for a lifecycle that will never fire.
- `onComplete` callback wrapped in `try/finally` so a throwing callback can't leave the gate unreleased.
- `clientMessageId` pinned ONCE at queue entry so the synchronous ThreadStore mirror and the eventual `bridge.sendTurn` use the same id.
- Legacy fallback (media / rewrite / no-bridge) also funnels through the queue. Its release is tied to the legacy SSE bridge's own `onComplete` so a subsequent v1 `bridge.sendTurn` can't race the legacy turn at the WS one-turn lock.
- User message mirrored into ThreadStore SYNCHRONOUSLY before the queue gate so a queued prompt's bubble is visible the instant the user clicks Send (rather than waiting on the prior turn to drain).

## Test plan

- [x] `npx vitest run` — 172 passing (4 expected failures from the test-only `feature-flags.ts` override; not committed).
- [x] `serialises 3 rapid sends per session, awaiting prior turn lifecycle` — directly asserts queue ordering with a mocked bridge + lifecycle handler.
- [x] `releases the per-session queue when the bridge transitions to closed` — asserts navigation teardown drains the queue.
- [x] `releases the queue even when the onComplete callback throws` — defensive regression for the try/finally.
- [x] `orders mixed text + media sends through the same per-session queue` — ensures legacy fallback doesn't overtake.
- [x] `mirrors a queued v1 user message synchronously, before the gate clears` — asserts immediate-bubble UX for queued prompts.
- [x] `appendCompletionBubble_routes_burst_of_3_sibling_envelopes_to_distinct_threads` — locks in the synchronous routing invariant the handoff requested.
- [ ] Live soak: `live-overflow-stress: media-mix-soak-five-skills` (in progress — pre-fix 1/5, target ≥4/5).

🤖 Generated with [Claude Code](https://claude.com/claude-code)