### PR TITLE
fix(runtime): dedup legacy Background row in hydrate.messages against replayed_envelopes (M10.5 followup)

### DIFF
--- a/src/store/thread-store.test.ts
+++ b/src/store/thread-store.test.ts
@@ -2513,4 +2513,212 @@ describe("setHydrateSnapshot reload-mid-stream fallback (M10.5)", () => {
     expect(threads).toHaveLength(1);
     expect(threads[0].userMsg.text).toBe("AUTHORITATIVE rest user text");
   });
+
+  /**
+   * M10.5 reload-mid-stream regression (the bug
+   * `tests/m10-harden-reload-midstream.spec.ts` catches): when the
+   * server returns a hydrate carrying BOTH the legacy `Background`-source
+   * companion row in `messages[]` AND the `turn/spawn_complete` envelope
+   * in `replayed_envelopes[]` (with the same media), the SPA must not
+   * render the companion as a separate bubble.
+   *
+   * Pre-fix: `seedFromHydrateMessages` fed the companion verbatim into
+   * `replayHistory`, producing 1 user + 3 assistant (ack + companion +
+   * envelope-completion). Post-fix: the seed pass drops covered
+   * background rows BEFORE feeding `replayHistory`, leaving 1 user + 2
+   * assistant (ack + envelope-completion).
+   */
+  it("drops covered background companion rows from the seed feed when an envelope covers them", () => {
+    ThreadStore.setHydrateSnapshot(SID, undefined, {
+      messages: [
+        {
+          seq: 0,
+          role: "user",
+          content: "Use deep_research to find news about Rust.",
+          client_message_id: "cmid-user-1",
+          thread_id: "cmid-user-1",
+          persisted_at: "2026-05-04T00:00:00Z",
+        },
+        {
+          // Spawn-ack — background source, no media. NOT covered by
+          // the envelope (envelope's message_id is the completion's,
+          // not the ack's), so MUST survive the seed.
+          seq: 19,
+          message_id: "local:research:ack:19",
+          source: "background",
+          role: "assistant",
+          content: "Spawning deep_research…",
+          thread_id: "cmid-user-1",
+          persisted_at: "2026-05-04T00:00:01Z",
+        },
+        {
+          // Per-file companion — background source, with media. Covered
+          // by the envelope's media-subset → MUST be dropped from the
+          // seed feed so the dedup pass + envelope-emit don't end up
+          // rendering both the companion and the completion.
+          seq: 22,
+          message_id: "local:research:companion:22",
+          source: "background",
+          role: "assistant",
+          content: "",
+          thread_id: "cmid-user-1",
+          media: ["pf/rust-news.md"],
+          persisted_at: "2026-05-04T00:00:02Z",
+        },
+      ],
+      replayed_envelopes: [
+        {
+          thread_id: "cmid-user-1",
+          task_id: "task_research",
+          seq: 25,
+          message_id: "local:research:complete:25",
+          content: "## Rust news\nFull report inline.",
+          media: ["pf/rust-news.md"],
+          persisted_at: "2026-05-04T00:00:03Z",
+        },
+      ],
+    });
+
+    const threads = ThreadStore.getThreads(SID);
+    expect(threads).toHaveLength(1);
+    expect(threads[0].userMsg.text).toBe(
+      "Use deep_research to find news about Rust.",
+    );
+    // Exactly 2 assistant responses: the spawn-ack (preserved because
+    // its message_id does NOT match the envelope and it has no media)
+    // and the envelope's completion bubble. The covered background
+    // companion was filtered before the seed reached `replayHistory`.
+    expect(threads[0].responses).toHaveLength(2);
+    const responseTexts = threads[0].responses.map((r) => r.text);
+    expect(responseTexts).toContain("Spawning deep_research…");
+    expect(responseTexts).toContain("## Rust news\nFull report inline.");
+    // The completion bubble carries the media (the companion's path
+    // surfaces here once, not twice).
+    const fileBubbles = threads[0].responses.filter((r) => r.files.length > 0);
+    expect(fileBubbles).toHaveLength(1);
+    expect(fileBubbles[0].files.map((f) => f.path)).toEqual(["pf/rust-news.md"]);
+  });
+
+  /**
+   * Adjacent-seq case: when the spawn-ack and the per-file companion
+   * sit at adjacent seqs (N, N+1), pre-fix `replayHistory` would
+   * `mergeMediaCompanionInto` and donate the companion's `historySeq`
+   * onto the ack — leaving the dedup loop downstream to drop the
+   * merged ack (defensive check passes because `meta.source ===
+   * "background"`), and then `appendCompletionBubble` appends the
+   * envelope as a fresh bubble. The shape WAS 1 user + 1 envelope
+   * (the ack lost), which loses the spawn-ack visibility too.
+   * Post-fix: covered companion rows are filtered before the merge,
+   * so the ack survives intact and the envelope is its sibling.
+   */
+  it("preserves the spawn-ack when companion at adjacent seq is covered by envelope", () => {
+    ThreadStore.setHydrateSnapshot(SID, undefined, {
+      messages: [
+        {
+          seq: 0,
+          role: "user",
+          content: "Q",
+          client_message_id: "cmid-1",
+          thread_id: "cmid-1",
+          persisted_at: "2026-05-04T00:00:00Z",
+        },
+        {
+          // Spawn-ack at adjacent seq.
+          seq: 19,
+          message_id: "local:ack:19",
+          source: "background",
+          role: "assistant",
+          content: "Spawning…",
+          thread_id: "cmid-1",
+          persisted_at: "2026-05-04T00:00:01Z",
+        },
+        {
+          // Companion at the immediately-next seq — pre-fix this
+          // adjacency triggered `mergeMediaCompanionInto` and the
+          // ack lost its `historySeq` to the companion.
+          seq: 20,
+          message_id: "local:companion:20",
+          source: "background",
+          role: "assistant",
+          content: "",
+          thread_id: "cmid-1",
+          media: ["pf/report.md"],
+          persisted_at: "2026-05-04T00:00:02Z",
+        },
+      ],
+      replayed_envelopes: [
+        {
+          thread_id: "cmid-1",
+          task_id: "task_x",
+          seq: 25,
+          message_id: "local:complete:25",
+          content: "## Result\nDone.",
+          media: ["pf/report.md"],
+          persisted_at: "2026-05-04T00:00:03Z",
+        },
+      ],
+    });
+
+    const threads = ThreadStore.getThreads(SID);
+    expect(threads).toHaveLength(1);
+    const responseTexts = threads[0].responses.map((r) => r.text);
+    // Both the spawn-ack and the envelope's completion are visible
+    // (the ack is NOT consumed by an adjacent-seq merge with a row
+    // that should never have been seeded in the first place).
+    expect(responseTexts).toContain("Spawning…");
+    expect(responseTexts).toContain("## Result\nDone.");
+    expect(threads[0].responses).toHaveLength(2);
+  });
+
+  /**
+   * Guard: a background row whose media does NOT match any envelope
+   * (separate completion whose envelope aged out of the retention
+   * window) MUST survive the seed. Delete-only-when-positive-evidence,
+   * mirroring the dedup pass's rule.
+   */
+  it("preserves background rows whose media is NOT covered by any envelope", () => {
+    ThreadStore.setHydrateSnapshot(SID, undefined, {
+      messages: [
+        {
+          seq: 0,
+          role: "user",
+          content: "Q",
+          client_message_id: "cmid-1",
+          thread_id: "cmid-1",
+          persisted_at: "2026-05-04T00:00:00Z",
+        },
+        {
+          seq: 30,
+          message_id: "local:other:30",
+          source: "background",
+          role: "assistant",
+          content: "",
+          thread_id: "cmid-1",
+          media: ["pf/orphan.md"],
+          persisted_at: "2026-05-04T00:00:01Z",
+        },
+      ],
+      replayed_envelopes: [
+        {
+          thread_id: "cmid-1",
+          task_id: "task_a",
+          seq: 19,
+          message_id: "local:a:19",
+          content: "envelope A",
+          media: ["pf/different.md"],
+          persisted_at: "2026-05-04T00:00:02Z",
+        },
+      ],
+    });
+
+    const threads = ThreadStore.getThreads(SID);
+    // Both the surviving companion AND the envelope's completion are
+    // present (the orphan companion is preserved because no envelope
+    // covers its media).
+    const allFiles = threads[0].responses.flatMap((r) =>
+      r.files.map((f) => f.path),
+    );
+    expect(allFiles).toContain("pf/orphan.md");
+    expect(allFiles).toContain("pf/different.md");
+  });
 });

