### PR TITLE
fix(runtime): drop empty late assistant message/persisted to kill phantom bubble

### DIFF
--- a/src/runtime/ui-protocol-event-router.ts
+++ b/src/runtime/ui-protocol-event-router.ts
@@ -161,6 +161,26 @@ export function handleMessagePersisted(
       event,
     );
     if (promoted) return;
+    // Phantom-bubble defence (production bug 2026-05-09):
+    // Multi-iteration agent loops (assistant -> tool -> assistant) emit
+    // multiple `message/persisted` events per turn under the same
+    // `thread_id`. The router promotes/finalises the live
+    // `pendingAssistant` on the FIRST assistant persisted event for the
+    // turn. The wire shape per UPCR-2026-012 is metadata-only (no
+    // `content`) — every subsequent assistant persisted event for the
+    // same turn carries `content=""` and (typically) `media=[]`, and
+    // its streamed text already landed in the now-finalised bubble.
+    // Falling through to `appendPersistedMessage` for those events
+    // would synthesise an empty-content empty-media row that renders
+    // as a phantom timestamp-only bubble. Drop the event when it has
+    // no media (no attachment to render) — the streamed text is
+    // already on the bubble we finalised earlier. Media-bearing late
+    // artifacts still flow through to `appendPersistedMessage` for
+    // attachment merging.
+    const eventMedia = event.media ?? [];
+    if (eventMedia.length === 0) {
+      return;
+    }
   }
   ThreadStore.appendPersistedMessage(
     cfg.sessionId,

--- a/src/store/thread-store.test.ts
+++ b/src/store/thread-store.test.ts
@@ -658,6 +658,51 @@ describe("thread-store", () => {
   });
 
   // ---------------------------------------------------------------------------
+  // Production phantom (mini1 dspfac.crew.ominix.io 2026-05-08): Q1 sent over
+  // the WS lane finalizes correctly with content, then a second
+  // `addUserMessage` for the SAME clientMessageId (legacy mirror, retry,
+  // double-publish) re-creates a streaming `pendingAssistant` on the
+  // already-finalized thread — surfacing as a phantom empty bubble that
+  // never finalizes. `isRunning` then stays true for that thread because
+  // the renderer reads `pendingAssistant.status === "streaming"`, blocking
+  // the user from seeing a clean post-send state.
+  //
+  // The fix: addUserMessage MUST NOT spawn a fresh pendingAssistant on a
+  // thread that already has at least one finalized assistant response —
+  // a follow-up turn would have a fresh `clientMessageId` and root its
+  // own thread.
+  // ---------------------------------------------------------------------------
+
+  it("addUserMessage_does_not_spawn_phantom_pending_on_already_finalized_thread", () => {
+    // Q1: user sends, assistant streams, turn finalizes cleanly.
+    makeUser("今天北京的天气如何", "cmid-q1");
+    ThreadStore.appendAssistantToken("cmid-q1", "北京今天天气晴朗，气温 18.4°C");
+    ThreadStore.finalizeAssistant("cmid-q1", { committedSeq: 1 });
+
+    const afterFinalize = ThreadStore.getThreads(SESSION)[0];
+    expect(afterFinalize.pendingAssistant).toBeNull();
+    expect(afterFinalize.responses).toHaveLength(1);
+
+    // A second `addUserMessage` for the SAME cmid arrives — this is the
+    // production trigger (legacy SSE mirror running after the WS path
+    // already finalized; retry-path re-publishing the same payload; etc.).
+    // The user already saw their answer; this MUST NOT create a fresh
+    // streaming pending.
+    ThreadStore.addUserMessage(SESSION, {
+      text: "今天北京的天气如何",
+      clientMessageId: "cmid-q1",
+    });
+
+    const after = ThreadStore.getThreads(SESSION)[0];
+    expect(
+      after.pendingAssistant,
+      "second addUserMessage on a finalized thread MUST NOT spawn a phantom streaming bubble — that empty bubble pins isRunning=true and surfaces as the empty-timestamp ghost the user reported on mini1 2026-05-08",
+    ).toBeNull();
+    expect(after.responses).toHaveLength(1);
+    expect(after.responses[0].text).toBe("北京今天天气晴朗，气温 18.4°C");
+  });
+
+  // ---------------------------------------------------------------------------
   // PR J Fix 1: Adjacent media-only companion coalescing
   //
   // After reload: assistant text record N (e.g. Chinese-language deep-research

--- a/src/store/thread-store.ts
+++ b/src/store/thread-store.ts
@@ -343,39 +343,64 @@ export function addUserMessage(
   const pendingAssistant = makeAssistantPlaceholder(opts.clientMessageId);
 
   // If a thread already exists with this id, adopt it instead of
-  // double-inserting. Two flavours:
-  //  • Orphan bucket — created earlier by a late background event whose
-  //    user message hadn't been added yet. Preserve its `responses` and
-  //    in-flight `pendingAssistant` (codex review #2: replacing them
-  //    with an empty placeholder would discard runtime progress).
-  //  • Hydrated history thread — `responses` is already populated and
-  //    `pendingAssistant` is null. Open a fresh pending for the new turn.
+  // double-inserting. Three flavours:
+  //  • Orphan bucket with no responses yet — created earlier by a late
+  //    background event whose user message hadn't been added yet.
+  //    Preserve its in-flight `pendingAssistant`; if none, open a fresh
+  //    pending so the upcoming stream events have a slot to land in.
+  //  • In-flight thread (pending non-null) — keep the live pending,
+  //    don't disturb runtime progress (codex review #2).
+  //  • ALREADY-FINALIZED thread (pending null AND responses contain an
+  //    assistant) — DO NOT spawn a fresh streaming pending. The thread
+  //    has already been answered; this is a re-mirror / replay /
+  //    cross-transport double-publish (mini1 2026-05-08: WS path
+  //    finalises Q1 cleanly, then a late legacy-mirror or retry calls
+  //    `addUserMessage` for the same cmid; pre-fix this minted a
+  //    streaming pending that pinned `isRunning=true` and surfaced as
+  //    the empty timestamp-only ghost bubble in the DOM). A real
+  //    follow-up turn always has a fresh `clientMessageId` and roots
+  //    its own thread.
   const existing = state.byId.get(opts.clientMessageId);
   if (existing) {
     existing.userMsg = userMsg;
     if (!existing.pendingAssistant) {
-      existing.pendingAssistant = pendingAssistant;
+      const alreadyAnswered = existing.responses.some(
+        (r) => r.role === "assistant",
+      );
+      if (!alreadyAnswered) {
+        existing.pendingAssistant = pendingAssistant;
+      }
     }
     notify();
     return {
       threadId: opts.clientMessageId,
-      pendingAssistantId: existing.pendingAssistant.id,
+      pendingAssistantId:
+        existing.pendingAssistant?.id ?? pendingAssistant.id,
     };
   }
 
   // Adopt any orphan thread bucket that was created earlier (a late
   // background event arrived ahead of the user message) — even if it
   // landed in a different session's state. Carry over its responses
-  // and in-flight pending so the runtime progress isn't dropped.
+  // and in-flight pending so the runtime progress isn't dropped. Same
+  // already-answered guard as the same-session branch above: if the
+  // orphan already carries a finalized assistant response, do NOT
+  // mint a fresh streaming pending — that would surface as the
+  // phantom empty bubble.
   for (const otherState of sessionsByKey.values()) {
     if (otherState === state) continue;
     const orphan = otherState.byId.get(opts.clientMessageId);
     if (!orphan) continue;
+    const orphanAlreadyAnswered =
+      !orphan.pendingAssistant &&
+      orphan.responses.some((r) => r.role === "assistant");
     const adopted: Thread = {
       id: opts.clientMessageId,
       userMsg,
       responses: orphan.responses,
-      pendingAssistant: orphan.pendingAssistant ?? pendingAssistant,
+      pendingAssistant: orphanAlreadyAnswered
+        ? null
+        : (orphan.pendingAssistant ?? pendingAssistant),
     };
     // Detach from the wrong session.
     otherState.byId.delete(opts.clientMessageId);
@@ -385,7 +410,7 @@ export function addUserMessage(
     notify();
     return {
       threadId: adopted.id,
-      pendingAssistantId: adopted.pendingAssistant!.id,
+      pendingAssistantId: adopted.pendingAssistant?.id ?? pendingAssistant.id,
     };
   }
 


### PR DESCRIPTION
## Summary
- Multi-iteration agent loops emit multiple \`message/persisted\` events per turn (seq=1 tool-call assistant, seq=3 final-text assistant). The first promotes the streamed pending bubble correctly; the second had no pending to promote and \`appendPersistedMessage\` synthesised an empty-text/empty-media row → phantom timestamp-only bubble.
- Fix in \`ui-protocol-event-router.ts::handleMessagePersisted\`: when \`tryPromotePendingFromPersisted\` returns false for an assistant event with no media, drop it. The streamed text is already on the bubble we finalised earlier.
- Defence-in-depth in \`thread-store.ts::addUserMessage\`: don't mint a fresh streaming \`pendingAssistant\` for a thread that already has a finalised assistant response.

## Production repro (pre-fix)
\`https://dspfac.crew.ominix.io/chat\` — send 北京天气 question → real answer arrives, then ~4s later an empty timestamp-only assistant bubble appears. Send button stays disabled (correctly, because the input was cleared); user can't tell the second bubble is phantom and concludes "no answer". Filed in this session 2026-05-09.

## Verified post-fix
- Bundle \`index-B-CGGYR9.js\` deployed to mini1/mini2/mini3.
- \`tests/_oneoff-mini1-q1q2.spec.ts\` (deploy-wave2 e2e): Q1 + Q2 both pass with 0 empty assistant bubbles in 17.3s.
- 191/191 vitest unit tests pass (new regression in \`thread-store.test.ts\`).

## Test plan
- [ ] Codex pre-merge review.
- [ ] Manual: send several rapid messages on \`dspfac.crew.ominix.io\`, confirm no orphan bubbles, no stuck input.
- [ ] Soak harness will be tightened in a follow-up PR to fail on phantom bubbles (separate issue — \`bubbleHasRealContent\` filter masked this bug for weeks).

## Files
- \`src/runtime/ui-protocol-event-router.ts\` — phantom-bubble drop
- \`src/store/thread-store.ts\` — defence-in-depth
- \`src/store/thread-store.test.ts\` — regression test