### PR TITLE
feat(store): M9-γ-3 — ThreadStore projection-mode shim under projection_v1 flag (closes #840)

### DIFF
--- a/src/runtime/ui-protocol-types.ts
+++ b/src/runtime/ui-protocol-types.ts
@@ -340,3 +340,206 @@ export interface SessionHydrateResult {
   pending_approvals?: unknown[];
   replayed_envelopes?: TurnSpawnCompleteEvent[];
 }
+
+// ─── M9-γ canonical projection envelope (UPCR-2026-014) ────────────────────
+//
+// Mirrors `crates/octos-core/src/ui_protocol.rs` (Rust enum uses
+// `serde(tag = "type", content = "data", rename_all = "snake_case")`).
+//
+// Spec: `api/OCTOS_UI_PROTOCOL_V1_SPEC_2026-04-24.md` § 14
+// "M9-γ Envelope".
+// ADR: `docs/M9-GAMMA-SERVER-PROJECTION-ADR.md`.
+//
+// **Hard barrier**: per the ADR, `turn_completed` is the terminal
+// payload for a `thread_id`. No further `assistant_*`/`tool_*`
+// payloads on the same thread are valid after it.
+//
+// These types are sourced verbatim from γ-1 PR #848
+// (`feat/m9-gamma-1-envelope-spec`). When that PR's web mirror lands
+// upstream, this block becomes the import surface for the M9-γ-2
+// projection function (`src/store/projection.ts`) and the M9-γ-3
+// `ThreadStore` cutover.
+
+/** Multi-turn cluster identity — the chat thread this envelope projects
+ *  into. All envelopes for one logical conversation share a `thread_id`. */
+export type ThreadId = string;
+
+/** Server-assigned UUID of a durable message row. Stable across replays.
+ *  Mirrors `MessageMeta.message_id` in the Rust types. */
+export type EnvelopeMessageId = string;
+
+/** Client optimism + idempotency token. Web client mints; UUIDv7 in prod.
+ *  ONLY the optimistic <GhostBubble> overlay consults this — the
+ *  projection itself never does. */
+export type ClientMessageId = string;
+
+/** RFC 3339 timestamp string (e.g. "2026-05-09T18:30:01Z"). */
+export type IsoTimestamp = string;
+
+/** Sub-typed numeric for the strict per-thread server ordering. */
+export type Seq = number;
+
+/** Token usage carried on `turn_completed` envelopes. Mirrors
+ *  `EnvelopeTokenUsage` in the Rust types. All fields default to zero
+ *  and are omitted on the wire when zero (serde
+ *  `skip_serializing_if = "is_zero_u64"`). */
+export interface EnvelopeTokenUsage {
+  input_tokens?: number;
+  output_tokens?: number;
+  reasoning_tokens?: number;
+  cache_read_tokens?: number;
+  cache_write_tokens?: number;
+}
+
+/** Metadata carried on `assistant_persisted` envelopes. Mirrors
+ *  `MessageMeta` in the Rust types. */
+export interface MessageMeta {
+  /** Server-assigned UUID of the durable row. */
+  message_id: EnvelopeMessageId;
+  /** Wall-clock RFC 3339 commit time. */
+  persisted_at: IsoTimestamp;
+  /** File attachments persisted with the message — typically a single
+   *  `.md` / `.mp3` / `.pptx` artefact. Empty for assistant rows that
+   *  carry only text. Omitted on the wire when empty. */
+  media?: string[];
+}
+
+/** Status carried on `tool_end` payloads. Mirrors `EnvelopeToolEndStatus`
+ *  (snake_case wire form) in the Rust types. */
+export type EnvelopeToolEndStatus = "complete" | "error";
+
+/** File attachment carried on `user_message` envelopes. Mirrors `FileRef`
+ *  in the Rust types (γ-1 PR #848 commit `ac589b73`). The `path` field
+ *  is the durable filesystem path the server can resolve; `mime` and
+ *  `size_bytes` are optional metadata captured at upload time. */
+export interface FileRef {
+  path: string;
+  mime?: string;
+  size_bytes?: number;
+}
+
+interface UserMessagePayload {
+  type: "user_message";
+  data: { text: string; files: FileRef[] };
+}
+
+interface AssistantDeltaPayload {
+  type: "assistant_delta";
+  data: { text: string };
+}
+
+interface AssistantPersistedPayload {
+  type: "assistant_persisted";
+  data: { text: string; meta: MessageMeta };
+}
+
+interface ToolStartPayload {
+  type: "tool_start";
+  data: { tool_call_id: string; name: string };
+}
+
+interface ToolProgressPayload {
+  type: "tool_progress";
+  data: { tool_call_id: string; message: string };
+}
+
+interface ToolEndPayload {
+  type: "tool_end";
+  data: {
+    tool_call_id: string;
+    status: EnvelopeToolEndStatus;
+    /** Set iff `status === 'error'`. Omitted on the wire when null. */
+    error?: string;
+  };
+}
+
+interface FileAttachedPayload {
+  type: "file_attached";
+  data: { path: string; mime: string; size_bytes: number };
+}
+
+interface TurnCompletedPayload {
+  type: "turn_completed";
+  data: { token_usage: EnvelopeTokenUsage };
+}
+
+/** Sealed tagged union of payloads carried by the M9-γ projection
+ *  envelope. The discriminator is `type`; payload data lives under
+ *  `data`. Variant names are snake_case to match the wire / Rust shape. */
+export type Payload =
+  | UserMessagePayload
+  | AssistantDeltaPayload
+  | AssistantPersistedPayload
+  | ToolStartPayload
+  | ToolProgressPayload
+  | ToolEndPayload
+  | FileAttachedPayload
+  | TurnCompletedPayload;
+
+/** Canonical M9-γ projection envelope.
+ *
+ *  Per UPCR-2026-014 and the M9-γ ADR, this is the single shape the
+ *  web client's deterministic projection consumes. The committed
+ *  envelope log is `Envelope[]` indexed by `(thread_id, seq)`; the
+ *  projection is a pure function from that log to `ChatViewModel`.
+ *
+ *  Identity collapses to `seq` — the only key the projection cares
+ *  about. `client_message_id` lives ONLY on user-message-rooted
+ *  envelopes so the optimistic `<GhostBubble>` overlay can match its
+ *  server reflection and unmount; the projection itself NEVER consults
+ *  it. */
+export interface Envelope {
+  thread_id: ThreadId;
+  seq: Seq;
+  /** Present on user-message-rooted envelopes (the optimistic
+   *  `<GhostBubble>` overlay matches its server reflection here).
+   *  Absent on internal events (assistant deltas, tool events,
+   *  turn_completed). The projection MUST NOT consult this field. */
+  client_message_id?: ClientMessageId;
+  payload: Payload;
+}
+
+/** Wire-form capability flag for UPCR-2026-014. Servers advertise it via
+ *  `UiProtocolCapabilities.supported_features`; clients request it via
+ *  the `X-Octos-Ui-Features` header. Mirrors
+ *  `UI_PROTOCOL_FEATURE_PROJECTION_ENVELOPE_V1` in the Rust types. */
+export const UI_PROTOCOL_FEATURE_PROJECTION_ENVELOPE_V1 = "projection.envelope.v1";
+
+// ── Type guards (optional ergonomic helpers) ─────────────────────────────
+//
+// The projection function will switch on `envelope.payload.type` and
+// rely on TS's discriminated-union narrowing. These helpers exist for
+// callers that need a runtime check (e.g. a debug overlay rendering a
+// raw envelope).
+
+export function isUserMessage(p: Payload): p is UserMessagePayload {
+  return p.type === "user_message";
+}
+
+export function isAssistantDelta(p: Payload): p is AssistantDeltaPayload {
+  return p.type === "assistant_delta";
+}
+
+export function isAssistantPersisted(p: Payload): p is AssistantPersistedPayload {
+  return p.type === "assistant_persisted";
+}
+
+export function isToolStart(p: Payload): p is ToolStartPayload {
+  return p.type === "tool_start";
+}
+
+export function isToolProgress(p: Payload): p is ToolProgressPayload {
+  return p.type === "tool_progress";
+}
+
+export function isToolEnd(p: Payload): p is ToolEndPayload {
+  return p.type === "tool_end";
+}
+
+export function isFileAttached(p: Payload): p is FileAttachedPayload {
+  return p.type === "file_attached";
+}
+
+export function isTurnCompleted(p: Payload): p is TurnCompletedPayload {
+  return p.type === "turn_completed";
+}

--- a/src/store/projection-store.ts
+++ b/src/store/projection-store.ts
@@ -91,7 +91,6 @@ export function isProjectionV1Enabled(): boolean {
       const live = readFlagFromStorage();
       if (live !== cachedProjectionV1Enabled) {
         warnedAboutMidSessionChange = true;
-        // eslint-disable-next-line no-console
         console.warn(
           "[octos] octos_projection_v1 changed mid-session; the new " +
             "value is ignored until reload to avoid starting the " +

--- a/src/store/projection-store.ts
+++ b/src/store/projection-store.ts
@@ -1,0 +1,180 @@
+/**
+ * M9-γ-3: Projection-mode store wrapper around γ-2's pure `project()` fn.
+ *
+ * Spec: `api/OCTOS_UI_PROTOCOL_V1_SPEC_2026-04-24.md` § 14 (M9-γ Envelope).
+ * ADR:  `docs/M9-GAMMA-SERVER-PROJECTION-ADR.md` (PR #830).
+ * γ-2:  `src/store/projection.ts` (PR #93, the pure projection function).
+ * Issue: octos-org/octos#840.
+ *
+ * Behind the `projection_v1` feature flag (window.localStorage
+ * `octos_projection_v1` === "1"), `ThreadStore` translates every legacy
+ * mutation entry point into an `Envelope` and ingests it here. This
+ * module owns the committed envelope log and exposes the projected
+ * `ChatViewModel` for projection-only tests / future renderers.
+ *
+ * Intentional split from `thread-store.ts`:
+ *   - The thread-store stays the migration-time facade (legacy reducer
+ *     remains the source of truth for `getThreads()` so 191 existing
+ *     tests pass under both flag states).
+ *   - This store accumulates the committed envelope log and provides
+ *     the projection-mode read surface for new tests + γ-4's optimistic
+ *     overlay + γ-5's full cutover.
+ *
+ * Single mutation entry point: `ingest(envelope)`. Identity is
+ * `(thread_id, seq)`. The shim synthesizes client-side seqs from a
+ * per-thread monotonic counter so the projection (which dedupes on
+ * `(thread_id, seq)`) sees deterministic ordering even before the
+ * server's authoritative seq lands.
+ *
+ * Sessions are addressed by an opaque "store key" — the same string
+ * `thread-store.ts` uses internally (`sessionId` or `sessionId#topic`).
+ * Keeping the addressing space identical avoids a (sessionId, topic)
+ * round-trip on every dual-write hot-path call.
+ */
+
+import { project, projectWithMetrics } from "./projection";
+import type { ChatViewModel, ProjectionMetrics } from "./projection";
+import type { Envelope } from "../runtime/ui-protocol-types";
+
+// ─── Feature flag ──────────────────────────────────────────────────────────
+
+/** localStorage key gating projection-mode dual-writes. Production
+ *  default is OFF; tests flip the flag in their setup. */
+const PROJECTION_V1_FLAG_KEY = "octos_projection_v1";
+
+/** Read the projection-mode flag. Safe in non-browser test envs (jsdom
+ *  exposes `localStorage`; Node doesn't — the access is wrapped). */
+export function isProjectionV1Enabled(): boolean {
+  try {
+    if (typeof globalThis === "undefined") return false;
+    const ls = (globalThis as { localStorage?: Storage }).localStorage;
+    if (!ls) return false;
+    return ls.getItem(PROJECTION_V1_FLAG_KEY) === "1";
+  } catch {
+    // Some jsdom configurations throw on `localStorage` access (security
+    // origin checks). Treat unreachable storage as flag-off.
+    return false;
+  }
+}
+
+/** Test helper: flip the flag in the current jsdom origin. */
+export function __setProjectionV1ForTests(enabled: boolean): void {
+  try {
+    const ls = (globalThis as { localStorage?: Storage }).localStorage;
+    if (!ls) return;
+    if (enabled) ls.setItem(PROJECTION_V1_FLAG_KEY, "1");
+    else ls.removeItem(PROJECTION_V1_FLAG_KEY);
+  } catch {
+    // No-op when storage is unavailable.
+  }
+}
+
+// ─── Internal state ────────────────────────────────────────────────────────
+
+/** Committed envelope log per session storeKey. Append-only. */
+const envelopesByKey = new Map<string, Envelope[]>();
+
+/** Per-(storeKey, thread) monotonic seq counter. Used by the shim when
+ *  no server-assigned seq is available — the projection dedupes by
+ *  `(thread_id, seq)` so deterministic per-thread ordering is what
+ *  matters, not the absolute integer value. */
+const seqCountersByKey = new Map<string, Map<string, number>>();
+
+// ─── Public API ────────────────────────────────────────────────────────────
+
+/**
+ * Synthesize the next client-side seq for a thread. Per-thread
+ * monotonic (NOT `Date.now()` — must be deterministic for
+ * re-projection).
+ *
+ * The server's authoritative seq arrives separately on a real ingest
+ * path; the projection dedupes by exact `(thread_id, seq)` match. As
+ * long as our shim's seqs are unique within the thread (which a
+ * monotonic counter guarantees), the projection produces a stable view.
+ *
+ * Counter is 1-based so that `seq >= 0` checks (the projection treats
+ * `lastSeq = -1` as the initial sentinel) admit the first envelope.
+ */
+export function nextSeq(storeKey: string, threadId: string): number {
+  let perThread = seqCountersByKey.get(storeKey);
+  if (!perThread) {
+    perThread = new Map();
+    seqCountersByKey.set(storeKey, perThread);
+  }
+  const next = (perThread.get(threadId) ?? 0) + 1;
+  perThread.set(threadId, next);
+  return next;
+}
+
+/** The single mutation entry point. Append the envelope to the
+ *  committed log. The projection dedupes / orders / barriers — this
+ *  function does NOT validate the envelope's seq nor enforce
+ *  monotonicity; that's the projection's job (and the bridge's, in
+ *  production). */
+export function ingest(storeKey: string, envelope: Envelope): void {
+  let log = envelopesByKey.get(storeKey);
+  if (!log) {
+    log = [];
+    envelopesByKey.set(storeKey, log);
+  }
+  log.push(envelope);
+}
+
+/** Get the committed envelope log for a session. Returned as a
+ *  read-only view; callers must NOT mutate. Useful for projection-only
+ *  tests that want to assert on the raw log shape. */
+export function getEnvelopes(storeKey: string): ReadonlyArray<Envelope> {
+  return envelopesByKey.get(storeKey) ?? [];
+}
+
+/** Compute and return the projected `ChatViewModel` for a session. */
+export function getProjection(storeKey: string): ChatViewModel {
+  return project(getEnvelopes(storeKey));
+}
+
+/** Variant that surfaces metrics counters alongside the view. */
+export function getProjectionWithMetrics(
+  storeKey: string,
+): { view: ChatViewModel; metrics: ProjectionMetrics } {
+  return projectWithMetrics(getEnvelopes(storeKey));
+}
+
+/** Drop all projection state for a session (envelope log + counters).
+ *  Mirrors `thread-store.clearSession` semantics: a topic-less call
+ *  sweeps the bare key AND every topic-suffixed variant. */
+export function clearProjection(sessionId: string, topic?: string): void {
+  const trimmedTopic = topic?.trim();
+  if (trimmedTopic) {
+    const key = `${sessionId}#${trimmedTopic}`;
+    envelopesByKey.delete(key);
+    seqCountersByKey.delete(key);
+    return;
+  }
+  for (const k of [...envelopesByKey.keys()]) {
+    if (k === sessionId || k.startsWith(`${sessionId}#`)) {
+      envelopesByKey.delete(k);
+    }
+  }
+  for (const k of [...seqCountersByKey.keys()]) {
+    if (k === sessionId || k.startsWith(`${sessionId}#`)) {
+      seqCountersByKey.delete(k);
+    }
+  }
+}
+
+/** Build the shared store-key string. Mirrors `thread-store`'s
+ *  internal `storeKey` so dual-writes target the same bucket. */
+export function projectionStoreKey(
+  sessionId: string,
+  topic?: string,
+): string {
+  const trimmedTopic = topic?.trim();
+  return trimmedTopic ? `${sessionId}#${trimmedTopic}` : sessionId;
+}
+
+/** Test-only helper: reset all projection-store state. */
+export function __resetProjectionForTests(): void {
+  envelopesByKey.clear();
+  seqCountersByKey.clear();
+  __setProjectionV1ForTests(false);
+}

--- a/src/store/projection-store.ts
+++ b/src/store/projection-store.ts
@@ -21,15 +21,30 @@
  *     overlay + γ-5's full cutover.
  *
  * Single mutation entry point: `ingest(envelope)`. Identity is
- * `(thread_id, seq)`. The shim synthesizes client-side seqs from a
- * per-thread monotonic counter so the projection (which dedupes on
- * `(thread_id, seq)`) sees deterministic ordering even before the
- * server's authoritative seq lands.
+ * `(thread_id, sign(seq), abs(seq))` — see "Seq namespaces" below.
  *
  * Sessions are addressed by an opaque "store key" — the same string
  * `thread-store.ts` uses internally (`sessionId` or `sessionId#topic`).
  * Keeping the addressing space identical avoids a (sessionId, topic)
  * round-trip on every dual-write hot-path call.
+ *
+ * ─── Seq namespaces (codex round-1 BLOCK 1) ──────────────────────────────
+ *
+ * The shim mints client-side seqs when the caller has no server seq
+ * (streamed deltas, in-flight tool starts, etc.). The server also
+ * assigns its own seqs at persistence time (`historySeq`,
+ * `committedSeq`). Pre-fix, both lived in the SAME positive integer
+ * space starting at 1 — so a synthetic `seq=1` for a streamed delta
+ * collided with a server-issued `seq=1` on the persisted row, and the
+ * projection's `(thread_id, seq)` dedup falsely treated them as
+ * duplicates.
+ *
+ * Fix (Option A): SYNTHETIC seqs are NEGATIVE (-1, -2, -3, …); SERVER
+ * seqs stay NON-NEGATIVE (0, 1, 2, …). The projection dedups on
+ * `(thread_id, sign(seq), abs(seq))` so the two namespaces never
+ * collide. Out-of-order checks are done WITHIN each namespace
+ * separately — a `seq=+1` envelope arriving after `seq=-3` is NOT
+ * out-of-order; they live on different tracks.
  */
 
 import { project, projectWithMetrics } from "./projection";
@@ -42,9 +57,15 @@ import type { Envelope } from "../runtime/ui-protocol-types";
  *  default is OFF; tests flip the flag in their setup. */
 const PROJECTION_V1_FLAG_KEY = "octos_projection_v1";
 
-/** Read the projection-mode flag. Safe in non-browser test envs (jsdom
- *  exposes `localStorage`; Node doesn't — the access is wrapped). */
-export function isProjectionV1Enabled(): boolean {
+/** Cached snapshot of the flag's value on first read. The flag is
+ *  intentionally locked in at first read so a mid-session flip can't
+ *  start the projection log from the next shimmed event with no prior
+ *  envelope history (codex round-1 BLOCK 5). A subsequent flip is a
+ *  one-shot `console.warn` and ignored until reload. */
+let cachedProjectionV1Enabled: boolean | null = null;
+let warnedAboutMidSessionChange = false;
+
+function readFlagFromStorage(): boolean {
   try {
     if (typeof globalThis === "undefined") return false;
     const ls = (globalThis as { localStorage?: Storage }).localStorage;
@@ -57,16 +78,52 @@ export function isProjectionV1Enabled(): boolean {
   }
 }
 
-/** Test helper: flip the flag in the current jsdom origin. */
+/** Read the projection-mode flag. Cached on first call so a mid-session
+ *  flip can't start the projection log mid-stream. Subsequent flag
+ *  changes log a one-shot warning and are otherwise ignored until the
+ *  next reload. Tests reset the cache via `__setProjectionV1ForTests`. */
+export function isProjectionV1Enabled(): boolean {
+  if (cachedProjectionV1Enabled !== null) {
+    // Detect a mid-session flip and warn (once). The cache wins; the
+    // observed flag value at first read is the source of truth for the
+    // rest of the session.
+    if (!warnedAboutMidSessionChange) {
+      const live = readFlagFromStorage();
+      if (live !== cachedProjectionV1Enabled) {
+        warnedAboutMidSessionChange = true;
+        // eslint-disable-next-line no-console
+        console.warn(
+          "[octos] octos_projection_v1 changed mid-session; the new " +
+            "value is ignored until reload to avoid starting the " +
+            "projection log mid-stream.",
+        );
+      }
+    }
+    return cachedProjectionV1Enabled;
+  }
+  cachedProjectionV1Enabled = readFlagFromStorage();
+  return cachedProjectionV1Enabled;
+}
+
+/** Test helper: flip the flag in the current jsdom origin AND reset the
+ *  cache so the next `isProjectionV1Enabled()` call re-reads it. Without
+ *  the cache reset, vitest-level flips would all see the value latched
+ *  from the very first read in the worker process. */
 export function __setProjectionV1ForTests(enabled: boolean): void {
   try {
     const ls = (globalThis as { localStorage?: Storage }).localStorage;
-    if (!ls) return;
+    if (!ls) {
+      cachedProjectionV1Enabled = null;
+      warnedAboutMidSessionChange = false;
+      return;
+    }
     if (enabled) ls.setItem(PROJECTION_V1_FLAG_KEY, "1");
     else ls.removeItem(PROJECTION_V1_FLAG_KEY);
   } catch {
     // No-op when storage is unavailable.
   }
+  cachedProjectionV1Enabled = null;
+  warnedAboutMidSessionChange = false;
 }
 
 // ─── Internal state ────────────────────────────────────────────────────────
@@ -74,26 +131,26 @@ export function __setProjectionV1ForTests(enabled: boolean): void {
 /** Committed envelope log per session storeKey. Append-only. */
 const envelopesByKey = new Map<string, Envelope[]>();
 
-/** Per-(storeKey, thread) monotonic seq counter. Used by the shim when
- *  no server-assigned seq is available — the projection dedupes by
- *  `(thread_id, seq)` so deterministic per-thread ordering is what
- *  matters, not the absolute integer value. */
+/** Per-(storeKey, thread) monotonic counter for SYNTHETIC seqs. The
+ *  counter holds the magnitude (1, 2, 3, …) and `nextSeq` returns its
+ *  negation (-1, -2, -3, …) so synthetic seqs never collide with the
+ *  server's non-negative namespace. The projection dedupes on
+ *  `(thread_id, sign(seq), abs(seq))` — as long as our shim's magnitudes
+ *  are unique within the thread (which a monotonic counter guarantees),
+ *  the projection produces a stable view. */
 const seqCountersByKey = new Map<string, Map<string, number>>();
 
 // ─── Public API ────────────────────────────────────────────────────────────
 
 /**
- * Synthesize the next client-side seq for a thread. Per-thread
+ * Synthesize the next client-side seq for a thread. Returns a NEGATIVE
+ * integer (-1, -2, -3, …) — the synthetic namespace. Per-thread
  * monotonic (NOT `Date.now()` — must be deterministic for
  * re-projection).
  *
- * The server's authoritative seq arrives separately on a real ingest
- * path; the projection dedupes by exact `(thread_id, seq)` match. As
- * long as our shim's seqs are unique within the thread (which a
- * monotonic counter guarantees), the projection produces a stable view.
- *
- * Counter is 1-based so that `seq >= 0` checks (the projection treats
- * `lastSeq = -1` as the initial sentinel) admit the first envelope.
+ * Server-issued seqs are non-negative; synthetic seqs are strictly
+ * negative. The two namespaces never collide. See the module-level
+ * "Seq namespaces" doc-comment.
  */
 export function nextSeq(storeKey: string, threadId: string): number {
   let perThread = seqCountersByKey.get(storeKey);
@@ -101,9 +158,9 @@ export function nextSeq(storeKey: string, threadId: string): number {
     perThread = new Map();
     seqCountersByKey.set(storeKey, perThread);
   }
-  const next = (perThread.get(threadId) ?? 0) + 1;
-  perThread.set(threadId, next);
-  return next;
+  const magnitude = (perThread.get(threadId) ?? 0) + 1;
+  perThread.set(threadId, magnitude);
+  return -magnitude;
 }
 
 /** The single mutation entry point. Append the envelope to the

--- a/src/store/projection-store.ts
+++ b/src/store/projection-store.ts
@@ -21,33 +21,30 @@
  *     overlay + γ-5's full cutover.
  *
  * Single mutation entry point: `ingest(envelope)`. Identity is
- * `(thread_id, sign(seq), abs(seq))` — see "Seq namespaces" below.
+ * `(thread_id, seq)`.
  *
  * Sessions are addressed by an opaque "store key" — the same string
  * `thread-store.ts` uses internally (`sessionId` or `sessionId#topic`).
  * Keeping the addressing space identical avoids a (sessionId, topic)
  * round-trip on every dual-write hot-path call.
  *
- * ─── Seq namespaces (codex round-1 BLOCK 1) ──────────────────────────────
+ * ─── Seq policy (gap-buffer canonical) ───────────────────────────────────
  *
  * The shim mints client-side seqs when the caller has no server seq
- * (streamed deltas, in-flight tool starts, etc.). The server also
- * assigns its own seqs at persistence time (`historySeq`,
- * `committedSeq`). Pre-fix, both lived in the SAME positive integer
- * space starting at 1 — so a synthetic `seq=1` for a streamed delta
- * collided with a server-issued `seq=1` on the persisted row, and the
- * projection's `(thread_id, seq)` dedup falsely treated them as
- * duplicates.
- *
- * Fix (Option A): SYNTHETIC seqs are NEGATIVE (-1, -2, -3, …); SERVER
- * seqs stay NON-NEGATIVE (0, 1, 2, …). The projection dedups on
- * `(thread_id, sign(seq), abs(seq))` so the two namespaces never
- * collide. Out-of-order checks are done WITHIN each namespace
- * separately — a `seq=+1` envelope arriving after `seq=-3` is NOT
- * out-of-order; they live on different tracks.
+ * (streamed deltas, in-flight tool starts, etc.). The shim's seqs are
+ * 0-based per-thread monotonic — matching the projection's gap-buffer
+ * `expectedNextSeq=0` initialization. Server-issued seqs (historySeq /
+ * committedSeq) flow through `ingest()` with the server's own seq value;
+ * the projection's gap-buffer drains in canonical order regardless of
+ * arrival order. Identity is `(thread_id, seq)`; same-seq arrivals are
+ * deduplicated, gap-buffered fills drain when the gap closes.
  */
 
-import { project, projectWithMetrics } from "./projection";
+import {
+  __resetProjectionCacheForTesting,
+  project,
+  projectWithMetrics,
+} from "./projection";
 import type { ChatViewModel, ProjectionMetrics } from "./projection";
 import type { Envelope } from "../runtime/ui-protocol-types";
 
@@ -130,26 +127,23 @@ export function __setProjectionV1ForTests(enabled: boolean): void {
 /** Committed envelope log per session storeKey. Append-only. */
 const envelopesByKey = new Map<string, Envelope[]>();
 
-/** Per-(storeKey, thread) monotonic counter for SYNTHETIC seqs. The
- *  counter holds the magnitude (1, 2, 3, …) and `nextSeq` returns its
- *  negation (-1, -2, -3, …) so synthetic seqs never collide with the
- *  server's non-negative namespace. The projection dedupes on
- *  `(thread_id, sign(seq), abs(seq))` — as long as our shim's magnitudes
- *  are unique within the thread (which a monotonic counter guarantees),
- *  the projection produces a stable view. */
+/** Per-(storeKey, thread) monotonic counter for shim-minted seqs.
+ *  Counter advances by 1 on each call; first value returned is 0,
+ *  matching projection's `expectedNextSeq=0` initialization so the very
+ *  first envelope on a thread applies in-order under gap-buffer
+ *  semantics. */
 const seqCountersByKey = new Map<string, Map<string, number>>();
 
 // ─── Public API ────────────────────────────────────────────────────────────
 
 /**
- * Synthesize the next client-side seq for a thread. Returns a NEGATIVE
- * integer (-1, -2, -3, …) — the synthetic namespace. Per-thread
- * monotonic (NOT `Date.now()` — must be deterministic for
- * re-projection).
- *
- * Server-issued seqs are non-negative; synthetic seqs are strictly
- * negative. The two namespaces never collide. See the module-level
- * "Seq namespaces" doc-comment.
+ * Synthesize the next client-side seq for a thread. Returns a
+ * non-negative integer (0, 1, 2, …) — per-thread monotonic, not
+ * `Date.now()`-based, so re-projecting the committed log is
+ * deterministic. The projection dedupes on `(thread_id, seq)`; the shim
+ * caller is responsible for not minting a synthetic seq when the server
+ * is going to assign its own (the migration shim only mints for
+ * pre-persistence in-flight events).
  */
 export function nextSeq(storeKey: string, threadId: string): number {
   let perThread = seqCountersByKey.get(storeKey);
@@ -157,9 +151,9 @@ export function nextSeq(storeKey: string, threadId: string): number {
     perThread = new Map();
     seqCountersByKey.set(storeKey, perThread);
   }
-  const magnitude = (perThread.get(threadId) ?? 0) + 1;
-  perThread.set(threadId, magnitude);
-  return -magnitude;
+  const next = perThread.get(threadId) ?? 0;
+  perThread.set(threadId, next + 1);
+  return next;
 }
 
 /** The single mutation entry point. Append the envelope to the
@@ -228,9 +222,14 @@ export function projectionStoreKey(
   return trimmedTopic ? `${sessionId}#${trimmedTopic}` : sessionId;
 }
 
-/** Test-only helper: reset all projection-store state. */
+/** Test-only helper: reset all projection-store state, including the
+ *  pure-function projection's per-thread ThreadView cache. The cache
+ *  lives in `projection.ts` module scope; without clearing it, a thread
+ *  whose `(appliedCount, lastSeq)` matches a stale entry from a previous
+ *  test would return the stale view. */
 export function __resetProjectionForTests(): void {
   envelopesByKey.clear();
   seqCountersByKey.clear();
+  __resetProjectionCacheForTesting();
   __setProjectionV1ForTests(false);
 }

--- a/src/store/projection.test.ts
+++ b/src/store/projection.test.ts
@@ -1,0 +1,549 @@
+/**
+ * M9-γ-2 projection tests.
+ *
+ * Three property tests (determinism, ordering, idempotency) plus the
+ * `turn_completed` barrier and one focused unit test per payload variant.
+ *
+ * The "shuffled-within-thread" property is checked via permutation of
+ * cross-thread interleavings while preserving per-thread seq monotonicity
+ * — exactly the invariant the spec promises (§ 14.1: `seq` is strictly
+ * monotonic WITHIN a thread; cross-thread ordering is not specified).
+ */
+
+import { beforeEach, describe, expect, it } from "vitest";
+
+import type {
+  Envelope,
+  EnvelopeTokenUsage,
+  FileRef,
+  MessageMeta,
+  Payload,
+} from "../runtime/ui-protocol-types";
+
+import {
+  __resetProjectionCacheForTesting,
+  project,
+  projectWithMetrics,
+} from "./projection";
+
+beforeEach(() => {
+  // Per-thread ThreadView cache is module-scoped; reset between
+  // tests so re-used thread ids (`t1`, `t2`) don't return stale refs.
+  __resetProjectionCacheForTesting();
+});
+
+// ─── Helpers ──────────────────────────────────────────────────────────────
+
+const META: MessageMeta = {
+  message_id: "01900000-0000-7000-8000-000000000001",
+  persisted_at: "2026-05-09T18:30:01Z",
+};
+
+function env(
+  thread_id: string,
+  seq: number,
+  payload: Payload,
+  client_message_id?: string,
+): Envelope {
+  return client_message_id !== undefined
+    ? { thread_id, seq, payload, client_message_id }
+    : { thread_id, seq, payload };
+}
+
+const uMsg = (text: string, files: FileRef[] = []): Payload => ({
+  type: "user_message",
+  data: { text, files },
+});
+
+const aDelta = (text: string): Payload => ({
+  type: "assistant_delta",
+  data: { text },
+});
+
+const aPersisted = (text: string, meta: MessageMeta = META): Payload => ({
+  type: "assistant_persisted",
+  data: { text, meta },
+});
+
+const tStart = (id: string, name: string): Payload => ({
+  type: "tool_start",
+  data: { tool_call_id: id, name },
+});
+
+const tProgress = (id: string, message: string): Payload => ({
+  type: "tool_progress",
+  data: { tool_call_id: id, message },
+});
+
+const tEnd = (
+  id: string,
+  status: "complete" | "error",
+  error?: string,
+): Payload =>
+  status === "error"
+    ? {
+        type: "tool_end",
+        data: { tool_call_id: id, status, ...(error !== undefined ? { error } : {}) },
+      }
+    : { type: "tool_end", data: { tool_call_id: id, status } };
+
+const fAttached = (
+  path: string,
+  mime: string,
+  size_bytes: number,
+): Payload => ({
+  type: "file_attached",
+  data: { path, mime, size_bytes },
+});
+
+const tCompleted = (token_usage: EnvelopeTokenUsage = {}): Payload => ({
+  type: "turn_completed",
+  data: { token_usage },
+});
+
+/** Generate every interleaving of multiple per-thread streams that
+ *  preserves each stream's internal order. Matches the "permutation
+ *  that respects per-thread seq monotonicity" promise in the brief. */
+function* interleavings<T>(streams: ReadonlyArray<ReadonlyArray<T>>): Generator<T[]> {
+  const indices = streams.map(() => 0);
+
+  function* recur(prefix: T[]): Generator<T[]> {
+    let allDone = true;
+    for (let i = 0; i < streams.length; i += 1) {
+      if (indices[i] < streams[i].length) {
+        allDone = false;
+        const next = streams[i][indices[i]];
+        indices[i] += 1;
+        prefix.push(next);
+        yield* recur(prefix);
+        prefix.pop();
+        indices[i] -= 1;
+      }
+    }
+    if (allDone) yield prefix.slice();
+  }
+
+  yield* recur([]);
+}
+
+// Deep-equality JSON compare — `toEqual` is fine, but we want a
+// byte-stable signature to prove determinism literally.
+function fingerprint(value: unknown): string {
+  return JSON.stringify(value, (_key, v) => {
+    if (v instanceof Map) {
+      return Object.fromEntries(v.entries());
+    }
+    return v;
+  });
+}
+
+// ─── Property: determinism ─────────────────────────────────────────────────
+
+describe("project — determinism", () => {
+  it("should produce byte-identical output across repeated calls on the same input", () => {
+    const log: Envelope[] = [
+      env("t1", 0, aDelta("Hello "), "u-1"),
+      env("t1", 1, aDelta("world")),
+      env("t1", 2, tStart("tc-1", "shell")),
+      env("t1", 3, tProgress("tc-1", "running…")),
+      env("t1", 4, tEnd("tc-1", "complete")),
+      env("t1", 5, fAttached("/tmp/a.md", "text/markdown", 100)),
+      env("t1", 6, aPersisted("Hello world")),
+      env("t1", 7, tCompleted({ input_tokens: 10, output_tokens: 20 })),
+    ];
+
+    const a = project(log);
+    const b = project(log);
+    const c = project([...log]); // fresh array, same envelopes
+
+    expect(a).toEqual(b);
+    expect(a).toEqual(c);
+    expect(fingerprint(a)).toBe(fingerprint(b));
+    expect(fingerprint(a)).toBe(fingerprint(c));
+  });
+});
+
+// ─── Property: ordering by seq ─────────────────────────────────────────────
+
+describe("project — ordering by seq", () => {
+  it("should produce identical view-models for any cross-thread interleaving that preserves per-thread seq monotonicity", () => {
+    // Two independent thread streams, each in seq order.
+    const t1: Envelope[] = [
+      env("t1", 0, aDelta("hi"), "u-t1"),
+      env("t1", 1, aPersisted("hi")),
+      env("t1", 2, tCompleted()),
+    ];
+    const t2: Envelope[] = [
+      env("t2", 0, aDelta("yo"), "u-t2"),
+      env("t2", 1, aDelta("!")),
+      env("t2", 2, tStart("tc-x", "web")),
+      env("t2", 3, tEnd("tc-x", "complete")),
+    ];
+
+    const reference = project([...t1, ...t2]);
+    const refFp = fingerprint(reference);
+
+    let count = 0;
+    for (const interleave of interleavings([t1, t2])) {
+      const got = project(interleave);
+      // Per-thread state must match.
+      const byThread = new Map(got.threads.map((t) => [t.thread_id, t]));
+      const refByThread = new Map(reference.threads.map((t) => [t.thread_id, t]));
+      expect(byThread.size).toBe(refByThread.size);
+      for (const [tid, refThread] of refByThread) {
+        expect(byThread.get(tid)).toEqual(refThread);
+      }
+      // The cross-thread `threads` array order is determined by
+      // first-seen seq, which depends on the interleave — so we don't
+      // demand byte-identity on the OUTER fingerprint.
+      count += 1;
+    }
+    // Sanity: we generated more than one permutation.
+    expect(count).toBeGreaterThan(1);
+    // And the canonical (concatenated) ordering is itself a valid
+    // permutation, so the reference exists.
+    expect(refFp.length).toBeGreaterThan(0);
+  });
+
+  it("should preserve thread row order = first-seen seq across threads", () => {
+    // t2 introduces first; t1 follows.
+    const log: Envelope[] = [
+      env("t2", 0, aDelta("first")),
+      env("t1", 0, aDelta("second")),
+    ];
+    const view = project(log);
+    expect(view.threads.map((t) => t.thread_id)).toEqual(["t2", "t1"]);
+  });
+});
+
+// ─── Property: idempotency ────────────────────────────────────────────────
+
+describe("project — idempotency", () => {
+  it("should ignore an exact-duplicate (thread_id, seq) envelope", () => {
+    const base: Envelope[] = [
+      env("t1", 0, aDelta("Hello "), "u-1"),
+      env("t1", 1, aDelta("world")),
+      env("t1", 2, aPersisted("Hello world")),
+    ];
+    const dup = env("t1", 1, aDelta("ZZZ")); // same (thread_id, seq) as base[1]
+    const withDup = [...base, dup];
+
+    const a = projectWithMetrics(base);
+    const b = projectWithMetrics(withDup);
+
+    expect(b.view).toEqual(a.view);
+    expect(b.metrics.duplicates).toBe(1);
+    expect(a.metrics.duplicates).toBe(0);
+  });
+
+  it("should buffer out-of-order envelopes and apply them once the gap fills (codex BLOCK 1)", () => {
+    // seq 0,2,1 — pre-fix dropped seq=1 permanently.
+    const log: Envelope[] = [
+      env("t1", 0, aDelta("a")),
+      env("t1", 2, aDelta("c")),
+      env("t1", 1, aDelta("b")),
+    ];
+    const result = projectWithMetrics(log);
+    const t = result.view.threads[0];
+    expect(t.assistant?.text).toBe("abc");
+    // seq 2 took the buffering path; seq 1 was the in-order arrival
+    // that drained the gap (no bump).
+    expect(result.metrics.outOfOrder).toBe(1);
+    expect(result.metrics.duplicates).toBe(0);
+  });
+
+  it("should buffer arrivals beyond the gap until the gap fills (large gap)", () => {
+    // seq 0, 5, 2, 1 — when 1 arrives, drain 1; 2 was already
+    // buffered so drain 2; 3,4 missing so 5 stays buffered.
+    const log: Envelope[] = [
+      env("t1", 0, aDelta("a")),
+      env("t1", 5, aDelta("z")),
+      env("t1", 2, aDelta("c")),
+      env("t1", 1, aDelta("b")),
+    ];
+    const result = projectWithMetrics(log);
+    const t = result.view.threads[0];
+    expect(t.assistant?.text).toBe("abc");
+    // seq 5 + seq 2 buffered (=2). seq 1 was in-order (no bump).
+    expect(result.metrics.outOfOrder).toBe(2);
+  });
+
+  it("should produce identical output for [0,1,2] and [0,2,1] (codex BLOCK 2 order-independence)", () => {
+    const inOrder: Envelope[] = [
+      env("t1", 0, aDelta("a")),
+      env("t1", 1, aDelta("b")),
+      env("t1", 2, aDelta("c")),
+    ];
+    const outOfOrder: Envelope[] = [
+      env("t1", 0, aDelta("a")),
+      env("t1", 2, aDelta("c")),
+      env("t1", 1, aDelta("b")),
+    ];
+    expect(project(inOrder)).toEqual(project(outOfOrder));
+  });
+});
+
+// ─── turn_completed barrier ───────────────────────────────────────────────
+
+describe("project — turn_completed barrier", () => {
+  it("should drop any envelope after turn_completed for the same thread and bump the metric", () => {
+    const log: Envelope[] = [
+      env("t1", 0, aDelta("hi")),
+      env("t1", 1, aPersisted("hi")),
+      env("t1", 2, tCompleted({ input_tokens: 1, output_tokens: 2 })),
+      env("t1", 3, aDelta("LATE")), // forbidden post-barrier delta
+      env("t1", 4, tStart("tc-late", "shell")), // forbidden post-barrier tool
+      env("t1", 5, fAttached("/tmp/late.md", "text/markdown", 1)),
+    ];
+    const result = projectWithMetrics(log);
+    const t = result.view.threads[0];
+    expect(t.completed).toBe(true);
+    expect(t.tokenUsage).toEqual({ input_tokens: 1, output_tokens: 2 });
+    expect(t.assistant?.text).toBe("hi");
+    expect(t.toolCalls).toEqual([]);
+    expect(t.files).toEqual([]);
+    expect(result.metrics.droppedAfterTurnCompleted).toBe(3);
+  });
+
+  it("should not affect other threads when one thread completes", () => {
+    const log: Envelope[] = [
+      env("t1", 0, aDelta("a")),
+      env("t1", 1, tCompleted()),
+      env("t2", 0, aDelta("b")), // different thread, must survive
+      env("t1", 2, aDelta("LATE")),
+    ];
+    const result = projectWithMetrics(log);
+    const byThread = new Map(result.view.threads.map((t) => [t.thread_id, t]));
+    expect(byThread.get("t1")?.completed).toBe(true);
+    expect(byThread.get("t1")?.assistant?.text).toBe("a");
+    expect(byThread.get("t2")?.completed).toBe(false);
+    expect(byThread.get("t2")?.assistant?.text).toBe("b");
+    expect(result.metrics.droppedAfterTurnCompleted).toBe(1);
+  });
+});
+
+// ─── Per-variant focused unit tests ───────────────────────────────────────
+
+describe("project — assistant_delta accumulates text", () => {
+  it("should concatenate fragments in seq order", () => {
+    const log: Envelope[] = [
+      env("t1", 0, aDelta("foo ")),
+      env("t1", 1, aDelta("bar ")),
+      env("t1", 2, aDelta("baz")),
+    ];
+    const view = project(log);
+    expect(view.threads[0].assistant?.text).toBe("foo bar baz");
+    expect(view.threads[0].assistant?.persisted).toBe(false);
+    expect(view.threads[0].assistant?.meta).toBeNull();
+  });
+});
+
+describe("project — assistant_persisted replaces text + finalizes meta", () => {
+  it("should replace streamed text with persisted text and stamp meta", () => {
+    const meta: MessageMeta = {
+      message_id: "01900000-0000-7000-8000-000000000018",
+      persisted_at: "2026-05-09T18:30:01Z",
+      media: ["report.md"],
+    };
+    const log: Envelope[] = [
+      env("t1", 0, aDelta("Hello ")),
+      env("t1", 1, aDelta("wo")),
+      env("t1", 2, aPersisted("Hello world", meta)),
+    ];
+    const view = project(log);
+    const a = view.threads[0].assistant!;
+    expect(a.text).toBe("Hello world");
+    expect(a.meta).toEqual(meta);
+    expect(a.persisted).toBe(true);
+  });
+});
+
+describe("project — tool_start adds a toolCall", () => {
+  it("should open a tool-call card keyed on tool_call_id", () => {
+    const log: Envelope[] = [env("t1", 0, tStart("tc-1", "shell"))];
+    const view = project(log);
+    expect(view.threads[0].toolCalls).toEqual([
+      {
+        tool_call_id: "tc-1",
+        name: "shell",
+        progress: [],
+        status: null,
+        error: null,
+      },
+    ]);
+  });
+});
+
+describe("project — tool_progress appends to the matching toolCall", () => {
+  it("should append progress messages in seq order", () => {
+    const log: Envelope[] = [
+      env("t1", 0, tStart("tc-1", "shell")),
+      env("t1", 1, tProgress("tc-1", "starting")),
+      env("t1", 2, tProgress("tc-1", "running…")),
+      env("t1", 3, tProgress("tc-1", "almost done")),
+    ];
+    const view = project(log);
+    expect(view.threads[0].toolCalls[0].progress).toEqual([
+      "starting",
+      "running…",
+      "almost done",
+    ]);
+  });
+});
+
+describe("project — tool_end stamps status (and error iff status==error)", () => {
+  it("should set status=complete with no error", () => {
+    const log: Envelope[] = [
+      env("t1", 0, tStart("tc-1", "shell")),
+      env("t1", 1, tEnd("tc-1", "complete")),
+    ];
+    const view = project(log);
+    expect(view.threads[0].toolCalls[0].status).toBe("complete");
+    expect(view.threads[0].toolCalls[0].error).toBeNull();
+  });
+
+  it("should set status=error and surface the error string", () => {
+    const log: Envelope[] = [
+      env("t1", 0, tStart("tc-2", "web")),
+      env("t1", 1, tEnd("tc-2", "error", "boom")),
+    ];
+    const view = project(log);
+    expect(view.threads[0].toolCalls[0].status).toBe("error");
+    expect(view.threads[0].toolCalls[0].error).toBe("boom");
+  });
+});
+
+describe("project — file_attached adds to files", () => {
+  it("should record arrival order with the envelope's seq", () => {
+    const log: Envelope[] = [
+      env("t1", 0, fAttached("/tmp/a.md", "text/markdown", 10)),
+      env("t1", 1, fAttached("/tmp/b.mp3", "audio/mpeg", 2048)),
+    ];
+    const view = project(log);
+    expect(view.threads[0].files).toEqual([
+      { seq: 0, path: "/tmp/a.md", mime: "text/markdown", size_bytes: 10 },
+      { seq: 1, path: "/tmp/b.mp3", mime: "audio/mpeg", size_bytes: 2048 },
+    ]);
+  });
+});
+
+// ─── Misc surface checks ──────────────────────────────────────────────────
+
+describe("project — user view captures client_message_id when present", () => {
+  it("should record the client_message_id from the first envelope", () => {
+    const log: Envelope[] = [
+      env("t1", 0, aDelta("hi"), "u-token-1"),
+      env("t1", 1, aDelta("there")),
+    ];
+    const view = project(log);
+    // Until a `user_message` envelope lands, text/files default to
+    // empty (codex BLOCK 3: no first-envelope-seen fallback).
+    expect(view.threads[0].user).toEqual({
+      seq: 0,
+      client_message_id: "u-token-1",
+      text: "",
+      files: [],
+    });
+  });
+
+  it("should leave client_message_id unset when the envelope omits it", () => {
+    const log: Envelope[] = [env("t1", 0, aDelta("hi"))];
+    const view = project(log);
+    expect(view.threads[0].user).toEqual({ seq: 0, text: "", files: [] });
+  });
+});
+
+describe("project — empty input", () => {
+  it("should produce an empty view-model", () => {
+    const view = project([]);
+    expect(view).toEqual({ threads: [] });
+  });
+});
+
+// ─── BLOCK 3: user_message payload populates UserView ────────────────────
+
+describe("project — user_message variant (codex BLOCK 3)", () => {
+  it("should populate UserView.text and UserView.files from a user_message envelope", () => {
+    const files: FileRef[] = [
+      { path: "/tmp/notes.md", mime: "text/markdown", size_bytes: 42 },
+    ];
+    const log: Envelope[] = [
+      env("t1", 0, uMsg("Hello!", files), "u-1"),
+      env("t1", 1, aDelta("Hi ")),
+      env("t1", 2, aDelta("there")),
+    ];
+    const view = project(log);
+    const u = view.threads[0].user!;
+    expect(u.text).toBe("Hello!");
+    expect(u.files).toEqual(files);
+    expect(u.client_message_id).toBe("u-1");
+    expect(u.seq).toBe(0);
+    expect(view.threads[0].assistant?.text).toBe("Hi there");
+  });
+
+  it("should NOT clobber UserView.text from a later assistant_delta (no first-envelope fallback)", () => {
+    const log: Envelope[] = [env("t1", 0, aDelta("assistant content"))];
+    const view = project(log);
+    expect(view.threads[0].user?.text).toBe("");
+    expect(view.threads[0].user?.files).toEqual([]);
+  });
+
+  it("should preserve UserView.text under buffered out-of-order arrival of the user_message envelope", () => {
+    const files: FileRef[] = [{ path: "/tmp/x.png" }];
+    const log: Envelope[] = [
+      env("t1", 1, aDelta("after"), "u-late"),
+      env("t1", 0, uMsg("typed", files), "u-late"),
+    ];
+    const view = project(log);
+    const u = view.threads[0].user!;
+    expect(u.text).toBe("typed");
+    expect(u.files).toEqual(files);
+    expect(view.threads[0].assistant?.text).toBe("after");
+  });
+
+  it("should ignore a second user_message payload (first-seen wins per thread)", () => {
+    const log: Envelope[] = [
+      env("t1", 0, uMsg("first")),
+      env("t1", 1, uMsg("second")),
+    ];
+    const view = project(log);
+    expect(view.threads[0].user?.text).toBe("first");
+  });
+});
+
+// ─── BLOCK 4: referential stability across project() calls ───────────────
+
+describe("project — referential stability (codex BLOCK 4)", () => {
+  it("should return the same ChatViewModel reference for the same input array", () => {
+    const log: Envelope[] = [
+      env("t1", 0, uMsg("hi"), "u-1"),
+      env("t1", 1, aDelta("hello")),
+    ];
+    const a = project(log);
+    const b = project(log);
+    expect(a).toBe(b);
+  });
+
+  it("should reuse per-thread ThreadView refs across distinct projections when the thread is unchanged", () => {
+    const log1: Envelope[] = [
+      env("t1", 0, uMsg("hi"), "u-1"),
+      env("t1", 1, aDelta("hello")),
+    ];
+    const log2: Envelope[] = log1.slice();
+    const v1 = project(log1);
+    const v2 = project(log2);
+    expect(v1).not.toBe(v2);
+    expect(v1.threads[0]).toBe(v2.threads[0]);
+  });
+
+  it("should mint a new ThreadView ref when the thread's contents materially change", () => {
+    const log1: Envelope[] = [env("t1", 0, uMsg("hi"))];
+    const log2: Envelope[] = [
+      env("t1", 0, uMsg("hi")),
+      env("t1", 1, aDelta("more")),
+    ];
+    const v1 = project(log1);
+    const v2 = project(log2);
+    expect(v1.threads[0]).not.toBe(v2.threads[0]);
+  });
+});

--- a/src/store/projection.ts
+++ b/src/store/projection.ts
@@ -1,0 +1,480 @@
+/**
+ * M9-γ-2: Pure-function projection `(envelopes) → ChatViewModel`.
+ *
+ * Spec: `api/OCTOS_UI_PROTOCOL_V1_SPEC_2026-04-24.md` § 14
+ *       "M9-γ Envelope".
+ * ADR:  `docs/M9-GAMMA-SERVER-PROJECTION-ADR.md`.
+ * UPCR: `UPCR-2026-014`.
+ *
+ * Pure: no React, no hooks, no Date.now, no fetch. Same `Envelope[]`
+ * input ⇒ byte-identical `ChatViewModel`. Identity is `(thread_id, seq)`.
+ *
+ * **Order-independence (codex BLOCK 1, 2)**: out-of-order envelopes are
+ * BUFFERED, not dropped. Each thread tracks `expectedNextSeq`. Arrivals
+ * with `seq > expectedNextSeq` are buffered as gap candidates; arrivals
+ * with `seq < expectedNextSeq` AND not yet applied are buffered as
+ * "fill the gap". When a gap fills the projection drains the buffer in
+ * canonical seq order. The only true drops are exact-`(thread_id, seq)`
+ * duplicates of an applied envelope (`metrics.duplicates`) and arrivals
+ * after `turn_completed` on the same thread
+ * (`metrics.droppedAfterTurnCompleted`). `metrics.outOfOrder` counts
+ * buffered-then-drained envelopes (back-compat name; not dropped).
+ *
+ * **`turn_completed` barrier**: the projection ignores trailing
+ * envelopes after `turn_completed` on a `thread_id` and bumps
+ * `droppedAfterTurnCompleted`. The bridge re-syncs the connection.
+ *
+ * **Referential stability (codex BLOCK 4)**: top-level `project()`
+ * memoizes by input-array identity (same `envelopes` ref ⇒ same
+ * `ChatViewModel` ref). Per-thread `ThreadView` caching is keyed on
+ * `(appliedCount, lastSeq)`: when a thread's contributing envelopes
+ * haven't changed across distinct `project()` calls, the projection
+ * returns the same `ThreadView` reference. This is the simpler
+ * variant the brief authorised — a future iteration may switch to a
+ * structural hash when callers need finer-grained reuse.
+ */
+
+import type {
+  Envelope,
+  EnvelopeTokenUsage,
+  EnvelopeToolEndStatus,
+  FileRef,
+  MessageMeta,
+  Payload,
+} from "../runtime/ui-protocol-types";
+
+// ─── ChatViewModel shape ───────────────────────────────────────────────────
+
+export interface UserView {
+  /** First seq in this thread; stable identity for the row. */
+  seq: number;
+  /** Reflected from `Envelope.client_message_id` on the user-message-
+   *  rooted envelope. The projection never consults this for identity;
+   *  γ-4's `<GhostBubble>` overlay uses it to match-and-unmount. */
+  client_message_id?: string;
+  /** User-typed text from a `user_message` envelope. Empty until a
+   *  `user_message` envelope has been observed. */
+  text: string;
+  /** File attachments from a `user_message` envelope. */
+  files: ReadonlyArray<FileRef>;
+}
+
+export interface AssistantView {
+  text: string;
+  meta: MessageMeta | null;
+  persisted: boolean;
+}
+
+export interface ToolCallView {
+  tool_call_id: string;
+  name: string;
+  progress: ReadonlyArray<string>;
+  status: EnvelopeToolEndStatus | null;
+  error: string | null;
+}
+
+export interface FileView {
+  seq: number;
+  path: string;
+  mime: string;
+  size_bytes: number;
+}
+
+export interface ThreadView {
+  thread_id: string;
+  user: UserView | null;
+  assistant: AssistantView | null;
+  toolCalls: ReadonlyArray<ToolCallView>;
+  files: ReadonlyArray<FileView>;
+  completed: boolean;
+  tokenUsage: EnvelopeTokenUsage | null;
+}
+
+export interface ChatViewModel {
+  threads: ReadonlyArray<ThreadView>;
+}
+
+// ─── Projection metrics ─────────────────────────────────────────────────
+
+export interface ProjectionMetrics {
+  /** Exact `(thread_id, seq)` collision of an already-applied envelope. */
+  duplicates: number;
+  /** Envelopes ignored because they arrived after `turn_completed`. */
+  droppedAfterTurnCompleted: number;
+  /** Envelopes that arrived out of canonical seq order and were
+   *  buffered until the gap filled (NOT dropped — eventually applied). */
+  outOfOrder: number;
+}
+
+export interface ProjectionResult {
+  view: ChatViewModel;
+  metrics: ProjectionMetrics;
+}
+
+// ─── Memoization (codex BLOCK 4) ───────────────────────────────────────────
+
+const projectionCache = new WeakMap<
+  ReadonlyArray<Envelope>,
+  ProjectionResult
+>();
+
+// Per-thread ThreadView cache keyed on (appliedCount, lastSeq). When
+// a thread_id produces the same tuple across distinct projections, we
+// return the same ThreadView ref. Bounded by the number of distinct
+// thread_ids observed in the process lifetime.
+const threadViewCache = new Map<
+  string,
+  { count: number; lastSeq: number; view: ThreadView }
+>();
+
+/** Test-only: drop the per-thread cache. Tests that re-use the same
+ *  `thread_id` across cases need the cache cleared in `beforeEach` so
+ *  cross-test bleed doesn't return a stale ThreadView reference. */
+export function __resetProjectionCacheForTesting(): void {
+  threadViewCache.clear();
+  // projectionCache is a WeakMap keyed on input identity; unrelated
+  // tests can't collide there, so no clear required.
+}
+
+// ─── Projection ────────────────────────────────────────────────────────────
+
+export function project(envelopes: ReadonlyArray<Envelope>): ChatViewModel {
+  return projectWithMetrics(envelopes).view;
+}
+
+export function projectWithMetrics(
+  envelopes: ReadonlyArray<Envelope>,
+): ProjectionResult {
+  const cached = projectionCache.get(envelopes);
+  if (cached) return cached;
+  const computed = computeProjection(envelopes);
+  projectionCache.set(envelopes, computed);
+  return computed;
+}
+
+function computeProjection(
+  envelopes: ReadonlyArray<Envelope>,
+): ProjectionResult {
+  interface ThreadAcc {
+    thread_id: string;
+    user: MutableUserView | null;
+    assistantText: string;
+    assistantMeta: MessageMeta | null;
+    assistantPersisted: boolean;
+    assistantSeen: boolean;
+    toolOrder: string[];
+    tools: Map<string, MutableToolCall>;
+    files: FileView[];
+    completed: boolean;
+    tokenUsage: EnvelopeTokenUsage | null;
+    seenSeqs: Set<number>;
+    lastSeq: number; // sentinel: -1
+    expectedNextSeq: number; // = lastSeq + 1
+    pendingByGap: Map<number, Envelope>;
+    seenUserMessage: boolean;
+    /** Envelopes APPLIED to this thread (excludes ignored dups /
+     *  dropped-after-completed). Used by the per-thread view cache. */
+    appliedCount: number;
+  }
+  interface MutableUserView {
+    seq: number;
+    client_message_id?: string;
+    text: string;
+    files: FileRef[];
+  }
+  interface MutableToolCall {
+    tool_call_id: string;
+    name: string;
+    progress: string[];
+    status: EnvelopeToolEndStatus | null;
+    error: string | null;
+  }
+
+  const threadOrder: string[] = [];
+  const threads = new Map<string, ThreadAcc>();
+
+  let duplicates = 0;
+  let droppedAfterTurnCompleted = 0;
+  let outOfOrder = 0;
+
+  const getThread = (thread_id: string): ThreadAcc => {
+    const existing = threads.get(thread_id);
+    if (existing) return existing;
+    const fresh: ThreadAcc = {
+      thread_id,
+      user: null,
+      assistantText: "",
+      assistantMeta: null,
+      assistantPersisted: false,
+      assistantSeen: false,
+      toolOrder: [],
+      tools: new Map(),
+      files: [],
+      completed: false,
+      tokenUsage: null,
+      seenSeqs: new Set(),
+      lastSeq: -1,
+      expectedNextSeq: 0,
+      pendingByGap: new Map(),
+      seenUserMessage: false,
+      appliedCount: 0,
+    };
+    threads.set(thread_id, fresh);
+    threadOrder.push(thread_id);
+    return fresh;
+  };
+
+  function applyEnvelope(thread: ThreadAcc, env: Envelope): void {
+    thread.seenSeqs.add(env.seq);
+    if (env.seq > thread.lastSeq) {
+      thread.lastSeq = env.seq;
+    }
+    thread.expectedNextSeq = thread.lastSeq + 1;
+    thread.appliedCount += 1;
+
+    // Capture user identity from the FIRST envelope we apply in
+    // canonical order. The previous "first envelope seen" fallback
+    // (codex BLOCK 3) reconstructed UserView.text from whatever
+    // payload the first envelope carried, which corrupted the user
+    // bubble whenever the first envelope was an assistant_delta. Now
+    // identity (seq + client_message_id) is captured here; text +
+    // files come exclusively from a user_message payload via
+    // applyPayload.
+    if (thread.user === null) {
+      thread.user = {
+        seq: env.seq,
+        ...(env.client_message_id !== undefined
+          ? { client_message_id: env.client_message_id }
+          : {}),
+        text: "",
+        files: [],
+      };
+    }
+
+    applyPayload(thread, env.payload);
+  }
+
+  function drainPending(thread: ThreadAcc): void {
+    while (
+      !thread.completed &&
+      thread.pendingByGap.has(thread.expectedNextSeq)
+    ) {
+      const next = thread.pendingByGap.get(thread.expectedNextSeq)!;
+      thread.pendingByGap.delete(thread.expectedNextSeq);
+      applyEnvelope(thread, next);
+    }
+  }
+
+  for (const env of envelopes) {
+    const thread = getThread(env.thread_id);
+
+    // True duplicate of an already-applied (thread_id, seq).
+    if (thread.seenSeqs.has(env.seq)) {
+      duplicates += 1;
+      continue;
+    }
+
+    // Hard barrier.
+    if (thread.completed) {
+      droppedAfterTurnCompleted += 1;
+      continue;
+    }
+
+    // In-order arrival.
+    if (env.seq === thread.expectedNextSeq) {
+      applyEnvelope(thread, env);
+      drainPending(thread);
+      continue;
+    }
+
+    // Future arrival (gap above expected): buffer.
+    if (env.seq > thread.expectedNextSeq) {
+      if (thread.pendingByGap.has(env.seq)) {
+        duplicates += 1;
+        continue;
+      }
+      thread.pendingByGap.set(env.seq, env);
+      outOfOrder += 1;
+      continue;
+    }
+
+    // Late fill (env.seq < expectedNextSeq, not yet seen): buffer +
+    // drain. Codex BLOCK 1: don't drop — buffer for canonical replay.
+    thread.pendingByGap.set(env.seq, env);
+    outOfOrder += 1;
+    drainPending(thread);
+  }
+
+  // Build immutable views with per-thread reference stability.
+  const threadViews: ThreadView[] = threadOrder.map((thread_id) => {
+    const acc = threads.get(thread_id)!;
+
+    const cached = threadViewCache.get(thread_id);
+    if (
+      cached &&
+      cached.count === acc.appliedCount &&
+      cached.lastSeq === acc.lastSeq
+    ) {
+      return cached.view;
+    }
+
+    const assistant: AssistantView | null = acc.assistantSeen
+      ? {
+          text: acc.assistantText,
+          meta: acc.assistantMeta,
+          persisted: acc.assistantPersisted,
+        }
+      : null;
+    const toolCalls: ToolCallView[] = acc.toolOrder.map((tcId) => {
+      const t = acc.tools.get(tcId)!;
+      return {
+        tool_call_id: t.tool_call_id,
+        name: t.name,
+        progress: t.progress.slice(),
+        status: t.status,
+        error: t.error,
+      };
+    });
+    const userView: UserView | null = acc.user
+      ? {
+          seq: acc.user.seq,
+          ...(acc.user.client_message_id !== undefined
+            ? { client_message_id: acc.user.client_message_id }
+            : {}),
+          text: acc.user.text,
+          files: acc.user.files.slice(),
+        }
+      : null;
+    const view: ThreadView = {
+      thread_id: acc.thread_id,
+      user: userView,
+      assistant,
+      toolCalls,
+      files: acc.files.slice(),
+      completed: acc.completed,
+      tokenUsage: acc.tokenUsage,
+    };
+    threadViewCache.set(thread_id, {
+      count: acc.appliedCount,
+      lastSeq: acc.lastSeq,
+      view,
+    });
+    return view;
+  });
+
+  return {
+    view: { threads: threadViews },
+    metrics: { duplicates, droppedAfterTurnCompleted, outOfOrder },
+  };
+
+  // ── inner: payload dispatch ───────────────────────────────────────────
+  function applyPayload(thread: ThreadAcc, payload: Payload): void {
+    switch (payload.type) {
+      case "user_message": {
+        // Codex BLOCK 3: populate UserView.text + files from the
+        // user_message payload. First-seen wins per thread.
+        if (!thread.user) {
+          thread.user = {
+            seq: thread.lastSeq,
+            text: payload.data.text,
+            files: payload.data.files.slice(),
+          };
+        } else if (!thread.seenUserMessage) {
+          thread.user.text = payload.data.text;
+          thread.user.files = payload.data.files.slice();
+        }
+        thread.seenUserMessage = true;
+        return;
+      }
+      case "assistant_delta": {
+        thread.assistantSeen = true;
+        if (!thread.assistantPersisted) {
+          thread.assistantText += payload.data.text;
+        }
+        return;
+      }
+      case "assistant_persisted": {
+        thread.assistantSeen = true;
+        thread.assistantText = payload.data.text;
+        thread.assistantMeta = payload.data.meta;
+        thread.assistantPersisted = true;
+        return;
+      }
+      case "tool_start": {
+        const id = payload.data.tool_call_id;
+        if (thread.tools.has(id)) return;
+        thread.tools.set(id, {
+          tool_call_id: id,
+          name: payload.data.name,
+          progress: [],
+          status: null,
+          error: null,
+        });
+        thread.toolOrder.push(id);
+        return;
+      }
+      case "tool_progress": {
+        const id = payload.data.tool_call_id;
+        const tool = thread.tools.get(id);
+        if (!tool) {
+          const opened: MutableToolCall = {
+            tool_call_id: id,
+            name: "",
+            progress: [payload.data.message],
+            status: null,
+            error: null,
+          };
+          thread.tools.set(id, opened);
+          thread.toolOrder.push(id);
+          return;
+        }
+        tool.progress.push(payload.data.message);
+        return;
+      }
+      case "tool_end": {
+        const id = payload.data.tool_call_id;
+        const tool = thread.tools.get(id);
+        if (!tool) {
+          const opened: MutableToolCall = {
+            tool_call_id: id,
+            name: "",
+            progress: [],
+            status: payload.data.status,
+            error:
+              payload.data.status === "error"
+                ? payload.data.error ?? null
+                : null,
+          };
+          thread.tools.set(id, opened);
+          thread.toolOrder.push(id);
+          return;
+        }
+        tool.status = payload.data.status;
+        tool.error =
+          payload.data.status === "error"
+            ? payload.data.error ?? null
+            : null;
+        return;
+      }
+      case "file_attached": {
+        thread.files.push({
+          seq: thread.lastSeq,
+          path: payload.data.path,
+          mime: payload.data.mime,
+          size_bytes: payload.data.size_bytes,
+        });
+        return;
+      }
+      case "turn_completed": {
+        thread.completed = true;
+        thread.tokenUsage = payload.data.token_usage;
+        return;
+      }
+      default: {
+        const _exhaustive: never = payload;
+        void _exhaustive;
+        return;
+      }
+    }
+  }
+}

--- a/src/store/thread-store.test.ts
+++ b/src/store/thread-store.test.ts
@@ -14,13 +14,30 @@
  *  10. abort_marks_pending_assistant_as_complete_with_partial_text
  *  11. reordered_arrival_preserves_send_order
  *  12. subscribe_notifies_on_change
+ *
+ * M9-γ-3 (issue #840): every test in this file runs twice — once with
+ * the `projection_v1` flag OFF (legacy reducer is the source of truth)
+ * and once ON (the shim translates each entry point into a projection
+ * envelope and ingests it in parallel; legacy reducer continues to
+ * back `getThreads()`). Parametrising with `describe.each` keeps the
+ * test names distinguishable in the runner output.
  */
 
-import { afterEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import * as ThreadStore from "./thread-store";
+import {
+  __resetProjectionForTests,
+  __setProjectionV1ForTests,
+  getEnvelopes,
+  getProjection,
+  getProjectionWithMetrics,
+  ingest as projectionIngest,
+  projectionStoreKey,
+} from "./projection-store";
 
 afterEach(() => {
   ThreadStore.__resetForTests();
+  __resetProjectionForTests();
   vi.unstubAllGlobals();
 });
 
@@ -33,7 +50,16 @@ function makeUser(text: string, cmid: string) {
   });
 }
 
-describe("thread-store", () => {
+const FLAG_STATES = [
+  { label: "projectionV1=false", projectionV1: false },
+  { label: "projectionV1=true", projectionV1: true },
+] as const;
+
+describe.each(FLAG_STATES)("thread-store [$label]", ({ projectionV1 }) => {
+  beforeEach(() => {
+    __setProjectionV1ForTests(projectionV1);
+  });
+
   it("creates_thread_on_user_message", () => {
     makeUser("hello", "cmid-1");
     const threads = ThreadStore.getThreads(SESSION);
@@ -1763,7 +1789,12 @@ describe("thread-store", () => {
 // M10 Phase 6.2 (Bug C): WS session/hydrate dedup pass
 // ---------------------------------------------------------------------------
 
-describe("applyHydrateDedup (M10 Phase 6.2)", () => {
+describe.each(FLAG_STATES)(
+  "applyHydrateDedup (M10 Phase 6.2) [$label]",
+  ({ projectionV1 }) => {
+    beforeEach(() => {
+      __setProjectionV1ForTests(projectionV1);
+    });
   const SID = "sess-bug-c";
 
   it("drops the legacy spawn-ack row when an envelope's message_id matches it, then renders the envelope", () => {
@@ -2247,9 +2278,15 @@ describe("applyHydrateDedup (M10 Phase 6.2)", () => {
       "envelope final",
     ]);
   });
-});
+  },
+);
 
-describe("setHydrateSnapshot reload-mid-stream fallback (M10.5)", () => {
+describe.each(FLAG_STATES)(
+  "setHydrateSnapshot reload-mid-stream fallback (M10.5) [$label]",
+  ({ projectionV1 }) => {
+    beforeEach(() => {
+      __setProjectionV1ForTests(projectionV1);
+    });
   const SID = "sess-reload-mid-stream";
 
   /**
@@ -2765,5 +2802,256 @@ describe("setHydrateSnapshot reload-mid-stream fallback (M10.5)", () => {
     );
     expect(allFiles).toContain("pf/orphan.md");
     expect(allFiles).toContain("pf/different.md");
+  });
+  },
+);
+
+// ---------------------------------------------------------------------------
+// M9-γ-3 (issue #840): projection-mode-only behaviour.
+//
+// These tests run ONLY with `octos_projection_v1 === "1"` and exercise
+// the scenarios the legacy reducer handles imperfectly. Each one
+// asserts on `getProjection(...)` (the pure-function view computed from
+// the committed envelope log), NOT on `getThreads(...)` (the legacy
+// state). The projection-only invariants verified here are the ones
+// γ-5 will inherit when the legacy reducer is retired.
+// ---------------------------------------------------------------------------
+
+describe("ThreadStore projection-mode (M9-γ-3, octos#840)", () => {
+  const SID = "sess-projection";
+
+  beforeEach(() => {
+    __setProjectionV1ForTests(true);
+  });
+
+  it("phantom_bubble_repro_two_assistant_persisted_envelopes_at_seq_1_and_3_accumulate_without_phantom", () => {
+    // The 2026-05-09 production phantom-bubble pattern: two
+    // `assistant_persisted` events for the same thread land at seq 1
+    // and seq 3 (an interleaving tool_progress at seq 2 in between).
+    // Legacy `appendCompletionBubble` could spawn a phantom row at
+    // seq=1 and then a SECOND row at seq=3 because the historySeq
+    // dedup path fell through under specific media-merge donations.
+    // The projection collapses both into the SAME thread's
+    // assistant slot — `(thread_id, seq)` is the only identity it
+    // recognises, so seq 1 finalises the bubble and seq 3 (the only
+    // legitimate replay shape) overwrites text/meta in place.
+    ThreadStore.addUserMessage(SID, {
+      text: "research X",
+      clientMessageId: "cmid-1",
+    });
+    const key = projectionStoreKey(SID);
+
+    // Inject the two persisted envelopes directly through the
+    // projection-store so we control the exact `seq` values. We use
+    // `projectionIngest` rather than the legacy entry points so the
+    // test pins the projection's own dedup contract — independent of
+    // what the legacy reducer would have done.
+    projectionIngest(key, {
+      thread_id: "cmid-1",
+      seq: 1,
+      payload: {
+        type: "assistant_persisted",
+        data: {
+          text: "first persisted",
+          meta: {
+            message_id: "msg-1",
+            persisted_at: "2026-05-09T10:00:01Z",
+          },
+        },
+      },
+    });
+    projectionIngest(key, {
+      thread_id: "cmid-1",
+      seq: 2,
+      payload: { type: "assistant_delta", data: { text: " (drift)" } },
+    });
+    projectionIngest(key, {
+      thread_id: "cmid-1",
+      seq: 3,
+      payload: {
+        type: "assistant_persisted",
+        data: {
+          text: "second persisted (canonical)",
+          meta: {
+            message_id: "msg-3",
+            persisted_at: "2026-05-09T10:00:03Z",
+          },
+        },
+      },
+    });
+
+    const view = getProjection(key);
+    // Exactly ONE thread, one assistant slot — no phantom row.
+    expect(view.threads).toHaveLength(1);
+    const thread = view.threads[0];
+    expect(thread.thread_id).toBe("cmid-1");
+    expect(thread.assistant?.persisted).toBe(true);
+    // Last persisted wins (canonical text).
+    expect(thread.assistant?.text).toBe("second persisted (canonical)");
+    expect(thread.assistant?.meta?.message_id).toBe("msg-3");
+  });
+
+  it("late_tool_progress_after_turn_completed_is_dropped_by_projection_hard_barrier", () => {
+    // Legacy `appendToolProgress` would re-open a `pendingAssistant`
+    // for a finalized thread (the spawn_only late-progress path); the
+    // projection's hard barrier on `turn_completed` drops the event
+    // and bumps `metrics.droppedAfterTurnCompleted` instead.
+    ThreadStore.addUserMessage(SID, {
+      text: "run pipeline",
+      clientMessageId: "cmid-1",
+    });
+    ThreadStore.addToolCall("cmid-1", "tc-1", "deep_research");
+    ThreadStore.finalizeAssistant("cmid-1", { committedSeq: 5 });
+
+    // After finalize → projection saw `turn_completed`. Late progress
+    // arrives for the same thread.
+    ThreadStore.appendToolProgress("cmid-1", "tc-1", "[late] still working");
+
+    const key = projectionStoreKey(SID);
+    const { view, metrics } = getProjectionWithMetrics(key);
+    const thread = view.threads.find((t) => t.thread_id === "cmid-1");
+    expect(thread?.completed).toBe(true);
+    // The late `tool_progress` envelope was emitted by the shim AND
+    // ingested into the log, BUT the projection's barrier dropped
+    // it — so the tool's `progress` array does NOT contain the late
+    // message.
+    const toolCall = thread?.toolCalls.find((tc) => tc.tool_call_id === "tc-1");
+    expect(toolCall?.progress).not.toContain("[late] still working");
+    // The projection counter records the drop.
+    expect(metrics.droppedAfterTurnCompleted).toBeGreaterThanOrEqual(1);
+  });
+
+  it("out_of_order_delivery_seq_3_then_seq_2_is_held_until_seq_2_lands_via_projection_dedup", () => {
+    // Inject envelopes in `seq=3, seq=2` order. Per γ-2's projection
+    // semantics, the seq=2 envelope is treated as out-of-order
+    // (strictly less than the high-water mark seq=3) and dropped,
+    // bumping `metrics.outOfOrder`. The projection's stable identity
+    // is `(thread_id, seq)` — once seq=3 is committed, seq=2 is a
+    // duplicate of an earlier state.
+    const key = projectionStoreKey(SID);
+    ThreadStore.addUserMessage(SID, {
+      text: "out of order",
+      clientMessageId: "cmid-1",
+    });
+    projectionIngest(key, {
+      thread_id: "cmid-1",
+      seq: 3,
+      payload: { type: "assistant_delta", data: { text: "third" } },
+    });
+    projectionIngest(key, {
+      thread_id: "cmid-1",
+      seq: 2,
+      payload: { type: "assistant_delta", data: { text: "second" } },
+    });
+    const { view, metrics } = getProjectionWithMetrics(key);
+    expect(metrics.outOfOrder).toBeGreaterThanOrEqual(1);
+    const thread = view.threads.find((t) => t.thread_id === "cmid-1");
+    // Only the seq=3 delta is applied; seq=2 (out-of-order) is dropped.
+    expect(thread?.assistant?.text).toBe("third");
+  });
+
+  it("cross_session_orphan_envelope_for_unknown_thread_is_appended_no_orphan_bucket_needed", () => {
+    // Legacy `findThreadById`/`ensureOrphanThread` allocates a
+    // placeholder bucket when a `tool_progress` arrives for an
+    // unknown thread. The projection just appends the envelope and
+    // the projected view exposes the orphan thread as its own row —
+    // no host-session-picking heuristic, no placeholder allocation.
+    const key = projectionStoreKey(SID);
+    projectionIngest(key, {
+      thread_id: "cmid-orphan",
+      seq: 1,
+      payload: {
+        type: "tool_progress",
+        data: { tool_call_id: "tc-orphan", message: "orphan log line" },
+      },
+    });
+    const view = getProjection(key);
+    const orphan = view.threads.find((t) => t.thread_id === "cmid-orphan");
+    expect(orphan).toBeDefined();
+    // The projection opens a tool-call card with empty `name` (per
+    // γ-2's "progress without a prior start" path) — exactly the
+    // shape γ-5's render layer keys off.
+    const tc = orphan?.toolCalls.find((tc) => tc.tool_call_id === "tc-orphan");
+    expect(tc).toBeDefined();
+    expect(tc?.progress).toContain("orphan log line");
+  });
+
+  it("identity_collapse_client_message_id_is_captured_on_envelope_but_projection_keys_on_seq", () => {
+    // The brief: an envelope's `client_message_id` field is captured
+    // but only used for the optimistic overlay (γ-4); the projection
+    // itself ignores it for identity. We verify both halves:
+    //
+    //   (1) The envelope log carries `client_message_id` on the
+    //       first envelope for a thread (γ-4's GhostBubble overlay
+    //       reads this).
+    //   (2) The projection's `(thread_id, seq)` dedup is unaffected
+    //       by `client_message_id`: two envelopes that share
+    //       `(thread_id, seq)` BUT differ on `client_message_id` are
+    //       still treated as duplicates (the second one is dropped).
+    ThreadStore.addUserMessage(SID, {
+      text: "identity collapse",
+      clientMessageId: "cmid-collapse",
+    });
+    const key = projectionStoreKey(SID);
+    // The shim should have associated `cmid-collapse` with the next
+    // envelope this thread emits. Trigger one by streaming a token.
+    ThreadStore.appendAssistantToken("cmid-collapse", "hi");
+
+    const log = getEnvelopes(key);
+    const firstForThread = log.find(
+      (e) => e.thread_id === "cmid-collapse",
+    );
+    expect(firstForThread).toBeDefined();
+    expect(firstForThread?.client_message_id).toBe("cmid-collapse");
+
+    // Now deliberately re-ingest the same `(thread_id, seq)` with a
+    // DIFFERENT `client_message_id` — the projection's idempotency
+    // guard drops it; `client_message_id` plays no role in identity.
+    const dupSeq = firstForThread!.seq;
+    projectionIngest(key, {
+      thread_id: "cmid-collapse",
+      seq: dupSeq,
+      client_message_id: "cmid-NOT-the-same",
+      payload: { type: "assistant_delta", data: { text: " stray" } },
+    });
+    const { metrics } = getProjectionWithMetrics(key);
+    expect(metrics.duplicates).toBeGreaterThanOrEqual(1);
+    // The projection's user view still carries the ORIGINAL cmid
+    // (set on first-seen envelope) — not the duplicate's cmid.
+    const view = getProjection(key);
+    const thread = view.threads.find((t) => t.thread_id === "cmid-collapse");
+    expect(thread?.user?.client_message_id).toBe("cmid-collapse");
+  });
+
+  it("shim_synthesizes_per_thread_monotonic_seqs_so_re_projection_is_deterministic", () => {
+    // Constraint from the brief: shim seq synthesis must be
+    // per-thread monotonic (NOT `Date.now()`) so that re-projecting
+    // the committed log is deterministic. We verify by issuing a
+    // sequence of mutations and asserting the envelope log carries
+    // strictly-increasing seqs WITHIN each thread (not across).
+    ThreadStore.addUserMessage(SID, { text: "Q1", clientMessageId: "cm-1" });
+    ThreadStore.addUserMessage(SID, { text: "Q2", clientMessageId: "cm-2" });
+    ThreadStore.appendAssistantToken("cm-1", "A1.1");
+    ThreadStore.appendAssistantToken("cm-2", "A2.1");
+    ThreadStore.appendAssistantToken("cm-1", "A1.2");
+    ThreadStore.appendAssistantToken("cm-2", "A2.2");
+
+    const key = projectionStoreKey(SID);
+    const log = getEnvelopes(key);
+    // Group by thread_id and verify monotonicity.
+    const byThread = new Map<string, number[]>();
+    for (const env of log) {
+      const arr = byThread.get(env.thread_id) ?? [];
+      arr.push(env.seq);
+      byThread.set(env.thread_id, arr);
+    }
+    for (const seqs of byThread.values()) {
+      for (let i = 1; i < seqs.length; i += 1) {
+        expect(seqs[i]).toBeGreaterThan(seqs[i - 1]);
+      }
+    }
+    // Cross-thread independence: cm-1 and cm-2 each start their own
+    // counter — neither one's seqs are functions of the other's.
+    expect(byThread.get("cm-1")?.[0]).toBe(byThread.get("cm-2")?.[0]);
   });
 });

--- a/src/store/thread-store.test.ts
+++ b/src/store/thread-store.test.ts
@@ -2826,15 +2826,14 @@ describe("ThreadStore projection-mode (M9-γ-3, octos#840)", () => {
 
   it("phantom_bubble_repro_two_assistant_persisted_envelopes_at_seq_1_and_3_accumulate_without_phantom", () => {
     // The 2026-05-09 production phantom-bubble pattern: two
-    // `assistant_persisted` events for the same thread land at seq 1
-    // and seq 3 (an interleaving tool_progress at seq 2 in between).
+    // `assistant_persisted` events for the same thread land at seq 0
+    // and seq 2 (an interleaving tool_progress at seq 1 in between).
     // Legacy `appendCompletionBubble` could spawn a phantom row at
-    // seq=1 and then a SECOND row at seq=3 because the historySeq
+    // seq=0 and then a SECOND row at seq=2 because the historySeq
     // dedup path fell through under specific media-merge donations.
-    // The projection collapses both into the SAME thread's
-    // assistant slot — `(thread_id, seq)` is the only identity it
-    // recognises, so seq 1 finalises the bubble and seq 3 (the only
-    // legitimate replay shape) overwrites text/meta in place.
+    // Under gap-buffer projection semantics, both seqs apply in
+    // canonical order; `assistant_persisted` REPLACES the assistant
+    // text/meta in-place, so seq=2 (the canonical replay) wins.
     ThreadStore.addUserMessage(SID, {
       text: "research X",
       clientMessageId: "cmid-1",
@@ -2848,7 +2847,7 @@ describe("ThreadStore projection-mode (M9-γ-3, octos#840)", () => {
     // what the legacy reducer would have done.
     projectionIngest(key, {
       thread_id: "cmid-1",
-      seq: 1,
+      seq: 0,
       payload: {
         type: "assistant_persisted",
         data: {
@@ -2862,12 +2861,12 @@ describe("ThreadStore projection-mode (M9-γ-3, octos#840)", () => {
     });
     projectionIngest(key, {
       thread_id: "cmid-1",
-      seq: 2,
+      seq: 1,
       payload: { type: "assistant_delta", data: { text: " (drift)" } },
     });
     projectionIngest(key, {
       thread_id: "cmid-1",
-      seq: 3,
+      seq: 2,
       payload: {
         type: "assistant_persisted",
         data: {
@@ -2921,13 +2920,15 @@ describe("ThreadStore projection-mode (M9-γ-3, octos#840)", () => {
     expect(metrics.droppedAfterTurnCompleted).toBeGreaterThanOrEqual(1);
   });
 
-  it("out_of_order_delivery_seq_3_then_seq_2_is_held_until_seq_2_lands_via_projection_dedup", () => {
-    // Inject envelopes in `seq=3, seq=2` order. Per γ-2's projection
-    // semantics, the seq=2 envelope is treated as out-of-order
-    // (strictly less than the high-water mark seq=3) and dropped,
-    // bumping `metrics.outOfOrder`. The projection's stable identity
-    // is `(thread_id, seq)` — once seq=3 is committed, seq=2 is a
-    // duplicate of an earlier state.
+  it("out_of_order_delivery_seq_2_then_seq_1_is_buffered_and_drained_in_canonical_order", () => {
+    // Inject envelopes in `seq=2, seq=1, seq=0` reverse order. Under
+    // γ-2's gap-buffer semantics, out-of-order envelopes are BUFFERED
+    // (not dropped) until the gap closes, then drained in canonical
+    // seq order. `metrics.outOfOrder` counts buffered-then-drained
+    // envelopes (back-compat name; not lost). The accumulated
+    // assistant text reflects canonical seq order: "zeroth firstthird"
+    // wait no — seqs 0,1,2 have text "zeroth", "first", "second"
+    // applied in that order, concatenated.
     const key = projectionStoreKey(SID);
     ThreadStore.addUserMessage(SID, {
       text: "out of order",
@@ -2935,19 +2936,30 @@ describe("ThreadStore projection-mode (M9-γ-3, octos#840)", () => {
     });
     projectionIngest(key, {
       thread_id: "cmid-1",
-      seq: 3,
-      payload: { type: "assistant_delta", data: { text: "third" } },
-    });
-    projectionIngest(key, {
-      thread_id: "cmid-1",
       seq: 2,
       payload: { type: "assistant_delta", data: { text: "second" } },
     });
+    projectionIngest(key, {
+      thread_id: "cmid-1",
+      seq: 1,
+      payload: { type: "assistant_delta", data: { text: "first" } },
+    });
+    projectionIngest(key, {
+      thread_id: "cmid-1",
+      seq: 0,
+      payload: { type: "assistant_delta", data: { text: "zeroth" } },
+    });
     const { view, metrics } = getProjectionWithMetrics(key);
-    expect(metrics.outOfOrder).toBeGreaterThanOrEqual(1);
+    // Two envelopes (seq=2, seq=1) were buffered; seq=0 closed the
+    // gap and drained both. The counter is back-compat-named
+    // `outOfOrder`.
+    expect(metrics.outOfOrder).toBeGreaterThanOrEqual(2);
+    expect(metrics.duplicates).toBe(0);
     const thread = view.threads.find((t) => t.thread_id === "cmid-1");
-    // Only the seq=3 delta is applied; seq=2 (out-of-order) is dropped.
-    expect(thread?.assistant?.text).toBe("third");
+    // Canonical-order concatenation: 0 → "zeroth", 1 → "first",
+    // 2 → "second" — gap-buffer drains them in seq order regardless
+    // of arrival order.
+    expect(thread?.assistant?.text).toBe("zeroth" + "first" + "second");
   });
 
   it("cross_session_orphan_envelope_for_unknown_thread_is_appended_no_orphan_bucket_needed", () => {
@@ -2959,7 +2971,7 @@ describe("ThreadStore projection-mode (M9-γ-3, octos#840)", () => {
     const key = projectionStoreKey(SID);
     projectionIngest(key, {
       thread_id: "cmid-orphan",
-      seq: 1,
+      seq: 0,
       payload: {
         type: "tool_progress",
         data: { tool_call_id: "tc-orphan", message: "orphan log line" },
@@ -3026,10 +3038,9 @@ describe("ThreadStore projection-mode (M9-γ-3, octos#840)", () => {
   it("shim_synthesizes_per_thread_monotonic_seqs_so_re_projection_is_deterministic", () => {
     // Constraint from the brief: shim seq synthesis must be
     // per-thread monotonic (NOT `Date.now()`) so that re-projecting
-    // the committed log is deterministic. Synthetic seqs live in the
-    // NEGATIVE namespace (codex round-1 BLOCK 1) — they're monotonic
-    // in MAGNITUDE (-1, -2, -3, …) so `abs(seq)` is strictly
-    // increasing within a thread.
+    // the committed log is deterministic. Under gap-buffer projection
+    // semantics, the shim mints non-negative seqs starting at 0 to
+    // match `expectedNextSeq=0` initialization.
     ThreadStore.addUserMessage(SID, { text: "Q1", clientMessageId: "cm-1" });
     ThreadStore.addUserMessage(SID, { text: "Q2", clientMessageId: "cm-2" });
     ThreadStore.appendAssistantToken("cm-1", "A1.1");
@@ -3039,7 +3050,7 @@ describe("ThreadStore projection-mode (M9-γ-3, octos#840)", () => {
 
     const key = projectionStoreKey(SID);
     const log = getEnvelopes(key);
-    // Group by thread_id and verify monotonicity in MAGNITUDE.
+    // Group by thread_id and verify monotonicity.
     const byThread = new Map<string, number[]>();
     for (const env of log) {
       const arr = byThread.get(env.thread_id) ?? [];
@@ -3047,11 +3058,12 @@ describe("ThreadStore projection-mode (M9-γ-3, octos#840)", () => {
       byThread.set(env.thread_id, arr);
     }
     for (const seqs of byThread.values()) {
-      // All synthetic seqs are in the negative namespace.
-      for (const s of seqs) expect(s).toBeLessThan(0);
-      // |seq_i| > |seq_{i-1}| — strictly increasing magnitude.
+      // Shim mints non-negative seqs so the gap-buffer projection's
+      // expectedNextSeq=0 initialization fits the first arrival.
+      for (const s of seqs) expect(s).toBeGreaterThanOrEqual(0);
+      // Strictly increasing per-thread.
       for (let i = 1; i < seqs.length; i += 1) {
-        expect(Math.abs(seqs[i])).toBeGreaterThan(Math.abs(seqs[i - 1]));
+        expect(seqs[i]).toBeGreaterThan(seqs[i - 1]);
       }
     }
     // Cross-thread independence: cm-1 and cm-2 each start their own
@@ -3061,26 +3073,23 @@ describe("ThreadStore projection-mode (M9-γ-3, octos#840)", () => {
 
   // ── codex round-1 BLOCK 1: synthetic / server seq namespaces ──────────
 
-  it("seq_namespace_synthetic_negative_does_not_collide_with_server_positive", () => {
-    // Pre-fix repro: shim minted synthetic seq=1 for an in-flight
-    // assistant_delta, and a subsequent server-issued
-    // assistant_persisted with historySeq=1 was treated as a duplicate
-    // of the same `(thread_id, seq)` and silently dropped — the
-    // persisted text never replaced the streamed delta. After
-    // BLOCK 1's namespace split, the shim mints seq=-1 for the delta
-    // and the projection accepts seq=+1 (server) as a distinct
-    // envelope on a different track.
+  it("streamed_delta_then_persisted_envelope_apply_in_canonical_seq_order_under_gap_buffer", () => {
+    // Under gap-buffer semantics, the shim mints a non-negative
+    // synthetic seq for the streamed delta (seq=0) and a subsequent
+    // server-issued `assistant_persisted` carries the next seq (seq=1
+    // here). Both apply in canonical order; the persisted payload
+    // REPLACES the assistant text/meta in place, so the persisted
+    // canonical text wins.
     ThreadStore.addUserMessage(SID, {
       text: "stream then persist",
       clientMessageId: "cmid-1",
     });
 
-    // Synthetic delta — minted by the shim with seq < 0.
+    // Synthetic delta — shim mints seq=0.
     ThreadStore.appendAssistantToken("cmid-1", "streamed");
 
-    // Server-issued persisted envelope with historySeq=1 (lands as
-    // `seq=+1` in the projection's server namespace). This is exactly
-    // the value where the pre-fix collision would have happened.
+    // Server-issued persisted envelope with seq=1 (next after the
+    // synthetic delta). The gap-buffer applies it in order.
     const key = projectionStoreKey(SID);
     projectionIngest(key, {
       thread_id: "cmid-1",
@@ -3098,52 +3107,58 @@ describe("ThreadStore projection-mode (M9-γ-3, octos#840)", () => {
     });
 
     const { view, metrics } = getProjectionWithMetrics(key);
-    // No duplicate dropped: the synthetic delta and the server
-    // persisted live in disjoint namespaces.
+    // Both applied in order — neither dropped as a duplicate.
     expect(metrics.duplicates).toBe(0);
     const thread = view.threads.find((t) => t.thread_id === "cmid-1");
-    // The persisted text wins (both were applied; persisted is the
-    // canonical finalised text).
+    // The persisted text wins (assistant_persisted REPLACES text).
     expect(thread?.assistant?.persisted).toBe(true);
     expect(thread?.assistant?.text).toBe("persisted-canonical");
   });
 
-  it("seq_namespace_server_seq_after_synthetic_is_not_out_of_order", () => {
-    // Verify that an out-of-order check is INSIDE each namespace, not
-    // across them. A synthetic seq=-3 followed by a server seq=+1 is
-    // legitimate: the synthetic high-water mark (magnitude=3) does
-    // not block the first server-namespace envelope.
+  it("late_arriving_envelope_with_seq_below_high_water_buffers_then_drains_under_gap_buffer", () => {
+    // Under the canonical gap-buffer projection (γ-2 fixup), an
+    // envelope arriving with `seq < expectedNextSeq` is BUFFERED for
+    // a possible canonical replay rather than dropped. The shim mints
+    // non-negative monotonic seqs so a streamed delta and a
+    // subsequent late-fill on a lower seq are reconciled by the
+    // projection's drain logic.
     ThreadStore.addUserMessage(SID, {
-      text: "interleaved namespaces",
+      text: "interleaved arrivals",
       clientMessageId: "cmid-1",
     });
 
-    // Bump the synthetic high-water mark via three streamed tokens
-    // (each shim mint allocates one synthetic seq).
+    // Two streamed tokens through the shim — synthetic seqs 0, 1.
     ThreadStore.appendAssistantToken("cmid-1", "a");
     ThreadStore.appendAssistantToken("cmid-1", "b");
-    ThreadStore.appendAssistantToken("cmid-1", "c");
 
-    // Server-namespace envelope with seq=1 — would-be-rejected
-    // pre-fix because |seq|=3 was already the per-thread high water.
+    // A late-arriving envelope at seq=3 (gap above expected=2). The
+    // gap-buffer holds it pending. seq=3 contributes a tool_start.
     const key = projectionStoreKey(SID);
     projectionIngest(key, {
       thread_id: "cmid-1",
-      seq: 1,
+      seq: 3,
       payload: {
         type: "tool_start",
         data: { tool_call_id: "tc-srv", name: "external_tool" },
       },
     });
+    // seq=2 closes the gap; seq=3 drains immediately after.
+    projectionIngest(key, {
+      thread_id: "cmid-1",
+      seq: 2,
+      payload: { type: "assistant_delta", data: { text: "c" } },
+    });
 
     const { view, metrics } = getProjectionWithMetrics(key);
-    // The server envelope was applied — not classified as
-    // out-of-order, not classified as a duplicate.
-    expect(metrics.outOfOrder).toBe(0);
+    // seq=3 was buffered then drained; counted in `outOfOrder`
+    // (back-compat name for buffered-then-applied).
+    expect(metrics.outOfOrder).toBeGreaterThanOrEqual(1);
+    expect(metrics.duplicates).toBe(0);
     const thread = view.threads.find((t) => t.thread_id === "cmid-1");
     expect(
       thread?.toolCalls.find((tc) => tc.tool_call_id === "tc-srv"),
     ).toBeDefined();
+    expect(thread?.assistant?.text).toBe("abc");
   });
 
   // ── codex round-1 BLOCK 2: retry-collapse emits tool_start ────────────

--- a/src/store/thread-store.test.ts
+++ b/src/store/thread-store.test.ts
@@ -3026,9 +3026,10 @@ describe("ThreadStore projection-mode (M9-γ-3, octos#840)", () => {
   it("shim_synthesizes_per_thread_monotonic_seqs_so_re_projection_is_deterministic", () => {
     // Constraint from the brief: shim seq synthesis must be
     // per-thread monotonic (NOT `Date.now()`) so that re-projecting
-    // the committed log is deterministic. We verify by issuing a
-    // sequence of mutations and asserting the envelope log carries
-    // strictly-increasing seqs WITHIN each thread (not across).
+    // the committed log is deterministic. Synthetic seqs live in the
+    // NEGATIVE namespace (codex round-1 BLOCK 1) — they're monotonic
+    // in MAGNITUDE (-1, -2, -3, …) so `abs(seq)` is strictly
+    // increasing within a thread.
     ThreadStore.addUserMessage(SID, { text: "Q1", clientMessageId: "cm-1" });
     ThreadStore.addUserMessage(SID, { text: "Q2", clientMessageId: "cm-2" });
     ThreadStore.appendAssistantToken("cm-1", "A1.1");
@@ -3038,7 +3039,7 @@ describe("ThreadStore projection-mode (M9-γ-3, octos#840)", () => {
 
     const key = projectionStoreKey(SID);
     const log = getEnvelopes(key);
-    // Group by thread_id and verify monotonicity.
+    // Group by thread_id and verify monotonicity in MAGNITUDE.
     const byThread = new Map<string, number[]>();
     for (const env of log) {
       const arr = byThread.get(env.thread_id) ?? [];
@@ -3046,8 +3047,11 @@ describe("ThreadStore projection-mode (M9-γ-3, octos#840)", () => {
       byThread.set(env.thread_id, arr);
     }
     for (const seqs of byThread.values()) {
+      // All synthetic seqs are in the negative namespace.
+      for (const s of seqs) expect(s).toBeLessThan(0);
+      // |seq_i| > |seq_{i-1}| — strictly increasing magnitude.
       for (let i = 1; i < seqs.length; i += 1) {
-        expect(seqs[i]).toBeGreaterThan(seqs[i - 1]);
+        expect(Math.abs(seqs[i])).toBeGreaterThan(Math.abs(seqs[i - 1]));
       }
     }
     // Cross-thread independence: cm-1 and cm-2 each start their own

--- a/src/store/thread-store.test.ts
+++ b/src/store/thread-store.test.ts
@@ -3058,4 +3058,231 @@ describe("ThreadStore projection-mode (M9-γ-3, octos#840)", () => {
     // counter — neither one's seqs are functions of the other's.
     expect(byThread.get("cm-1")?.[0]).toBe(byThread.get("cm-2")?.[0]);
   });
+
+  // ── codex round-1 BLOCK 1: synthetic / server seq namespaces ──────────
+
+  it("seq_namespace_synthetic_negative_does_not_collide_with_server_positive", () => {
+    // Pre-fix repro: shim minted synthetic seq=1 for an in-flight
+    // assistant_delta, and a subsequent server-issued
+    // assistant_persisted with historySeq=1 was treated as a duplicate
+    // of the same `(thread_id, seq)` and silently dropped — the
+    // persisted text never replaced the streamed delta. After
+    // BLOCK 1's namespace split, the shim mints seq=-1 for the delta
+    // and the projection accepts seq=+1 (server) as a distinct
+    // envelope on a different track.
+    ThreadStore.addUserMessage(SID, {
+      text: "stream then persist",
+      clientMessageId: "cmid-1",
+    });
+
+    // Synthetic delta — minted by the shim with seq < 0.
+    ThreadStore.appendAssistantToken("cmid-1", "streamed");
+
+    // Server-issued persisted envelope with historySeq=1 (lands as
+    // `seq=+1` in the projection's server namespace). This is exactly
+    // the value where the pre-fix collision would have happened.
+    const key = projectionStoreKey(SID);
+    projectionIngest(key, {
+      thread_id: "cmid-1",
+      seq: 1,
+      payload: {
+        type: "assistant_persisted",
+        data: {
+          text: "persisted-canonical",
+          meta: {
+            message_id: "msg-server-1",
+            persisted_at: "2026-05-09T11:00:01Z",
+          },
+        },
+      },
+    });
+
+    const { view, metrics } = getProjectionWithMetrics(key);
+    // No duplicate dropped: the synthetic delta and the server
+    // persisted live in disjoint namespaces.
+    expect(metrics.duplicates).toBe(0);
+    const thread = view.threads.find((t) => t.thread_id === "cmid-1");
+    // The persisted text wins (both were applied; persisted is the
+    // canonical finalised text).
+    expect(thread?.assistant?.persisted).toBe(true);
+    expect(thread?.assistant?.text).toBe("persisted-canonical");
+  });
+
+  it("seq_namespace_server_seq_after_synthetic_is_not_out_of_order", () => {
+    // Verify that an out-of-order check is INSIDE each namespace, not
+    // across them. A synthetic seq=-3 followed by a server seq=+1 is
+    // legitimate: the synthetic high-water mark (magnitude=3) does
+    // not block the first server-namespace envelope.
+    ThreadStore.addUserMessage(SID, {
+      text: "interleaved namespaces",
+      clientMessageId: "cmid-1",
+    });
+
+    // Bump the synthetic high-water mark via three streamed tokens
+    // (each shim mint allocates one synthetic seq).
+    ThreadStore.appendAssistantToken("cmid-1", "a");
+    ThreadStore.appendAssistantToken("cmid-1", "b");
+    ThreadStore.appendAssistantToken("cmid-1", "c");
+
+    // Server-namespace envelope with seq=1 — would-be-rejected
+    // pre-fix because |seq|=3 was already the per-thread high water.
+    const key = projectionStoreKey(SID);
+    projectionIngest(key, {
+      thread_id: "cmid-1",
+      seq: 1,
+      payload: {
+        type: "tool_start",
+        data: { tool_call_id: "tc-srv", name: "external_tool" },
+      },
+    });
+
+    const { view, metrics } = getProjectionWithMetrics(key);
+    // The server envelope was applied — not classified as
+    // out-of-order, not classified as a duplicate.
+    expect(metrics.outOfOrder).toBe(0);
+    const thread = view.threads.find((t) => t.thread_id === "cmid-1");
+    expect(
+      thread?.toolCalls.find((tc) => tc.tool_call_id === "tc-srv"),
+    ).toBeDefined();
+  });
+
+  // ── codex round-1 BLOCK 2: retry-collapse emits tool_start ────────────
+
+  it("addToolCall_retry_collapse_emits_tool_start_for_new_tool_call_id", () => {
+    // The retry-collapse path mutates the existing legacy tool entry
+    // (incrementing retryCount) and returns early. Pre-fix, no
+    // `tool_start` envelope was emitted for the NEW tool_call_id, so
+    // the projection's tool card was either keyed on the OLD id (if
+    // legacy reused it via mutation) or never opened — and any
+    // subsequent `tool_progress` for the new id would synthesise an
+    // empty-name card. Post-fix: the retry-collapse path emits a
+    // fresh `tool_start { tool_call_id: NEW, name }` envelope so the
+    // projection opens a properly-named card under the new id.
+    ThreadStore.addUserMessage(SID, {
+      text: "retry me",
+      clientMessageId: "cmid-1",
+    });
+    ThreadStore.addToolCall("cmid-1", "tc-1", "fetch_thing");
+    ThreadStore.setToolCallStatus("cmid-1", "tc-1", "error");
+    // The retry: same name, NEW id. Legacy collapses; projection
+    // must still see a `tool_start` for tc-2.
+    ThreadStore.addToolCall("cmid-1", "tc-2", "fetch_thing");
+
+    const key = projectionStoreKey(SID);
+    const log = getEnvelopes(key);
+    const startsForTc2 = log.filter(
+      (e) =>
+        e.payload.type === "tool_start" &&
+        e.payload.data.tool_call_id === "tc-2",
+    );
+    expect(startsForTc2).toHaveLength(1);
+    expect(
+      startsForTc2[0].payload.type === "tool_start" &&
+        startsForTc2[0].payload.data.name,
+    ).toBe("fetch_thing");
+
+    // And the projected view: tc-2 has a card with the right name.
+    const view = getProjection(key);
+    const thread = view.threads.find((t) => t.thread_id === "cmid-1");
+    const tc2 = thread?.toolCalls.find((tc) => tc.tool_call_id === "tc-2");
+    expect(tc2).toBeDefined();
+    expect(tc2?.name).toBe("fetch_thing");
+  });
+
+  // ── codex round-1 BLOCK 3: finalizeAssistant emits tool_end on sweep ──
+
+  it("finalizeAssistant_emits_tool_end_for_swept_running_tool_calls_before_turn_completed", () => {
+    // Legacy `finalizeAssistant` sweeps any tool calls still in
+    // `"running"` to `"complete"` (the wire never delivered a
+    // `tool_end` for them). Pre-fix, the projection's tool card
+    // stayed in `status: null` because no `tool_end` envelope was
+    // emitted, AND the subsequent `turn_completed` envelope's hard
+    // barrier meant a late tool_end on the wire could never close
+    // the card. Post-fix: finalize emits a synthetic `tool_end`
+    // BEFORE `turn_completed` for every swept call.
+    ThreadStore.addUserMessage(SID, {
+      text: "run pipeline",
+      clientMessageId: "cmid-1",
+    });
+    ThreadStore.addToolCall("cmid-1", "tc-A", "step_one");
+    ThreadStore.addToolCall("cmid-1", "tc-B", "step_two");
+    // tc-B finishes explicitly via tool_end; tc-A is left running.
+    ThreadStore.setToolCallStatus("cmid-1", "tc-B", "complete");
+    // Now finalize — the sweep should close tc-A in the projection.
+    ThreadStore.finalizeAssistant("cmid-1", { committedSeq: 7 });
+
+    const key = projectionStoreKey(SID);
+    const log = getEnvelopes(key);
+
+    // Find the indices of tool_end events for tc-A and the
+    // turn_completed event — the tool_end MUST come first.
+    const tcAEndIdx = log.findIndex(
+      (e) =>
+        e.payload.type === "tool_end" &&
+        e.payload.data.tool_call_id === "tc-A",
+    );
+    const turnCompletedIdx = log.findIndex(
+      (e) => e.payload.type === "turn_completed",
+    );
+    expect(tcAEndIdx).toBeGreaterThanOrEqual(0);
+    expect(turnCompletedIdx).toBeGreaterThanOrEqual(0);
+    expect(tcAEndIdx).toBeLessThan(turnCompletedIdx);
+
+    // And the projected view: tc-A is closed with status=complete.
+    const view = getProjection(key);
+    const thread = view.threads.find((t) => t.thread_id === "cmid-1");
+    const tcA = thread?.toolCalls.find((tc) => tc.tool_call_id === "tc-A");
+    expect(tcA?.status).toBe("complete");
+    expect(thread?.completed).toBe(true);
+  });
+
+  // ── codex round-1 BLOCK 5: mid-session flag flip is ignored ───────────
+
+  it("mid_session_projection_v1_flag_flip_is_ignored_until_reload", () => {
+    // The flag is read once and cached on first call; a subsequent
+    // localStorage flip is logged as a one-shot warning and
+    // otherwise ignored — pre-fix, flipping the flag mid-session
+    // would start the projection log from the next shimmed event
+    // with no prior envelope history, leaving the projection in an
+    // inconsistent state.
+    //
+    // First read latches the cache at "true" (from the suite's
+    // `beforeEach`). Now flip localStorage to "0" WITHOUT calling
+    // `__setProjectionV1ForTests` (the test helper resets the
+    // cache); the cached value should win.
+    const warnSpy = vi
+      .spyOn(console, "warn")
+      .mockImplementation(() => undefined);
+    try {
+      // Prime the cache by issuing a mutation under projectionV1=true.
+      ThreadStore.addUserMessage(SID, {
+        text: "first",
+        clientMessageId: "cm-1",
+      });
+      ThreadStore.appendAssistantToken("cm-1", "hello");
+
+      const key = projectionStoreKey(SID);
+      expect(getEnvelopes(key).length).toBeGreaterThan(0);
+      const beforeFlipCount = getEnvelopes(key).length;
+
+      // Flip the raw flag bypassing the test helper.
+      globalThis.localStorage?.removeItem("octos_projection_v1");
+
+      // Subsequent mutation should STILL emit envelopes (the cached
+      // value wins), AND a single console.warn should fire.
+      ThreadStore.appendAssistantToken("cm-1", " world");
+      const afterFlipCount = getEnvelopes(key).length;
+      expect(afterFlipCount).toBeGreaterThan(beforeFlipCount);
+      expect(warnSpy).toHaveBeenCalledTimes(1);
+      expect(warnSpy.mock.calls[0][0]).toMatch(/octos_projection_v1/);
+
+      // Multiple subsequent mutations DO NOT spam the warning —
+      // it's a one-shot.
+      ThreadStore.appendAssistantToken("cm-1", "!");
+      ThreadStore.appendAssistantToken("cm-1", "?");
+      expect(warnSpy).toHaveBeenCalledTimes(1);
+    } finally {
+      warnSpy.mockRestore();
+    }
+  });
 });

--- a/src/store/thread-store.ts
+++ b/src/store/thread-store.ts
@@ -1236,19 +1236,12 @@ export function stampPendingHistorySeq(
   // `message/persisted` that arrived BEFORE its `message/delta`.
   // Intentionally no envelope emission here.
   //
-  // Why this no-op is safe under the projection (codex round-1
-  // BLOCK 4): the `historySeq` value here is the SERVER-issued seq
-  // (non-negative). After BLOCK 1's namespace separation, the server
-  // namespace is disjoint from the synthetic namespace minted by the
-  // shim, so this stamp doesn't need to be reflected in the
-  // projection log to keep dedup honest — the server seq will arrive
-  // on the wire as part of the eventual `assistant_persisted` /
-  // `turn_completed` envelope, and THAT envelope is what carries the
-  // text/meta the projection needs. Pre-fix (when synthetic and
-  // server seqs shared a namespace) a stamp-without-emission could
-  // have caused the eventual server-side envelope to be dropped as
-  // an out-of-order duplicate of an earlier synthetic seq; that race
-  // can no longer happen.
+  // Why this no-op is safe under the projection: the `historySeq`
+  // stamp is purely a legacy reducer detail. The projection's gap-
+  // buffer applies envelopes in canonical `(thread_id, seq)` order on
+  // arrival; the eventual `assistant_persisted` / `turn_completed`
+  // envelope is what finalises the bubble. A bare stamp without
+  // text/meta carries no projection-relevant payload, so we elide it.
 }
 
 export interface FinalizeAssistantOptions {

--- a/src/store/thread-store.ts
+++ b/src/store/thread-store.ts
@@ -713,6 +713,24 @@ export function addToolCall(
       progress: last.progress,
     };
     notify();
+
+    // M9-γ-3 dual-write (codex round-1 BLOCK 2): the retry-collapse
+    // path mutates legacy state in place but the wire still receives a
+    // fresh `tool_start` for the NEW `tool_call_id`. The projection
+    // keys tool cards on `tool_call_id`, so without this emission a
+    // retry would never open a card for the new id and any subsequent
+    // `tool_progress` / `tool_end` envelope would synthesise an
+    // empty-name placeholder card (γ-2's "progress without a prior
+    // start" path) — mismatching the legacy reducer's view.
+    if (isProjectionV1Enabled() && toolCallId) {
+      const key = shimResolveKey(threadId);
+      if (key) {
+        shimIngest(key, threadId, {
+          type: "tool_start",
+          data: { tool_call_id: toolCallId, name },
+        });
+      }
+    }
     return;
   }
 
@@ -1216,10 +1234,21 @@ export function stampPendingHistorySeq(
   // `persisted_at`); a bare seq-stamp without text/meta is purely a
   // legacy bookkeeping fix the v1 router needs to acknowledge a
   // `message/persisted` that arrived BEFORE its `message/delta`.
-  // Intentionally no envelope emission here — γ-2's projection has no
-  // payload variant for this and the seq itself is not (yet) used by
-  // the projection's identity. (Captured as a deferred edge case in
-  // the M9-γ-3 PR description.)
+  // Intentionally no envelope emission here.
+  //
+  // Why this no-op is safe under the projection (codex round-1
+  // BLOCK 4): the `historySeq` value here is the SERVER-issued seq
+  // (non-negative). After BLOCK 1's namespace separation, the server
+  // namespace is disjoint from the synthetic namespace minted by the
+  // shim, so this stamp doesn't need to be reflected in the
+  // projection log to keep dedup honest — the server seq will arrive
+  // on the wire as part of the eventual `assistant_persisted` /
+  // `turn_completed` envelope, and THAT envelope is what carries the
+  // text/meta the projection needs. Pre-fix (when synthetic and
+  // server seqs shared a namespace) a stamp-without-emission could
+  // have caused the eventual server-side envelope to be dropped as
+  // an out-of-order duplicate of an earlier synthetic seq; that race
+  // can no longer happen.
 }
 
 export interface FinalizeAssistantOptions {
@@ -1249,9 +1278,17 @@ export function finalizeAssistant(
     // lost over the wire would otherwise leave the chip spinning forever.
     // Only flip running → complete; preserve "error" and existing
     // "complete" entries (tool_end already arrived for those).
-    const sweptToolCalls = thread.pendingAssistant.toolCalls.map((tc) =>
-      tc.status === "running" ? { ...tc, status: "complete" as const } : tc,
-    );
+    // Also remember which ids were swept so the projection dual-write
+    // below can emit synthetic `tool_end` envelopes for them BEFORE
+    // `turn_completed` (codex round-1 BLOCK 3).
+    const sweptToolCallIds: string[] = [];
+    const sweptToolCalls = thread.pendingAssistant.toolCalls.map((tc) => {
+      if (tc.status === "running") {
+        if (tc.id) sweptToolCallIds.push(tc.id);
+        return { ...tc, status: "complete" as const };
+      }
+      return tc;
+    });
 
     const finalized: ThreadMessage = {
       ...thread.pendingAssistant,
@@ -1277,6 +1314,21 @@ export function finalizeAssistant(
     if (isProjectionV1Enabled()) {
       const key = shimResolveKey(threadId);
       if (key) {
+        // codex round-1 BLOCK 3: emit a synthetic `tool_end` for every
+        // tool call that legacy `finalizeAssistant` swept from
+        // `running` → `complete` (the wire never delivered an explicit
+        // tool_end). MUST happen BEFORE `turn_completed` since the
+        // projection's hard barrier drops anything after a thread is
+        // marked complete — a late tool_end on the wire would never
+        // reach the projection's tool card. Empty-id calls (legacy
+        // daemon path) are skipped at sweep-collection time.
+        for (const sweptId of sweptToolCallIds) {
+          shimIngest(key, threadId, {
+            type: "tool_end",
+            data: { tool_call_id: sweptId, status: "complete" },
+          });
+        }
+
         const meta = opts.meta ?? finalized.meta;
         const usage =
           meta !== undefined

--- a/src/store/thread-store.ts
+++ b/src/store/thread-store.ts
@@ -22,6 +22,17 @@ import { getMessages as fetchMessages } from "@/api/sessions";
 import type { MessageInfo } from "@/api/types";
 import { displayFilenameFromPath } from "@/lib/utils";
 import { recordRuntimeCounter } from "@/runtime/observability";
+import type {
+  Envelope,
+  EnvelopeToolEndStatus,
+  Payload,
+} from "@/runtime/ui-protocol-types";
+import {
+  ingest as projectionIngest,
+  isProjectionV1Enabled,
+  nextSeq as projectionNextSeq,
+  projectionStoreKey,
+} from "./projection-store";
 
 // ---------------------------------------------------------------------------
 // Types
@@ -176,6 +187,20 @@ function findThreadById(
   return null;
 }
 
+/** Find the storeKey hosting the given thread. Used by the projection-mode
+ *  shim: legacy entry points like `appendAssistantToken` carry a
+ *  threadId without (sessionId, topic), so the shim walks
+ *  `sessionsByKey` to find the bucket — same lookup as `findThreadById`
+ *  but returning the key string for `projectionIngest()`. Returns null
+ *  when the thread is not yet hosted (caller should skip the dual-write
+ *  rather than silently invent a bucket). */
+function findStoreKeyForThread(threadId: string): string | null {
+  for (const [key, state] of sessionsByKey.entries()) {
+    if (state.byId.has(threadId)) return key;
+  }
+  return null;
+}
+
 /** Pick a "best guess" session to host a brand-new orphan thread bucket
  *  created in response to a late background event whose user message we
  *  never saw (page reload, multi-tab, etc.). Picks the session with the
@@ -318,6 +343,104 @@ function sortResponsesInThread(thread: Thread): void {
 }
 
 // ---------------------------------------------------------------------------
+// Projection-mode shim (M9-γ-3, issue #840)
+//
+// When the `octos_projection_v1` localStorage flag is `"1"`, every
+// legacy mutation entry point ALSO synthesizes an `Envelope` and
+// ingests it into the projection store (`./projection-store.ts`). The
+// legacy reducer continues to run unchanged so `getThreads()` keeps
+// returning the same `Thread[]` shape — that's why the existing 191
+// tests pass under both flag states. The projection log accumulates in
+// parallel; new projection-only tests assert against
+// `getProjection()`.
+//
+// Seq synthesis: per-(storeKey, threadId) monotonic counter inside
+// `projection-store`. Deterministic, NOT `Date.now()` — when γ-5 stops
+// using the legacy reducer, the projection re-projects the same log
+// and produces a byte-identical view.
+// ---------------------------------------------------------------------------
+
+/** Resolve the storeKey for a thread when only the threadId is in
+ *  hand. Walks live sessions; returns null when the thread has not yet
+ *  been routed (e.g. the very first call before `addUserMessage`). The
+ *  shim uses this to skip translating envelopes for un-routed threads —
+ *  no information is lost; the projection just doesn't see the event,
+ *  same as if the legacy reducer dropped it as orphan-without-host. */
+function shimResolveKey(threadId: string): string | null {
+  return findStoreKeyForThread(threadId);
+}
+
+/** Pending `client_message_id` per (storeKey, threadId). Set when
+ *  `addUserMessage` opens a thread; consumed (cleared) on the FIRST
+ *  envelope emitted for that thread so the cmid lands exactly once on
+ *  the wire. The projection captures the cmid into its `UserView` from
+ *  the first envelope it sees for a given thread. */
+const pendingClientMessageIds = new Map<string, Map<string, string>>();
+
+function setPendingClientMessageId(
+  storeKey: string,
+  threadId: string,
+  cmid: string,
+): void {
+  let perThread = pendingClientMessageIds.get(storeKey);
+  if (!perThread) {
+    perThread = new Map();
+    pendingClientMessageIds.set(storeKey, perThread);
+  }
+  perThread.set(threadId, cmid);
+}
+
+function consumePendingClientMessageId(
+  storeKey: string,
+  threadId: string,
+): string | undefined {
+  const perThread = pendingClientMessageIds.get(storeKey);
+  if (!perThread) return undefined;
+  const cmid = perThread.get(threadId);
+  if (cmid === undefined) return undefined;
+  perThread.delete(threadId);
+  return cmid;
+}
+
+/** Translate-and-ingest helper for the dual-write path. Handles the
+ *  pending-cmid handoff so a thread's first envelope carries the
+ *  client_message_id without callers having to thread it through every
+ *  shim site explicitly. */
+function shimIngest(
+  storeKey: string,
+  threadId: string,
+  payload: Payload,
+  options: { client_message_id?: string; seq?: number } = {},
+): void {
+  const seq = options.seq ?? projectionNextSeq(storeKey, threadId);
+  const cmid =
+    options.client_message_id !== undefined
+      ? options.client_message_id
+      : consumePendingClientMessageId(storeKey, threadId);
+  const envelope: Envelope = {
+    thread_id: threadId,
+    seq,
+    payload,
+    ...(cmid !== undefined ? { client_message_id: cmid } : {}),
+  };
+  projectionIngest(storeKey, envelope);
+}
+
+/** Map a legacy `ThreadToolCall.status` (which carries `"running"` for
+ *  in-flight calls) to the projection's `tool_end` status enum
+ *  (`"complete" | "error"`). The projection has no concept of a
+ *  running/in-flight tool — `tool_start` opens, `tool_end` closes.
+ *  `"running"` is a no-op signal that does not warrant a `tool_end`
+ *  envelope; the shim returns null and the caller skips emission. */
+function shimMapToolEndStatus(
+  status: "running" | "complete" | "error",
+): EnvelopeToolEndStatus | null {
+  if (status === "complete") return "complete";
+  if (status === "error") return "error";
+  return null;
+}
+
+// ---------------------------------------------------------------------------
 // Public API — mutators
 // ---------------------------------------------------------------------------
 
@@ -422,6 +545,18 @@ export function addUserMessage(
   };
   insertThreadInTimestampOrder(state, thread);
   notify();
+
+  // M9-γ-3 dual-write: a fresh user message roots the thread. The
+  // projection has no `user_message` payload variant — user identity
+  // is captured implicitly from the FIRST envelope that names a given
+  // `thread_id` (per γ-2 `projection.ts` § "Capture user identity").
+  // We register the cmid in the pending-cmid map so the next envelope
+  // for this thread carries `client_message_id` on the wire — that's
+  // what γ-4's GhostBubble overlay matches against.
+  if (isProjectionV1Enabled()) {
+    setPendingClientMessageId(key, thread.id, opts.clientMessageId);
+  }
+
   return {
     threadId: thread.id,
     pendingAssistantId: pendingAssistant.id,
@@ -457,6 +592,17 @@ export function appendAssistantToken(threadId: string, token: string): void {
   const slot = ensurePendingAssistant(found.thread);
   slot.text += token;
   notify();
+
+  // M9-γ-3 dual-write: streamed token → assistant_delta envelope.
+  if (isProjectionV1Enabled()) {
+    const key = shimResolveKey(threadId);
+    if (key) {
+      shimIngest(key, threadId, {
+        type: "assistant_delta",
+        data: { text: token },
+      });
+    }
+  }
 }
 
 export function replaceAssistantText(threadId: string, text: string): void {
@@ -472,6 +618,24 @@ export function replaceAssistantText(threadId: string, text: string): void {
   const slot = ensurePendingAssistant(found.thread);
   slot.text = text;
   notify();
+
+  // M9-γ-3 dual-write: legacy `replace` semantics has no direct
+  // projection counterpart (projection accumulates deltas + finalises
+  // on `assistant_persisted`). Emit the full replacement text as an
+  // `assistant_delta`. This is OK for the migration window: projection
+  // and legacy disagree on accumulated text shape, but legacy is the
+  // current truth source for `getThreads()`. γ-5 will retire the legacy
+  // path entirely; by then the SSE bridge no longer emits `replace`
+  // events (only deltas + persisted), so the drift goes away.
+  if (isProjectionV1Enabled()) {
+    const key = shimResolveKey(threadId);
+    if (key) {
+      shimIngest(key, threadId, {
+        type: "assistant_delta",
+        data: { text },
+      });
+    }
+  }
 }
 
 /**
@@ -560,6 +724,21 @@ export function addToolCall(
     retryCount: 0,
   });
   notify();
+
+  // M9-γ-3 dual-write: tool_start envelope. The projection requires a
+  // non-empty `tool_call_id` for routing (it keys on `tool_call_id`);
+  // legacy supports the empty-id fallback for legacy daemons. Skip the
+  // dual-write for empty-id calls — the projection isn't responsible
+  // for legacy compat, γ-5 cleanup makes the server's id mandatory.
+  if (isProjectionV1Enabled() && toolCallId) {
+    const key = shimResolveKey(threadId);
+    if (key) {
+      shimIngest(key, threadId, {
+        type: "tool_start",
+        data: { tool_call_id: toolCallId, name },
+      });
+    }
+  }
 }
 
 /** Maximum runtime progress entries kept per tool call. Old entries are
@@ -629,6 +808,21 @@ export function appendToolProgress(
     );
   }
   notify();
+
+  // M9-γ-3 dual-write: tool_progress envelope. Per the brief, the
+  // projection drops late tool_progress events that arrive after a
+  // `turn_completed` for the same thread (see the projection's hard
+  // barrier). The shim emits unconditionally; the projection itself
+  // enforces the barrier and bumps `metrics.droppedAfterTurnCompleted`.
+  if (isProjectionV1Enabled() && toolCallId) {
+    const key = shimResolveKey(threadId);
+    if (key) {
+      shimIngest(key, threadId, {
+        type: "tool_progress",
+        data: { tool_call_id: toolCallId, message },
+      });
+    }
+  }
 }
 
 export function setToolCallStatus(
@@ -657,6 +851,23 @@ export function setToolCallStatus(
   if (idx === -1) return;
   tcs[idx] = { ...tcs[idx], status };
   notify();
+
+  // M9-γ-3 dual-write: setToolCallStatus → tool_end envelope. Skip
+  // the `"running"` flavour (projection has no in-flight status —
+  // tool_start opens, tool_end closes); only `"complete"` and
+  // `"error"` translate to a wire-level `tool_end`.
+  if (isProjectionV1Enabled() && toolCallId) {
+    const endStatus = shimMapToolEndStatus(status);
+    if (endStatus !== null) {
+      const key = shimResolveKey(threadId);
+      if (key) {
+        shimIngest(key, threadId, {
+          type: "tool_end",
+          data: { tool_call_id: toolCallId, status: endStatus },
+        });
+      }
+    }
+  }
 }
 
 /**
@@ -846,6 +1057,37 @@ export function appendCompletionBubble(
   thread.responses.push(completion);
   sortResponsesInThread(thread);
   notify();
+
+  // M9-γ-3 dual-write: completion bubble → assistant_persisted envelope.
+  // The projection enforces text/meta finalisation here. Use the
+  // server-authoritative `historySeq` as the projection seq when the
+  // caller supplied one (matches the wire-level seq on a replay) so
+  // late re-emissions of the same row dedup cleanly via the
+  // projection's `(thread_id, seq)` idempotency.
+  if (isProjectionV1Enabled()) {
+    const key =
+      shimResolveKey(threadId) ??
+      (opts.sessionId
+        ? projectionStoreKey(opts.sessionId, opts.topic)
+        : null);
+    if (key) {
+      const messageId = opts.messageId ?? completion.id;
+      shimIngest(key, threadId, {
+        type: "assistant_persisted",
+        data: {
+          text: opts.text,
+          meta: {
+            message_id: messageId,
+            persisted_at:
+              opts.persistedAt ??
+              new Date(completion.timestamp).toISOString(),
+            ...(opts.media.length > 0 ? { media: opts.media.slice() } : {}),
+          },
+        },
+      }, opts.historySeq !== undefined ? { seq: opts.historySeq } : undefined);
+    }
+  }
+
   return true;
 }
 
@@ -919,6 +1161,25 @@ export function appendAssistantFile(
   if (slot.files.some((f) => f.path === file.path)) return true;
   slot.files = [...slot.files, file];
   notify();
+
+  // M9-γ-3 dual-write: file delivery → file_attached envelope. Legacy
+  // `MessageFile` doesn't carry `mime` / `size_bytes`; use defensible
+  // defaults that the projection accepts (the wire-level event always
+  // carries both, this is only the migration-time shim).
+  if (isProjectionV1Enabled()) {
+    const key = shimResolveKey(threadId);
+    if (key) {
+      shimIngest(key, threadId, {
+        type: "file_attached",
+        data: {
+          path: file.path,
+          mime: "",
+          size_bytes: 0,
+        },
+      });
+    }
+  }
+
   return true;
 }
 
@@ -948,6 +1209,17 @@ export function stampPendingHistorySeq(
       found.thread.pendingAssistant.intra_thread_seq ?? historySeq,
   };
   notify();
+
+  // M9-γ-3 dual-write: stamp-only operation has no projection
+  // counterpart. The projection finalises bubbles on
+  // `assistant_persisted` (which carries `meta.message_id` +
+  // `persisted_at`); a bare seq-stamp without text/meta is purely a
+  // legacy bookkeeping fix the v1 router needs to acknowledge a
+  // `message/persisted` that arrived BEFORE its `message/delta`.
+  // Intentionally no envelope emission here — γ-2's projection has no
+  // payload variant for this and the seq itself is not (yet) used by
+  // the projection's identity. (Captured as a deferred edge case in
+  // the M9-γ-3 PR description.)
 }
 
 export interface FinalizeAssistantOptions {
@@ -994,6 +1266,36 @@ export function finalizeAssistant(
     sortResponsesInThread(thread);
     thread.pendingAssistant = null;
     notify();
+
+    // M9-γ-3 dual-write: finalize → turn_completed envelope (the
+    // projection's hard barrier). Maps token usage best-effort from
+    // the legacy `meta` (which carries `tokens_in` / `tokens_out` —
+    // we mirror them onto the projection's `input_tokens` /
+    // `output_tokens`). The barrier is what the brief's projection-
+    // only test "Late `tool_progress` after `turn_completed`"
+    // exercises.
+    if (isProjectionV1Enabled()) {
+      const key = shimResolveKey(threadId);
+      if (key) {
+        const meta = opts.meta ?? finalized.meta;
+        const usage =
+          meta !== undefined
+            ? {
+                ...(meta.tokens_in
+                  ? { input_tokens: meta.tokens_in }
+                  : {}),
+                ...(meta.tokens_out
+                  ? { output_tokens: meta.tokens_out }
+                  : {}),
+              }
+            : {};
+        shimIngest(key, threadId, {
+          type: "turn_completed",
+          data: { token_usage: usage },
+        });
+      }
+    }
+
     return;
   }
 }
@@ -2065,6 +2367,32 @@ export function appendPersistedMessage(
   thread.responses.push(built);
   sortResponsesInThread(thread);
   notify();
+
+  // M9-γ-3 dual-write: a persisted assistant row corresponds to an
+  // `assistant_persisted` envelope. Tool/system rows have no projection
+  // counterpart in γ-2 (the projection's payload tagged-union doesn't
+  // carry tool-result rows — they live as `tool_end` + per-tool
+  // progress). Limit the dual-write to assistant rows for now; γ-5
+  // will fold tool persistence into the projection's surface.
+  if (isProjectionV1Enabled() && built.role === "assistant") {
+    const key = projectionStoreKey(sessionId, topic);
+    const messageId = built.id;
+    const persistedAt = message.timestamp
+      ? new Date(message.timestamp).toISOString()
+      : new Date().toISOString();
+    const media = (message.media ?? []).slice();
+    shimIngest(key, threadId, {
+      type: "assistant_persisted",
+      data: {
+        text: built.text,
+        meta: {
+          message_id: messageId,
+          persisted_at: persistedAt,
+          ...(media.length > 0 ? { media } : {}),
+        },
+      },
+    }, built.historySeq !== undefined ? { seq: built.historySeq } : undefined);
+  }
 }
 
 // ---------------------------------------------------------------------------
@@ -2132,6 +2460,7 @@ export function clearSession(sessionId: string, topic?: string): void {
     loadedSessions.delete(key);
     loadingPromises.delete(key);
     hydrateSnapshotByKey.delete(key);
+    pendingClientMessageIds.delete(key);
   } else {
     for (const k of [...sessionsByKey.keys()]) {
       if (k === sessionId || k.startsWith(`${sessionId}#`)) {
@@ -2139,6 +2468,7 @@ export function clearSession(sessionId: string, topic?: string): void {
         loadedSessions.delete(k);
         loadingPromises.delete(k);
         hydrateSnapshotByKey.delete(k);
+        pendingClientMessageIds.delete(k);
       }
     }
     // Codex round-5 P3: a hydrate snapshot may exist without a
@@ -2249,6 +2579,7 @@ export function __resetForTests(): void {
   loadingPromises.clear();
   snapshotCache.clear();
   hydrateSnapshotByKey.clear();
+  pendingClientMessageIds.clear();
   version = 0;
   idCounter = 0;
 }


### PR DESCRIPTION
## Summary

- Behind a `projection_v1` localStorage flag (`octos_projection_v1` === \"1\"), `ThreadStore` translates every legacy mutation entry point into a γ-2 `Envelope` and ingests it into a new committed-log store (`src/store/projection-store.ts`). The legacy reducer continues to back `getThreads()` so all existing thread-store tests pass under both flag states; the projection's `ChatViewModel` is the deterministic foundation γ-5 will switch the renderer over to.
- Shim translation: `addUserMessage` registers cmid for the next envelope; `appendAssistantToken`/`replaceAssistantText` → `assistant_delta`; `addToolCall` → `tool_start`; `appendToolProgress` → `tool_progress`; `setToolCallStatus` → `tool_end`; `appendCompletionBubble`/`appendPersistedMessage` → `assistant_persisted`; `appendAssistantFile` → `file_attached`; `finalizeAssistant` → `turn_completed`. `stampPendingHistorySeq` has no γ-2 counterpart and is a deliberate no-op (deferred edge case, captured in code comments).
- Seq synthesis is per-(storeKey, threadId) monotonic in `projection-store.nextSeq` — NOT `Date.now()` — so re-projection of the committed log is byte-deterministic.
- Refs: ADR `docs/M9-GAMMA-SERVER-PROJECTION-ADR.md` (PR octos-org/octos#830); γ-2 `src/store/projection.ts` (PR #93). Closes octos-org/octos#840.

## Test plan

- [x] `npx vitest run src/store/thread-store.test.ts` — 158 tests pass (76 existing × 2 flag states = 152 parameterised + 6 new projection-only tests).
- [x] `npx vitest run` — full unit suite: 289 tests pass across 8 files.
- [x] `npx tsc --noEmit` — clean.
- [x] `npx tsc -b` — clean.
- [x] `npx eslint src/store/projection-store.ts src/store/thread-store.ts src/store/thread-store.test.ts` — clean.
- [x] Five-plus projection-only tests covering brief's scenarios:
  - phantom-bubble repro (two `assistant_persisted` envelopes at seq 1 and 3 collapse into one bubble)
  - late `tool_progress` after `turn_completed` (dropped by hard barrier; `metrics.droppedAfterTurnCompleted` bumps)
  - out-of-order delivery (seq=3 then seq=2 → seq=2 dropped; `metrics.outOfOrder` bumps)
  - cross-session orphan envelope (no orphan-bucket allocation needed)
  - identity collapse (`client_message_id` captured for γ-4 overlay but never used for projection identity)
  - shim seq monotonicity (per-thread independent counters)

## Deferred (γ-3.5 / γ-5 / γ-6)

- Legacy reducers stay alive in this PR; γ-5 cuts over `getThreads()` to read from `getProjection()` and γ-6 deletes the legacy state machine.
- `stampPendingHistorySeq` has no γ-2 payload variant; deferred until γ-2 surface is widened or the legacy seq-stamp is retired.
- `replaceAssistantText` emits `assistant_delta` with the full text — projection accumulates rather than replaces. Acknowledged drift; goes away in γ-5 when the SSE bridge stops emitting `replace`.
- `appendPersistedMessage` limits the dual-write to assistant rows (tool/system rows have no γ-2 payload variant).