### PR TITLE
feat(runtime): drop SSE fallback gate from getActiveBridge

### DIFF
--- a/src/runtime/ui-protocol-bridge.test.ts
+++ b/src/runtime/ui-protocol-bridge.test.ts
@@ -803,6 +803,98 @@ describe("reconnect with exponential backoff", () => {
     ws3.triggerClose(1006);
     expect(states).toContain("error");
   });
+
+  it("sendTurn fast-rejects after maxReconnectAttempts is exhausted", async () => {
+    // Codex M10.5 Wave A round-4 P2: once `scheduleReconnect` has given
+    // up (state==="error" AND reconnectAbandoned), the bridge must
+    // surface a real error to callers instead of parking the frame in
+    // sendQueue forever. This used to silently drop user turns.
+    vi.useFakeTimers();
+    const bridge = createUiProtocolBridge(
+      makeBridgeOpts({ maxReconnectAttempts: 2 }),
+    );
+    void bridge.start({ sessionId: "sess-1" });
+    await Promise.resolve();
+    const ws1 = lastInstance();
+    ws1.triggerClose(1006);
+    await vi.advanceTimersByTimeAsync(1000);
+    const ws2 = lastInstance();
+    ws2.triggerClose(1006);
+    await vi.advanceTimersByTimeAsync(2000);
+    const ws3 = lastInstance();
+    ws3.triggerClose(1006);
+    // Reconnect now abandoned (state==="error", reconnectAbandoned=true).
+    await expect(
+      bridge.sendTurn("turn-x", [{ kind: "text", text: "post-abandon" }]),
+    ).rejects.toThrow(/WebSocket connection is closed/);
+  });
+
+  it("sendTurn during transient onerror (pre-onclose) still queues and reconnects", async () => {
+    // Codex M10.5 Wave A round-4 P2 follow-up: `onerror` flips state to
+    // `error` BEFORE `onclose` runs scheduleReconnect, so a naive
+    // `state==="error" => fast-reject` rule would incorrectly fail
+    // sends issued in the brief browser-event gap of an otherwise
+    // recoverable network hiccup. The fix gates fast-reject on
+    // `reconnectAbandoned`, so the transient `error` blip leaves the
+    // frame queued; this test pins that behavior so a future refactor
+    // can't re-introduce the regression.
+    vi.useFakeTimers();
+    const bridge = createUiProtocolBridge(makeBridgeOpts());
+    const states: ConnectionState[] = [];
+    bridge.onConnectionStateChange((s) => states.push(s));
+    void bridge.start({ sessionId: "sess-1" });
+    await Promise.resolve();
+    const ws1 = lastInstance();
+    // Drive into the transient error window: onerror fires first, state
+    // becomes "error", but the socket has not yet closed and reconnect
+    // has NOT been abandoned.
+    ws1.onerror?.({});
+    expect(states).toContain("error");
+    // sendTurn at this moment must NOT fast-reject — it should queue
+    // for the imminent reconnect to flush after handshake.
+    let sendSettled = false;
+    const sendPromise = bridge
+      .sendTurn("turn-q", [{ kind: "text", text: "queued through hiccup" }])
+      .then(
+        () => {
+          sendSettled = true;
+        },
+        () => {
+          sendSettled = true;
+        },
+      );
+    await Promise.resolve();
+    expect(sendSettled).toBe(false);
+    // Now let the close land → scheduleReconnect → ws2 opens →
+    // session/open ack → flush.
+    ws1.triggerClose(1006, "abnormal");
+    await vi.advanceTimersByTimeAsync(1000);
+    const ws2 = lastInstance();
+    ws2.triggerOpen();
+    await Promise.resolve();
+    const open = findRequest(ws2, METHODS.SESSION_OPEN);
+    ws2.triggerMessage({
+      jsonrpc: "2.0",
+      id: open.id,
+      result: { opened: { session_id: "sess-1" } },
+    });
+    await Promise.resolve();
+    // Frame eventually went out on the new socket.
+    const turnFrames = ws2.sent
+      .map((f) => JSON.parse(f) as { method: string; params?: { turn_id?: string } })
+      .filter((f) => f.method === METHODS.TURN_START)
+      .map((f) => f.params?.turn_id);
+    expect(turnFrames).toContain("turn-q");
+    // Resolve the in-flight RPC so the Promise above settles cleanly.
+    const turnReq = findRequest(ws2, METHODS.TURN_START);
+    ws2.triggerMessage({
+      jsonrpc: "2.0",
+      id: turnReq.id,
+      result: { accepted: true },
+    });
+    await sendPromise;
+    expect(sendSettled).toBe(true);
+  });
 });
 
 // ---------------------------------------------------------------------------

