### PR TITLE
fix(auth): redirect to /login on token rejection

### DIFF
--- a/src/auth/auth-context.tsx
+++ b/src/auth/auth-context.tsx
@@ -6,6 +6,7 @@ import {
   useCallback,
   type ReactNode,
 } from "react";
+import { useLocation, useNavigate } from "react-router-dom";
 import * as authApi from "@/api/auth";
 import {
   clearToken,
@@ -24,6 +25,12 @@ interface AuthState {
   login: (email: string, code: string) => Promise<void>;
   loginWithToken: (token: string) => Promise<void>;
   logout: () => Promise<void>;
+  /** Re-validate the stored token against `/api/auth/me`. Call this from
+   *  any code path that sees an authenticated request rejected (e.g. the
+   *  WS bridge's close-with-1008, a 401 from a long-lived poll). On
+   *  rejection it wipes localStorage + redirects the user to `/login`,
+   *  same as the initial-mount syncMe failure path. */
+  revalidate: () => Promise<void>;
 }
 
 const AuthContext = createContext<AuthState | null>(null);
@@ -34,6 +41,25 @@ export function AuthProvider({ children }: { children: ReactNode }) {
   const [authStatus, setAuthStatus] = useState<AuthStatusResponse | null>(null);
   const [token, setTokenState] = useState<string | null>(getToken());
   const [loading, setLoading] = useState(true);
+  const navigate = useNavigate();
+  const location = useLocation();
+
+  // Centralised auth-fail handler: wipe token slots, clear React state,
+  // and redirect to /login UNLESS we're already there (don't loop on the
+  // login page itself when its own /api/auth/verify call rejects). The
+  // initial-mount syncMe failure, the WS bridge's auth-1008 close, and
+  // any future 401-from-a-long-poll path should all funnel through this
+  // single helper so the SPA never lingers on an authenticated route
+  // with a dead token (the "/chat zombie state" Yue hit on 2026-05-08).
+  const failAuthAndRedirect = useCallback(() => {
+    clearToken();
+    setTokenState(null);
+    setUser(null);
+    setPortal(null);
+    if (location.pathname !== "/login") {
+      navigate("/login", { replace: true });
+    }
+  }, [navigate, location.pathname]);
 
   const syncMe = useCallback(async () => {
     const resp = await authApi.me();
@@ -71,13 +97,23 @@ export function AuthProvider({ children }: { children: ReactNode }) {
     }
     syncMe()
       .catch(() => {
-        clearToken();
-        setTokenState(null);
-        setUser(null);
-        setPortal(null);
+        failAuthAndRedirect();
       })
       .finally(() => setLoading(false));
-  }, [token, user, syncMe]);
+  }, [token, user, syncMe, failAuthAndRedirect]);
+
+  const revalidate = useCallback(async () => {
+    // Caller flagged that an authenticated request was rejected; re-run
+    // the canonical auth probe and let `failAuthAndRedirect` handle the
+    // cleanup if the token is genuinely dead. If syncMe succeeds, the
+    // rejection was for a different reason (server-side bug, transient
+    // race) and we leave the session intact.
+    try {
+      await syncMe();
+    } catch {
+      failAuthAndRedirect();
+    }
+  }, [syncMe, failAuthAndRedirect]);
 
   const login = useCallback(async (email: string, code: string) => {
     const resp = await authApi.verify(email, code);
@@ -121,7 +157,7 @@ export function AuthProvider({ children }: { children: ReactNode }) {
 
   return (
     <AuthContext.Provider
-      value={{ user, portal, authStatus, token, loading, login, loginWithToken, logout }}
+      value={{ user, portal, authStatus, token, loading, login, loginWithToken, logout, revalidate }}
     >
       {children}
     </AuthContext.Provider>


### PR DESCRIPTION
## Summary

Closes the **/chat zombie state** Yue hit testing mini1 on 2026-05-08: token expired between Q1 ('巴黎的天气') and Q2 ('现在巴黎的时间...'). The mount-time \`syncMe()\` failure path cleared tokens but never navigated, so the SPA stayed on /chat with a dead token. WS couldn't reconnect, sends silently failed, the typed Q2 vanished.

Real-user flow that hits this: any OTP-issued token that gets rejected (expiry, server-side rotation, session replacement). Soak missed it because the soak harness uses an always-valid admin token and never exercises the AuthGuard 401 path.

## Changes

- **\`failAuthAndRedirect()\`** centralised helper: clears both localStorage slots, resets React state, navigates to \`/login\` via react-router. Skips the navigate if already on \`/login\` (no loops on a \`/api/auth/verify\` rejection from the login page itself).
- **\`syncMe().catch()\`** now funnels through the helper.
- **\`revalidate()\`** exposed on AuthContext for other code paths to call when they see authenticated requests rejected (e.g. the WS bridge's 1008-close path, future API-401 interceptors). On rejection, it funnels through the same helper.

## What ships in a follow-up

Wiring \`revalidate()\` into the WS bridge's send-failure path is queued for Task 12 (don't-roll-back-optimistic-user-message) since they share the upstream error handler — better one cohesive UX change than two partial ones.

## Test plan

- [x] \`npx tsc -b\` clean
- [x] Targeted vitest: \`src/runtime/ui-protocol-runtime.test.ts\` 4/4 pass
- [ ] Live regression test (Task 14 follow-up): inject expired token mid-session, assert URL becomes \`/login\` within 5s

## Author note

Yue clarified after Task 2 (PR #89) that SSE fallback is buggy and the M10 path is supposed to retire it. That landed; this is the parallel auth-side fix so users see a real \"please re-login\" state instead of silently bouncing through dead transports.