### PR TITLE
fix(runtime): feed hydrate messages into replayHistory when REST is empty (M10.5)

### DIFF
--- a/src/store/thread-store.test.ts
+++ b/src/store/thread-store.test.ts
@@ -2372,6 +2372,42 @@ describe("setHydrateSnapshot reload-mid-stream fallback (M10.5)", () => {
   });
 
   /**
+   * Codex SPA round 2 P2: a hydrate with non-system but assistant/
+   * tool-only rows would produce orphan-placeholder threads (empty
+   * user bubble) via `replayHistory`. Pre-fix the cached-hydrate
+   * re-apply hook would then call `applyHydrateDedup` again, which
+   * re-entered `seedFromHydrateMessages` (the placeholder threads
+   * matched `allThreadsAreOrphanPlaceholders`) and infinite-looped.
+   * Post-fix: require at least one user row before seeding.
+   */
+  it("does not recurse when hydrate.messages has no user row", () => {
+    expect(() => {
+      ThreadStore.setHydrateSnapshot(SID, undefined, {
+        messages: [
+          {
+            seq: 0,
+            role: "assistant",
+            content: "stale assistant rumination",
+            thread_id: "cmid-orphan",
+            persisted_at: "2026-05-04T00:00:00Z",
+          },
+          {
+            seq: 1,
+            role: "tool",
+            content: "tool result",
+            thread_id: "cmid-orphan",
+            persisted_at: "2026-05-04T00:00:01Z",
+          },
+        ],
+        replayed_envelopes: [],
+      });
+    }).not.toThrow();
+    // No threads created — without a user row the seed is a no-op
+    // (we'd rather show nothing than orphan-place an unrooted history).
+    expect(ThreadStore.getThreads(SID)).toHaveLength(0);
+  });
+
+  /**
    * Codex SPA round 1 P2.2: when an envelope is delivered BEFORE the
    * `session/hydrate` response (live wire ordering), the store
    * already holds an orphan-placeholder thread with an empty user

--- a/src/store/thread-store.test.ts
+++ b/src/store/thread-store.test.ts
@@ -2337,6 +2337,109 @@ describe("setHydrateSnapshot reload-mid-stream fallback (M10.5)", () => {
   });
 
   /**
+   * Codex SPA round 1 P2.1: when `hydrate.messages` carries only
+   * system rows (older daemons emit a system bootstrap on every
+   * session), `replayHistory` skips them and leaves the store empty.
+   * Pre-P2-fix `setHydrateSnapshot` would re-invoke
+   * `applyHydrateDedup` from `replayHistory`'s cached-hydrate hook,
+   * which would call `seedFromHydrateMessages` again on the still-
+   * empty store — infinite recursion until the call stack overflows.
+   * Post-fix: system rows are filtered before deciding to seed, so
+   * the seed pass is a no-op (no recursion).
+   */
+  it("does not recurse when hydrate.messages carries only system rows", () => {
+    expect(() => {
+      ThreadStore.setHydrateSnapshot(SID, undefined, {
+        messages: [
+          {
+            seq: 0,
+            role: "system",
+            content: "session bootstrap",
+            persisted_at: "2026-05-04T00:00:00Z",
+          },
+          {
+            seq: 1,
+            role: "system",
+            content: "system policy",
+            persisted_at: "2026-05-04T00:00:01Z",
+          },
+        ],
+        replayed_envelopes: [],
+      });
+    }).not.toThrow();
+    // No threads created — system rows are not user-rooted.
+    expect(ThreadStore.getThreads(SID)).toHaveLength(0);
+  });
+
+  /**
+   * Codex SPA round 1 P2.2: when an envelope is delivered BEFORE the
+   * `session/hydrate` response (live wire ordering), the store
+   * already holds an orphan-placeholder thread with an empty user
+   * bubble. The seed pass MUST treat that state as still-seedable so
+   * the canonical hydrate history (real user prompt + narration)
+   * replaces the placeholder. Pre-fix the placeholder was treated as
+   * authoritative and the user prompt was never restored.
+   */
+  it("seeds over orphan placeholders created by an early envelope", () => {
+    // Simulate envelope-before-hydrate ordering: a
+    // `turn/spawn_complete` lands before `session/hydrate` returns.
+    // `appendCompletionBubble` creates an orphan-placeholder thread
+    // (empty user bubble) hosting the envelope's content.
+    ThreadStore.appendCompletionBubble("cmid-user-1", {
+      text: "## Research delivered\nFull text inline.",
+      media: [],
+      spawnComplete: true,
+      sourceClientMessageId: "cmid-user-1",
+      sessionId: SID,
+    });
+
+    const beforeSeed = ThreadStore.getThreads(SID);
+    expect(beforeSeed).toHaveLength(1);
+    expect(beforeSeed[0].userMsg.text).toBe("");
+
+    // Now hydrate lands with the canonical history (REST is still []).
+    ThreadStore.setHydrateSnapshot(SID, undefined, {
+      messages: [
+        {
+          seq: 0,
+          role: "user",
+          content: "do the research",
+          client_message_id: "cmid-user-1",
+          thread_id: "cmid-user-1",
+          persisted_at: "2026-05-04T00:00:00Z",
+        },
+        {
+          seq: 1,
+          role: "assistant",
+          content: "spawning the deep_research task",
+          thread_id: "cmid-user-1",
+          persisted_at: "2026-05-04T00:00:01Z",
+        },
+      ],
+      replayed_envelopes: [
+        {
+          thread_id: "cmid-user-1",
+          task_id: "task_research",
+          seq: 19,
+          message_id: "local:research:19",
+          content: "## Research delivered\nFull text inline.",
+          media: [],
+          persisted_at: "2026-05-04T00:00:02Z",
+        },
+      ],
+    });
+
+    const afterSeed = ThreadStore.getThreads(SID);
+    expect(afterSeed).toHaveLength(1);
+    expect(afterSeed[0].userMsg.text).toBe("do the research");
+    expect(afterSeed[0].userMsg.clientMessageId).toBe("cmid-user-1");
+    // Both the narration AND the envelope's completion are reachable.
+    const responseTexts = afterSeed[0].responses.map((r) => r.text);
+    expect(responseTexts).toContain("spawning the deep_research task");
+    expect(responseTexts).toContain("## Research delivered\nFull text inline.");
+  });
+
+  /**
    * Symmetrical guard for the happy path: a real REST response with
    * authoritative rows must win over the hydrate seed. Ensures the
    * fallback never silently overrides REST data.

--- a/src/store/thread-store.test.ts
+++ b/src/store/thread-store.test.ts
@@ -2203,3 +2203,175 @@ describe("applyHydrateDedup (M10 Phase 6.2)", () => {
     ]);
   });
 });
+
+describe("setHydrateSnapshot reload-mid-stream fallback (M10.5)", () => {
+  const SID = "sess-reload-mid-stream";
+
+  /**
+   * The brief's hardening test (`m10-harden-reload-midstream.spec.ts`)
+   * lives behind `OCTOS_LIVE_PROBE=1` and exercises a real WS reload.
+   * This unit test pins the data shape the SPA must produce for that
+   * scenario — when REST `loadHistory` returned `[]` (e.g. server
+   * returned the wrong session-key path before the M10.5 server fix
+   * landed) but WS `session/hydrate` carried the canonical
+   * `messages[]` plus a retained `replayed_envelopes[]` for the
+   * completion. Pre-fix the SPA only emitted the envelope as an
+   * orphan completion bubble; the user prompt + ack + narration rows
+   * were silently dropped.
+   */
+  it("seeds the store from hydrate.messages when REST returned [] and the envelope upgrades the spawn-ack in place", () => {
+    // Note: REST loadHistory was NOT called — `sessionsByKey` is
+    // empty for this session. This is the post-M10.5-server-fix
+    // race where REST hasn't run yet OR the REST proxy returned `[]`
+    // for the WS-key-mismatch case the server PR closes.
+    ThreadStore.setHydrateSnapshot(SID, undefined, {
+      messages: [
+        {
+          seq: 0,
+          role: "user",
+          content: "tell me the weather in NYC",
+          client_message_id: "cmid-user-1",
+          thread_id: "cmid-user-1",
+          persisted_at: "2026-05-04T00:00:00Z",
+        },
+        {
+          seq: 1,
+          role: "assistant",
+          content: "Looking up the latest forecast.",
+          thread_id: "cmid-user-1",
+          persisted_at: "2026-05-04T00:00:01Z",
+        },
+        {
+          // The spawn-ack the envelope upgrades. Marked `background`
+          // so the dedup pass either drops it (covered) or
+          // `appendCompletionBubble` upgrades it via `historySeq`
+          // match (this row is the placeholder shape with no media).
+          seq: 19,
+          message_id: "local:weather:19",
+          source: "background",
+          role: "assistant",
+          content: "",
+          thread_id: "cmid-user-1",
+          persisted_at: "2026-05-04T00:00:02Z",
+        },
+      ],
+      replayed_envelopes: [
+        {
+          thread_id: "cmid-user-1",
+          task_id: "task_weather",
+          seq: 19,
+          message_id: "local:weather:19",
+          content: "## NYC weather\nSunny, 72°F.",
+          media: [],
+          persisted_at: "2026-05-04T00:00:02Z",
+        },
+      ],
+    });
+
+    // Result must be: 1 user thread + 2 assistant responses
+    //   • "Looking up the latest forecast." (the narration row)
+    //   • "## NYC weather\nSunny, 72°F."  (the envelope, upgrading
+    //     the spawn-ack in place, NOT a sibling orphan bubble)
+    const threads = ThreadStore.getThreads(SID);
+    expect(threads).toHaveLength(1);
+    expect(threads[0].userMsg.text).toBe("tell me the weather in NYC");
+    expect(threads[0].userMsg.clientMessageId).toBe("cmid-user-1");
+    const responseTexts = threads[0].responses.map((r) => r.text);
+    expect(responseTexts).toContain("Looking up the latest forecast.");
+    expect(responseTexts).toContain("## NYC weather\nSunny, 72°F.");
+    // Exactly 2 assistant responses — the narration + the envelope's
+    // upgraded completion. NOT 3 (narration + ack + envelope), which
+    // would be the post-seed-but-pre-upgrade shape, and NOT 1 (just
+    // the envelope), which would be the pre-fix orphan shape.
+    expect(threads[0].responses).toHaveLength(2);
+    // Critically: NOT a sibling orphan thread with empty user bubble.
+    // Pre-fix the store ended up with 2 threads — one empty
+    // placeholder hosting the envelope.
+    for (const t of threads) {
+      expect(t.userMsg.text).not.toBe("");
+    }
+  });
+
+  /**
+   * Confirm the seed is idempotent: a subsequent `replayHistory` call
+   * (REST retries fire at 2s/5s/12s) replaces state wholesale, so a
+   * real REST response that lands later WINS for any overlap with the
+   * hydrate seed. Pre-fix this was already true for a non-empty REST
+   * response; this test pins the post-fix invariant that even when
+   * REST is `[]` the seed is preserved (not wiped) until a non-empty
+   * REST result arrives.
+   */
+  it("preserves the hydrate seed when a subsequent REST loadHistory returns []", () => {
+    ThreadStore.setHydrateSnapshot(SID, undefined, {
+      messages: [
+        {
+          seq: 0,
+          role: "user",
+          content: "hello",
+          client_message_id: "cmid-1",
+          thread_id: "cmid-1",
+          persisted_at: "2026-05-04T00:00:00Z",
+        },
+        {
+          seq: 1,
+          role: "assistant",
+          content: "hi back",
+          thread_id: "cmid-1",
+          persisted_at: "2026-05-04T00:00:01Z",
+        },
+      ],
+      replayed_envelopes: [],
+    });
+
+    // Pre-condition: hydrate seed populated the store.
+    expect(ThreadStore.getThreads(SID)).toHaveLength(1);
+
+    // REST replay returns []. Pre-M10.5-fix server, this is exactly
+    // what the SPA saw on reload-mid-stream. `replayHistory` MUST
+    // re-apply the cached hydrate so the user prompt stays visible.
+    ThreadStore.replayHistory(SID, []);
+
+    const threads = ThreadStore.getThreads(SID);
+    expect(threads).toHaveLength(1);
+    expect(threads[0].userMsg.text).toBe("hello");
+  });
+
+  /**
+   * Symmetrical guard for the happy path: a real REST response with
+   * authoritative rows must win over the hydrate seed. Ensures the
+   * fallback never silently overrides REST data.
+   */
+  it("REST loadHistory wins over hydrate seed for any overlap", () => {
+    ThreadStore.setHydrateSnapshot(SID, undefined, {
+      messages: [
+        {
+          seq: 0,
+          role: "user",
+          content: "stale hydrate user",
+          client_message_id: "cmid-1",
+          thread_id: "cmid-1",
+          persisted_at: "2026-05-04T00:00:00Z",
+        },
+      ],
+      replayed_envelopes: [],
+    });
+
+    // REST returns the authoritative shape — text differs from the
+    // hydrate seed (e.g. user edited their prompt before the server
+    // commit landed).
+    ThreadStore.replayHistory(SID, [
+      {
+        seq: 0,
+        role: "user",
+        content: "AUTHORITATIVE rest user text",
+        client_message_id: "cmid-1",
+        thread_id: "cmid-1",
+        timestamp: "2026-05-04T00:00:00Z",
+      },
+    ]);
+
+    const threads = ThreadStore.getThreads(SID);
+    expect(threads).toHaveLength(1);
+    expect(threads[0].userMsg.text).toBe("AUTHORITATIVE rest user text");
+  });
+});