--- a/src/store/thread-store.ts
+++ b/src/store/thread-store.ts
@@ -1536,10 +1536,81 @@ function allThreadsAreOrphanPlaceholders(state: SessionState): boolean {
   return true;
 }
 
+/**
+ * M10.5 reload-mid-stream regression fix: predicate matching the
+ * `applyHydrateDedup` envelope-coverage contract for a single hydrate
+ * row. A row is "covered" when:
+ *
+ *   - `source === "background"` (the legacy companion marker the live
+ *     wire suppresses for negotiated clients), AND either
+ *
+ *     (a) `message_id` matches some envelope's `message_id` — the
+ *         spawn-ack the envelope replaces; OR
+ *     (b) `media` is non-empty AND every path is in some envelope's
+ *         `media` set, with anchor (`thread_id`) match required and
+ *         `turn_id` agreement when both sides expose it (codex
+ *         round-6 P2 on the dedup loop applies here too).
+ *
+ * Use cases:
+ *   • `seedFromHydrateMessages` filters covered rows BEFORE feeding
+ *     `replayHistory` so the seed step never produces a sibling
+ *     bubble for the legacy companion. Without this, the dedup loop
+ *     downstream still drops the row but only if its `historySeq`
+ *     survives `replayHistory`'s adjacent-merge intact — and any
+ *     companion that the live wire emits AFTER the hydrate seed (via
+ *     `message/persisted` for a long-running spawn_only completion)
+ *     would still produce a duplicate bubble. Filtering at the seed
+ *     contract level prevents both classes.
+ *
+ *   • `applyHydrateDedup`'s downstream loop continues to apply the
+ *     same predicate to the post-seed thread state for any row that
+ *     somehow survived (e.g. cached snapshot re-applied after a REST
+ *     replay reseeded the store).
+ *
+ * Defensive: rows whose `source` is not `"background"` and rows whose
+ * coverage cannot be proven (no message_id match AND no anchor for
+ * the media-subset check) are NOT covered. We only delete on positive
+ * evidence — a duplicate render is recoverable; an erased row is not.
+ */
+function hydrateRowCoveredByEnvelope(
+  row: HydrateMessageRow,
+  envelopes: HydrateEnvelope[],
+): boolean {
+  if (envelopes.length === 0) return false;
+  if (row.source !== "background") return false;
+
+  // (a) message_id match — session-unique, works without thread_id.
+  if (row.message_id) {
+    for (const e of envelopes) {
+      if (e.message_id === row.message_id) return true;
+    }
+  }
+
+  // (b) anchor + media-subset match. Anchor required so a different
+  // completion in a different thread that happens to reuse a media
+  // path is never wrongly covered. When both sides expose `turn_id`
+  // they must agree (codex round-6 P2 on the dedup loop); when either
+  // side omits it we fall back to anchor+media match (current server
+  // emits `turn_id: None` on `MessagePersistedEvent`s).
+  const anchor = row.thread_id;
+  if (!anchor) return false;
+  if (!row.media || row.media.length === 0) return false;
+  for (const e of envelopes) {
+    const envAnchor = e.thread_id ?? e.response_to_client_message_id ?? null;
+    if (envAnchor !== anchor) continue;
+    if (row.turn_id && e.turn_id && row.turn_id !== e.turn_id) continue;
+    const envMedia = new Set(e.media ?? []);
+    if (envMedia.size === 0) continue;
+    if (row.media.every((p) => envMedia.has(p))) return true;
+  }
+  return false;
+}
+
 function seedFromHydrateMessages(
   sessionId: string,
   topic: string | undefined,
   rows: HydrateMessageRow[],
+  envelopes: HydrateEnvelope[],
 ): boolean {
   if (rows.length === 0) return false;
   const key = storeKey(sessionId, topic);
@@ -1562,6 +1633,16 @@ function seedFromHydrateMessages(
   const apiMessages: MessageInfo[] = [];
   let hasUserRow = false;
   for (const row of rows) {
+    // M10.5 reload-mid-stream regression: skip rows the envelope
+    // contract already covers, BEFORE feeding `replayHistory`. If we
+    // let a covered `Background`-source row through, `replayHistory`
+    // may fold it into a sibling bubble via `mergeMediaCompanionInto`
+    // (donating its `historySeq`) and then `appendCompletionBubble`
+    // appends the envelope as a SEPARATE bubble — yielding the
+    // 1 user + 3 assistant shape `m10-harden-reload-midstream` catches.
+    // Drop the row at the seed contract; the envelope-emit pass then
+    // produces exactly 1 completion bubble downstream.
+    if (hydrateRowCoveredByEnvelope(row, envelopes)) continue;
     const info = hydrateRowToMessageInfo(row);
     if (!info) continue;
     // Codex SPA round 1 P2.1: `replayHistory` skips `system` rows.
@@ -1657,8 +1738,13 @@ export function applyHydrateDedup(
   // M10.5 reload-mid-stream fallback: if REST hasn't seeded the store
   // yet (it returned `[]` or hasn't fired) but WS hydrate carried the
   // full message list, seed from hydrate first so the dedup pass below
-  // and the envelope-emit have a thread to anchor to.
-  seedFromHydrateMessages(sessionId, topic, messages);
+  // and the envelope-emit have a thread to anchor to. Pass `envelopes`
+  // through so the seed step drops `Background`-source companion rows
+  // covered by an envelope BEFORE `replayHistory`'s adjacent-merge can
+  // fold their `historySeq` onto a sibling bubble — the bug
+  // `m10-harden-reload-midstream` catches when both the legacy
+  // companion AND the envelope land in the same hydrate response.
+  seedFromHydrateMessages(sessionId, topic, messages, envelopes);
   if (envelopes.length === 0) return;
 
   // Build the seq → row metadata index, including media so we can


### PR DESCRIPTION
## Summary

Reload-mid-stream regression after M10.5 PRs #84 + server #795: when WS `session/hydrate` returns BOTH the legacy `Background`-source companion row in `messages[]` AND the `turn/spawn_complete` envelope in `replayed_envelopes[]` (with the same media), the SPA rendered 1 user + 3 assistant (ack + companion + envelope-completion). Target: 1 user + ≤2 assistant.

- Extract `hydrateRowCoveredByEnvelope` predicate matching PR #83's `applyHydrateDedup` envelope-coverage contract (background source + message_id match OR media-subset under matching anchor with optional turn_id discrimination).
- Apply the predicate in `seedFromHydrateMessages` BEFORE feeding `replayHistory` so covered companion rows never trigger the adjacent-merge `historySeq`-donation hazard or render as a sibling bubble. Defensive: only drops on positive evidence.

## Test plan

- [x] `npx vitest run` — 193/193 pass (added 3 unit tests, including one that fails pre-fix to pin the adjacent-seq merge hazard)
- [x] `npx tsc --noEmit` — clean
- [x] `codex review --base main` — approved, no BLOCKs
- [ ] Build SPA, deploy to mini1, re-run `m10-harden-reload-midstream.spec.ts` (target: 1 user + ≤2 assistant)
- [ ] Wave-6n soak (5 non-skipped scenarios) — still 5/5

Production code: 28 non-comment LOC added in `src/store/thread-store.ts`.