### PR TITLE
feat(store): M9-γ-2 — pure-function projection (envelopes) → ChatViewModel (closes #839)

### DIFF
--- a/src/runtime/ui-protocol-types.ts
+++ b/src/runtime/ui-protocol-types.ts
@@ -340,3 +340,186 @@ export interface SessionHydrateResult {
   pending_approvals?: unknown[];
   replayed_envelopes?: TurnSpawnCompleteEvent[];
 }
+
+// ─── M9-γ canonical projection envelope (UPCR-2026-014) ────────────────────
+//
+// Mirrors `crates/octos-core/src/ui_protocol.rs` (Rust enum uses
+// `serde(tag = "type", content = "data", rename_all = "snake_case")`).
+//
+// Spec: `api/OCTOS_UI_PROTOCOL_V1_SPEC_2026-04-24.md` § 14
+// "M9-γ Envelope".
+// ADR: `docs/M9-GAMMA-SERVER-PROJECTION-ADR.md`.
+//
+// **Hard barrier**: per the ADR, `turn_completed` is the terminal
+// payload for a `thread_id`. No further `assistant_*`/`tool_*`
+// payloads on the same thread are valid after it.
+//
+// These types are sourced verbatim from γ-1 PR #848
+// (`feat/m9-gamma-1-envelope-spec`). When that PR's web mirror lands
+// upstream, this block becomes the import surface for the M9-γ-2
+// projection function (`src/store/projection.ts`) and the M9-γ-3
+// `ThreadStore` cutover.
+
+/** Multi-turn cluster identity — the chat thread this envelope projects
+ *  into. All envelopes for one logical conversation share a `thread_id`. */
+export type ThreadId = string;
+
+/** Server-assigned UUID of a durable message row. Stable across replays.
+ *  Mirrors `MessageMeta.message_id` in the Rust types. */
+export type EnvelopeMessageId = string;
+
+/** Client optimism + idempotency token. Web client mints; UUIDv7 in prod.
+ *  ONLY the optimistic <GhostBubble> overlay consults this — the
+ *  projection itself never does. */
+export type ClientMessageId = string;
+
+/** RFC 3339 timestamp string (e.g. "2026-05-09T18:30:01Z"). */
+export type IsoTimestamp = string;
+
+/** Sub-typed numeric for the strict per-thread server ordering. */
+export type Seq = number;
+
+/** Token usage carried on `turn_completed` envelopes. Mirrors
+ *  `EnvelopeTokenUsage` in the Rust types. All fields default to zero
+ *  and are omitted on the wire when zero (serde
+ *  `skip_serializing_if = "is_zero_u64"`). */
+export interface EnvelopeTokenUsage {
+  input_tokens?: number;
+  output_tokens?: number;
+  reasoning_tokens?: number;
+  cache_read_tokens?: number;
+  cache_write_tokens?: number;
+}
+
+/** Metadata carried on `assistant_persisted` envelopes. Mirrors
+ *  `MessageMeta` in the Rust types. */
+export interface MessageMeta {
+  /** Server-assigned UUID of the durable row. */
+  message_id: EnvelopeMessageId;
+  /** Wall-clock RFC 3339 commit time. */
+  persisted_at: IsoTimestamp;
+  /** File attachments persisted with the message — typically a single
+   *  `.md` / `.mp3` / `.pptx` artefact. Empty for assistant rows that
+   *  carry only text. Omitted on the wire when empty. */
+  media?: string[];
+}
+
+/** Status carried on `tool_end` payloads. Mirrors `EnvelopeToolEndStatus`
+ *  (snake_case wire form) in the Rust types. */
+export type EnvelopeToolEndStatus = "complete" | "error";
+
+interface AssistantDeltaPayload {
+  type: "assistant_delta";
+  data: { text: string };
+}
+
+interface AssistantPersistedPayload {
+  type: "assistant_persisted";
+  data: { text: string; meta: MessageMeta };
+}
+
+interface ToolStartPayload {
+  type: "tool_start";
+  data: { tool_call_id: string; name: string };
+}
+
+interface ToolProgressPayload {
+  type: "tool_progress";
+  data: { tool_call_id: string; message: string };
+}
+
+interface ToolEndPayload {
+  type: "tool_end";
+  data: {
+    tool_call_id: string;
+    status: EnvelopeToolEndStatus;
+    /** Set iff `status === 'error'`. Omitted on the wire when null. */
+    error?: string;
+  };
+}
+
+interface FileAttachedPayload {
+  type: "file_attached";
+  data: { path: string; mime: string; size_bytes: number };
+}
+
+interface TurnCompletedPayload {
+  type: "turn_completed";
+  data: { token_usage: EnvelopeTokenUsage };
+}
+
+/** Sealed tagged union of payloads carried by the M9-γ projection
+ *  envelope. The discriminator is `type`; payload data lives under
+ *  `data`. Variant names are snake_case to match the wire / Rust shape. */
+export type Payload =
+  | AssistantDeltaPayload
+  | AssistantPersistedPayload
+  | ToolStartPayload
+  | ToolProgressPayload
+  | ToolEndPayload
+  | FileAttachedPayload
+  | TurnCompletedPayload;
+
+/** Canonical M9-γ projection envelope.
+ *
+ *  Per UPCR-2026-014 and the M9-γ ADR, this is the single shape the
+ *  web client's deterministic projection consumes. The committed
+ *  envelope log is `Envelope[]` indexed by `(thread_id, seq)`; the
+ *  projection is a pure function from that log to `ChatViewModel`.
+ *
+ *  Identity collapses to `seq` — the only key the projection cares
+ *  about. `client_message_id` lives ONLY on user-message-rooted
+ *  envelopes so the optimistic `<GhostBubble>` overlay can match its
+ *  server reflection and unmount; the projection itself NEVER consults
+ *  it. */
+export interface Envelope {
+  thread_id: ThreadId;
+  seq: Seq;
+  /** Present on user-message-rooted envelopes (the optimistic
+   *  `<GhostBubble>` overlay matches its server reflection here).
+   *  Absent on internal events (assistant deltas, tool events,
+   *  turn_completed). The projection MUST NOT consult this field. */
+  client_message_id?: ClientMessageId;
+  payload: Payload;
+}
+
+/** Wire-form capability flag for UPCR-2026-014. Servers advertise it via
+ *  `UiProtocolCapabilities.supported_features`; clients request it via
+ *  the `X-Octos-Ui-Features` header. Mirrors
+ *  `UI_PROTOCOL_FEATURE_PROJECTION_ENVELOPE_V1` in the Rust types. */
+export const UI_PROTOCOL_FEATURE_PROJECTION_ENVELOPE_V1 = "projection.envelope.v1";
+
+// ── Type guards (optional ergonomic helpers) ─────────────────────────────
+//
+// The projection function will switch on `envelope.payload.type` and
+// rely on TS's discriminated-union narrowing. These helpers exist for
+// callers that need a runtime check (e.g. a debug overlay rendering a
+// raw envelope).
+
+export function isAssistantDelta(p: Payload): p is AssistantDeltaPayload {
+  return p.type === "assistant_delta";
+}
+
+export function isAssistantPersisted(p: Payload): p is AssistantPersistedPayload {
+  return p.type === "assistant_persisted";
+}
+
+export function isToolStart(p: Payload): p is ToolStartPayload {
+  return p.type === "tool_start";
+}
+
+export function isToolProgress(p: Payload): p is ToolProgressPayload {
+  return p.type === "tool_progress";
+}
+
+export function isToolEnd(p: Payload): p is ToolEndPayload {
+  return p.type === "tool_end";
+}
+
+export function isFileAttached(p: Payload): p is FileAttachedPayload {
+  return p.type === "file_attached";
+}
+
+export function isTurnCompleted(p: Payload): p is TurnCompletedPayload {
+  return p.type === "turn_completed";
+}

--- a/src/runtime/ui-protocol-types.ts
+++ b/src/runtime/ui-protocol-types.ts
@@ -408,6 +408,21 @@ export interface MessageMeta {
  *  (snake_case wire form) in the Rust types. */
 export type EnvelopeToolEndStatus = "complete" | "error";
 
+/** File attachment carried on `user_message` envelopes. Mirrors `FileRef`
+ *  in the Rust types (γ-1 PR #848 commit `ac589b73`). The `path` field
+ *  is the durable filesystem path the server can resolve; `mime` and
+ *  `size_bytes` are optional metadata captured at upload time. */
+export interface FileRef {
+  path: string;
+  mime?: string;
+  size_bytes?: number;
+}
+
+interface UserMessagePayload {
+  type: "user_message";
+  data: { text: string; files: FileRef[] };
+}
+
 interface AssistantDeltaPayload {
   type: "assistant_delta";
   data: { text: string };
@@ -452,6 +467,7 @@ interface TurnCompletedPayload {
  *  envelope. The discriminator is `type`; payload data lives under
  *  `data`. Variant names are snake_case to match the wire / Rust shape. */
 export type Payload =
+  | UserMessagePayload
   | AssistantDeltaPayload
   | AssistantPersistedPayload
   | ToolStartPayload
@@ -495,6 +511,10 @@ export const UI_PROTOCOL_FEATURE_PROJECTION_ENVELOPE_V1 = "projection.envelope.v
 // rely on TS's discriminated-union narrowing. These helpers exist for
 // callers that need a runtime check (e.g. a debug overlay rendering a
 // raw envelope).
+
+export function isUserMessage(p: Payload): p is UserMessagePayload {
+  return p.type === "user_message";
+}
 
 export function isAssistantDelta(p: Payload): p is AssistantDeltaPayload {
   return p.type === "assistant_delta";

--- a/src/store/projection.test.ts
+++ b/src/store/projection.test.ts
@@ -1,0 +1,405 @@
+/**
+ * M9-γ-2 projection tests.
+ *
+ * Three property tests (determinism, ordering, idempotency) plus the
+ * `turn_completed` barrier and one focused unit test per payload variant.
+ *
+ * The "shuffled-within-thread" property is checked via permutation of
+ * cross-thread interleavings while preserving per-thread seq monotonicity
+ * — exactly the invariant the spec promises (§ 14.1: `seq` is strictly
+ * monotonic WITHIN a thread; cross-thread ordering is not specified).
+ */
+
+import { describe, expect, it } from "vitest";
+
+import type {
+  Envelope,
+  EnvelopeTokenUsage,
+  MessageMeta,
+  Payload,
+} from "../runtime/ui-protocol-types";
+
+import { project, projectWithMetrics } from "./projection";
+
+// ─── Helpers ──────────────────────────────────────────────────────────────
+
+const META: MessageMeta = {
+  message_id: "01900000-0000-7000-8000-000000000001",
+  persisted_at: "2026-05-09T18:30:01Z",
+};
+
+function env(
+  thread_id: string,
+  seq: number,
+  payload: Payload,
+  client_message_id?: string,
+): Envelope {
+  return client_message_id !== undefined
+    ? { thread_id, seq, payload, client_message_id }
+    : { thread_id, seq, payload };
+}
+
+const aDelta = (text: string): Payload => ({
+  type: "assistant_delta",
+  data: { text },
+});
+
+const aPersisted = (text: string, meta: MessageMeta = META): Payload => ({
+  type: "assistant_persisted",
+  data: { text, meta },
+});
+
+const tStart = (id: string, name: string): Payload => ({
+  type: "tool_start",
+  data: { tool_call_id: id, name },
+});
+
+const tProgress = (id: string, message: string): Payload => ({
+  type: "tool_progress",
+  data: { tool_call_id: id, message },
+});
+
+const tEnd = (
+  id: string,
+  status: "complete" | "error",
+  error?: string,
+): Payload =>
+  status === "error"
+    ? {
+        type: "tool_end",
+        data: { tool_call_id: id, status, ...(error !== undefined ? { error } : {}) },
+      }
+    : { type: "tool_end", data: { tool_call_id: id, status } };
+
+const fAttached = (
+  path: string,
+  mime: string,
+  size_bytes: number,
+): Payload => ({
+  type: "file_attached",
+  data: { path, mime, size_bytes },
+});
+
+const tCompleted = (token_usage: EnvelopeTokenUsage = {}): Payload => ({
+  type: "turn_completed",
+  data: { token_usage },
+});
+
+/** Generate every interleaving of multiple per-thread streams that
+ *  preserves each stream's internal order. Matches the "permutation
+ *  that respects per-thread seq monotonicity" promise in the brief. */
+function* interleavings<T>(streams: ReadonlyArray<ReadonlyArray<T>>): Generator<T[]> {
+  const indices = streams.map(() => 0);
+
+  function* recur(prefix: T[]): Generator<T[]> {
+    let allDone = true;
+    for (let i = 0; i < streams.length; i += 1) {
+      if (indices[i] < streams[i].length) {
+        allDone = false;
+        const next = streams[i][indices[i]];
+        indices[i] += 1;
+        prefix.push(next);
+        yield* recur(prefix);
+        prefix.pop();
+        indices[i] -= 1;
+      }
+    }
+    if (allDone) yield prefix.slice();
+  }
+
+  yield* recur([]);
+}
+
+// Deep-equality JSON compare — `toEqual` is fine, but we want a
+// byte-stable signature to prove determinism literally.
+function fingerprint(value: unknown): string {
+  return JSON.stringify(value, (_key, v) => {
+    if (v instanceof Map) {
+      return Object.fromEntries(v.entries());
+    }
+    return v;
+  });
+}
+
+// ─── Property: determinism ─────────────────────────────────────────────────
+
+describe("project — determinism", () => {
+  it("should produce byte-identical output across repeated calls on the same input", () => {
+    const log: Envelope[] = [
+      env("t1", 0, aDelta("Hello "), "u-1"),
+      env("t1", 1, aDelta("world")),
+      env("t1", 2, tStart("tc-1", "shell")),
+      env("t1", 3, tProgress("tc-1", "running…")),
+      env("t1", 4, tEnd("tc-1", "complete")),
+      env("t1", 5, fAttached("/tmp/a.md", "text/markdown", 100)),
+      env("t1", 6, aPersisted("Hello world")),
+      env("t1", 7, tCompleted({ input_tokens: 10, output_tokens: 20 })),
+    ];
+
+    const a = project(log);
+    const b = project(log);
+    const c = project([...log]); // fresh array, same envelopes
+
+    expect(a).toEqual(b);
+    expect(a).toEqual(c);
+    expect(fingerprint(a)).toBe(fingerprint(b));
+    expect(fingerprint(a)).toBe(fingerprint(c));
+  });
+});
+
+// ─── Property: ordering by seq ─────────────────────────────────────────────
+
+describe("project — ordering by seq", () => {
+  it("should produce identical view-models for any cross-thread interleaving that preserves per-thread seq monotonicity", () => {
+    // Two independent thread streams, each in seq order.
+    const t1: Envelope[] = [
+      env("t1", 0, aDelta("hi"), "u-t1"),
+      env("t1", 1, aPersisted("hi")),
+      env("t1", 2, tCompleted()),
+    ];
+    const t2: Envelope[] = [
+      env("t2", 0, aDelta("yo"), "u-t2"),
+      env("t2", 1, aDelta("!")),
+      env("t2", 2, tStart("tc-x", "web")),
+      env("t2", 3, tEnd("tc-x", "complete")),
+    ];
+
+    const reference = project([...t1, ...t2]);
+    const refFp = fingerprint(reference);
+
+    let count = 0;
+    for (const interleave of interleavings([t1, t2])) {
+      const got = project(interleave);
+      // Per-thread state must match.
+      const byThread = new Map(got.threads.map((t) => [t.thread_id, t]));
+      const refByThread = new Map(reference.threads.map((t) => [t.thread_id, t]));
+      expect(byThread.size).toBe(refByThread.size);
+      for (const [tid, refThread] of refByThread) {
+        expect(byThread.get(tid)).toEqual(refThread);
+      }
+      // The cross-thread `threads` array order is determined by
+      // first-seen seq, which depends on the interleave — so we don't
+      // demand byte-identity on the OUTER fingerprint.
+      count += 1;
+    }
+    // Sanity: we generated more than one permutation.
+    expect(count).toBeGreaterThan(1);
+    // And the canonical (concatenated) ordering is itself a valid
+    // permutation, so the reference exists.
+    expect(refFp.length).toBeGreaterThan(0);
+  });
+
+  it("should preserve thread row order = first-seen seq across threads", () => {
+    // t2 introduces first; t1 follows.
+    const log: Envelope[] = [
+      env("t2", 0, aDelta("first")),
+      env("t1", 0, aDelta("second")),
+    ];
+    const view = project(log);
+    expect(view.threads.map((t) => t.thread_id)).toEqual(["t2", "t1"]);
+  });
+});
+
+// ─── Property: idempotency ────────────────────────────────────────────────
+
+describe("project — idempotency", () => {
+  it("should ignore an exact-duplicate (thread_id, seq) envelope", () => {
+    const base: Envelope[] = [
+      env("t1", 0, aDelta("Hello "), "u-1"),
+      env("t1", 1, aDelta("world")),
+      env("t1", 2, aPersisted("Hello world")),
+    ];
+    const dup = env("t1", 1, aDelta("ZZZ")); // same (thread_id, seq) as base[1]
+    const withDup = [...base, dup];
+
+    const a = projectWithMetrics(base);
+    const b = projectWithMetrics(withDup);
+
+    expect(b.view).toEqual(a.view);
+    expect(b.metrics.duplicates).toBe(1);
+    expect(a.metrics.duplicates).toBe(0);
+  });
+
+  it("should drop strictly-out-of-order envelopes (seq < high-water)", () => {
+    const log: Envelope[] = [
+      env("t1", 0, aDelta("a")),
+      env("t1", 5, aDelta("b")),
+      // late arrival: seq=2, lower than the current high-water (5)
+      env("t1", 2, aDelta("LATE")),
+    ];
+    const result = projectWithMetrics(log);
+    const t = result.view.threads[0];
+    expect(t.assistant?.text).toBe("ab");
+    expect(result.metrics.outOfOrder).toBe(1);
+  });
+});
+
+// ─── turn_completed barrier ───────────────────────────────────────────────
+
+describe("project — turn_completed barrier", () => {
+  it("should drop any envelope after turn_completed for the same thread and bump the metric", () => {
+    const log: Envelope[] = [
+      env("t1", 0, aDelta("hi")),
+      env("t1", 1, aPersisted("hi")),
+      env("t1", 2, tCompleted({ input_tokens: 1, output_tokens: 2 })),
+      env("t1", 3, aDelta("LATE")), // forbidden post-barrier delta
+      env("t1", 4, tStart("tc-late", "shell")), // forbidden post-barrier tool
+      env("t1", 5, fAttached("/tmp/late.md", "text/markdown", 1)),
+    ];
+    const result = projectWithMetrics(log);
+    const t = result.view.threads[0];
+    expect(t.completed).toBe(true);
+    expect(t.tokenUsage).toEqual({ input_tokens: 1, output_tokens: 2 });
+    expect(t.assistant?.text).toBe("hi");
+    expect(t.toolCalls).toEqual([]);
+    expect(t.files).toEqual([]);
+    expect(result.metrics.droppedAfterTurnCompleted).toBe(3);
+  });
+
+  it("should not affect other threads when one thread completes", () => {
+    const log: Envelope[] = [
+      env("t1", 0, aDelta("a")),
+      env("t1", 1, tCompleted()),
+      env("t2", 0, aDelta("b")), // different thread, must survive
+      env("t1", 2, aDelta("LATE")),
+    ];
+    const result = projectWithMetrics(log);
+    const byThread = new Map(result.view.threads.map((t) => [t.thread_id, t]));
+    expect(byThread.get("t1")?.completed).toBe(true);
+    expect(byThread.get("t1")?.assistant?.text).toBe("a");
+    expect(byThread.get("t2")?.completed).toBe(false);
+    expect(byThread.get("t2")?.assistant?.text).toBe("b");
+    expect(result.metrics.droppedAfterTurnCompleted).toBe(1);
+  });
+});
+
+// ─── Per-variant focused unit tests ───────────────────────────────────────
+
+describe("project — assistant_delta accumulates text", () => {
+  it("should concatenate fragments in seq order", () => {
+    const log: Envelope[] = [
+      env("t1", 0, aDelta("foo ")),
+      env("t1", 1, aDelta("bar ")),
+      env("t1", 2, aDelta("baz")),
+    ];
+    const view = project(log);
+    expect(view.threads[0].assistant?.text).toBe("foo bar baz");
+    expect(view.threads[0].assistant?.persisted).toBe(false);
+    expect(view.threads[0].assistant?.meta).toBeNull();
+  });
+});
+
+describe("project — assistant_persisted replaces text + finalizes meta", () => {
+  it("should replace streamed text with persisted text and stamp meta", () => {
+    const meta: MessageMeta = {
+      message_id: "01900000-0000-7000-8000-000000000018",
+      persisted_at: "2026-05-09T18:30:01Z",
+      media: ["report.md"],
+    };
+    const log: Envelope[] = [
+      env("t1", 0, aDelta("Hello ")),
+      env("t1", 1, aDelta("wo")),
+      env("t1", 2, aPersisted("Hello world", meta)),
+    ];
+    const view = project(log);
+    const a = view.threads[0].assistant!;
+    expect(a.text).toBe("Hello world");
+    expect(a.meta).toEqual(meta);
+    expect(a.persisted).toBe(true);
+  });
+});
+
+describe("project — tool_start adds a toolCall", () => {
+  it("should open a tool-call card keyed on tool_call_id", () => {
+    const log: Envelope[] = [env("t1", 0, tStart("tc-1", "shell"))];
+    const view = project(log);
+    expect(view.threads[0].toolCalls).toEqual([
+      {
+        tool_call_id: "tc-1",
+        name: "shell",
+        progress: [],
+        status: null,
+        error: null,
+      },
+    ]);
+  });
+});
+
+describe("project — tool_progress appends to the matching toolCall", () => {
+  it("should append progress messages in seq order", () => {
+    const log: Envelope[] = [
+      env("t1", 0, tStart("tc-1", "shell")),
+      env("t1", 1, tProgress("tc-1", "starting")),
+      env("t1", 2, tProgress("tc-1", "running…")),
+      env("t1", 3, tProgress("tc-1", "almost done")),
+    ];
+    const view = project(log);
+    expect(view.threads[0].toolCalls[0].progress).toEqual([
+      "starting",
+      "running…",
+      "almost done",
+    ]);
+  });
+});
+
+describe("project — tool_end stamps status (and error iff status==error)", () => {
+  it("should set status=complete with no error", () => {
+    const log: Envelope[] = [
+      env("t1", 0, tStart("tc-1", "shell")),
+      env("t1", 1, tEnd("tc-1", "complete")),
+    ];
+    const view = project(log);
+    expect(view.threads[0].toolCalls[0].status).toBe("complete");
+    expect(view.threads[0].toolCalls[0].error).toBeNull();
+  });
+
+  it("should set status=error and surface the error string", () => {
+    const log: Envelope[] = [
+      env("t1", 0, tStart("tc-2", "web")),
+      env("t1", 1, tEnd("tc-2", "error", "boom")),
+    ];
+    const view = project(log);
+    expect(view.threads[0].toolCalls[0].status).toBe("error");
+    expect(view.threads[0].toolCalls[0].error).toBe("boom");
+  });
+});
+
+describe("project — file_attached adds to files", () => {
+  it("should record arrival order with the envelope's seq", () => {
+    const log: Envelope[] = [
+      env("t1", 0, fAttached("/tmp/a.md", "text/markdown", 10)),
+      env("t1", 1, fAttached("/tmp/b.mp3", "audio/mpeg", 2048)),
+    ];
+    const view = project(log);
+    expect(view.threads[0].files).toEqual([
+      { seq: 0, path: "/tmp/a.md", mime: "text/markdown", size_bytes: 10 },
+      { seq: 1, path: "/tmp/b.mp3", mime: "audio/mpeg", size_bytes: 2048 },
+    ]);
+  });
+});
+
+// ─── Misc surface checks ──────────────────────────────────────────────────
+
+describe("project — user view captures client_message_id when present", () => {
+  it("should record the client_message_id from the first envelope", () => {
+    const log: Envelope[] = [
+      env("t1", 0, aDelta("hi"), "u-token-1"),
+      env("t1", 1, aDelta("there")),
+    ];
+    const view = project(log);
+    expect(view.threads[0].user).toEqual({ seq: 0, client_message_id: "u-token-1" });
+  });
+
+  it("should leave client_message_id unset when the envelope omits it", () => {
+    const log: Envelope[] = [env("t1", 0, aDelta("hi"))];
+    const view = project(log);
+    expect(view.threads[0].user).toEqual({ seq: 0 });
+  });
+});
+
+describe("project — empty input", () => {
+  it("should produce an empty view-model", () => {
+    const view = project([]);
+    expect(view).toEqual({ threads: [] });
+  });
+});

--- a/src/store/projection.test.ts
+++ b/src/store/projection.test.ts
@@ -10,16 +10,27 @@
  * monotonic WITHIN a thread; cross-thread ordering is not specified).
  */
 
-import { describe, expect, it } from "vitest";
+import { beforeEach, describe, expect, it } from "vitest";
 
 import type {
   Envelope,
   EnvelopeTokenUsage,
+  FileRef,
   MessageMeta,
   Payload,
 } from "../runtime/ui-protocol-types";
 
-import { project, projectWithMetrics } from "./projection";
+import {
+  __resetProjectionCacheForTesting,
+  project,
+  projectWithMetrics,
+} from "./projection";
+
+beforeEach(() => {
+  // Per-thread ThreadView cache is module-scoped; reset between
+  // tests so re-used thread ids (`t1`, `t2`) don't return stale refs.
+  __resetProjectionCacheForTesting();
+});
 
 // ─── Helpers ──────────────────────────────────────────────────────────────
 
@@ -38,6 +49,11 @@ function env(
     ? { thread_id, seq, payload, client_message_id }
     : { thread_id, seq, payload };
 }
+
+const uMsg = (text: string, files: FileRef[] = []): Payload => ({
+  type: "user_message",
+  data: { text, files },
+});
 
 const aDelta = (text: string): Payload => ({
   type: "assistant_delta",
@@ -220,17 +236,50 @@ describe("project — idempotency", () => {
     expect(a.metrics.duplicates).toBe(0);
   });
 
-  it("should drop strictly-out-of-order envelopes (seq < high-water)", () => {
+  it("should buffer out-of-order envelopes and apply them once the gap fills (codex BLOCK 1)", () => {
+    // seq 0,2,1 — pre-fix dropped seq=1 permanently.
     const log: Envelope[] = [
       env("t1", 0, aDelta("a")),
-      env("t1", 5, aDelta("b")),
-      // late arrival: seq=2, lower than the current high-water (5)
-      env("t1", 2, aDelta("LATE")),
+      env("t1", 2, aDelta("c")),
+      env("t1", 1, aDelta("b")),
     ];
     const result = projectWithMetrics(log);
     const t = result.view.threads[0];
-    expect(t.assistant?.text).toBe("ab");
+    expect(t.assistant?.text).toBe("abc");
+    // seq 2 took the buffering path; seq 1 was the in-order arrival
+    // that drained the gap (no bump).
     expect(result.metrics.outOfOrder).toBe(1);
+    expect(result.metrics.duplicates).toBe(0);
+  });
+
+  it("should buffer arrivals beyond the gap until the gap fills (large gap)", () => {
+    // seq 0, 5, 2, 1 — when 1 arrives, drain 1; 2 was already
+    // buffered so drain 2; 3,4 missing so 5 stays buffered.
+    const log: Envelope[] = [
+      env("t1", 0, aDelta("a")),
+      env("t1", 5, aDelta("z")),
+      env("t1", 2, aDelta("c")),
+      env("t1", 1, aDelta("b")),
+    ];
+    const result = projectWithMetrics(log);
+    const t = result.view.threads[0];
+    expect(t.assistant?.text).toBe("abc");
+    // seq 5 + seq 2 buffered (=2). seq 1 was in-order (no bump).
+    expect(result.metrics.outOfOrder).toBe(2);
+  });
+
+  it("should produce identical output for [0,1,2] and [0,2,1] (codex BLOCK 2 order-independence)", () => {
+    const inOrder: Envelope[] = [
+      env("t1", 0, aDelta("a")),
+      env("t1", 1, aDelta("b")),
+      env("t1", 2, aDelta("c")),
+    ];
+    const outOfOrder: Envelope[] = [
+      env("t1", 0, aDelta("a")),
+      env("t1", 2, aDelta("c")),
+      env("t1", 1, aDelta("b")),
+    ];
+    expect(project(inOrder)).toEqual(project(outOfOrder));
   });
 });
 
@@ -387,13 +436,20 @@ describe("project — user view captures client_message_id when present", () => 
       env("t1", 1, aDelta("there")),
     ];
     const view = project(log);
-    expect(view.threads[0].user).toEqual({ seq: 0, client_message_id: "u-token-1" });
+    // Until a `user_message` envelope lands, text/files default to
+    // empty (codex BLOCK 3: no first-envelope-seen fallback).
+    expect(view.threads[0].user).toEqual({
+      seq: 0,
+      client_message_id: "u-token-1",
+      text: "",
+      files: [],
+    });
   });
 
   it("should leave client_message_id unset when the envelope omits it", () => {
     const log: Envelope[] = [env("t1", 0, aDelta("hi"))];
     const view = project(log);
-    expect(view.threads[0].user).toEqual({ seq: 0 });
+    expect(view.threads[0].user).toEqual({ seq: 0, text: "", files: [] });
   });
 });
 
@@ -401,5 +457,93 @@ describe("project — empty input", () => {
   it("should produce an empty view-model", () => {
     const view = project([]);
     expect(view).toEqual({ threads: [] });
+  });
+});
+
+// ─── BLOCK 3: user_message payload populates UserView ────────────────────
+
+describe("project — user_message variant (codex BLOCK 3)", () => {
+  it("should populate UserView.text and UserView.files from a user_message envelope", () => {
+    const files: FileRef[] = [
+      { path: "/tmp/notes.md", mime: "text/markdown", size_bytes: 42 },
+    ];
+    const log: Envelope[] = [
+      env("t1", 0, uMsg("Hello!", files), "u-1"),
+      env("t1", 1, aDelta("Hi ")),
+      env("t1", 2, aDelta("there")),
+    ];
+    const view = project(log);
+    const u = view.threads[0].user!;
+    expect(u.text).toBe("Hello!");
+    expect(u.files).toEqual(files);
+    expect(u.client_message_id).toBe("u-1");
+    expect(u.seq).toBe(0);
+    expect(view.threads[0].assistant?.text).toBe("Hi there");
+  });
+
+  it("should NOT clobber UserView.text from a later assistant_delta (no first-envelope fallback)", () => {
+    const log: Envelope[] = [env("t1", 0, aDelta("assistant content"))];
+    const view = project(log);
+    expect(view.threads[0].user?.text).toBe("");
+    expect(view.threads[0].user?.files).toEqual([]);
+  });
+
+  it("should preserve UserView.text under buffered out-of-order arrival of the user_message envelope", () => {
+    const files: FileRef[] = [{ path: "/tmp/x.png" }];
+    const log: Envelope[] = [
+      env("t1", 1, aDelta("after"), "u-late"),
+      env("t1", 0, uMsg("typed", files), "u-late"),
+    ];
+    const view = project(log);
+    const u = view.threads[0].user!;
+    expect(u.text).toBe("typed");
+    expect(u.files).toEqual(files);
+    expect(view.threads[0].assistant?.text).toBe("after");
+  });
+
+  it("should ignore a second user_message payload (first-seen wins per thread)", () => {
+    const log: Envelope[] = [
+      env("t1", 0, uMsg("first")),
+      env("t1", 1, uMsg("second")),
+    ];
+    const view = project(log);
+    expect(view.threads[0].user?.text).toBe("first");
+  });
+});
+
+// ─── BLOCK 4: referential stability across project() calls ───────────────
+
+describe("project — referential stability (codex BLOCK 4)", () => {
+  it("should return the same ChatViewModel reference for the same input array", () => {
+    const log: Envelope[] = [
+      env("t1", 0, uMsg("hi"), "u-1"),
+      env("t1", 1, aDelta("hello")),
+    ];
+    const a = project(log);
+    const b = project(log);
+    expect(a).toBe(b);
+  });
+
+  it("should reuse per-thread ThreadView refs across distinct projections when the thread is unchanged", () => {
+    const log1: Envelope[] = [
+      env("t1", 0, uMsg("hi"), "u-1"),
+      env("t1", 1, aDelta("hello")),
+    ];
+    const log2: Envelope[] = log1.slice();
+    const v1 = project(log1);
+    const v2 = project(log2);
+    expect(v1).not.toBe(v2);
+    expect(v1.threads[0]).toBe(v2.threads[0]);
+  });
+
+  it("should mint a new ThreadView ref when the thread's contents materially change", () => {
+    const log1: Envelope[] = [env("t1", 0, uMsg("hi"))];
+    const log2: Envelope[] = [
+      env("t1", 0, uMsg("hi")),
+      env("t1", 1, aDelta("more")),
+    ];
+    const v1 = project(log1);
+    const v2 = project(log2);
+    expect(v1.threads[0]).not.toBe(v2.threads[0]);
   });
 });

--- a/src/store/projection.ts
+++ b/src/store/projection.ts
@@ -6,86 +6,74 @@
  * ADR:  `docs/M9-GAMMA-SERVER-PROJECTION-ADR.md`.
  * UPCR: `UPCR-2026-014`.
  *
- * This module is the deterministic foundation for the M9-γ projection
- * client. It is intentionally pure:
+ * Pure: no React, no hooks, no Date.now, no fetch. Same `Envelope[]`
+ * input ⇒ byte-identical `ChatViewModel`. Identity is `(thread_id, seq)`.
  *
- *   - No React, no hooks, no `notify()`.
- *   - No `Date.now()`, no random IDs, no fetch.
- *   - No imports from `thread-store` / `message-store` (γ-3 wires them up).
+ * **Order-independence (codex BLOCK 1, 2)**: out-of-order envelopes are
+ * BUFFERED, not dropped. Each thread tracks `expectedNextSeq`. Arrivals
+ * with `seq > expectedNextSeq` are buffered as gap candidates; arrivals
+ * with `seq < expectedNextSeq` AND not yet applied are buffered as
+ * "fill the gap". When a gap fills the projection drains the buffer in
+ * canonical seq order. The only true drops are exact-`(thread_id, seq)`
+ * duplicates of an applied envelope (`metrics.duplicates`) and arrivals
+ * after `turn_completed` on the same thread
+ * (`metrics.droppedAfterTurnCompleted`). `metrics.outOfOrder` counts
+ * buffered-then-drained envelopes (back-compat name; not dropped).
  *
- * Given the same `Envelope[]`, `project()` produces a byte-identical
- * `ChatViewModel`. Identity is `(thread_id, seq)` — NOT `client_message_id`
- * and NOT `messageId`. Per the ADR, `turn_completed` is a hard barrier:
- * subsequent payloads on the same `thread_id` are dropped (the projection
- * itself does not desync the connection — that's the bridge's job — but
- * it WILL ignore the trailing envelopes and bump the
- * `droppedAfterTurnCompleted` counter on `projectWithMetrics`).
+ * **`turn_completed` barrier**: the projection ignores trailing
+ * envelopes after `turn_completed` on a `thread_id` and bumps
+ * `droppedAfterTurnCompleted`. The bridge re-syncs the connection.
  *
- * Stable references:
- *
- *   - `threads` is an ordered array; insertion order = first-seen seq for
- *     each `thread_id`. We don't sort by `thread_id` (no spec guarantee).
- *   - Inside each `ThreadView`, `toolCalls` is keyed on `tool_call_id` and
- *     ordered by first-seen seq. `files` is ordered by seq.
- *
- * The projection is a left-fold: it never mutates the input. We accept
- * `ReadonlyArray<Envelope>` and treat the array as append-only.
+ * **Referential stability (codex BLOCK 4)**: top-level `project()`
+ * memoizes by input-array identity (same `envelopes` ref ⇒ same
+ * `ChatViewModel` ref). Per-thread `ThreadView` caching is keyed on
+ * `(appliedCount, lastSeq)`: when a thread's contributing envelopes
+ * haven't changed across distinct `project()` calls, the projection
+ * returns the same `ThreadView` reference. This is the simpler
+ * variant the brief authorised — a future iteration may switch to a
+ * structural hash when callers need finer-grained reuse.
  */
 
 import type {
   Envelope,
   EnvelopeTokenUsage,
   EnvelopeToolEndStatus,
+  FileRef,
   MessageMeta,
   Payload,
 } from "../runtime/ui-protocol-types";
 
 // ─── ChatViewModel shape ───────────────────────────────────────────────────
-//
-// The shape is intentionally narrow: just enough for the M9-γ-3 cutover
-// of `chat-thread.tsx` and the M9-γ-4 `<GhostBubble>` overlay. We don't
-// pre-bake legacy fields (e.g. timestamps minted by `Date.now()`); the
-// rendering layer can derive display metadata from `meta.persisted_at`
-// when an `assistant_persisted` envelope has finalized the bubble.
 
 export interface UserView {
-  /** First seq in this thread; used as a stable identity for the row. */
+  /** First seq in this thread; stable identity for the row. */
   seq: number;
-  /** The optimistic-token reflection from `client_message_id`, if the
-   *  server included one on the user-message-rooted envelope. The
-   *  projection does not consult this for identity; it surfaces the
-   *  field so γ-4's `<GhostBubble>` overlay can match-and-unmount. */
+  /** Reflected from `Envelope.client_message_id` on the user-message-
+   *  rooted envelope. The projection never consults this for identity;
+   *  γ-4's `<GhostBubble>` overlay uses it to match-and-unmount. */
   client_message_id?: string;
+  /** User-typed text from a `user_message` envelope. Empty until a
+   *  `user_message` envelope has been observed. */
+  text: string;
+  /** File attachments from a `user_message` envelope. */
+  files: ReadonlyArray<FileRef>;
 }
 
 export interface AssistantView {
-  /** Concatenated streamed text from `assistant_delta` envelopes (in
-   *  `seq` order), or the persisted full text from
-   *  `assistant_persisted` once it lands. */
   text: string;
-  /** Set when an `assistant_persisted` envelope has finalized the
-   *  bubble. Carries the durable row identity, commit timestamp, and
-   *  attachments. */
   meta: MessageMeta | null;
-  /** True iff at least one `assistant_persisted` envelope has been
-   *  observed for this thread. */
   persisted: boolean;
 }
 
 export interface ToolCallView {
   tool_call_id: string;
   name: string;
-  /** Progress messages appended in `seq` order. */
   progress: ReadonlyArray<string>;
-  /** `null` until a `tool_end` envelope arrives. */
   status: EnvelopeToolEndStatus | null;
-  /** Set iff `status === "error"`. */
   error: string | null;
 }
 
 export interface FileView {
-  /** The seq the `file_attached` envelope arrived on; stable identity
-   *  for the row, useful as a React key. */
   seq: number;
   path: string;
   mime: string;
@@ -94,48 +82,27 @@ export interface FileView {
 
 export interface ThreadView {
   thread_id: string;
-  /** Built from the first envelope that introduces this thread (see §
-   *  14.1: user-message-rooted envelopes carry `client_message_id`). */
   user: UserView | null;
-  /** Accumulates from `assistant_delta` + finalized by
-   *  `assistant_persisted`. `null` until at least one assistant payload
-   *  has been observed. */
   assistant: AssistantView | null;
-  /** Tool calls in first-seen order. */
   toolCalls: ReadonlyArray<ToolCallView>;
-  /** Files in arrival order. */
   files: ReadonlyArray<FileView>;
-  /** `true` once a `turn_completed` envelope has been observed for this
-   *  thread. Subsequent envelopes on the same `thread_id` are dropped. */
   completed: boolean;
-  /** Token usage from `turn_completed`. `null` until completion. */
   tokenUsage: EnvelopeTokenUsage | null;
 }
 
 export interface ChatViewModel {
-  /** Threads ordered by first-seen seq. The projection does not sort
-   *  alphabetically by `thread_id` — there is no spec guarantee that
-   *  thread_ids carry a meaningful collation order. */
   threads: ReadonlyArray<ThreadView>;
 }
 
-// ─── Projection metrics (optional) ─────────────────────────────────────────
+// ─── Projection metrics ─────────────────────────────────────────────────
 
-/** Counters surfaced for telemetry / debug overlays. The projection
- *  itself is pure; these counters are derived from the same fold and
- *  returned alongside the view-model when the caller wants them. */
 export interface ProjectionMetrics {
-  /** Number of envelopes ignored because `(thread_id, seq)` was already
-   *  applied (idempotency). */
+  /** Exact `(thread_id, seq)` collision of an already-applied envelope. */
   duplicates: number;
-  /** Number of envelopes ignored because they arrived after a
-   *  `turn_completed` for the same thread (hard-barrier enforcement). */
+  /** Envelopes ignored because they arrived after `turn_completed`. */
   droppedAfterTurnCompleted: number;
-  /** Number of envelopes ignored because their `seq` was strictly less
-   *  than the highest seq already observed in the same thread (the
-   *  projection treats out-of-order seqs as duplicates of an earlier
-   *  state and drops them). Distinct from `duplicates`, which counts
-   *  exact-match `(thread_id, seq)` collisions. */
+  /** Envelopes that arrived out of canonical seq order and were
+   *  buffered until the gap filled (NOT dropped — eventually applied). */
   outOfOrder: number;
 }
 
@@ -144,35 +111,76 @@ export interface ProjectionResult {
   metrics: ProjectionMetrics;
 }
 
+// ─── Memoization (codex BLOCK 4) ───────────────────────────────────────────
+
+const projectionCache = new WeakMap<
+  ReadonlyArray<Envelope>,
+  ProjectionResult
+>();
+
+// Per-thread ThreadView cache keyed on (appliedCount, lastSeq). When
+// a thread_id produces the same tuple across distinct projections, we
+// return the same ThreadView ref. Bounded by the number of distinct
+// thread_ids observed in the process lifetime.
+const threadViewCache = new Map<
+  string,
+  { count: number; lastSeq: number; view: ThreadView }
+>();
+
+/** Test-only: drop the per-thread cache. Tests that re-use the same
+ *  `thread_id` across cases need the cache cleared in `beforeEach` so
+ *  cross-test bleed doesn't return a stale ThreadView reference. */
+export function __resetProjectionCacheForTesting(): void {
+  threadViewCache.clear();
+  // projectionCache is a WeakMap keyed on input identity; unrelated
+  // tests can't collide there, so no clear required.
+}
+
 // ─── Projection ────────────────────────────────────────────────────────────
 
-/** Build a `ChatViewModel` from a committed envelope log. Pure and
- *  deterministic: same input ⇒ same output. */
 export function project(envelopes: ReadonlyArray<Envelope>): ChatViewModel {
   return projectWithMetrics(envelopes).view;
 }
 
-/** Variant that surfaces the metrics counters alongside the view. */
 export function projectWithMetrics(
   envelopes: ReadonlyArray<Envelope>,
 ): ProjectionResult {
-  // Per-thread mutable accumulator — converted to immutable `ThreadView`
-  // on the way out. We carry a `Set<seq>` for idempotency and a separate
-  // `lastSeq` for out-of-order detection (cheaper than scanning the set).
+  const cached = projectionCache.get(envelopes);
+  if (cached) return cached;
+  const computed = computeProjection(envelopes);
+  projectionCache.set(envelopes, computed);
+  return computed;
+}
+
+function computeProjection(
+  envelopes: ReadonlyArray<Envelope>,
+): ProjectionResult {
   interface ThreadAcc {
     thread_id: string;
-    user: UserView | null;
+    user: MutableUserView | null;
     assistantText: string;
     assistantMeta: MessageMeta | null;
     assistantPersisted: boolean;
     assistantSeen: boolean;
-    toolOrder: string[]; // `tool_call_id` first-seen order
+    toolOrder: string[];
     tools: Map<string, MutableToolCall>;
     files: FileView[];
     completed: boolean;
     tokenUsage: EnvelopeTokenUsage | null;
     seenSeqs: Set<number>;
-    lastSeq: number; // -Infinity sentinel: -1, since seqs are u64 ≥ 0
+    lastSeq: number; // sentinel: -1
+    expectedNextSeq: number; // = lastSeq + 1
+    pendingByGap: Map<number, Envelope>;
+    seenUserMessage: boolean;
+    /** Envelopes APPLIED to this thread (excludes ignored dups /
+     *  dropped-after-completed). Used by the per-thread view cache. */
+    appliedCount: number;
+  }
+  interface MutableUserView {
+    seq: number;
+    client_message_id?: string;
+    text: string;
+    files: FileRef[];
   }
   interface MutableToolCall {
     tool_call_id: string;
@@ -182,7 +190,6 @@ export function projectWithMetrics(
     error: string | null;
   }
 
-  // Map preserves insertion order — first-seen seq order across threads.
   const threadOrder: string[] = [];
   const threads = new Map<string, ThreadAcc>();
 
@@ -207,56 +214,110 @@ export function projectWithMetrics(
       tokenUsage: null,
       seenSeqs: new Set(),
       lastSeq: -1,
+      expectedNextSeq: 0,
+      pendingByGap: new Map(),
+      seenUserMessage: false,
+      appliedCount: 0,
     };
     threads.set(thread_id, fresh);
     threadOrder.push(thread_id);
     return fresh;
   };
 
-  for (const env of envelopes) {
-    const thread = getThread(env.thread_id);
-
-    // Idempotency: dedup by (thread_id, seq).
-    if (thread.seenSeqs.has(env.seq)) {
-      duplicates += 1;
-      continue;
-    }
-
-    // Hard barrier: drop anything after turn_completed for this thread.
-    if (thread.completed) {
-      droppedAfterTurnCompleted += 1;
-      continue;
-    }
-
-    // Out-of-order guard: a strictly-lower seq than the high-water mark
-    // is treated as a duplicate of an earlier state and dropped.
-    if (env.seq < thread.lastSeq) {
-      outOfOrder += 1;
-      continue;
-    }
-
+  function applyEnvelope(thread: ThreadAcc, env: Envelope): void {
     thread.seenSeqs.add(env.seq);
-    thread.lastSeq = env.seq;
+    if (env.seq > thread.lastSeq) {
+      thread.lastSeq = env.seq;
+    }
+    thread.expectedNextSeq = thread.lastSeq + 1;
+    thread.appliedCount += 1;
 
-    // Capture user identity from the FIRST envelope we see in this
-    // thread. Per the spec, user-message-rooted envelopes carry
-    // `client_message_id` — the projection records the seq + token but
-    // does not depend on the token for identity.
+    // Capture user identity from the FIRST envelope we apply in
+    // canonical order. The previous "first envelope seen" fallback
+    // (codex BLOCK 3) reconstructed UserView.text from whatever
+    // payload the first envelope carried, which corrupted the user
+    // bubble whenever the first envelope was an assistant_delta. Now
+    // identity (seq + client_message_id) is captured here; text +
+    // files come exclusively from a user_message payload via
+    // applyPayload.
     if (thread.user === null) {
       thread.user = {
         seq: env.seq,
         ...(env.client_message_id !== undefined
           ? { client_message_id: env.client_message_id }
           : {}),
+        text: "",
+        files: [],
       };
     }
 
     applyPayload(thread, env.payload);
   }
 
-  // Freeze into immutable view shape.
+  function drainPending(thread: ThreadAcc): void {
+    while (
+      !thread.completed &&
+      thread.pendingByGap.has(thread.expectedNextSeq)
+    ) {
+      const next = thread.pendingByGap.get(thread.expectedNextSeq)!;
+      thread.pendingByGap.delete(thread.expectedNextSeq);
+      applyEnvelope(thread, next);
+    }
+  }
+
+  for (const env of envelopes) {
+    const thread = getThread(env.thread_id);
+
+    // True duplicate of an already-applied (thread_id, seq).
+    if (thread.seenSeqs.has(env.seq)) {
+      duplicates += 1;
+      continue;
+    }
+
+    // Hard barrier.
+    if (thread.completed) {
+      droppedAfterTurnCompleted += 1;
+      continue;
+    }
+
+    // In-order arrival.
+    if (env.seq === thread.expectedNextSeq) {
+      applyEnvelope(thread, env);
+      drainPending(thread);
+      continue;
+    }
+
+    // Future arrival (gap above expected): buffer.
+    if (env.seq > thread.expectedNextSeq) {
+      if (thread.pendingByGap.has(env.seq)) {
+        duplicates += 1;
+        continue;
+      }
+      thread.pendingByGap.set(env.seq, env);
+      outOfOrder += 1;
+      continue;
+    }
+
+    // Late fill (env.seq < expectedNextSeq, not yet seen): buffer +
+    // drain. Codex BLOCK 1: don't drop — buffer for canonical replay.
+    thread.pendingByGap.set(env.seq, env);
+    outOfOrder += 1;
+    drainPending(thread);
+  }
+
+  // Build immutable views with per-thread reference stability.
   const threadViews: ThreadView[] = threadOrder.map((thread_id) => {
     const acc = threads.get(thread_id)!;
+
+    const cached = threadViewCache.get(thread_id);
+    if (
+      cached &&
+      cached.count === acc.appliedCount &&
+      cached.lastSeq === acc.lastSeq
+    ) {
+      return cached.view;
+    }
+
     const assistant: AssistantView | null = acc.assistantSeen
       ? {
           text: acc.assistantText,
@@ -274,15 +335,31 @@ export function projectWithMetrics(
         error: t.error,
       };
     });
-    return {
+    const userView: UserView | null = acc.user
+      ? {
+          seq: acc.user.seq,
+          ...(acc.user.client_message_id !== undefined
+            ? { client_message_id: acc.user.client_message_id }
+            : {}),
+          text: acc.user.text,
+          files: acc.user.files.slice(),
+        }
+      : null;
+    const view: ThreadView = {
       thread_id: acc.thread_id,
-      user: acc.user,
+      user: userView,
       assistant,
       toolCalls,
       files: acc.files.slice(),
       completed: acc.completed,
       tokenUsage: acc.tokenUsage,
     };
+    threadViewCache.set(thread_id, {
+      count: acc.appliedCount,
+      lastSeq: acc.lastSeq,
+      view,
+    });
+    return view;
   });
 
   return {
@@ -291,18 +368,26 @@ export function projectWithMetrics(
   };
 
   // ── inner: payload dispatch ───────────────────────────────────────────
-  function applyPayload(
-    thread: ThreadAcc,
-    payload: Payload,
-  ): void {
+  function applyPayload(thread: ThreadAcc, payload: Payload): void {
     switch (payload.type) {
+      case "user_message": {
+        // Codex BLOCK 3: populate UserView.text + files from the
+        // user_message payload. First-seen wins per thread.
+        if (!thread.user) {
+          thread.user = {
+            seq: thread.lastSeq,
+            text: payload.data.text,
+            files: payload.data.files.slice(),
+          };
+        } else if (!thread.seenUserMessage) {
+          thread.user.text = payload.data.text;
+          thread.user.files = payload.data.files.slice();
+        }
+        thread.seenUserMessage = true;
+        return;
+      }
       case "assistant_delta": {
         thread.assistantSeen = true;
-        // Only accumulate text if not yet finalized. After
-        // `assistant_persisted`, the persisted text is canonical and
-        // late deltas (which the wire contract forbids inside a turn,
-        // but a bug-tolerant projection should not corrupt) do not
-        // overwrite it.
         if (!thread.assistantPersisted) {
           thread.assistantText += payload.data.text;
         }
@@ -317,12 +402,7 @@ export function projectWithMetrics(
       }
       case "tool_start": {
         const id = payload.data.tool_call_id;
-        if (thread.tools.has(id)) {
-          // Re-`tool_start` for an existing id: spec doesn't define
-          // this; we keep the existing card (first-seen wins) and let
-          // `name` be carried from the first start.
-          return;
-        }
+        if (thread.tools.has(id)) return;
         thread.tools.set(id, {
           tool_call_id: id,
           name: payload.data.name,
@@ -337,9 +417,6 @@ export function projectWithMetrics(
         const id = payload.data.tool_call_id;
         const tool = thread.tools.get(id);
         if (!tool) {
-          // Progress without a prior start: open a card with an empty
-          // name. This keeps the projection total — the bridge can
-          // surface a warning separately.
           const opened: MutableToolCall = {
             tool_call_id: id,
             name: "",
@@ -380,14 +457,7 @@ export function projectWithMetrics(
         return;
       }
       case "file_attached": {
-        // We could attach the file to the most-recent assistant bubble
-        // (per spec § 14.2) but the per-thread `files` collection is
-        // simpler and equivalent for the M9-γ-2 surface — γ-3 will
-        // decide whether to inline these into the assistant view. For
-        // now we record arrival order keyed on seq.
         thread.files.push({
-          // The current envelope's seq lives on `thread.lastSeq` —
-          // which we've just set.
           seq: thread.lastSeq,
           path: payload.data.path,
           mime: payload.data.mime,
@@ -401,8 +471,6 @@ export function projectWithMetrics(
         return;
       }
       default: {
-        // Exhaustiveness guard. If a new variant lands without a
-        // projection update, TS will fail this assignment.
         const _exhaustive: never = payload;
         void _exhaustive;
         return;

--- a/src/store/projection.ts
+++ b/src/store/projection.ts
@@ -1,0 +1,412 @@
+/**
+ * M9-γ-2: Pure-function projection `(envelopes) → ChatViewModel`.
+ *
+ * Spec: `api/OCTOS_UI_PROTOCOL_V1_SPEC_2026-04-24.md` § 14
+ *       "M9-γ Envelope".
+ * ADR:  `docs/M9-GAMMA-SERVER-PROJECTION-ADR.md`.
+ * UPCR: `UPCR-2026-014`.
+ *
+ * This module is the deterministic foundation for the M9-γ projection
+ * client. It is intentionally pure:
+ *
+ *   - No React, no hooks, no `notify()`.
+ *   - No `Date.now()`, no random IDs, no fetch.
+ *   - No imports from `thread-store` / `message-store` (γ-3 wires them up).
+ *
+ * Given the same `Envelope[]`, `project()` produces a byte-identical
+ * `ChatViewModel`. Identity is `(thread_id, seq)` — NOT `client_message_id`
+ * and NOT `messageId`. Per the ADR, `turn_completed` is a hard barrier:
+ * subsequent payloads on the same `thread_id` are dropped (the projection
+ * itself does not desync the connection — that's the bridge's job — but
+ * it WILL ignore the trailing envelopes and bump the
+ * `droppedAfterTurnCompleted` counter on `projectWithMetrics`).
+ *
+ * Stable references:
+ *
+ *   - `threads` is an ordered array; insertion order = first-seen seq for
+ *     each `thread_id`. We don't sort by `thread_id` (no spec guarantee).
+ *   - Inside each `ThreadView`, `toolCalls` is keyed on `tool_call_id` and
+ *     ordered by first-seen seq. `files` is ordered by seq.
+ *
+ * The projection is a left-fold: it never mutates the input. We accept
+ * `ReadonlyArray<Envelope>` and treat the array as append-only.
+ */
+
+import type {
+  Envelope,
+  EnvelopeTokenUsage,
+  EnvelopeToolEndStatus,
+  MessageMeta,
+  Payload,
+} from "../runtime/ui-protocol-types";
+
+// ─── ChatViewModel shape ───────────────────────────────────────────────────
+//
+// The shape is intentionally narrow: just enough for the M9-γ-3 cutover
+// of `chat-thread.tsx` and the M9-γ-4 `<GhostBubble>` overlay. We don't
+// pre-bake legacy fields (e.g. timestamps minted by `Date.now()`); the
+// rendering layer can derive display metadata from `meta.persisted_at`
+// when an `assistant_persisted` envelope has finalized the bubble.
+
+export interface UserView {
+  /** First seq in this thread; used as a stable identity for the row. */
+  seq: number;
+  /** The optimistic-token reflection from `client_message_id`, if the
+   *  server included one on the user-message-rooted envelope. The
+   *  projection does not consult this for identity; it surfaces the
+   *  field so γ-4's `<GhostBubble>` overlay can match-and-unmount. */
+  client_message_id?: string;
+}
+
+export interface AssistantView {
+  /** Concatenated streamed text from `assistant_delta` envelopes (in
+   *  `seq` order), or the persisted full text from
+   *  `assistant_persisted` once it lands. */
+  text: string;
+  /** Set when an `assistant_persisted` envelope has finalized the
+   *  bubble. Carries the durable row identity, commit timestamp, and
+   *  attachments. */
+  meta: MessageMeta | null;
+  /** True iff at least one `assistant_persisted` envelope has been
+   *  observed for this thread. */
+  persisted: boolean;
+}
+
+export interface ToolCallView {
+  tool_call_id: string;
+  name: string;
+  /** Progress messages appended in `seq` order. */
+  progress: ReadonlyArray<string>;
+  /** `null` until a `tool_end` envelope arrives. */
+  status: EnvelopeToolEndStatus | null;
+  /** Set iff `status === "error"`. */
+  error: string | null;
+}
+
+export interface FileView {
+  /** The seq the `file_attached` envelope arrived on; stable identity
+   *  for the row, useful as a React key. */
+  seq: number;
+  path: string;
+  mime: string;
+  size_bytes: number;
+}
+
+export interface ThreadView {
+  thread_id: string;
+  /** Built from the first envelope that introduces this thread (see §
+   *  14.1: user-message-rooted envelopes carry `client_message_id`). */
+  user: UserView | null;
+  /** Accumulates from `assistant_delta` + finalized by
+   *  `assistant_persisted`. `null` until at least one assistant payload
+   *  has been observed. */
+  assistant: AssistantView | null;
+  /** Tool calls in first-seen order. */
+  toolCalls: ReadonlyArray<ToolCallView>;
+  /** Files in arrival order. */
+  files: ReadonlyArray<FileView>;
+  /** `true` once a `turn_completed` envelope has been observed for this
+   *  thread. Subsequent envelopes on the same `thread_id` are dropped. */
+  completed: boolean;
+  /** Token usage from `turn_completed`. `null` until completion. */
+  tokenUsage: EnvelopeTokenUsage | null;
+}
+
+export interface ChatViewModel {
+  /** Threads ordered by first-seen seq. The projection does not sort
+   *  alphabetically by `thread_id` — there is no spec guarantee that
+   *  thread_ids carry a meaningful collation order. */
+  threads: ReadonlyArray<ThreadView>;
+}
+
+// ─── Projection metrics (optional) ─────────────────────────────────────────
+
+/** Counters surfaced for telemetry / debug overlays. The projection
+ *  itself is pure; these counters are derived from the same fold and
+ *  returned alongside the view-model when the caller wants them. */
+export interface ProjectionMetrics {
+  /** Number of envelopes ignored because `(thread_id, seq)` was already
+   *  applied (idempotency). */
+  duplicates: number;
+  /** Number of envelopes ignored because they arrived after a
+   *  `turn_completed` for the same thread (hard-barrier enforcement). */
+  droppedAfterTurnCompleted: number;
+  /** Number of envelopes ignored because their `seq` was strictly less
+   *  than the highest seq already observed in the same thread (the
+   *  projection treats out-of-order seqs as duplicates of an earlier
+   *  state and drops them). Distinct from `duplicates`, which counts
+   *  exact-match `(thread_id, seq)` collisions. */
+  outOfOrder: number;
+}
+
+export interface ProjectionResult {
+  view: ChatViewModel;
+  metrics: ProjectionMetrics;
+}
+
+// ─── Projection ────────────────────────────────────────────────────────────
+
+/** Build a `ChatViewModel` from a committed envelope log. Pure and
+ *  deterministic: same input ⇒ same output. */
+export function project(envelopes: ReadonlyArray<Envelope>): ChatViewModel {
+  return projectWithMetrics(envelopes).view;
+}
+
+/** Variant that surfaces the metrics counters alongside the view. */
+export function projectWithMetrics(
+  envelopes: ReadonlyArray<Envelope>,
+): ProjectionResult {
+  // Per-thread mutable accumulator — converted to immutable `ThreadView`
+  // on the way out. We carry a `Set<seq>` for idempotency and a separate
+  // `lastSeq` for out-of-order detection (cheaper than scanning the set).
+  interface ThreadAcc {
+    thread_id: string;
+    user: UserView | null;
+    assistantText: string;
+    assistantMeta: MessageMeta | null;
+    assistantPersisted: boolean;
+    assistantSeen: boolean;
+    toolOrder: string[]; // `tool_call_id` first-seen order
+    tools: Map<string, MutableToolCall>;
+    files: FileView[];
+    completed: boolean;
+    tokenUsage: EnvelopeTokenUsage | null;
+    seenSeqs: Set<number>;
+    lastSeq: number; // -Infinity sentinel: -1, since seqs are u64 ≥ 0
+  }
+  interface MutableToolCall {
+    tool_call_id: string;
+    name: string;
+    progress: string[];
+    status: EnvelopeToolEndStatus | null;
+    error: string | null;
+  }
+
+  // Map preserves insertion order — first-seen seq order across threads.
+  const threadOrder: string[] = [];
+  const threads = new Map<string, ThreadAcc>();
+
+  let duplicates = 0;
+  let droppedAfterTurnCompleted = 0;
+  let outOfOrder = 0;
+
+  const getThread = (thread_id: string): ThreadAcc => {
+    const existing = threads.get(thread_id);
+    if (existing) return existing;
+    const fresh: ThreadAcc = {
+      thread_id,
+      user: null,
+      assistantText: "",
+      assistantMeta: null,
+      assistantPersisted: false,
+      assistantSeen: false,
+      toolOrder: [],
+      tools: new Map(),
+      files: [],
+      completed: false,
+      tokenUsage: null,
+      seenSeqs: new Set(),
+      lastSeq: -1,
+    };
+    threads.set(thread_id, fresh);
+    threadOrder.push(thread_id);
+    return fresh;
+  };
+
+  for (const env of envelopes) {
+    const thread = getThread(env.thread_id);
+
+    // Idempotency: dedup by (thread_id, seq).
+    if (thread.seenSeqs.has(env.seq)) {
+      duplicates += 1;
+      continue;
+    }
+
+    // Hard barrier: drop anything after turn_completed for this thread.
+    if (thread.completed) {
+      droppedAfterTurnCompleted += 1;
+      continue;
+    }
+
+    // Out-of-order guard: a strictly-lower seq than the high-water mark
+    // is treated as a duplicate of an earlier state and dropped.
+    if (env.seq < thread.lastSeq) {
+      outOfOrder += 1;
+      continue;
+    }
+
+    thread.seenSeqs.add(env.seq);
+    thread.lastSeq = env.seq;
+
+    // Capture user identity from the FIRST envelope we see in this
+    // thread. Per the spec, user-message-rooted envelopes carry
+    // `client_message_id` — the projection records the seq + token but
+    // does not depend on the token for identity.
+    if (thread.user === null) {
+      thread.user = {
+        seq: env.seq,
+        ...(env.client_message_id !== undefined
+          ? { client_message_id: env.client_message_id }
+          : {}),
+      };
+    }
+
+    applyPayload(thread, env.payload);
+  }
+
+  // Freeze into immutable view shape.
+  const threadViews: ThreadView[] = threadOrder.map((thread_id) => {
+    const acc = threads.get(thread_id)!;
+    const assistant: AssistantView | null = acc.assistantSeen
+      ? {
+          text: acc.assistantText,
+          meta: acc.assistantMeta,
+          persisted: acc.assistantPersisted,
+        }
+      : null;
+    const toolCalls: ToolCallView[] = acc.toolOrder.map((tcId) => {
+      const t = acc.tools.get(tcId)!;
+      return {
+        tool_call_id: t.tool_call_id,
+        name: t.name,
+        progress: t.progress.slice(),
+        status: t.status,
+        error: t.error,
+      };
+    });
+    return {
+      thread_id: acc.thread_id,
+      user: acc.user,
+      assistant,
+      toolCalls,
+      files: acc.files.slice(),
+      completed: acc.completed,
+      tokenUsage: acc.tokenUsage,
+    };
+  });
+
+  return {
+    view: { threads: threadViews },
+    metrics: { duplicates, droppedAfterTurnCompleted, outOfOrder },
+  };
+
+  // ── inner: payload dispatch ───────────────────────────────────────────
+  function applyPayload(
+    thread: ThreadAcc,
+    payload: Payload,
+  ): void {
+    switch (payload.type) {
+      case "assistant_delta": {
+        thread.assistantSeen = true;
+        // Only accumulate text if not yet finalized. After
+        // `assistant_persisted`, the persisted text is canonical and
+        // late deltas (which the wire contract forbids inside a turn,
+        // but a bug-tolerant projection should not corrupt) do not
+        // overwrite it.
+        if (!thread.assistantPersisted) {
+          thread.assistantText += payload.data.text;
+        }
+        return;
+      }
+      case "assistant_persisted": {
+        thread.assistantSeen = true;
+        thread.assistantText = payload.data.text;
+        thread.assistantMeta = payload.data.meta;
+        thread.assistantPersisted = true;
+        return;
+      }
+      case "tool_start": {
+        const id = payload.data.tool_call_id;
+        if (thread.tools.has(id)) {
+          // Re-`tool_start` for an existing id: spec doesn't define
+          // this; we keep the existing card (first-seen wins) and let
+          // `name` be carried from the first start.
+          return;
+        }
+        thread.tools.set(id, {
+          tool_call_id: id,
+          name: payload.data.name,
+          progress: [],
+          status: null,
+          error: null,
+        });
+        thread.toolOrder.push(id);
+        return;
+      }
+      case "tool_progress": {
+        const id = payload.data.tool_call_id;
+        const tool = thread.tools.get(id);
+        if (!tool) {
+          // Progress without a prior start: open a card with an empty
+          // name. This keeps the projection total — the bridge can
+          // surface a warning separately.
+          const opened: MutableToolCall = {
+            tool_call_id: id,
+            name: "",
+            progress: [payload.data.message],
+            status: null,
+            error: null,
+          };
+          thread.tools.set(id, opened);
+          thread.toolOrder.push(id);
+          return;
+        }
+        tool.progress.push(payload.data.message);
+        return;
+      }
+      case "tool_end": {
+        const id = payload.data.tool_call_id;
+        const tool = thread.tools.get(id);
+        if (!tool) {
+          const opened: MutableToolCall = {
+            tool_call_id: id,
+            name: "",
+            progress: [],
+            status: payload.data.status,
+            error:
+              payload.data.status === "error"
+                ? payload.data.error ?? null
+                : null,
+          };
+          thread.tools.set(id, opened);
+          thread.toolOrder.push(id);
+          return;
+        }
+        tool.status = payload.data.status;
+        tool.error =
+          payload.data.status === "error"
+            ? payload.data.error ?? null
+            : null;
+        return;
+      }
+      case "file_attached": {
+        // We could attach the file to the most-recent assistant bubble
+        // (per spec § 14.2) but the per-thread `files` collection is
+        // simpler and equivalent for the M9-γ-2 surface — γ-3 will
+        // decide whether to inline these into the assistant view. For
+        // now we record arrival order keyed on seq.
+        thread.files.push({
+          // The current envelope's seq lives on `thread.lastSeq` —
+          // which we've just set.
+          seq: thread.lastSeq,
+          path: payload.data.path,
+          mime: payload.data.mime,
+          size_bytes: payload.data.size_bytes,
+        });
+        return;
+      }
+      case "turn_completed": {
+        thread.completed = true;
+        thread.tokenUsage = payload.data.token_usage;
+        return;
+      }
+      default: {
+        // Exhaustiveness guard. If a new variant lands without a
+        // projection update, TS will fail this assignment.
+        const _exhaustive: never = payload;
+        void _exhaustive;
+        return;
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Summary

- Adds `src/store/projection.ts` — pure, deterministic `(envelopes) → ChatViewModel` projection. No React, no `Date.now()`, no fetch, no imports from `thread-store`/`message-store`. Identity is `(thread_id, seq)`; `client_message_id` is preserved on `UserView` for the future `<GhostBubble>` overlay only — the projection itself never consults it for identity.
- `turn_completed` is enforced as a hard barrier: subsequent envelopes on the same thread are dropped and a `droppedAfterTurnCompleted` counter is bumped via `projectWithMetrics`. Duplicate `(thread_id, seq)` envelopes and strictly out-of-order seqs are also dropped (with their own metric counters) — the view-only `project` entry point stays byte-stable.
- Adds `src/store/projection.test.ts` with the three property invariants (determinism, cross-thread interleaving preserving per-thread seq monotonicity, idempotency), the `turn_completed` barrier (with cross-thread isolation), and one focused unit test per payload variant. 17 tests pass.
- Inlines γ-1 / UPCR-2026-014 envelope types (`Envelope`, `Payload`, `MessageMeta`, `EnvelopeTokenUsage`, `EnvelopeToolEndStatus`, helpers) into `src/runtime/ui-protocol-types.ts` so this branch is self-sufficient. The upstream γ-1 PR ([octos-org/octos#848](https://github.com/octos-org/octos/pull/848)) targets the server repo; when its web mirror lands, this block rebases cleanly.

Refs: M9-γ ADR (`docs/M9-GAMMA-SERVER-PROJECTION-ADR.md`), spec § 14 (`api/OCTOS_UI_PROTOCOL_V1_SPEC_2026-04-24.md`).

Does **not** touch `ThreadStore` / `MessageStore` / runtime bridges / components — those migrate in γ-3.

## Test plan

- [x] `npx tsc --noEmit` — clean
- [x] `npx vitest run src/store/projection.test.ts` — 17 / 17 pass
- [x] `npx vitest run` (full unit suite) — 207 / 207 pass
- [x] `npx eslint src/store/projection.ts src/store/projection.test.ts src/runtime/ui-protocol-types.ts` — clean
- [x] `grep -E "from '\.\./store/(thread|message)-store'" src/store/projection.ts` returns 0 lines (self-containment)