--- a/src/store/thread-store.ts
+++ b/src/store/thread-store.ts
@@ -131,6 +131,10 @@ const snapshotCache = new Map<string, { version: number; data: Thread[] }>();
  * post-`session/open` hydrate call (see `ui-protocol-runtime.ts`).
  * Cleared by `clearSession`.
  */
+// `HydrateSnapshot` (defined alongside `applyHydrateDedup` below) is
+// the authoritative shape; this Parameters lookup keeps the cache
+// value tied to whatever the dedup pass accepts so it stays in sync
+// if the function's signature widens further.
 const hydrateSnapshotByKey = new Map<
   string,
   Parameters<typeof applyHydrateDedup>[2]
@@ -1375,23 +1379,36 @@ export function replayHistory(
 }
 
 /**
- * M10 Phase 6.2 (Bug C): cache the WS `session/hydrate` result so that
- * subsequent `replayHistory` calls (the forced retries in
- * chat-thread.tsx) re-run the dedup pass against the freshly-replayed
- * thread state. Triggers an immediate dedup pass on the current state
- * so a hydrate that lands AFTER the first `replayHistory` still
- * cleans up the duplicate rows.
+ * M10 Phase 6.2 (Bug C) + M10.5 reload-mid-stream fix: cache the WS
+ * `session/hydrate` result so that subsequent `replayHistory` calls
+ * (the forced retries in chat-thread.tsx) re-run the dedup pass
+ * against the freshly-replayed thread state. Triggers an immediate
+ * dedup pass on the current state so a hydrate that lands AFTER the
+ * first `replayHistory` still cleans up the duplicate rows.
+ *
+ * M10.5: also runs `applyHydrateDedup` when the store is empty for
+ * this scope (no thread state yet). The dedup function's own
+ * `seedFromHydrateMessages` will populate the store from
+ * `hydrate.messages` when REST returned `[]`. Without this branch the
+ * SPA produced an orphan completion bubble whenever REST and WS
+ * disagreed about whether the session had any history.
  */
 export function setHydrateSnapshot(
   sessionId: string,
   topic: string | undefined,
-  hydrate: Parameters<typeof applyHydrateDedup>[2],
+  hydrate: HydrateSnapshot,
 ): void {
   const key = storeKey(sessionId, topic);
   hydrateSnapshotByKey.set(key, hydrate);
-  if (sessionsByKey.has(key)) {
-    applyHydrateDedup(sessionId, topic, hydrate);
-  }
+  // Always invoke the dedup pass:
+  //   • If the store already has thread state for this scope, dedup
+  //     coalesces the legacy spawn-ack rows behind retained envelopes
+  //     (Bug C).
+  //   • If the store is empty for this scope, the dedup pass's
+  //     `seedFromHydrateMessages` step populates it from
+  //     `hydrate.messages` so the user prompt + narration row are
+  //     visible (M10.5 reload-mid-stream fallback).
+  applyHydrateDedup(sessionId, topic, hydrate);
 }
 
 /**
@@ -1435,33 +1452,150 @@ export function setHydrateSnapshot(
  * connection), or envelopes without an anchor thread are skipped — we
  * never delete a row we can't prove is the legacy duplicate.
  */
