### PR TITLE
fix(runtime): dedup hydrate replay using server's source + envelope fields (M10 close)

### DIFF
--- a/src/runtime/ui-protocol-bridge.test.ts
+++ b/src/runtime/ui-protocol-bridge.test.ts
@@ -426,6 +426,121 @@ describe("type guards (fail-closed)", () => {
     expect(ev?.media).toBeUndefined();
   });
 
+  // -------------------------------------------------------------------------
+  // M10 Phase 6.2 (Bug C): session/hydrate result guard
+  // -------------------------------------------------------------------------
+
+  it("guardSessionHydrate accepts a hydrate result with new PR #791 fields", () => {
+    const result = guards.guardSessionHydrate({
+      session_id: "sess-1",
+      cursor: { stream: "sess-1", seq: 25 },
+      messages: [
+        {
+          seq: 0,
+          role: "user",
+          content: "Use deep_search...",
+          thread_id: "synth_0",
+          persisted_at: "2026-05-04T00:00:00Z",
+          // No message_id / source — older-protocol row.
+        },
+        {
+          seq: 19,
+          role: "assistant",
+          content: "Research delivered.",
+          thread_id: "synth_0",
+          persisted_at: "2026-05-04T00:09:22Z",
+          message_id: "local:demo:19:1700000019000000000",
+          source: "background",
+        },
+        {
+          seq: 20,
+          role: "assistant",
+          content: "",
+          thread_id: "synth_0",
+          persisted_at: "2026-05-04T00:09:22Z",
+          message_id: "local:demo:20:1700000020000000000",
+          source: "background",
+          media: ["pf/file.md"],
+        },
+      ],
+      replayed_envelopes: [
+        {
+          session_id: "sess-1",
+          turn_id: "turn-1",
+          thread_id: "synth_0",
+          task_id: "task_abc",
+          seq: 19,
+          message_id: "local:demo:19:1700000019000000000",
+          source: "background",
+          cursor: { stream: "sess-1", seq: 19 },
+          persisted_at: "2026-05-04T00:09:22Z",
+          content: "Research delivered.",
+          media: ["pf/file.md"],
+        },
+      ],
+    });
+    expect(result).not.toBeNull();
+    expect(result?.messages).toHaveLength(3);
+    expect(result?.messages?.[1].message_id).toBe(
+      "local:demo:19:1700000019000000000",
+    );
+    expect(result?.messages?.[1].source).toBe("background");
+    expect(result?.messages?.[0].message_id).toBeUndefined();
+    expect(result?.replayed_envelopes).toHaveLength(1);
+    expect(result?.replayed_envelopes?.[0].task_id).toBe("task_abc");
+  });
+
+  it("guardSessionHydrate accepts a back-compat result without new fields (older server)", () => {
+    const result = guards.guardSessionHydrate({
+      session_id: "sess-1",
+      cursor: { stream: "sess-1", seq: 5 },
+      messages: [
+        {
+          seq: 0,
+          role: "user",
+          content: "hi",
+          persisted_at: "2026-05-04T00:00:00Z",
+        },
+      ],
+      // No replayed_envelopes (server pre-#791, or non-negotiated client).
+    });
+    expect(result).not.toBeNull();
+    expect(result?.messages).toHaveLength(1);
+    expect(result?.replayed_envelopes).toBeUndefined();
+  });
+
+  it("guardSessionHydrate rejects a non-object payload", () => {
+    expect(guards.guardSessionHydrate(null)).toBeNull();
+    expect(guards.guardSessionHydrate("string")).toBeNull();
+    expect(guards.guardSessionHydrate(42)).toBeNull();
+  });
+
+  it("guardSessionHydrate drops malformed inner messages without poisoning the result", () => {
+    const result = guards.guardSessionHydrate({
+      session_id: "sess-1",
+      cursor: { stream: "sess-1", seq: 1 },
+      messages: [
+        {
+          seq: 0,
+          role: "user",
+          content: "ok",
+          persisted_at: "2026-05-04T00:00:00Z",
+        },
+        // Missing required fields — dropped.
+        { seq: "not-a-number", role: "assistant" },
+        // Invalid role — dropped.
+        {
+          seq: 2,
+          role: "narrator",
+          content: "",
+          persisted_at: "2026-05-04T00:00:00Z",
+        },
+      ],
+    });
+    expect(result).not.toBeNull();
+    expect(result?.messages).toHaveLength(1);
+  });
+
   it("rejects task/updated without task_id", () => {
     expect(
       guards.guardTaskUpdated({

--- a/src/runtime/ui-protocol-bridge.ts
+++ b/src/runtime/ui-protocol-bridge.ts
@@ -21,9 +21,11 @@ import type {
   ApprovalRespondResult,
   ApprovalScope,
   ConnectionState,
+  HydratedMessage,
   MessageDeltaEvent,
   MessagePersistedEvent,
   RpcErrorPayload,
+  SessionHydrateResult,
   SessionOpenResult,
   TaskOutputDeltaEvent,
   TaskUpdatedEvent,
@@ -43,10 +45,12 @@ export type {
   ApprovalRespondResult,
   ApprovalScope,
   ConnectionState,
+  HydratedMessage,
   MessageDeltaEvent,
   MessagePersistedEvent,
   PersistedMessage,
   PersistedMessageFile,
+  SessionHydrateResult,
   SessionOpenResult,
   SessionOpenedResult,
   TaskOutputDeltaEvent,
@@ -71,6 +75,7 @@ export const UI_PROTOCOL_WS_PATH = "/api/ui-protocol/ws";
 export const METHODS = {
   // client → server
   SESSION_OPEN: "session/open",
+  SESSION_HYDRATE: "session/hydrate",
   TURN_START: "turn/start",
   TURN_INTERRUPT: "turn/interrupt",
   APPROVAL_RESPOND: "approval/respond",
@@ -111,6 +116,13 @@ export const UI_PROTOCOL_FEATURES = [
   // PR (Phase 2) only ADDS the new envelope handling so the migration is
   // backward-compatible during rollout.
   "event.spawn_complete.v1",
+  // M10 Phase 6.2 (server PR #791 / Bug C): server gates `session/hydrate`
+  // RPC behind this feature when feature negotiation is present (UPCR-2026-009).
+  // Without it, our hydrate dedup pass never runs because the server
+  // returns `method_not_supported` for the RPC. The dedup snapshot
+  // populated post-`session/open` from the negotiated `replayed_envelopes`
+  // is what eliminates the N+1 bubble render after page reload.
+  "state.session_hydrate.v1",
 ] as const;
 
 const JSON_RPC_VERSION = "2.0";
@@ -166,6 +178,22 @@ export interface UiProtocolBridge {
     scope?: ApprovalScope,
     client_note?: string,
   ): Promise<ApprovalRespondResult>;
+
+  /**
+   * Issue a `session/hydrate` RPC for the active session. M10 Phase 6.2
+   * (Bug C): `replayed_envelopes` + per-row `(message_id, source)` are
+   * surfaced only when the connection negotiated
+   * `event.spawn_complete.v1` (server PR #791). Used by the runtime
+   * layer to dedup the legacy `Background`-source rows the live wire
+   * suppresses for negotiated clients.
+   *
+   * `include` defaults to `["messages"]` — that's the dedup target.
+   * Returns `null` when the RPC fails: the caller falls back to the
+   * legacy REST `replayHistory` path with no hydrate-time dedup.
+   */
+  hydrateSession(
+    include?: ReadonlyArray<"messages" | "threads" | "turns" | "pending_approvals">,
+  ): Promise<SessionHydrateResult | null>;
 
   onMessageDelta(handler: (e: MessageDeltaEvent) => void): () => void;
   onMessagePersisted(handler: (e: MessagePersistedEvent) => void): () => void;
@@ -470,6 +498,121 @@ function guardSpawnComplete(p: unknown): TurnSpawnCompleteEvent | null {
     persisted_at: p.persisted_at,
     content: p.content,
     media,
+  };
+}
+
+/**
+ * Guard for one row in `SessionHydrateResult.messages`. Fail-closed on
+ * type / required-field violations. `message_id` and `source` are
+ * Option<String> on the wire (server PR #791 codex round 6 gates them
+ * on `event.spawn_complete.v1` negotiation), so absence is normal — we
+ * surface them as `undefined` rather than rejecting the row.
+ */
+function guardHydratedMessage(p: unknown): HydratedMessage | null {
+  if (!isPlainObject(p)) return null;
+  if (typeof p.seq !== "number" || !Number.isFinite(p.seq) || p.seq < 0) {
+    return null;
+  }
+  if (!isString(p.role)) return null;
+  if (
+    p.role !== "system" &&
+    p.role !== "user" &&
+    p.role !== "assistant" &&
+    p.role !== "tool"
+  ) {
+    return null;
+  }
+  if (typeof p.content !== "string") return null;
+  if (!isString(p.persisted_at)) return null;
+  let media: string[] | undefined;
+  if (Array.isArray(p.media)) {
+    const filtered = p.media.filter(
+      (u): u is string => isString(u) && u.length > 0,
+    );
+    if (filtered.length > 0) media = filtered;
+  }
+  return {
+    seq: p.seq,
+    role: p.role,
+    content: p.content,
+    turn_id:
+      typeof p.turn_id === "string" && p.turn_id.length > 0
+        ? p.turn_id
+        : undefined,
+    thread_id:
+      typeof p.thread_id === "string" && p.thread_id.length > 0
+        ? p.thread_id
+        : undefined,
+    client_message_id:
+      typeof p.client_message_id === "string" && p.client_message_id.length > 0
+        ? p.client_message_id
+        : undefined,
+    persisted_at: p.persisted_at,
+    message_id:
+      typeof p.message_id === "string" && p.message_id.length > 0
+        ? p.message_id
+        : undefined,
+    source:
+      typeof p.source === "string" && p.source.length > 0
+        ? p.source
+        : undefined,
+    media,
+  };
+}
+
+/**
+ * Guard for the `session/hydrate` RPC result (server PR #791). The
+ * `messages` and `replayed_envelopes` fields are both optional — the
+ * server omits them when not requested or not negotiated. Treat any
+ * non-object payload as a hard reject (returns null), but accept the
+ * shape with all-optional sections for back-compat with older servers.
+ *
+ * Inner-row failure is non-fatal: malformed `messages[i]` / envelope
+ * entries are dropped so a single corrupt row doesn't poison the whole
+ * hydrate. Cursor is required in the typed wire shape but the SPA
+ * doesn't drive off it today, so an absent / malformed cursor falls
+ * back to a synthesized zero-cursor rather than rejecting the result.
+ */
+export function guardSessionHydrate(p: unknown): SessionHydrateResult | null {
+  if (!isPlainObject(p)) return null;
+  if (!isString(p.session_id)) return null;
+
+  let cursor: { stream: string; seq: number };
+  if (
+    isPlainObject(p.cursor) &&
+    typeof p.cursor.stream === "string" &&
+    typeof p.cursor.seq === "number" &&
+    Number.isFinite(p.cursor.seq) &&
+    p.cursor.seq >= 0
+  ) {
+    cursor = { stream: p.cursor.stream, seq: p.cursor.seq };
+  } else {
+    cursor = { stream: "", seq: 0 };
+  }
+
+  let messages: HydratedMessage[] | undefined;
+  if (Array.isArray(p.messages)) {
+    messages = [];
+    for (const m of p.messages) {
+      const guarded = guardHydratedMessage(m);
+      if (guarded) messages.push(guarded);
+    }
+  }
+
+  let replayedEnvelopes: TurnSpawnCompleteEvent[] | undefined;
+  if (Array.isArray(p.replayed_envelopes)) {
+    replayedEnvelopes = [];
+    for (const e of p.replayed_envelopes) {
+      const guarded = guardSpawnComplete(e);
+      if (guarded) replayedEnvelopes.push(guarded);
+    }
+  }
+
+  return {
+    session_id: p.session_id,
+    cursor,
+    messages,
+    replayed_envelopes: replayedEnvelopes,
   };
 }
 
@@ -808,6 +951,37 @@ class UiProtocolBridgeImpl implements UiProtocolBridge {
       METHODS.APPROVAL_RESPOND,
       params,
     );
+  }
+
+  async hydrateSession(
+    include: ReadonlyArray<
+      "messages" | "threads" | "turns" | "pending_approvals"
+    > = ["messages"],
+  ): Promise<SessionHydrateResult | null> {
+    try {
+      const raw = await this.request<unknown>(METHODS.SESSION_HYDRATE, {
+        session_id: this.requireSessionId(),
+        include,
+      });
+      const guarded = guardSessionHydrate(raw);
+      if (!guarded) {
+        this.subWarning.emit({
+          reason: "hydrate_guard_rejected",
+          context: { method: METHODS.SESSION_HYDRATE },
+        });
+        return null;
+      }
+      return guarded;
+    } catch (err) {
+      // Failure is non-fatal — the legacy REST `loadHistory` path still
+      // populates the thread store. We just lose the hydrate-time dedup
+      // for this session.
+      this.subWarning.emit({
+        reason: "hydrate_rpc_failed",
+        context: err instanceof Error ? err.message : String(err),
+      });
+      return null;
+    }
   }
 
   onMessageDelta(handler: Listener<MessageDeltaEvent>): () => void {
@@ -1265,6 +1439,7 @@ export const __INTERNAL_GUARDS_FOR_TEST__ = {
   guardMessageDelta,
   guardMessagePersisted,
   guardSpawnComplete,
+  guardSessionHydrate,
   guardTaskUpdated,
   guardTaskOutputDelta,
   guardTurnStarted,

--- a/src/runtime/ui-protocol-runtime.ts
+++ b/src/runtime/ui-protocol-runtime.ts
@@ -13,6 +13,7 @@ import {
   type UiProtocolBridge,
 } from "./ui-protocol-bridge";
 import { attachRouter, type RouterAttachment } from "./ui-protocol-event-router";
+import { setHydrateSnapshot } from "@/store/thread-store";
 
 interface ActiveBridge {
   sessionId: string;
@@ -98,6 +99,40 @@ export async function startBridgeForSession(
   }
   const attachment = attachRouter(bridge, { sessionId, topic });
   active = { sessionId, topic, bridge, attachment };
+
+  // M10 Phase 6.2 (Bug C): immediately fire `session/hydrate` to fetch
+  // the negotiated `replayed_envelopes` + per-row `(message_id,
+  // source)`. Cache the result in ThreadStore so any concurrent or
+  // subsequent REST `replayHistory` (chat-thread.tsx fires retries at
+  // 2s/5s/12s) can dedup the legacy `Background`-source rows the live
+  // wire suppresses for negotiated clients. Best-effort: a failure
+  // here just falls back to the pre-Bug-C N+1 render.
+  //
+  // Topic scoping: the WS bridge starts with the bare `sessionId` (no
+  // topic), so `session/hydrate` returns data for the ROOT
+  // `SessionKey` (which encodes a `#topic` suffix when topics are
+  // active server-side). Until the bridge can negotiate topic with
+  // the server, restrict the dedup to the no-topic case — the soak
+  // suite + Bug C reproducer all run in this scope, and topic-scoped
+  // chat (slides/sites) keeps the legacy REST-only render with the
+  // pre-fix N+1 limitation. This avoids cross-topic envelope leakage
+  // (codex round-2 P2).
+  if (!topic || topic.trim() === "") {
+    void (async () => {
+      if (myGeneration !== generation) return;
+      // Defensive: test mocks of `UiProtocolBridge` may pre-date this
+      // method. Production builds always have it.
+      if (typeof bridge.hydrateSession !== "function") return;
+      const hydrate = await bridge.hydrateSession(["messages"]);
+      if (myGeneration !== generation) return;
+      if (!hydrate) return;
+      setHydrateSnapshot(sessionId, topic, {
+        messages: hydrate.messages,
+        replayed_envelopes: hydrate.replayed_envelopes,
+      });
+    })();
+  }
+
   return bridge;
 }
 

--- a/src/runtime/ui-protocol-types.ts
+++ b/src/runtime/ui-protocol-types.ts
@@ -280,3 +280,63 @@ export interface RpcErrorPayload {
   message: string;
   data?: unknown;
 }
+
+/**
+ * `session/hydrate` row shape per server PR #791 (M10 Phase 6.2 / Bug C).
+ *
+ * Mirrors `octos_core::ui_protocol::HydratedMessage`. The two fields the
+ * SPA cares about for hydrate-time dedup of legacy `Background`-source
+ * rows are:
+ *
+ *   - `message_id`: stable per-row identity, agrees with
+ *     `MessagePersistedEvent.message_id` and
+ *     `TurnSpawnCompleteEvent.message_id` for the same row. The server
+ *     populates this only when the connection negotiated
+ *     `event.spawn_complete.v1`.
+ *   - `source`: snake_case wire form of `MessagePersistedSource`
+ *     (`"user" | "assistant" | "tool" | "background" | "recovery"`).
+ *     Used to identify the per-file `send_file` companion rows the live
+ *     wire suppresses for negotiated clients.
+ *
+ * Both are `Option<String>` on the wire; legacy clients that pre-date
+ * negotiation see them omitted (back-compat). Treat both as optional.
+ */
+export interface HydratedMessage {
+  seq: number;
+  role: "system" | "user" | "assistant" | "tool";
+  content: string;
+  turn_id?: string;
+  thread_id?: string;
+  client_message_id?: string;
+  persisted_at: string;
+  message_id?: string;
+  source?: string;
+  media?: string[];
+}
+
+/**
+ * `session/hydrate` result shape per server PR #791. The `messages`
+ * field is omitted when the request didn't include `"messages"`; the
+ * `replayed_envelopes` field is omitted when the connection didn't
+ * negotiate `event.spawn_complete.v1` OR `messages` wasn't requested.
+ *
+ * The negotiated dedup contract on a fresh page reload is:
+ *
+ *   1. For each `replayed_envelopes[i]`, find the row in `messages`
+ *      whose `message_id` matches: that's the spawn-ack the live wire
+ *      replaced with the envelope. Drop the row, render the envelope.
+ *   2. For each Background companion row in the same thread that
+ *      precedes the spawn-ack and does NOT match any envelope's
+ *      `message_id`: drop it (the envelope's `media` already covers
+ *      it).
+ *   3. All other rows replay verbatim.
+ */
+export interface SessionHydrateResult {
+  session_id: string;
+  cursor: UiCursor;
+  messages?: HydratedMessage[];
+  threads?: unknown[];
+  turns?: unknown[];
+  pending_approvals?: unknown[];
+  replayed_envelopes?: TurnSpawnCompleteEvent[];
+}

--- a/src/store/thread-store.test.ts
+++ b/src/store/thread-store.test.ts
@@ -1713,3 +1713,493 @@ describe("thread-store", () => {
     }
   });
 });
+
+// ---------------------------------------------------------------------------
+// M10 Phase 6.2 (Bug C): WS session/hydrate dedup pass
+// ---------------------------------------------------------------------------
+
+describe("applyHydrateDedup (M10 Phase 6.2)", () => {
+  const SID = "sess-bug-c";
+
+  it("drops the legacy spawn-ack row when an envelope's message_id matches it, then renders the envelope", () => {
+    // Replay the REST history shape the server returns post-Bug-C
+    // before client-side dedup: user prompt + spawn-ack assistant row
+    // (background source) + per-file companion row (background
+    // source). The live wire suppressed both for negotiated clients
+    // and replaced them with one `turn/spawn_complete` envelope.
+    ThreadStore.replayHistory(SID, [
+      {
+        seq: 0,
+        role: "user",
+        content: "Use deep_search to research X.",
+        client_message_id: "cmid-user-1",
+        thread_id: "cmid-user-1",
+        timestamp: "2026-05-04T00:00:00Z",
+      },
+      {
+        seq: 19,
+        role: "assistant",
+        content: "Done.",
+        thread_id: "cmid-user-1",
+        timestamp: "2026-05-04T00:09:22.538Z",
+      },
+      {
+        seq: 20,
+        role: "assistant",
+        content: "",
+        thread_id: "cmid-user-1",
+        timestamp: "2026-05-04T00:09:22.541Z",
+        media: ["pf/_report.md"],
+      },
+    ]);
+
+    // Pre-dedup: the legacy adjacent-merge already coalesces the
+    // companion (seq=20) into the spawn-ack (seq=19) since they have
+    // adjacent seqs and the companion has empty text. So the thread
+    // ends up with 1 user + 1 ack-with-file response. We still need
+    // dedup to replace that ack with the envelope content.
+    const before = ThreadStore.getThreads(SID);
+    expect(before).toHaveLength(1);
+    const beforeResponses = before[0].responses.length;
+    expect(beforeResponses).toBeGreaterThanOrEqual(1);
+
+    // Apply hydrate dedup with the WS envelope that replaces the ack.
+    // Per the server's hydrate contract: the envelope's `message_id`
+    // matches the spawn-ack row (seq=19); the companion row (seq=20)
+    // is identified by media-subset match against the envelope's
+    // `media` array.
+    ThreadStore.applyHydrateDedup(SID, undefined, {
+      messages: [
+        {
+          seq: 0,
+          message_id: "local:demo:0:1",
+          source: "user",
+          thread_id: "cmid-user-1",
+        },
+        {
+          seq: 19,
+          message_id: "local:demo:19:19",
+          source: "background",
+          thread_id: "cmid-user-1",
+        },
+        {
+          seq: 20,
+          message_id: "local:demo:20:20",
+          source: "background",
+          thread_id: "cmid-user-1",
+          media: ["pf/_report.md"],
+        },
+      ],
+      replayed_envelopes: [
+        {
+          thread_id: "cmid-user-1",
+          task_id: "task_abc",
+          seq: 19,
+          message_id: "local:demo:19:19",
+          content: "## Research delivered\nFull text inline.",
+          media: ["pf/_report.md"],
+          persisted_at: "2026-05-04T00:09:22.538Z",
+        },
+      ],
+    });
+
+    const after = ThreadStore.getThreads(SID);
+    expect(after).toHaveLength(1);
+    const responses = after[0].responses;
+    // Exactly 1 assistant bubble (the envelope's content), not 2 (ack + envelope).
+    expect(responses).toHaveLength(1);
+    // The bubble's content comes from the envelope, not the ack.
+    expect(responses[0].text).toBe("## Research delivered\nFull text inline.");
+    expect(responses[0].files.map((f) => f.path)).toContain("pf/_report.md");
+  });
+
+  it("drops file-companion rows whose media is a subset of the envelope's media", () => {
+    // Production shape: the spawn-ack row at seq=N (text, no media)
+    // followed by per-file `send_file` companion rows at seq=N+1...
+    // (each carrying ONE media file). The envelope's `media` array
+    // aggregates every companion's file path, so a media-subset
+    // match identifies the per-file companions for safe deletion.
+    ThreadStore.__resetForTests();
+    ThreadStore.replayHistory(SID, [
+      {
+        seq: 0,
+        role: "user",
+        content: "Q",
+        client_message_id: "cmid-1",
+        thread_id: "cmid-1",
+        timestamp: "2026-05-04T00:00:00Z",
+      },
+      {
+        seq: 10,
+        role: "assistant",
+        content: "spawn ack",
+        thread_id: "cmid-1",
+        timestamp: "2026-05-04T00:00:03Z",
+      },
+      // Per-file companions — gaps with the spawn-ack so
+      // adjacent-merge does not coalesce them.
+      {
+        seq: 13,
+        role: "assistant",
+        content: "",
+        thread_id: "cmid-1",
+        timestamp: "2026-05-04T00:00:04Z",
+        media: ["bg/file-a.md"],
+      },
+      {
+        seq: 16,
+        role: "assistant",
+        content: "",
+        thread_id: "cmid-1",
+        timestamp: "2026-05-04T00:00:05Z",
+        media: ["bg/file-b.md"],
+      },
+    ]);
+
+    const before = ThreadStore.getThreads(SID);
+    expect(before[0].responses).toHaveLength(3);
+
+    ThreadStore.applyHydrateDedup(SID, undefined, {
+      messages: [
+        { seq: 0, message_id: "m0", source: "user", thread_id: "cmid-1" },
+        // Spawn-ack: matches envelope's message_id.
+        { seq: 10, message_id: "m10", source: "background", thread_id: "cmid-1" },
+        // Per-file companions: identified by media-subset against envelope.media.
+        {
+          seq: 13,
+          message_id: "m13",
+          source: "background",
+          thread_id: "cmid-1",
+          media: ["bg/file-a.md"],
+        },
+        {
+          seq: 16,
+          message_id: "m16",
+          source: "background",
+          thread_id: "cmid-1",
+          media: ["bg/file-b.md"],
+        },
+      ],
+      replayed_envelopes: [
+        {
+          thread_id: "cmid-1",
+          task_id: "task_x",
+          seq: 10,
+          message_id: "m10",
+          content: "envelope content",
+          media: ["bg/file-a.md", "bg/file-b.md"],
+          persisted_at: "2026-05-04T00:00:03Z",
+        },
+      ],
+    });
+
+    const after = ThreadStore.getThreads(SID);
+    // 3 background rows: spawn-ack matches by message_id, both
+    // per-file companions match by media-subset. All dropped, then
+    // envelope appended as 1 fresh bubble.
+    expect(after[0].responses).toHaveLength(1);
+    expect(after[0].responses[0].text).toBe("envelope content");
+    expect(after[0].responses[0].files.map((f) => f.path).sort()).toEqual([
+      "bg/file-a.md",
+      "bg/file-b.md",
+    ]);
+  });
+
+  it("preserves a background row whose media is NOT a subset of the envelope's media (different completion)", () => {
+    // Edge case: a separate spawn_only completion's row whose
+    // envelope aged out of the retention window. We must NOT drop
+    // it just because it sits in the same anchor as a known
+    // envelope (codex round 3 P2). Delete-only-when-positive-evidence.
+    ThreadStore.__resetForTests();
+    ThreadStore.replayHistory(SID, [
+      {
+        seq: 0,
+        role: "user",
+        content: "Q",
+        client_message_id: "cmid-1",
+        thread_id: "cmid-1",
+        timestamp: "2026-05-04T00:00:00Z",
+      },
+      {
+        seq: 10,
+        role: "assistant",
+        content: "spawn ack A",
+        thread_id: "cmid-1",
+        timestamp: "2026-05-04T00:00:03Z",
+      },
+      // A background row whose media doesn't appear in the envelope:
+      // belongs to a separate completion. Server retention window may
+      // have aged out its envelope. MUST NOT drop.
+      {
+        seq: 30,
+        role: "assistant",
+        content: "",
+        thread_id: "cmid-1",
+        timestamp: "2026-05-04T00:00:10Z",
+        media: ["bg/orphan.md"],
+      },
+    ]);
+
+    ThreadStore.applyHydrateDedup(SID, undefined, {
+      messages: [
+        { seq: 0, message_id: "m0", source: "user", thread_id: "cmid-1" },
+        { seq: 10, message_id: "m10", source: "background", thread_id: "cmid-1" },
+        {
+          seq: 30,
+          message_id: "m30",
+          source: "background",
+          thread_id: "cmid-1",
+          media: ["bg/orphan.md"],
+        },
+      ],
+      replayed_envelopes: [
+        {
+          thread_id: "cmid-1",
+          task_id: "task_a",
+          seq: 10,
+          message_id: "m10",
+          content: "completion A",
+          media: [], // no companions covered by this envelope
+          persisted_at: "2026-05-04T00:00:03Z",
+        },
+      ],
+    });
+
+    const after = ThreadStore.getThreads(SID)[0].responses;
+    // Spawn-ack A dropped (message_id match); orphan row preserved
+    // (media-subset miss); envelope appended.
+    expect(after).toHaveLength(2);
+    expect(after.find((r) => r.text === "completion A")).toBeDefined();
+    expect(
+      after.find((r) => r.files.some((f) => f.path === "bg/orphan.md")),
+    ).toBeDefined();
+  });
+
+  it("is a no-op without replayed_envelopes (older server / non-negotiated client)", () => {
+    ThreadStore.__resetForTests();
+    ThreadStore.replayHistory(SID, [
+      {
+        seq: 0,
+        role: "user",
+        content: "Q",
+        client_message_id: "cmid-1",
+        thread_id: "cmid-1",
+        timestamp: "2026-05-04T00:00:00Z",
+      },
+      {
+        seq: 1,
+        role: "assistant",
+        content: "A",
+        thread_id: "cmid-1",
+        timestamp: "2026-05-04T00:00:01Z",
+      },
+    ]);
+    const beforeIds = ThreadStore.getThreads(SID)[0].responses.map((r) => r.id);
+
+    ThreadStore.applyHydrateDedup(SID, undefined, {
+      messages: undefined,
+      replayed_envelopes: undefined,
+    });
+
+    const after = ThreadStore.getThreads(SID);
+    expect(after[0].responses).toHaveLength(1);
+    expect(after[0].responses.map((r) => r.id)).toEqual(beforeIds);
+  });
+
+  it("dedups by message_id even when the hydrated row omits thread_id (legacy row)", () => {
+    // Codex round-4 P2: legacy ledger rows can omit `thread_id` while
+    // still exposing the post-#791 stable `message_id`. The dedup
+    // pass MUST honour the message_id match without an anchor lookup,
+    // otherwise reloads of legacy sessions keep the spawn-ack
+    // duplicate.
+    ThreadStore.__resetForTests();
+    ThreadStore.replayHistory(SID, [
+      {
+        seq: 0,
+        role: "user",
+        content: "Q",
+        client_message_id: "cmid-1",
+        thread_id: "cmid-1",
+        timestamp: "2026-05-04T00:00:00Z",
+      },
+      {
+        seq: 5,
+        role: "assistant",
+        content: "spawn ack",
+        thread_id: "cmid-1",
+        timestamp: "2026-05-04T00:00:01Z",
+      },
+    ]);
+
+    ThreadStore.applyHydrateDedup(SID, undefined, {
+      messages: [
+        {
+          seq: 0,
+          message_id: "m0",
+          source: "user",
+          // No thread_id — legacy row.
+        },
+        {
+          seq: 5,
+          message_id: "m5",
+          source: "background",
+          // No thread_id — legacy row.
+        },
+      ],
+      replayed_envelopes: [
+        {
+          thread_id: "cmid-1",
+          task_id: "task_legacy",
+          seq: 5,
+          message_id: "m5",
+          content: "envelope replaces ack",
+          media: [],
+          persisted_at: "2026-05-04T00:00:01Z",
+        },
+      ],
+    });
+
+    const after = ThreadStore.getThreads(SID)[0].responses;
+    // Spawn-ack dropped via session-wide message_id match; envelope appended.
+    expect(after).toHaveLength(1);
+    expect(after[0].text).toBe("envelope replaces ack");
+  });
+
+  it("does not cross-cover companions of different turns sharing a media path", () => {
+    // Codex round-6 P2: two completions in the same anchor thread
+    // that emit the same media path must not pollute each other's
+    // dedup. Bound media-subset matching to the same turn_id when
+    // both sides expose it.
+    ThreadStore.__resetForTests();
+    ThreadStore.replayHistory(SID, [
+      {
+        seq: 0,
+        role: "user",
+        content: "Q",
+        client_message_id: "cmid-1",
+        thread_id: "cmid-1",
+        timestamp: "2026-05-04T00:00:00Z",
+      },
+      // Completion A's spawn-ack.
+      {
+        seq: 5,
+        role: "assistant",
+        content: "ack A",
+        thread_id: "cmid-1",
+        timestamp: "2026-05-04T00:00:01Z",
+      },
+      // Completion B's companion (different turn) reuses the same path.
+      {
+        seq: 8,
+        role: "assistant",
+        content: "",
+        thread_id: "cmid-1",
+        timestamp: "2026-05-04T00:00:02Z",
+        media: ["bg/shared.md"],
+      },
+    ]);
+
+    ThreadStore.applyHydrateDedup(SID, undefined, {
+      messages: [
+        { seq: 0, message_id: "m0", source: "user", thread_id: "cmid-1" },
+        {
+          seq: 5,
+          message_id: "m5",
+          source: "background",
+          thread_id: "cmid-1",
+          turn_id: "turn-A",
+        },
+        {
+          seq: 8,
+          message_id: "m8",
+          source: "background",
+          thread_id: "cmid-1",
+          turn_id: "turn-B",
+          media: ["bg/shared.md"],
+        },
+      ],
+      replayed_envelopes: [
+        // Only completion A's envelope is retained; B's aged out.
+        {
+          thread_id: "cmid-1",
+          turn_id: "turn-A",
+          task_id: "task_A",
+          seq: 5,
+          message_id: "m5",
+          content: "envelope A",
+          media: ["bg/shared.md"], // shares path with B's companion
+          persisted_at: "2026-05-04T00:00:01Z",
+        },
+      ],
+    });
+
+    const after = ThreadStore.getThreads(SID)[0].responses;
+    // Completion A's ack dropped via message_id match; B's companion
+    // PRESERVED (turn_id mismatch on media-subset path); envelope appended.
+    const texts = after.map((r) => r.text);
+    expect(texts).toContain("envelope A");
+    // B's companion bubble is still rendered (media-bearing,
+    // empty-text — visible via attachment).
+    expect(
+      after.some((r) => r.files.some((f) => f.path === "bg/shared.md") && r.text === ""),
+    ).toBe(true);
+  });
+
+  it("preserves non-background rows even when their seq overlaps the envelope's anchor", () => {
+    // A user-source row at seq=0 must NOT be dropped just because it
+    // precedes the envelope's seq in the same anchor. The (b) branch
+    // is gated on `source === "background"`.
+    ThreadStore.__resetForTests();
+    ThreadStore.replayHistory(SID, [
+      {
+        seq: 0,
+        role: "user",
+        content: "Q",
+        client_message_id: "cmid-1",
+        thread_id: "cmid-1",
+        timestamp: "2026-05-04T00:00:00Z",
+      },
+      {
+        seq: 5,
+        role: "assistant",
+        content: "regular assistant reply",
+        thread_id: "cmid-1",
+        timestamp: "2026-05-04T00:00:01Z",
+      },
+      {
+        seq: 10,
+        role: "assistant",
+        content: "spawn ack",
+        thread_id: "cmid-1",
+        timestamp: "2026-05-04T00:00:02Z",
+      },
+    ]);
+
+    ThreadStore.applyHydrateDedup(SID, undefined, {
+      messages: [
+        { seq: 0, message_id: "m0", source: "user", thread_id: "cmid-1" },
+        // Non-background — protected from dedup even though it precedes the envelope.
+        { seq: 5, message_id: "m5", source: "assistant", thread_id: "cmid-1" },
+        { seq: 10, message_id: "m10", source: "background", thread_id: "cmid-1" },
+      ],
+      replayed_envelopes: [
+        {
+          thread_id: "cmid-1",
+          task_id: "task_y",
+          seq: 10,
+          message_id: "m10",
+          content: "envelope final",
+          media: [],
+          persisted_at: "2026-05-04T00:00:02Z",
+        },
+      ],
+    });
+
+    const after = ThreadStore.getThreads(SID)[0].responses;
+    // Regular assistant reply preserved; spawn-ack replaced by envelope.
+    expect(after.map((r) => r.text)).toEqual([
+      "regular assistant reply",
+      "envelope final",
+    ]);
+  });
+});

--- a/src/store/thread-store.ts
+++ b/src/store/thread-store.ts
@@ -120,6 +120,22 @@ const loadingPromises = new Map<string, Promise<void>>();
 let version = 0;
 const snapshotCache = new Map<string, { version: number; data: Thread[] }>();
 
+/**
+ * M10 Phase 6.2 (Bug C): per-session WS `session/hydrate` snapshot
+ * cached so that subsequent `replayHistory` calls (the forced retries
+ * in chat-thread.tsx fire at 2s/5s/12s) can replay the dedup pass on
+ * the freshly-replayed thread state. Without this, the second retry
+ * would undo the dedup we applied after the first replay.
+ *
+ * Keyed by `storeKey(sessionId, topic)`. Populated by the bridge's
+ * post-`session/open` hydrate call (see `ui-protocol-runtime.ts`).
+ * Cleared by `clearSession`.
+ */
+const hydrateSnapshotByKey = new Map<
+  string,
+  Parameters<typeof applyHydrateDedup>[2]
+>();
+
 function notify() {
   version++;
   snapshotCache.clear();
@@ -1341,6 +1357,306 @@ export function replayHistory(
 
   sessionsByKey.set(key, state);
   loadedSessions.add(key);
+
+  // M10 Phase 6.2 (Bug C): if the bridge already hydrated, apply its
+  // dedup pass against the freshly-replayed thread state. The forced
+  // retries in chat-thread.tsx mean `replayHistory` fires multiple
+  // times on a reload; we re-apply each time to keep the post-refresh
+  // DOM convergent with the live wire's suppressed-row shape.
+  //
+  // We always `notify()` first so subscribers see the freshly-replayed
+  // history even if `applyHydrateDedup` short-circuits (e.g. cached
+  // snapshot from an older server has no `replayed_envelopes`).
+  notify();
+  const cachedHydrate = hydrateSnapshotByKey.get(key);
+  if (cachedHydrate) {
+    applyHydrateDedup(sessionId, topic, cachedHydrate);
+  }
+}
+
+/**
+ * M10 Phase 6.2 (Bug C): cache the WS `session/hydrate` result so that
+ * subsequent `replayHistory` calls (the forced retries in
+ * chat-thread.tsx) re-run the dedup pass against the freshly-replayed
+ * thread state. Triggers an immediate dedup pass on the current state
+ * so a hydrate that lands AFTER the first `replayHistory` still
+ * cleans up the duplicate rows.
+ */
+export function setHydrateSnapshot(
+  sessionId: string,
+  topic: string | undefined,
+  hydrate: Parameters<typeof applyHydrateDedup>[2],
+): void {
+  const key = storeKey(sessionId, topic);
+  hydrateSnapshotByKey.set(key, hydrate);
+  if (sessionsByKey.has(key)) {
+    applyHydrateDedup(sessionId, topic, hydrate);
+  }
+}
+
+/**
+ * M10 Phase 6.2 (Bug C): apply the WS `session/hydrate` dedup pass on
+ * top of an already-hydrated thread state. Server PR #791 surfaces
+ * three new fields on `session/hydrate` for connections that
+ * negotiated `event.spawn_complete.v1`:
+ *
+ *   - `messages[i].message_id`  — stable per-row identity
+ *   - `messages[i].source`      — wire-form `MessagePersistedSource`
+ *   - `replayed_envelopes[]`    — retained `turn/spawn_complete` events
+ *
+ * The legacy REST `loadHistory` path returns the FULL ledger including
+ * the per-file companion + spawn-ack rows that the live wire suppresses
+ * for negotiated clients (server side rounds-3..6 of PR #791 deemed
+ * server-side suppression intractable; the negotiated dedup contract
+ * lives on the client). Without this pass, a page reload renders N+1
+ * assistant bubbles where the live page rendered N.
+ *
+ * Algorithm (per server PR #791 docstring on `replayed_envelopes`):
+ *
+ *   1. Index envelopes by `message_id` (the spawn-ack's id) and by the
+ *      anchor `thread_id` (placement key).
+ *   2. Build a `seq → HydratedMessage` map over the hydrated rows so we
+ *      can look up `(message_id, source)` for each thread response by
+ *      its `historySeq`.
+ *   3. For each thread, walk responses and drop those whose hydrated
+ *      counterpart has `source === "background"` AND either:
+ *        (a) `message_id` matches an envelope's `message_id` — the
+ *            spawn-ack the envelope replaces; or
+ *        (b) it sits in the same anchor thread as an envelope and
+ *            has an earlier or equal `seq` than that envelope — a
+ *            per-file companion the envelope's `media` already
+ *            covers.
+ *   4. For each envelope, call `appendCompletionBubble` (idempotent via
+ *      its existing `messageId` dedup, so a live-wire envelope already
+ *      placed for the same row is a no-op).
+ *
+ * Best-effort: rows missing `historySeq`, hydrated rows whose
+ * `message_id` / `source` are absent (older server, or non-negotiated
+ * connection), or envelopes without an anchor thread are skipped — we
+ * never delete a row we can't prove is the legacy duplicate.
+ */
+export function applyHydrateDedup(
+  sessionId: string,
+  topic: string | undefined,
+  hydrate: {
+    messages?: Array<{
+      seq: number;
+      message_id?: string;
+      source?: string;
+      thread_id?: string;
+      turn_id?: string;
+      media?: string[];
+    }>;
+    replayed_envelopes?: Array<{
+      thread_id?: string;
+      turn_id?: string;
+      response_to_client_message_id?: string;
+      task_id: string;
+      seq: number;
+      message_id: string;
+      content: string;
+      media?: string[];
+      persisted_at: string;
+    }>;
+  },
+): void {
+  const envelopes = hydrate.replayed_envelopes ?? [];
+  const messages = hydrate.messages ?? [];
+  if (envelopes.length === 0) return;
+
+  // Build the seq → row metadata index, including media so we can
+  // identify per-file companion rows by media-subset against an
+  // envelope's coalesced media list.
+  const rowBySeq = new Map<
+    number,
+    {
+      message_id?: string;
+      source?: string;
+      thread_id?: string;
+      media?: string[];
+    }
+  >();
+  for (const m of messages) {
+    rowBySeq.set(m.seq, {
+      message_id: m.message_id,
+      source: m.source,
+      thread_id: m.thread_id,
+      media: m.media,
+    });
+  }
+
+  // Per-envelope dedup. Per server PR #791 docstring: an envelope
+  // coalesces (a) the spawn-ack row by `message_id` match, (b)
+  // per-file `send_file` companion rows whose `media` paths are a
+  // subset of the envelope's `media` array. We index each envelope
+  // independently so a row's media-subset match is bounded to the
+  // SPECIFIC envelope whose media it covers — not the union of all
+  // envelopes in the same anchor thread (codex round-5 P2: that
+  // union would wrongly cover an unrelated row whose envelope aged
+  // out of the retention window but whose media path happened to
+  // appear in another retained envelope).
+  //
+  // A background-source row is covered by an envelope `e` when:
+  //   (a) `m.message_id === e.message_id` (the spawn-ack match), OR
+  //   (b) `m.thread_id` matches `e`'s anchor, `m.media` is non-empty,
+  //       AND every path in `m.media` is in `e.media` (the per-file
+  //       companion match — bounded to a single envelope).
+  // Companions not matching ANY envelope are preserved (a duplicate
+  // render is recoverable; an erased row is not).
+  const allEnvelopeMessageIds = new Set<string>();
+  for (const e of envelopes) allEnvelopeMessageIds.add(e.message_id);
+
+  // Pre-compute each envelope's media set (frozen) for the per-row
+  // subset check below. Carries `turn_id` so the match can be bounded
+  // to the same turn when both sides expose it (codex round-6 P2:
+  // a thread with two background completions emitting the same media
+  // path must NOT cross-pollinate through anchor+media alone).
+  const envelopeMediaSets: Array<{
+    anchor: string | null;
+    turn_id: string | null;
+    media: Set<string>;
+  }> = envelopes.map((e) => ({
+    anchor: e.thread_id ?? e.response_to_client_message_id ?? null,
+    turn_id: e.turn_id ?? null,
+    media: new Set(e.media ?? []),
+  }));
+
+  // Collect per-anchor "covered by media-subset" seqs AND a separate
+  // session-wide "covered by message_id" seq set (for the
+  // no-thread-id fallback).
+  const coveredSeqsByAnchor = new Map<string, Set<number>>();
+  const coveredSeqsByMessageId = new Set<number>();
+  for (const m of messages) {
+    if (m.source !== "background") continue;
+
+    // (a) message_id match — session-unique, works without thread_id.
+    if (m.message_id && allEnvelopeMessageIds.has(m.message_id)) {
+      coveredSeqsByMessageId.add(m.seq);
+      // Continue to (b) for completeness — a row covered by both
+      // routes is still covered exactly once below.
+    }
+
+    // (b) per-envelope media-subset match. Anchor required (a
+    // different completion in a different thread may reuse the same
+    // path; we never cross thread boundaries on media match). When
+    // both sides expose a `turn_id`, they must agree (codex round-6
+    // P2: two completions in the same thread that share a media path
+    // must NOT bleed across each other on media-subset alone).
+    //
+    // When either side omits `turn_id` we fall back to anchor+media
+    // match. The current server (PR #791 era) emits `turn_id: None`
+    // for `MessagePersistedEvent`s and does not stamp it on hydrated
+    // rows for spawn_only completions — applying a strict turn_id
+    // requirement would disable the Bug C fix entirely for live
+    // production traffic. The residual theoretical risk (codex
+    // round-8 P2: two background completions under the same prompt
+    // emit the SAME exact media path) is negligible in practice
+    // because spawn_only artefact paths embed UUIDv7s, so
+    // cross-completion path collisions don't occur. Once the server
+    // typed-id work propagates `turn_id` onto Message rows, this
+    // fallback can become a hard equality check.
+    const anchor = m.thread_id;
+    if (!anchor) continue;
+    if (!m.media || m.media.length === 0) continue;
+    let matched = false;
+    for (const env of envelopeMediaSets) {
+      if (env.anchor !== anchor) continue;
+      if (m.turn_id && env.turn_id && m.turn_id !== env.turn_id) {
+        continue;
+      }
+      // Bound the subset check to a SINGLE envelope's media so a
+      // companion only counts as covered when there's a specific
+      // envelope it pairs with.
+      if (m.media.every((p) => env.media.has(p))) {
+        matched = true;
+        break;
+      }
+    }
+    if (matched) {
+      let bag = coveredSeqsByAnchor.get(anchor);
+      if (!bag) {
+        bag = new Set<number>();
+        coveredSeqsByAnchor.set(anchor, bag);
+      }
+      bag.add(m.seq);
+    }
+  }
+
+  const key = storeKey(sessionId, topic);
+  const state = sessionsByKey.get(key);
+  if (!state) {
+    // No thread state to dedup — emit envelopes as fresh bubbles below.
+  } else {
+    // For each thread, drop responses whose `historySeq` is covered
+    // either by an anchor's media-subset match OR by a session-wide
+    // message_id match (no thread_id required for the latter — codex
+    // round-4 P2). Handles both the post-merge case (where the row's
+    // historySeq was donated by the companion at seq=N+1) and the
+    // un-merged case (separate ack + companion rows at seqs N and
+    // N+1).
+    let mutated = false;
+    for (const thread of state.threads) {
+      const anchorCovered = coveredSeqsByAnchor.get(thread.id);
+      // No covered set for this thread by anchor AND no session-wide
+      // message_id matches → nothing to drop here.
+      if (!anchorCovered && coveredSeqsByMessageId.size === 0) continue;
+      const filtered: ThreadMessage[] = [];
+      for (const r of thread.responses) {
+        if (typeof r.historySeq !== "number") {
+          filtered.push(r);
+          continue;
+        }
+        const isCovered =
+          (anchorCovered && anchorCovered.has(r.historySeq)) ||
+          coveredSeqsByMessageId.has(r.historySeq);
+        if (!isCovered) {
+          filtered.push(r);
+          continue;
+        }
+        // Defense-in-depth: only drop rows whose hydrated counterpart
+        // is genuinely background. If `messages[]` is missing (older
+        // server) the row is preserved (no covered match anyway).
+        const meta = rowBySeq.get(r.historySeq);
+        if (meta && meta.source !== "background") {
+          // Meta says non-background — protect even if covered set
+          // included the seq (defensive against an upstream bug).
+          filtered.push(r);
+          continue;
+        }
+        mutated = true;
+      }
+      if (filtered.length !== thread.responses.length) {
+        thread.responses = filtered;
+      }
+    }
+    if (mutated) {
+      // Bump the snapshot version so downstream selectors recompute.
+      version++;
+      snapshotCache.delete(key);
+    }
+  }
+
+  // Emit each envelope as a completion bubble. `appendCompletionBubble`
+  // is idempotent via its `messageId` dedup, so a live-wire envelope
+  // already placed for the same row is a no-op. The legacy spawn-ack
+  // row (if it survived to this point) is upgraded in place by the
+  // existing `appendCompletionBubble` placeholder-upgrade path; if the
+  // dedup loop above already deleted it, this call appends fresh.
+  for (const e of envelopes) {
+    const placementKey = e.thread_id ?? e.response_to_client_message_id;
+    if (!placementKey) continue;
+    appendCompletionBubble(placementKey, {
+      text: e.content,
+      media: e.media ?? [],
+      spawnComplete: true,
+      sourceClientMessageId: e.response_to_client_message_id,
+      historySeq: e.seq,
+      messageId: e.message_id,
+      persistedAt: e.persisted_at,
+      sessionId,
+      topic,
+    });
+  }
   notify();
 }
 
@@ -1565,12 +1881,25 @@ export function clearSession(sessionId: string, topic?: string): void {
     sessionsByKey.delete(key);
     loadedSessions.delete(key);
     loadingPromises.delete(key);
+    hydrateSnapshotByKey.delete(key);
   } else {
     for (const k of [...sessionsByKey.keys()]) {
       if (k === sessionId || k.startsWith(`${sessionId}#`)) {
         sessionsByKey.delete(k);
         loadedSessions.delete(k);
         loadingPromises.delete(k);
+        hydrateSnapshotByKey.delete(k);
+      }
+    }
+    // Codex round-5 P3: a hydrate snapshot may exist without a
+    // matching `sessionsByKey` entry (the bridge cached the snapshot
+    // before REST `replayHistory` populated thread state). The
+    // sessionsByKey-only loop above misses it; sweep
+    // `hydrateSnapshotByKey` independently so a clear-then-replay
+    // sequence doesn't apply stale envelopes.
+    for (const k of [...hydrateSnapshotByKey.keys()]) {
+      if (k === sessionId || k.startsWith(`${sessionId}#`)) {
+        hydrateSnapshotByKey.delete(k);
       }
     }
   }
@@ -1669,6 +1998,7 @@ export function __resetForTests(): void {
   loadedSessions.clear();
   loadingPromises.clear();
   snapshotCache.clear();
+  hydrateSnapshotByKey.clear();
   version = 0;
   idCounter = 0;
 }

--- a/tests/probe-bug-c-web-hydrate.spec.ts
+++ b/tests/probe-bug-c-web-hydrate.spec.ts
@@ -1,0 +1,145 @@
+import { test, expect } from "@playwright/test";
+
+const BASE_URL = process.env.BASE_URL ?? "https://dspfac.crew.ominix.io";
+const TOKEN = process.env.OCTOS_AUTH_TOKEN ?? "octos-admin-2026";
+
+// Live probe: requires an opt-in env var so a default `npm test` /
+// `npx playwright test` invocation does not silently mutate the
+// production deployment. Run with:
+//   OCTOS_LIVE_PROBE=1 BASE_URL=... OCTOS_AUTH_TOKEN=... \
+//     npx playwright test tests/probe-bug-c-web-hydrate.spec.ts
+test.skip(
+  !process.env.OCTOS_LIVE_PROBE,
+  "set OCTOS_LIVE_PROBE=1 to run the live hydrate probe (M10 Bug C)",
+);
+
+/**
+ * Bug C — page-reload hydrate emits N+1 rows
+ *
+ * Server PR #791 (M10 Phase 6.2-orig) extended `session/hydrate` with
+ * `replayed_envelopes` + per-row `(message_id, source)` so negotiated
+ * clients can dedup the legacy `Background`-source rows the live wire
+ * suppresses. This SPA-side companion PR consumes those fields.
+ *
+ * Pass criterion: post-reload bubble count exactly equals pre-reload
+ * bubble count (NOT an inequality — we want bit-for-bit DOM parity
+ * after refresh for any session that contains a spawn_only completion).
+ */
+test("bug-c: hydrate after refresh does not inflate bubble count (web-side dedup)", async ({
+  page,
+}) => {
+  test.setTimeout(420_000);
+
+  const consoleErrors: string[] = [];
+  page.on("console", (m) => {
+    if (m.type() === "error") consoleErrors.push(m.text().slice(0, 250));
+  });
+
+  await page.addInitScript(
+    ({ token }) => {
+      localStorage.setItem("octos_session_token", token);
+      localStorage.setItem("octos_auth_token", token);
+      localStorage.setItem("selected_profile", "dspfac");
+      localStorage.setItem("chat_app_ui_v1", "1");
+      localStorage.setItem("octos_thread_store_v2", "1");
+    },
+    { token: TOKEN },
+  );
+
+  await page.goto(`${BASE_URL}/chat`, { waitUntil: "domcontentloaded" });
+  await page.waitForSelector("[data-testid='chat-input']", { timeout: 30_000 });
+  // Force a fresh chat so we have a clean slate.
+  await page
+    .locator("[data-testid='new-chat-button']")
+    .click()
+    .catch(() => {});
+  await page.waitForTimeout(800);
+
+  // Trigger a deep_research turn — spawns a `spawn_only` task whose
+  // background-source rows + `turn/spawn_complete` envelope land in
+  // the ledger. Pre-fix, the reload re-rendered all background rows.
+  await page
+    .locator("[data-testid='chat-input']")
+    .first()
+    .fill(
+      "Use deep_research to write a short note on the 2027 FIBA Cup. Keep it under 150 words.",
+    );
+  await page.locator("[data-testid='send-button']").first().click();
+
+  // Wait for the spawn_only completion to land — watch for a bubble
+  // that contains the report content or the file attachment marker.
+  const completionDeadline = Date.now() + 240_000;
+  while (Date.now() < completionDeadline) {
+    const completionVisible = await page
+      .locator("[data-testid='assistant-message']")
+      .filter({ hasText: /report|delivered|completed|FIBA|2027/i })
+      .count();
+    if (completionVisible >= 1) break;
+    await page.waitForTimeout(2_000);
+  }
+
+  // Capture the live session id so we can navigate back to it.
+  const liveSessionId = await page.evaluate(() =>
+    localStorage.getItem("octos_current_session"),
+  );
+  console.log(`--- live session id: ${liveSessionId} ---`);
+
+  // Pre-reload DOM snapshot.
+  const liveBubbles = await page.evaluate(() => {
+    const nodes = document.querySelectorAll(
+      "[data-testid='user-message'], [data-testid='assistant-message']",
+    );
+    return Array.from(nodes).map((el) => ({
+      role: el.getAttribute("data-testid"),
+      text: (el.textContent || "").trim().slice(0, 200),
+    }));
+  });
+  console.log(`--- live bubbles (${liveBubbles.length}) ---`);
+  for (const b of liveBubbles) console.log(`  ${b.role}: ${b.text.slice(0, 120)}`);
+
+  // Hard refresh — this is the path that exercises the WS hydrate
+  // dedup pass (bridge issues `session/hydrate`, the result is fed
+  // into `applyHydrateDedup` against the REST `replayHistory` state).
+  await page.reload({ waitUntil: "domcontentloaded" });
+  await page.waitForSelector("[data-testid='chat-input']", { timeout: 30_000 });
+  if (liveSessionId) {
+    await page.evaluate((sid) => {
+      localStorage.setItem("octos_current_session", sid);
+    }, liveSessionId);
+    await page.reload({ waitUntil: "domcontentloaded" });
+    await page.waitForSelector("[data-testid='chat-input']", {
+      timeout: 30_000,
+    });
+  }
+  // Allow REST hydrate + WS hydrate dedup to settle. The chat-thread
+  // mount fires forced retries at 2s/5s/12s; wait past the last one
+  // so the dedup pass has stabilised.
+  await page.waitForTimeout(15_000);
+
+  const reloadBubbles = await page.evaluate(() => {
+    const nodes = document.querySelectorAll(
+      "[data-testid='user-message'], [data-testid='assistant-message']",
+    );
+    return Array.from(nodes).map((el) => ({
+      role: el.getAttribute("data-testid"),
+      text: (el.textContent || "").trim().slice(0, 200),
+    }));
+  });
+  console.log(`--- reload bubbles (${reloadBubbles.length}) ---`);
+  for (const b of reloadBubbles) console.log(`  ${b.role}: ${b.text.slice(0, 120)}`);
+  console.log("--- console errors ---");
+  for (const e of consoleErrors.slice(0, 10)) console.log(" ", e);
+
+  // Pass criterion: post-refresh DOM has the SAME bubble count as
+  // pre-refresh. Pre-fix: reload count was live+N (per-file companion
+  // rows were re-rendered alongside the spawn_complete envelope).
+  expect(reloadBubbles.length).toBe(liveBubbles.length);
+
+  // Sanity: at least one user + one assistant bubble.
+  expect(
+    liveBubbles.filter((b) => b.role === "user-message").length,
+  ).toBeGreaterThanOrEqual(1);
+  expect(
+    liveBubbles.filter((b) => b.role === "assistant-message").length,
+  ).toBeGreaterThanOrEqual(1);
+});


### PR DESCRIPTION
## Summary

- M10 Phase 6.2-orig SPA-side companion to server PR #791. Consumes the new `session/hydrate` fields (`replayed_envelopes`, per-row `message_id`/`source`) to dedup the legacy `Background`-source rows the live wire suppresses for negotiated clients. Pre-fix: page reload of a chat with a `spawn_only` completion rendered N+1 assistant bubbles. Post-fix: post-reload DOM matches the live DOM bubble-for-bubble.
- Adds `state.session_hydrate.v1` to the bridge's negotiated feature list (without it the server returns `method_not_supported`).
- Bridge: `guardSessionHydrate`, `hydrateSession()` method, fail-closed type guard for `HydratedMessage`.
- Runtime: post-`session/open` `session/hydrate` call (no-topic case only), result cached in ThreadStore so all forced retries of `replayHistory` re-apply the dedup.
- Store: `applyHydrateDedup` removes background rows by (a) `message_id` match, (b) per-envelope media-subset (turn_id-bounded when present), then appends a completion bubble per envelope (idempotent via `appendCompletionBubble`'s existing message_id dedup).

## Codex review

7 iterations addressed: notify-on-empty-envelopes, topic-scoping, per-envelope media bounding, no-thread_id fallback, hydrate-snapshot sweep, and `state.session_hydrate.v1` capability negotiation. Final round 8 BLOCK ("require turn_id for media-subset") was rejected with documented reason — the current server emits `turn_id: None` for `MessagePersistedEvent`, so a strict turn_id requirement would disable the Bug C fix entirely for current production traffic; the residual theoretical risk is negligible because spawn_only artifact paths embed UUIDv7s.

## Test plan

- [x] `npx vitest run` — 179 unit tests pass (5 pre-existing failures unrelated to this change, from a test-only `feature-flags.ts` override in working tree)
- [x] 4 new `guardSessionHydrate` tests + 5 new `applyHydrateDedup` tests
- [ ] Live probe `tests/probe-bug-c-web-hydrate.spec.ts` (gated on `OCTOS_LIVE_PROBE=1`): assert post-reload bubble count == pre-reload bubble count
- [ ] Wave-6n acceptance soak: `live-thread-interleave` + `live-overflow-stress` (5 non-pending scenarios) all PASS