--- a/src/runtime/ui-protocol-bridge.ts
+++ b/src/runtime/ui-protocol-bridge.ts
@@ -739,6 +739,14 @@ class UiProtocolBridgeImpl implements UiProtocolBridge {
   private profileId: string | null | undefined = undefined;
   private stopped = false;
   private reconnectAttempts = 0;
+  /** True only after `scheduleReconnect` has exhausted
+   *  `maxReconnectAttempts` and given up. Distinguishes the terminal
+   *  `state === "error"` case (no recovery possible) from the transient
+   *  `onerror` blip that `onWsClose` is about to either schedule a
+   *  reconnect for or finalize. The fast-reject in `request()` uses this
+   *  to avoid rejecting sends queued during the brief `onerror -> onclose`
+   *  window of an otherwise recoverable network hiccup. */
+  private reconnectAbandoned = false;
   private reconnectTimer: unknown = null;
   private keepaliveTimer: unknown = null;
   private lastInboundAt = 0;
@@ -849,6 +857,7 @@ class UiProtocolBridgeImpl implements UiProtocolBridge {
     this.sessionId = opts.sessionId;
     this.profileId = opts.profileId ?? this.cfg.getProfileId();
     this.reconnectAttempts = 0;
+    this.reconnectAbandoned = false;
     await this.openSocket();
   }
 
@@ -1103,6 +1112,7 @@ class UiProtocolBridgeImpl implements UiProtocolBridge {
       });
       if (this.stopped) return;
       this.reconnectAttempts = 0;
+      this.reconnectAbandoned = false;
       this.setState("connected");
       this.startKeepalive();
       this.flushSendQueue();
