### PR TITLE
fix(runtime): probe auth on send failure

### DIFF
--- a/src/runtime/ui-protocol-send.ts
+++ b/src/runtime/ui-protocol-send.ts
@@ -17,8 +17,33 @@ import { displayFilenameFromPath } from "@/lib/utils";
 import { sendMessage as legacySendMessage } from "./sse-bridge";
 import type { SendOptions } from "./sse-bridge";
 import { getActiveBridge } from "./ui-protocol-runtime";
+import { request } from "@/api/client";
 
 export type { SendOptions } from "./sse-bridge";
+
+/** Re-validate the stored auth token after a send failure. The api/client
+ *  `request()` helper has a built-in 401-interceptor that calls
+ *  `clearToken()` + hard-redirects to `/login`, so a successful 401 here
+ *  drives the user to re-authenticate instead of leaving them on a /chat
+ *  page where the WS will never accept their next send.
+ *
+ *  Bug we're closing: token expiry mid-session yielded a "WS connection
+ *  rejected" close (1008) which surfaces here as a `bridge.sendTurn`
+ *  rejection. Pre-fix, the SPA marked the assistant bubble as error and
+ *  stopped — the user was stuck on /chat with a dead token, no signal
+ *  to re-login. Yue hit this 2026-05-08 testing mini1 (Q1 worked, Q2
+ *  vanished into a dead WS).
+ *
+ *  Probe is best-effort: if /api/auth/me succeeds, the token is still
+ *  valid and the WS rejection was for a different reason (server
+ *  hiccup, transient race) — we don't want to redirect spuriously.
+ *  If /api/auth/me 401s, request()'s interceptor handles cleanup. */
+function probeAuthAfterSendFailure(): void {
+  void request<unknown>("/api/auth/me").catch(() => {
+    // Swallowed — request() already handled redirect via its 401
+    // interceptor. Anything we add here would race with that.
+  });
+}
 
 export function sendMessage(opts: SendOptions): void {
   void enqueueSendV1(opts);
@@ -374,5 +399,10 @@ async function sendMessageV1(
     ThreadStore.finalizeAssistant(clientMessageId, { status: "error" });
     off();
     fireComplete();
+    // Token may have been rejected at WS upgrade — probe `/api/auth/me`
+    // to surface dead-token cases via api/client's 401 interceptor (which
+    // hard-redirects to /login). If the token is still good, this is a
+    // no-op and the user can retry.
+    probeAuthAfterSendFailure();
   }
 }


### PR DESCRIPTION
## Summary

Closes the second half of the bug Yue hit on mini1 2026-05-08. PR #90 added the AuthContext-side redirect path. This PR adds the bridge-side trigger: when a WS \`bridge.sendTurn\` rejects (token expired mid-session, server-side rotation, etc.), probe \`/api/auth/me\`. The existing \`api/client.request()\` 401-interceptor handles the redirect.

## Why this design

- No need to plumb React context through async layers — \`api/client.request()\` already has a 401-handler.
- Idempotent: if the token is still valid, the probe succeeds (no-op). Only dead tokens drive the user to /login.
- Best-effort: if the probe itself fails (network down), we swallow — the user's already seeing the assistant-error indicator from the existing catch block.

## Test plan

- [x] tsc clean
- [x] vitest 17/17 pass (\`ui-protocol-send.test.ts\` + \`ui-protocol-runtime.test.ts\`)
- [ ] Live regression test (Task 14 follow-up): inject expired token mid-session, send a turn, assert URL becomes \`/login\` within 5s of the send rejecting.

## Pairs with

- #90 (AuthContext redirect on syncMe failure) — covers the page-mount 401 path
- This PR — covers the WS-bridge-rejection-mid-session path

Together they close the 'dead /chat, no signal' zombie state.