+/**
+ * `HydratedMessage` shape `applyHydrateDedup` and `seedFromHydrateMessages`
+ * accept. Mirrors `octos_core::ui_protocol::HydratedMessage` (cf.
+ * `runtime/ui-protocol-types.ts`).
+ *
+ * The dedup pass below only reads the metadata fields (seq, message_id,
+ * source, thread_id, turn_id, media). The seed pass additionally reads
+ * `role`, `content`, `client_message_id`, and `persisted_at` so it can
+ * reconstruct the full `Thread` shape when REST `loadHistory` returned
+ * `[]` (M10.5 reload-mid-stream fallback).
+ *
+ * Both extra fields are optional on the wire — older servers omit them.
+ * When absent, the seed pass treats the row the same way the legacy REST
+ * `replayHistory` treats a `MessageInfo` with the same gaps: skip
+ * unknown roles, default the content to empty string, etc.
+ */
+export interface HydrateMessageRow {
+  seq: number;
+  message_id?: string;
+  source?: string;
+  thread_id?: string;
+  turn_id?: string;
+  media?: string[];
+  /** Wire role: `user | assistant | tool | system`. Absent on older
+   *  servers; treat as `assistant` so the row is at least visible. */
+  role?: string;
+  /** Verbatim text from the canonical session JSONL. */
+  content?: string;
+  /** Stable per-row client id. The seed pass uses this to root user
+   *  messages on the same `client_message_id` REST would have used. */
+  client_message_id?: string;
+  /** ISO-8601 persistence timestamp. Used for `Thread` ordering. */
+  persisted_at?: string;
+}
+
+export interface HydrateEnvelope {
+  thread_id?: string;
+  turn_id?: string;
+  response_to_client_message_id?: string;
+  task_id: string;
+  seq: number;
+  message_id: string;
+  content: string;
+  media?: string[];
+  persisted_at: string;
+}
+
+export interface HydrateSnapshot {
+  messages?: HydrateMessageRow[];
+  replayed_envelopes?: HydrateEnvelope[];
+}
+
+/**
+ * Convert a [`HydrateMessageRow`] (the WS `session/hydrate` shape) into
+ * a [`MessageInfo`] (the REST `/messages` shape) so the existing
+ * `replayHistory` logic can ingest it without reimplementing the whole
+ * adjacent-merge / orphan-thread / dedup pipeline. Skips rows that lack
+ * the minimum (`role` + `content`) needed to reconstruct a chat bubble.
+ */
+function hydrateRowToMessageInfo(row: HydrateMessageRow): MessageInfo | null {
+  if (!row.role || row.content === undefined) return null;
+  if (
+    row.role !== "user" &&
+    row.role !== "assistant" &&
+    row.role !== "tool" &&
+    row.role !== "system"
+  ) {
+    return null;
+  }
+  const timestamp =
+    typeof row.persisted_at === "string" && row.persisted_at.length > 0
+      ? row.persisted_at
+      : new Date().toISOString();
+  return {
+    seq: row.seq,
+    role: row.role,
+    content: row.content,
+    client_message_id: row.client_message_id,
+    thread_id: row.thread_id,
+    timestamp,
+    media: row.media,
+  };
+}
+
+/**
+ * M10.5 reload-mid-stream fallback: when REST `loadHistory` returned no
+ * rows (server-side bug or just race) but the WS `session/hydrate`
+ * carried `messages[]`, seed the store from those rows BEFORE
+ * `applyHydrateDedup` runs. Without this, the SPA renders only the
+ * envelope's completion bubble — with no user prompt or narration row
+ * to anchor it — producing the orphan-completion shape the M10
+ * hardening test catches.
+ *
+ * Idempotency: a subsequent `replayHistory` call (REST retries fire at
+ * 2s/5s/12s) replaces state wholesale, so a real REST response that
+ * lands later wins for any overlap with the hydrate seed. A second
+ * hydrate snapshot for an already-seeded session is a no-op (state is
+ * not empty).
+ *
+ * Returns `true` when seeding actually populated the store — callers
+ * can use this to decide whether `applyHydrateDedup`'s envelope-emit
+ * pass needs the now-existing thread state for placeholder upgrades.
+ */
+function seedFromHydrateMessages(
+  sessionId: string,
+  topic: string | undefined,
+  rows: HydrateMessageRow[],
+): boolean {
+  if (rows.length === 0) return false;
+  const key = storeKey(sessionId, topic);
+  const existing = sessionsByKey.get(key);
+  // REST result wins for any overlap — only seed when state is empty.
+  // This means: on a healthy REST response we never touch the seeded
+  // shape; on a `[]` REST response (the bug we're fixing) the seed
+  // remains visible until the next REST retry — which post-PR-1
+  // server fix is itself non-empty.
+  if (existing && existing.threads.length > 0) return false;
+
+  const apiMessages: MessageInfo[] = [];
+  for (const row of rows) {
+    const info = hydrateRowToMessageInfo(row);
+    if (info) apiMessages.push(info);
+  }
+  if (apiMessages.length === 0) return false;
+  // Reuse `replayHistory`'s adjacent-merge + orphan-thread synthesis.
+  // It replaces state for `key` wholesale, but `existing` was empty
+  // so this is a pure insert — no live data is at risk of being
+  // clobbered.
+  replayHistory(sessionId, apiMessages, topic);
+  return true;
+}
+
 export function applyHydrateDedup(
   sessionId: string,
   topic: string | undefined,
-  hydrate: {
-    messages?: Array<{
-      seq: number;
-      message_id?: string;
-      source?: string;
-      thread_id?: string;
-      turn_id?: string;
-      media?: string[];
-    }>;
-    replayed_envelopes?: Array<{
-      thread_id?: string;
-      turn_id?: string;
-      response_to_client_message_id?: string;
-      task_id: string;
-      seq: number;
-      message_id: string;
-      content: string;
-      media?: string[];
-      persisted_at: string;
-    }>;
-  },
+  hydrate: HydrateSnapshot,
 ): void {
   const envelopes = hydrate.replayed_envelopes ?? [];
   const messages = hydrate.messages ?? [];
+  // M10.5 reload-mid-stream fallback: if REST hasn't seeded the store
+  // yet (it returned `[]` or hasn't fired) but WS hydrate carried the
+  // full message list, seed from hydrate first so the dedup pass below
+  // and the envelope-emit have a thread to anchor to.
+  seedFromHydrateMessages(sessionId, topic, messages);
   if (envelopes.length === 0) return;
 
   // Build the seq → row metadata index, including media so we can

--- a/src/store/thread-store.ts
+++ b/src/store/thread-store.ts
@@ -1514,6 +1514,28 @@ function hydrateRowToMessageInfo(row: HydrateMessageRow): MessageInfo | null {
  * can use this to decide whether `applyHydrateDedup`'s envelope-emit
  * pass needs the now-existing thread state for placeholder upgrades.
  */
+/**
+ * Returns `true` when every thread in `state` is an orphan-placeholder
+ * — created by `appendCompletionBubble` for an envelope whose hydrate
+ * snapshot has not yet landed. Such a thread has an empty user-bubble
+ * (no text, no files) and is safe to replace with the canonical
+ * hydrate seed, which carries the real prompt + narration rows.
+ *
+ * Codex SPA round 1 P2.2: an envelope-before-hydrate ordering puts a
+ * placeholder thread in the store BEFORE `setHydrateSnapshot` runs.
+ * Without this predicate the seed pass would treat the placeholder as
+ * authoritative state and skip seeding, leaving the orphan-completion
+ * shape this fix exists to prevent.
+ */
+function allThreadsAreOrphanPlaceholders(state: SessionState): boolean {
+  if (state.threads.length === 0) return true;
+  for (const t of state.threads) {
+    if (t.userMsg.text.length > 0) return false;
+    if (t.userMsg.files.length > 0) return false;
+  }
+  return true;
+}
+
 function seedFromHydrateMessages(
   sessionId: string,
   topic: string | undefined,
@@ -1522,23 +1544,41 @@ function seedFromHydrateMessages(
   if (rows.length === 0) return false;
   const key = storeKey(sessionId, topic);
   const existing = sessionsByKey.get(key);
-  // REST result wins for any overlap — only seed when state is empty.
+  // REST result wins for any overlap — only seed when state is empty
+  // OR when the only existing threads are orphan placeholders created
+  // by an envelope that landed before the hydrate response (codex SPA
+  // round 1 P2.2).
+  //
   // This means: on a healthy REST response we never touch the seeded
   // shape; on a `[]` REST response (the bug we're fixing) the seed
   // remains visible until the next REST retry — which post-PR-1
-  // server fix is itself non-empty.
-  if (existing && existing.threads.length > 0) return false;
+  // server fix is itself non-empty; on an envelope-before-hydrate
+  // ordering, the placeholder thread is replaced by the canonical
+  // hydrate history.
+  if (existing && !allThreadsAreOrphanPlaceholders(existing)) {
+    return false;
+  }
 
   const apiMessages: MessageInfo[] = [];
   for (const row of rows) {
     const info = hydrateRowToMessageInfo(row);
-    if (info) apiMessages.push(info);
+    if (!info) continue;
+    // Codex SPA round 1 P2.1: `replayHistory` skips `system` rows.
+    // If we feed a system-only batch through, `replayHistory` writes
+    // empty state, then re-invokes `applyHydrateDedup` (via its
+    // cached-hydrate dedup re-application at the end), which calls
+    // `seedFromHydrateMessages` again on the still-empty store —
+    // infinite recursion until the call stack overflows.
+    //
+    // Filter system rows here so the seedable count reflects what
+    // `replayHistory` will actually persist.
+    if (info.role === "system") continue;
+    apiMessages.push(info);
   }
   if (apiMessages.length === 0) return false;
   // Reuse `replayHistory`'s adjacent-merge + orphan-thread synthesis.
-  // It replaces state for `key` wholesale, but `existing` was empty
-  // so this is a pure insert — no live data is at risk of being
-  // clobbered.
+  // It replaces state for `key` wholesale; an orphan-placeholder
+  // existing state is intentionally clobbered by the seed (P2.2).
   replayHistory(sessionId, apiMessages, topic);
   return true;
 }

--- a/src/store/thread-store.ts
+++ b/src/store/thread-store.ts
@@ -1560,6 +1560,7 @@ function seedFromHydrateMessages(
   }
 
   const apiMessages: MessageInfo[] = [];
+  let hasUserRow = false;
   for (const row of rows) {
     const info = hydrateRowToMessageInfo(row);
     if (!info) continue;
@@ -1574,8 +1575,22 @@ function seedFromHydrateMessages(
     // `replayHistory` will actually persist.
     if (info.role === "system") continue;
     apiMessages.push(info);
+    if (info.role === "user") hasUserRow = true;
   }
   if (apiMessages.length === 0) return false;
+  // Codex SPA round 2 P2: a hydrate with non-system but assistant/
+  // tool-only rows produces a `replayHistory` output that has only
+  // orphan-placeholder threads (empty user bubbles) — exactly the
+  // shape `allThreadsAreOrphanPlaceholders` greenlights for re-
+  // seeding. The cached-hydrate hook at the end of `replayHistory`
+  // would then call `applyHydrateDedup` again, which re-enters this
+  // function and recurses forever.
+  //
+  // Require at least one user row before seeding. A user-less hydrate
+  // is not a useful seed anyway: the canonical reload-mid-stream
+  // shape this fallback exists for ALWAYS carries the user prompt
+  // (it lives in the same JSONL the assistant rows do).
+  if (!hasUserRow) return false;
   // Reuse `replayHistory`'s adjacent-merge + orphan-thread synthesis.
   // It replaces state for `key` wholesale; an orphan-placeholder
   // existing state is intentionally clobbered by the seed (P2.2).

--- a/src/store/thread-store.ts
+++ b/src/store/thread-store.ts
@@ -1412,47 +1412,6 @@ export function setHydrateSnapshot(
 }
 
 /**
- * M10 Phase 6.2 (Bug C): apply the WS `session/hydrate` dedup pass on
- * top of an already-hydrated thread state. Server PR #791 surfaces
- * three new fields on `session/hydrate` for connections that
- * negotiated `event.spawn_complete.v1`:
- *
- *   - `messages[i].message_id`  — stable per-row identity
- *   - `messages[i].source`      — wire-form `MessagePersistedSource`
- *   - `replayed_envelopes[]`    — retained `turn/spawn_complete` events
- *
- * The legacy REST `loadHistory` path returns the FULL ledger including
- * the per-file companion + spawn-ack rows that the live wire suppresses
- * for negotiated clients (server side rounds-3..6 of PR #791 deemed
- * server-side suppression intractable; the negotiated dedup contract
- * lives on the client). Without this pass, a page reload renders N+1
- * assistant bubbles where the live page rendered N.
- *
- * Algorithm (per server PR #791 docstring on `replayed_envelopes`):
- *
- *   1. Index envelopes by `message_id` (the spawn-ack's id) and by the
- *      anchor `thread_id` (placement key).
- *   2. Build a `seq → HydratedMessage` map over the hydrated rows so we
- *      can look up `(message_id, source)` for each thread response by
- *      its `historySeq`.
- *   3. For each thread, walk responses and drop those whose hydrated
- *      counterpart has `source === "background"` AND either:
- *        (a) `message_id` matches an envelope's `message_id` — the
- *            spawn-ack the envelope replaces; or
- *        (b) it sits in the same anchor thread as an envelope and
- *            has an earlier or equal `seq` than that envelope — a
- *            per-file companion the envelope's `media` already
- *            covers.
- *   4. For each envelope, call `appendCompletionBubble` (idempotent via
- *      its existing `messageId` dedup, so a live-wire envelope already
- *      placed for the same row is a no-op).
- *
- * Best-effort: rows missing `historySeq`, hydrated rows whose
- * `message_id` / `source` are absent (older server, or non-negotiated
- * connection), or envelopes without an anchor thread are skipped — we
- * never delete a row we can't prove is the legacy duplicate.
- */
-/**
  * `HydratedMessage` shape `applyHydrateDedup` and `seedFromHydrateMessages`
  * accept. Mirrors `octos_core::ui_protocol::HydratedMessage` (cf.
  * `runtime/ui-protocol-types.ts`).
@@ -1584,6 +1543,55 @@ function seedFromHydrateMessages(
   return true;
 }
 
+/**
+ * M10 Phase 6.2 (Bug C): apply the WS `session/hydrate` dedup pass on
+ * top of an already-hydrated thread state. Server PR #791 surfaces
+ * three new fields on `session/hydrate` for connections that
+ * negotiated `event.spawn_complete.v1`:
+ *
+ *   - `messages[i].message_id`  — stable per-row identity
+ *   - `messages[i].source`      — wire-form `MessagePersistedSource`
+ *   - `replayed_envelopes[]`    — retained `turn/spawn_complete` events
+ *
+ * The legacy REST `loadHistory` path returns the FULL ledger including
+ * the per-file companion + spawn-ack rows that the live wire suppresses
+ * for negotiated clients (server side rounds-3..6 of PR #791 deemed
+ * server-side suppression intractable; the negotiated dedup contract
+ * lives on the client). Without this pass, a page reload renders N+1
+ * assistant bubbles where the live page rendered N.
+ *
+ * M10.5 reload-mid-stream addition: if `hydrate.messages` is non-empty
+ * AND the store has no thread state for this scope, seed it from those
+ * rows (via `seedFromHydrateMessages`) BEFORE the dedup pass. Without
+ * this, an empty REST `loadHistory` response leaves the dedup pass
+ * with no rows to coalesce and `appendCompletionBubble` produces an
+ * orphan completion (the bug
+ * `tests/m10-harden-reload-midstream.spec.ts` catches).
+ *
+ * Algorithm (per server PR #791 docstring on `replayed_envelopes`):
+ *
+ *   1. Index envelopes by `message_id` (the spawn-ack's id) and by the
+ *      anchor `thread_id` (placement key).
+ *   2. Build a `seq → HydratedMessage` map over the hydrated rows so we
+ *      can look up `(message_id, source)` for each thread response by
+ *      its `historySeq`.
+ *   3. For each thread, walk responses and drop those whose hydrated
+ *      counterpart has `source === "background"` AND either:
+ *        (a) `message_id` matches an envelope's `message_id` — the
+ *            spawn-ack the envelope replaces; or
+ *        (b) it sits in the same anchor thread as an envelope and
+ *            has an earlier or equal `seq` than that envelope — a
+ *            per-file companion the envelope's `media` already
+ *            covers.
+ *   4. For each envelope, call `appendCompletionBubble` (idempotent via
+ *      its existing `messageId` dedup, so a live-wire envelope already
+ *      placed for the same row is a no-op).
+ *
+ * Best-effort: rows missing `historySeq`, hydrated rows whose
+ * `message_id` / `source` are absent (older server, or non-negotiated
+ * connection), or envelopes without an anchor thread are skipped — we
+ * never delete a row we can't prove is the legacy duplicate.
+ */
 export function applyHydrateDedup(
   sessionId: string,
   topic: string | undefined,


### PR DESCRIPTION
## Summary

M10.5 reload-mid-stream **SPA half** (companion to octos-org/octos#795).

When the WS \`session/hydrate\` response carries \`messages[]\` (the
canonical chat history) but the REST \`loadHistory\` returned \`[]\`
(server-side key-mismatch bug, closed by #795), the runtime previously
rendered ONLY the envelope's completion bubble — with no user prompt or
narration row to anchor it. The result was an orphan completion that
the M10 hardening test
(\`tests/m10-harden-reload-midstream.spec.ts\`) detected.

## Root cause

\`setHydrateSnapshot\` cached the full \`hydrate.messages[]\` but
\`applyHydrateDedup\` only used the metadata fields (\`seq\`,
\`message_id\`, \`source\`, \`thread_id\`, \`turn_id\`, \`media\`). The
\`role\` / \`content\` / \`client_message_id\` / \`persisted_at\` fields were
silently dropped — so when REST was empty, no thread state ever
populated the store; \`appendCompletionBubble\` ran on an unrooted
completion and produced the orphan shape.

## Fix

When \`setHydrateSnapshot\` runs and the store is empty for that scope,
seed it from \`hydrate.messages\` (converting \`HydratedMessage\` →
\`MessageInfo\` and reusing \`replayHistory\`'s adjacent-merge / orphan-
thread / dedup pipeline) BEFORE \`applyHydrateDedup\` runs. The dedup
pass then upgrades the spawn-ack row in place via the existing
\`historySeq\` / \`messageId\` placeholder-upgrade path, leaving the
canonical 1 user + N assistant shape.

Idempotency:
- REST \`replayHistory\` replaces state wholesale, so a real REST
  response that lands later wins for any overlap with the seed.
- A second \`setHydrateSnapshot\` call for an already-seeded scope is a
  no-op (the seed-when-empty guard short-circuits).

Also widens the \`HydrateMessageRow\` / \`HydrateEnvelope\` /
\`HydrateSnapshot\` types to mirror
\`octos_core::ui_protocol::HydratedMessage\`.

## Test plan

- [x] \`npx tsc --noEmit\` clean
- [x] \`npx vitest run src/store/thread-store.test.ts\` — 70 passed (3 new)
  - \`seeds the store from hydrate.messages when REST returned [] and
    the envelope upgrades the spawn-ack in place\`
  - \`preserves the hydrate seed when a subsequent REST loadHistory
    returns []\`
  - \`REST loadHistory wins over hydrate seed for any overlap\`
- [ ] Post-merge: deploy to mini1, run
  \`tests/m10-harden-reload-midstream.spec.ts\` (\`OCTOS_LIVE_PROBE=1\`).
  Expect post-reload DOM = user + ack + narration + completion bubble,
  NOT an orphan completion.