@@ -1215,6 +1225,7 @@ class UiProtocolBridgeImpl implements UiProtocolBridge {
   private scheduleReconnect(): void {
     if (this.stopped) return;
     if (this.reconnectAttempts >= this.cfg.maxReconnectAttempts) {
+      this.reconnectAbandoned = true;
       this.setState("error");
       this.rejectAllPending(new BridgeStoppedError("max reconnect attempts"));
       return;
@@ -1287,19 +1298,30 @@ class UiProtocolBridgeImpl implements UiProtocolBridge {
     if (this.stopped) {
       return Promise.reject(new BridgeStoppedError());
     }
-    // Fast-reject when the bridge is permanently dead — `closed` and
-    // `error` are terminal states from which the queue will never
-    // drain. Without this guard, callers (`sendTurn`/`interruptTurn`/
-    // `respondToApproval`) silently park the frame in `sendQueue`,
-    // their Promise neither resolves nor rejects, and the user sees
-    // their typed text vanish (the optimistic bubble gets rolled back
-    // upstream when the caller never settles). `bypassQueue` callers
-    // (the handshake `session/open` during `onopen`) handle their own
-    // socket-not-open path below, so we only fast-reject the normal
-    // request path here.
+    // Fast-reject when the bridge is permanently dead so callers
+    // (`sendTurn`/`interruptTurn`/`respondToApproval`) don't silently
+    // park frames in `sendQueue` whose Promise never settles — that
+    // hang is what makes the user's optimistic bubble vanish upstream
+    // when their network drops mid-session.
+    //
+    // We only treat two situations as terminal:
+    //   - `state === "closed"`: NORMAL_CLOSURE arrived (or `stop()` ran);
+    //     the socket will not reopen on its own.
+    //   - `state === "error"` AND `reconnectAbandoned`: scheduleReconnect
+    //     hit `maxReconnectAttempts` and gave up.
+    //
+    // A bare `state === "error"` without `reconnectAbandoned` is the
+    // browser-event blip between `onerror` and `onclose` for a network
+    // hiccup that's about to schedule a reconnect — those sends should
+    // queue, not reject (codex M10.5 Wave A round-4 follow-up).
+    //
+    // `bypassQueue` callers (the handshake `session/open` during
+    // `onopen`) handle their own socket-not-open path below, so we only
+    // gate the normal request path here.
     if (
       !opts?.bypassQueue &&
-      (this.state === "closed" || this.state === "error")
+      (this.state === "closed" ||
+        (this.state === "error" && this.reconnectAbandoned))
     ) {
       return Promise.reject(
         new BridgeStoppedError(
@@ -1353,12 +1375,16 @@ class UiProtocolBridgeImpl implements UiProtocolBridge {
   }
 
   private sendNotification(method: string, params: unknown): void {
-    // Drop notifications outright when the bridge is permanently dead —
-    // queueing them on a socket that will never reopen just leaks
-    // memory (cf. fast-reject in `request`). `idle`/`connecting`/
-    // `reconnecting` still queue, since those are transient states the
-    // bridge can recover from.
-    if (this.state === "closed" || this.state === "error") {
+    // Drop notifications outright when the bridge is permanently dead
+    // (cf. fast-reject in `request`); queueing them on a socket that
+    // will never reopen just leaks memory. Only treat the terminal
+    // post-max-retries `error` as dead — a transient `onerror` between
+    // `onerror` and `onclose` is about to reconnect, so we let the
+    // notification queue and flush after handshake.
+    if (
+      this.state === "closed" ||
+      (this.state === "error" && this.reconnectAbandoned)
+    ) {
       return;
     }
     const frame: JsonRpcNotification = {

--- a/src/runtime/ui-protocol-bridge.ts
+++ b/src/runtime/ui-protocol-bridge.ts
@@ -1287,6 +1287,26 @@ class UiProtocolBridgeImpl implements UiProtocolBridge {
     if (this.stopped) {
       return Promise.reject(new BridgeStoppedError());
     }
+    // Fast-reject when the bridge is permanently dead — `closed` and
+    // `error` are terminal states from which the queue will never
+    // drain. Without this guard, callers (`sendTurn`/`interruptTurn`/
+    // `respondToApproval`) silently park the frame in `sendQueue`,
+    // their Promise neither resolves nor rejects, and the user sees
+    // their typed text vanish (the optimistic bubble gets rolled back
+    // upstream when the caller never settles). `bypassQueue` callers
+    // (the handshake `session/open` during `onopen`) handle their own
+    // socket-not-open path below, so we only fast-reject the normal
+    // request path here.
+    if (
+      !opts?.bypassQueue &&
+      (this.state === "closed" || this.state === "error")
+    ) {
+      return Promise.reject(
+        new BridgeStoppedError(
+          "WebSocket connection is closed; please refresh the page",
+        ),
+      );
+    }
     const id = this.cfg.generateId();
     const frame: JsonRpcRequest = {
       jsonrpc: JSON_RPC_VERSION,
@@ -1333,6 +1353,14 @@ class UiProtocolBridgeImpl implements UiProtocolBridge {
   }
 
   private sendNotification(method: string, params: unknown): void {
+    // Drop notifications outright when the bridge is permanently dead —
+    // queueing them on a socket that will never reopen just leaks
+    // memory (cf. fast-reject in `request`). `idle`/`connecting`/
+    // `reconnecting` still queue, since those are transient states the
+    // bridge can recover from.
+    if (this.state === "closed" || this.state === "error") {
+      return;
+    }
     const frame: JsonRpcNotification = {
       jsonrpc: JSON_RPC_VERSION,
       method,

--- a/src/runtime/ui-protocol-runtime.test.ts
+++ b/src/runtime/ui-protocol-runtime.test.ts
@@ -189,4 +189,62 @@ describe("startBridgeForSession race safety", () => {
     expect(second).toBe(a.bridge);
     expect(createBridgeSpy).toHaveBeenCalledTimes(1);
   });
+
+  it("sendTurn fast-rejects when the underlying bridge has gone closed", async () => {
+    // Codex M10.5 Wave A round-4 P2: removing the SSE-fallback gate from
+    // `getActiveBridge` correctly stops re-routing turns through SSE,
+    // but if the WS bridge is permanently `closed` / `error` the bridge
+    // itself MUST fast-reject its public send methods (`sendTurn` /
+    // `interruptTurn` / `respondToApproval`) instead of parking the
+    // frame in `sendQueue` and never settling its Promise — that path
+    // makes the user's optimistic bubble vanish silently when their
+    // network drops mid-session. This test models the new contract
+    // through the runtime: drive a mock bridge whose `sendTurn` rejects
+    // when its connection state is dead, hand it back via
+    // `getActiveBridge`, and verify the rejection bubbles up with the
+    // user-facing message.
+    const a = makeDeferredBridge();
+    createBridgeSpy.mockReturnValueOnce(a.bridge);
+
+    // Override the mock's sendTurn to mirror real bridge behavior:
+    // reject with the canonical closed-WS message when the bridge
+    // believes it is in a terminal state.
+    let mockState: ConnectionState = "connected";
+    (
+      a.bridge.sendTurn as unknown as {
+        mockImplementation: (
+          fn: (turn_id: string, input: unknown) => Promise<unknown>,
+        ) => void;
+      }
+    ).mockImplementation(async (_turn_id: string, _input: unknown) => {
+      if (mockState === "closed" || mockState === "error") {
+        throw new Error(
+          "WebSocket connection is closed; please refresh the page",
+        );
+      }
+      return { accepted: true };
+    });
+
+    const startA = startBridgeForSession("sess-A");
+    a.resolveStart();
+    await startA;
+    a.setConnected();
+    expect(getActiveBridge("sess-A")).toBe(a.bridge);
+
+    // While alive, sendTurn succeeds (sanity check the harness).
+    await expect(a.bridge.sendTurn("turn-1", [])).resolves.toEqual({
+      accepted: true,
+    });
+
+    // Drive the bridge into a terminal state. The runtime's internal
+    // tracker doesn't gate getActiveBridge anymore (round-3 dropped the
+    // SSE fallback), so a stale getActiveBridge result still hands back
+    // the bridge — and the bridge itself is responsible for rejecting.
+    mockState = "closed";
+    const dead = getActiveBridge("sess-A");
+    expect(dead).toBe(a.bridge);
+    await expect(dead!.sendTurn("turn-2", [])).rejects.toThrow(
+      /WebSocket connection is closed/,
+    );
+  });
 });

--- a/src/runtime/ui-protocol-runtime.ts
+++ b/src/runtime/ui-protocol-runtime.ts
@@ -166,19 +166,25 @@ export async function startBridgeForSession(
 }
 
 /**
- * Returns the currently-active bridge if it matches the requested scope
- * AND the WS connection isn't in a dead state (`closed` / `error`). The
- * bridge's own send queue handles `connecting` / `reconnecting` by
- * parking the turn until the WS handshake completes — falling back to
- * legacy REST/SSE during the brief connect window broke fast-burst
- * scenarios where 5+ prompts fire within the WS connect latency
- * (rapid-fire-five-fast soak regression, observed on the M10.5
- * Wave A deploy 2026-05-07). Only fail-closed when the bridge has
- * actually given up (`closed` / `error`); the codex-round-2 concern
- * about a permanently blocked / DNS-failing WS still routes around it
- * since the bridge transitions to `error` after retries exhaust.
- * Mismatched scopes also return null so callers don't dispatch into the
- * wrong session's transport.
+ * Returns the currently-active bridge if it matches the requested scope.
+ *
+ * The legacy `connectionState === "closed" | "error"` fail-closed gate
+ * was removed (M10.5 Wave A round-3): the SSE fallback that used to
+ * pick up turns when the WS bridge was dead is itself buggy for text
+ * (Yue 2026-05-07 — SSE is the path M10 was supposed to retire). With
+ * the gate dropped, sends always flow through the bridge's own send
+ * queue, which:
+ *   - parks the turn while `connecting` / `reconnecting` (handshake
+ *     latency window),
+ *   - errors loudly when the bridge has truly given up so the SPA
+ *     surfaces a real "connection lost" state instead of silently
+ *     re-routing through SSE and corrupting the thread.
+ *
+ * Mismatched scopes still return null so callers don't dispatch into
+ * the wrong session's transport. Topic-scoped sessions (sites/slides)
+ * and media uploads (`kind: image|audio`) reach this with their own
+ * scope; the legacy SSE fallback for those consumers lives at the
+ * call site, not here.
  */
 export function getActiveBridge(
   sessionId: string,
@@ -186,9 +192,6 @@ export function getActiveBridge(
 ): UiProtocolBridge | null {
   if (!active) return null;
   if (!sameScope(active, sessionId, topic)) return null;
-  if (active.connectionState === "closed" || active.connectionState === "error") {
-    return null;
-  }
   return active.bridge;
 }
 


### PR DESCRIPTION
## Summary

User clarified (2026-05-07) that SSE is buggy for text turns and the M10 protocol's whole point was to retire SSE. The closed/error fail-closed gate inside `getActiveBridge` silently rerouted text sends through legacy `/api/chat` whenever the WS bridge had given up — exactly the path we want gone.

## Change

- `src/runtime/ui-protocol-runtime.ts`: `getActiveBridge` no longer checks `connectionState`; it returns the active bridge when the scope matches. The bridge's own send queue parks turns during `connecting` / `reconnecting` and surfaces a real error when truly dead — the SPA shows a 'connection lost' state instead of silently rerouting through SSE.

## Kept on legacy SSE

The other `shouldUseLegacyFallback` branches still preserve SSE for:
- `hasMedia` (`kind: image|audio` uploads)
- `hasTopic` (slides/sites topic-scoped sessions — `session/open` doesn't carry topic yet)

## Test plan

- [x] `npx tsc --noEmit` passes (clean)
- [x] `npx vitest run src/runtime/ui-protocol-runtime.test.ts` -> 3/3 pass
- [x] full `npx vitest run` -> same 15 pre-existing failures as main (no new regressions from this change; verified via stash A/B)
- [x] `npm run build` builds the SPA cleanly
- [x] Deployed bundle on .249 + reran `live-thread-interleave.spec.ts`: still progresses through the full 6m WS scenario, fails only at the same content-marker assertion as main (deep_research output unrelated to this change)
