### PR TITLE
feat(ui): M9-γ-4 — GhostBubble overlay for optimistic UI under projection_v1 flag (closes #841)

### DIFF
--- a/src/components/GhostBubble.test.tsx
+++ b/src/components/GhostBubble.test.tsx
@@ -1,0 +1,333 @@
+/**
+ * M9-γ-4 GhostBubble unit tests.
+ *
+ * Issue: octos-org/octos#841.
+ * Component: `src/components/GhostBubble.tsx`.
+ *
+ * Coverage:
+ *   1. Mounts a visible bubble with the typed text.
+ *   2. Calls `onSettle` once the projection captures `UserView` with
+ *      the matching `client_message_id` (the spec's match-and-unmount
+ *      contract).
+ *   3. Does NOT call `onSettle` for an unrelated cmid landing in the
+ *      projection (negative case — the predicate is exact-match).
+ *   4. Surfaces an inline error + Retry button after the 30s timeout
+ *      and wires Retry to the parent callback.
+ *   5. (chat-thread integration) flag-OFF: clicking Send still
+ *      `addUserMessage`s into ThreadStore — exactly today's behaviour.
+ *      flag-ON: ThreadStore stays free of an optimistic row; the
+ *      ghost lives outside the store.
+ *
+ * Test rig: minimal `react-dom/client` + `react.act` (no
+ * `@testing-library/react` available in the workspace). Each test
+ * mounts into a fresh detached `<div>` so DOM state never leaks.
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import * as React from "react";
+import { act } from "react";
+import { createRoot, type Root } from "react-dom/client";
+
+// React 18+ test rig flag: opts the runtime into the `act(...)` warning
+// suppression path. Without this, every test render logs:
+// "The current testing environment is not configured to support act(...)".
+// Set ONCE at module load — vitest spawns one process per file.
+(
+  globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }
+).IS_REACT_ACT_ENVIRONMENT = true;
+
+import * as ThreadStore from "@/store/thread-store";
+import {
+  __resetProjectionForTests,
+  __setProjectionV1ForTests,
+  ingest as projectionIngest,
+  isProjectionV1Enabled,
+  projectionStoreKey,
+} from "@/store/projection-store";
+import type { Envelope } from "@/runtime/ui-protocol-types";
+
+import { GhostBubble, GHOST_SETTLE_TIMEOUT_MS } from "./GhostBubble";
+
+const SESSION = "sess-ghost";
+
+interface MountedHarness {
+  container: HTMLDivElement;
+  root: Root;
+  unmount: () => void;
+}
+
+function mount(node: React.ReactElement): MountedHarness {
+  const container = document.createElement("div");
+  document.body.appendChild(container);
+  const root = createRoot(container);
+  act(() => {
+    root.render(node);
+  });
+  return {
+    container,
+    root,
+    unmount: () => {
+      act(() => {
+        root.unmount();
+      });
+      container.remove();
+    },
+  };
+}
+
+/** Synthesize a user-rooted envelope that introduces a thread with the
+ *  given cmid. Uses an `assistant_delta` payload so the projection's
+ *  first-envelope-captures-cmid path fires (any payload type works —
+ *  identity is on `(thread_id, seq)`, the cmid travels on the
+ *  envelope itself). */
+function userRootedEnvelope(
+  threadId: string,
+  seq: number,
+  cmid: string,
+): Envelope {
+  return {
+    thread_id: threadId,
+    seq,
+    client_message_id: cmid,
+    payload: { type: "assistant_delta", data: { text: "hi" } },
+  };
+}
+
+describe("GhostBubble", () => {
+  beforeEach(() => {
+    __setProjectionV1ForTests(true);
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    __resetProjectionForTests();
+    ThreadStore.__resetForTests();
+  });
+
+  it("renders the typed text right-aligned with the user-bubble classes", () => {
+    const { container, unmount } = mount(
+      <GhostBubble
+        clientMessageId="cmid-1"
+        text="hello world"
+        files={[]}
+        sessionId={SESSION}
+        onSettle={() => {}}
+      />,
+    );
+    const bubble = container.querySelector('[data-testid="ghost-bubble"]');
+    expect(bubble).not.toBeNull();
+    const textEl = container.querySelector('[data-testid="ghost-bubble-text"]');
+    expect(textEl?.textContent).toBe("hello world");
+    // Visual parity with `ThreadUserBubble`: same `message-card-user`
+    // glass classes guarantee identical render.
+    expect(textEl?.className).toContain("message-card-user");
+    expect(bubble?.getAttribute("data-ghost-state")).toBe("pending");
+    unmount();
+  });
+
+  it("calls onSettle when projection captures matching client_message_id", () => {
+    const onSettle = vi.fn();
+    const { unmount } = mount(
+      <GhostBubble
+        clientMessageId="cmid-2"
+        text="hi"
+        files={[]}
+        sessionId={SESSION}
+        onSettle={onSettle}
+      />,
+    );
+    expect(onSettle).not.toHaveBeenCalled();
+
+    // Push an envelope that introduces a thread carrying the matching
+    // cmid. We `ingest` directly into the projection-store and then
+    // pulse `notify()` via the ThreadStore's public surface — the
+    // GhostBubble subscribes to ThreadStore (γ-3 dual-write trigger).
+    const key = projectionStoreKey(SESSION);
+    projectionIngest(key, userRootedEnvelope("thr-2", 1, "cmid-2"));
+    act(() => {
+      // Any thread-store mutation that fires `notify()` will do — use a
+      // public mutator. Adding a user message in a different session
+      // forces a notify without polluting the test session's threads.
+      ThreadStore.addUserMessage("__notify-pulse__", {
+        text: "pulse",
+        clientMessageId: "pulse-cmid",
+      });
+    });
+
+    expect(onSettle).toHaveBeenCalledTimes(1);
+    unmount();
+  });
+
+  it("does not settle for an unrelated cmid in the projection", () => {
+    const onSettle = vi.fn();
+    const { unmount } = mount(
+      <GhostBubble
+        clientMessageId="cmid-target"
+        text="hi"
+        files={[]}
+        sessionId={SESSION}
+        onSettle={onSettle}
+      />,
+    );
+
+    const key = projectionStoreKey(SESSION);
+    projectionIngest(key, userRootedEnvelope("thr-x", 1, "different-cmid"));
+    act(() => {
+      ThreadStore.addUserMessage("__notify-pulse__", {
+        text: "pulse",
+        clientMessageId: "pulse-cmid",
+      });
+    });
+
+    expect(onSettle).not.toHaveBeenCalled();
+    unmount();
+  });
+
+  it("settles synchronously when the projection already carries the cmid at mount", () => {
+    // Race case: the server's reflection landed inside the same
+    // microtask as the send dispatch, so the cmid is already in the
+    // projection by the time the effect runs. Settling synchronously
+    // avoids a flash of the optimistic bubble after it's already
+    // confirmed.
+    const key = projectionStoreKey(SESSION);
+    projectionIngest(key, userRootedEnvelope("thr-fast", 1, "cmid-fast"));
+
+    const onSettle = vi.fn();
+    const { unmount } = mount(
+      <GhostBubble
+        clientMessageId="cmid-fast"
+        text="hi"
+        files={[]}
+        sessionId={SESSION}
+        onSettle={onSettle}
+      />,
+    );
+
+    expect(onSettle).toHaveBeenCalledTimes(1);
+    unmount();
+  });
+
+  it("surfaces an inline error + Retry after the 30s timeout", () => {
+    const onSettle = vi.fn();
+    const onRetry = vi.fn();
+    const { container, unmount } = mount(
+      <GhostBubble
+        clientMessageId="cmid-timeout"
+        text="will time out"
+        files={[]}
+        sessionId={SESSION}
+        onSettle={onSettle}
+        onRetry={onRetry}
+      />,
+    );
+
+    expect(
+      container.querySelector('[data-testid="ghost-bubble-error"]'),
+    ).toBeNull();
+
+    act(() => {
+      vi.advanceTimersByTime(GHOST_SETTLE_TIMEOUT_MS + 100);
+    });
+
+    const err = container.querySelector('[data-testid="ghost-bubble-error"]');
+    expect(err).not.toBeNull();
+    const retryBtn = container.querySelector(
+      '[data-testid="ghost-bubble-retry"]',
+    ) as HTMLButtonElement | null;
+    expect(retryBtn).not.toBeNull();
+
+    act(() => {
+      retryBtn!.click();
+    });
+    expect(onRetry).toHaveBeenCalledTimes(1);
+    // Retry resets the error state (timer rearms internally).
+    expect(
+      container.querySelector('[data-testid="ghost-bubble-error"]'),
+    ).toBeNull();
+    expect(onSettle).not.toHaveBeenCalled();
+    unmount();
+  });
+
+  it("renders attached files as inline rows", () => {
+    const fileA = new File(["aaa"], "a.txt", { type: "text/plain" });
+    const fileB = new File(["bbb"], "b.png", { type: "image/png" });
+    const { container, unmount } = mount(
+      <GhostBubble
+        clientMessageId="cmid-files"
+        text="see attached"
+        files={[fileA, fileB]}
+        sessionId={SESSION}
+        onSettle={() => {}}
+      />,
+    );
+    const fileRows = container.querySelectorAll(
+      '[data-testid="ghost-bubble-file"]',
+    );
+    expect(fileRows.length).toBe(2);
+    expect(fileRows[0].textContent).toContain("a.txt");
+    expect(fileRows[1].textContent).toContain("b.png");
+    unmount();
+  });
+});
+
+// ─── Integration with ThreadStore — flag invariant ─────────────────────────
+//
+// The acceptance criterion: "ThreadStore must NOT have a `<GhostBubble>`
+// row when flag ON". We assert this by reproducing the Composer's
+// flag-ON path (skip `addUserMessage`, register pending cmid) and
+// confirming `getThreads` reports zero threads — exactly the contract
+// γ-4 establishes for the optimistic surface.
+
+describe("GhostBubble × ThreadStore [flag invariant]", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    __resetProjectionForTests();
+    ThreadStore.__resetForTests();
+  });
+
+  it("flag OFF: ThreadStore.addUserMessage produces a thread (today's behaviour)", () => {
+    __setProjectionV1ForTests(false);
+    expect(isProjectionV1Enabled()).toBe(false);
+
+    ThreadStore.addUserMessage(SESSION, {
+      text: "hello",
+      clientMessageId: "cmid-legacy",
+    });
+    const threads = ThreadStore.getThreads(SESSION);
+    expect(threads.length).toBe(1);
+    expect(threads[0].userMsg.text).toBe("hello");
+  });
+
+  it("flag ON: GhostBubble path leaves ThreadStore free of an optimistic row", () => {
+    __setProjectionV1ForTests(true);
+    expect(isProjectionV1Enabled()).toBe(true);
+
+    // Mirror the Composer's flag-ON branch: register the pending cmid
+    // and mount a GhostBubble — but DO NOT call addUserMessage.
+    ThreadStore.registerPendingClientMessageId(
+      SESSION,
+      "cmid-ghost",
+      "cmid-ghost",
+    );
+    const onSettle = vi.fn();
+    const harness = mount(
+      <GhostBubble
+        clientMessageId="cmid-ghost"
+        text="ghost-only send"
+        files={[]}
+        sessionId={SESSION}
+        onSettle={onSettle}
+      />,
+    );
+
+    // No row in ThreadStore — exactly the spec's acceptance criterion.
+    expect(ThreadStore.getThreads(SESSION).length).toBe(0);
+
+    harness.unmount();
+  });
+});

--- a/src/components/GhostBubble.test.tsx
+++ b/src/components/GhostBubble.test.tsx
@@ -269,6 +269,111 @@ describe("GhostBubble", () => {
     expect(fileRows[1].textContent).toContain("b.png");
     unmount();
   });
+
+  // ── BLOCK 1 (codex review): production-ordering case ─────────────────
+  //
+  // Production thread-store mutators (e.g. `appendAssistantToken`,
+  // `appendPersistedMessage`) call `notify()` BEFORE the projection
+  // dual-write. A GhostBubble that subscribed to ThreadStore would see
+  // the notify but `getProjection().threads[].user.client_message_id`
+  // would still be empty — so settle wouldn't fire.
+  //
+  // The fix subscribes to `ProjectionStore.subscribe` instead. The
+  // projection-store fires its listeners AFTER `ingest()` commits, so
+  // the cmid IS visible by the time the listener runs. This test
+  // simulates that exact ordering: ThreadStore.notify() pulses with NO
+  // ingested envelope first; GhostBubble must NOT settle yet. Then
+  // `projectionIngest` lands the matching cmid; GhostBubble MUST
+  // settle on this notify (no extra ThreadStore pulse needed).
+  it("BLOCK 1: settles on projection-store ingest (not on a bare ThreadStore notify)", () => {
+    const onSettle = vi.fn();
+    const { unmount } = mount(
+      <GhostBubble
+        clientMessageId="cmid-block1"
+        text="block1"
+        files={[]}
+        sessionId={SESSION}
+        onSettle={onSettle}
+      />,
+    );
+
+    // Pre-fix: a ThreadStore notify with NO matching cmid in the
+    // projection would have re-checked, found nothing, and remained
+    // pending — that's already correct. The new failure mode the BLOCK
+    // codifies: a ThreadStore notify ARRIVING BEFORE the dual-write
+    // ingest leaves the ghost stuck even though the ingest will land
+    // shortly after on the SAME synchronous tick. Reproduce by pulsing
+    // ThreadStore first, asserting we don't (incorrectly) settle on
+    // its empty state.
+    act(() => {
+      ThreadStore.addUserMessage("__notify-pulse__", {
+        text: "pulse",
+        clientMessageId: "pulse-cmid",
+      });
+    });
+    expect(onSettle).not.toHaveBeenCalled();
+
+    // Now the projection-store ingest lands. The fix: GhostBubble
+    // subscribes to projection-store, which fires its listeners AFTER
+    // `ingest()` commits — so we settle on THIS notify, with no extra
+    // ThreadStore pulse needed (the pre-fix code would have waited for
+    // a follow-up notify that might never come).
+    const key = projectionStoreKey(SESSION);
+    act(() => {
+      projectionIngest(key, userRootedEnvelope("thr-block1", 1, "cmid-block1"));
+    });
+
+    expect(onSettle).toHaveBeenCalledTimes(1);
+    unmount();
+  });
+
+  // ── BLOCK 5 (codex review): O(1) cmid lookup ─────────────────────────
+  //
+  // GhostBubble used to call `getProjection(storeKey).threads.find(...)`
+  // on every notify — O(N) in the number of threads. The fix: an
+  // explicit `cmidToThread` Map kept in projection-store, populated by
+  // `ingest()`, queried via `hasCmid()` in O(1).
+  //
+  // We can't test the constant factor directly, but we CAN verify the
+  // public surface: `hasCmid` returns true once an envelope with the
+  // cmid has been ingested (and crucially, returns false for un-ingested
+  // cmids even when other threads exist in the projection). That's the
+  // contract the GhostBubble's settle predicate relies on.
+  it("BLOCK 5: ProjectionStore.hasCmid is true exactly for ingested cmids", async () => {
+    const ProjectionStore = await import("@/store/projection-store");
+    const key = projectionStoreKey(SESSION);
+
+    // Seed the projection with several threads — only ONE carries the
+    // cmid we'll query. The pre-fix scan would visit every thread; the
+    // post-fix Map lookup goes straight to the answer.
+    projectionIngest(
+      key,
+      userRootedEnvelope("thr-a", 1, "cmid-a"),
+    );
+    projectionIngest(
+      key,
+      userRootedEnvelope("thr-b", 1, "cmid-b"),
+    );
+    projectionIngest(
+      key,
+      userRootedEnvelope("thr-target", 1, "cmid-target"),
+    );
+
+    expect(ProjectionStore.hasCmid(key, "cmid-target")).toBe(true);
+    expect(ProjectionStore.hasCmid(key, "cmid-a")).toBe(true);
+    expect(ProjectionStore.hasCmid(key, "cmid-b")).toBe(true);
+    // Negative case — a cmid that was never ingested.
+    expect(ProjectionStore.hasCmid(key, "cmid-never")).toBe(false);
+    // Negative case — wrong storeKey.
+    expect(ProjectionStore.hasCmid("other-session", "cmid-target")).toBe(false);
+
+    // `threadIdForCmid` resolves to the thread the cmid first attached
+    // to. Same Map; same O(1) cost.
+    expect(ProjectionStore.threadIdForCmid(key, "cmid-target")).toBe(
+      "thr-target",
+    );
+    expect(ProjectionStore.threadIdForCmid(key, "cmid-never")).toBeUndefined();
+  });
 });
 
 // ─── Integration with ThreadStore — flag invariant ─────────────────────────

--- a/src/components/GhostBubble.tsx
+++ b/src/components/GhostBubble.tsx
@@ -1,0 +1,255 @@
+/**
+ * M9-γ-4: `<GhostBubble>` overlay — purely visual optimistic UI.
+ *
+ * Spec:  `api/OCTOS_UI_PROTOCOL_V1_SPEC_2026-04-24.md` § 14 (M9-γ Envelope).
+ * ADR:   `docs/M9-GAMMA-SERVER-PROJECTION-ADR.md` (PR #830).
+ * Issue: octos-org/octos#841.
+ * γ-3:   `src/store/projection-store.ts` (the projection log + flag).
+ *
+ * Under the `projection_v1` feature flag, clicking Send NO LONGER
+ * mutates `ThreadStore` synchronously. The Composer instead mounts one
+ * of these `<GhostBubble>` rows in its own React tree — visually
+ * identical to a real user bubble — and unmounts it once the projection
+ * sees a `UserView` with a matching `client_message_id`.
+ *
+ * The ghost is OUTSIDE `ThreadStore`. This component owns its own
+ * presentation state (text, files, attached_at). On every
+ * `ThreadStore.subscribe` notify (which the dual-write path triggers)
+ * we inspect the projection-store's `UserView` for our cmid; when it
+ * lands the ghost calls `onSettle` and the parent unmounts.
+ *
+ * Failure mode: if 30 seconds pass without settling, render an inline
+ * error + retry button. The 30s timer is local to the component (no
+ * global state). Retry calls a parent-supplied callback; failure does
+ * NOT pollute ThreadStore.
+ */
+
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { Download } from "lucide-react";
+import * as ThreadStore from "@/store/thread-store";
+import {
+  getProjection,
+  projectionStoreKey,
+} from "@/store/projection-store";
+
+// ---------------------------------------------------------------------------
+// Tunables
+// ---------------------------------------------------------------------------
+
+/** Hard ceiling on the optimistic settle wait. Past this, the ghost
+ *  surfaces a Retry affordance so the user is never stuck staring at a
+ *  bubble that has already been silently lost (e.g. WS dropped, server
+ *  rejected). 30s matches the M9-γ ADR's optimistic-overlay budget. */
+export const GHOST_SETTLE_TIMEOUT_MS = 30_000;
+
+// ---------------------------------------------------------------------------
+// Props
+// ---------------------------------------------------------------------------
+
+export interface GhostBubbleProps {
+  /** Pinned client_message_id; the projection's `UserView` must carry
+   *  this exact value for the ghost to settle. */
+  clientMessageId: string;
+  /** Visible text — same content the user typed (rendered identically
+   *  to a `ThreadUserBubble` so the optimistic UI is indistinguishable
+   *  from a settled bubble). */
+  text: string;
+  /** Pending file attachments (raw `File` objects, not yet uploaded).
+   *  We render their names + a generic "Sending…" affordance so the
+   *  user sees what's about to land. */
+  files: File[];
+  /** Session id the send was issued in — used to address the projection
+   *  store. Kept explicit (rather than read from `useSession`) so the
+   *  component is decoupled from the runtime context and trivially
+   *  testable. */
+  sessionId: string;
+  /** Optional topic scope (mirrors `historyTopic`). */
+  topic?: string;
+  /** Fired once the projection has captured `UserView.client_message_id
+   *  === clientMessageId`. The parent owns lifecycle and unmounts. */
+  onSettle: () => void;
+  /** Called when the user clicks Retry from the timeout error state.
+   *  Implementation re-issues the send via the Composer's normal
+   *  channel; failure must NOT pollute ThreadStore. */
+  onRetry?: () => void;
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function formatGhostTimestamp(ts: number): string {
+  const d = new Date(ts);
+  const pad = (n: number) => String(n).padStart(2, "0");
+  return `${d.getFullYear()}-${pad(d.getMonth() + 1)}-${pad(d.getDate())} ${pad(d.getHours())}:${pad(d.getMinutes())}:${pad(d.getSeconds())}`;
+}
+
+/** True iff the projection's view has a thread whose `user.client_message_id`
+ *  matches the supplied cmid. Internal — kept as a named function (not
+ *  inlined) so the predicate is a single, testable choke point if the
+ *  match semantics ever need to widen. */
+function projectionHasUserCmid(
+  storeKey: string,
+  clientMessageId: string,
+): boolean {
+  const view = getProjection(storeKey);
+  for (const t of view.threads) {
+    if (t.user?.client_message_id === clientMessageId) return true;
+  }
+  return false;
+}
+
+// ---------------------------------------------------------------------------
+// Component
+// ---------------------------------------------------------------------------
+
+/**
+ * Visual-only optimistic user bubble. Mounted by the Composer on Send
+ * under `projection_v1`; unmounted by the parent when `onSettle` fires
+ * (or kept around in error state for the user to retry).
+ */
+export function GhostBubble({
+  clientMessageId,
+  text,
+  files,
+  sessionId,
+  topic,
+  onSettle,
+  onRetry,
+}: GhostBubbleProps): React.ReactElement {
+  // attached_at is captured ONCE at mount so re-renders (e.g. from a
+  // ThreadStore notify) don't bump the displayed timestamp. We use the
+  // lazy-init form of `useState` so `Date.now()` is invoked exactly
+  // once (the initializer fn runs only on first render — no impure
+  // call during subsequent renders, and ESLint's "impure function in
+  // render" rule passes).
+  const [attachedAt, setAttachedAt] = useState<number>(() => Date.now());
+  const [timedOut, setTimedOut] = useState<boolean>(false);
+  const settledRef = useRef<boolean>(false);
+
+  const storeKey = useMemo(
+    () => projectionStoreKey(sessionId, topic),
+    [sessionId, topic],
+  );
+
+  // Subscribe to ThreadStore notifications. Each notify means an envelope
+  // was just dual-written into the projection — re-check whether our cmid
+  // has landed. We DON'T subscribe to a projection-store notify channel
+  // (γ-3 doesn't expose one); the dual-write fires `notify()` on every
+  // ingest, which is exactly what we need.
+  useEffect(() => {
+    if (settledRef.current) return;
+
+    // Fast-path: the projection might already carry our cmid by the
+    // time this effect runs (rare race: server reflection landed inside
+    // the same microtask as the send dispatch). Settling synchronously
+    // here is safe — the parent's unmount will tear down the timer below.
+    if (projectionHasUserCmid(storeKey, clientMessageId)) {
+      settledRef.current = true;
+      onSettle();
+      return;
+    }
+
+    const unsubscribe = ThreadStore.subscribe(() => {
+      if (settledRef.current) return;
+      if (projectionHasUserCmid(storeKey, clientMessageId)) {
+        settledRef.current = true;
+        unsubscribe();
+        onSettle();
+      }
+    });
+    return () => {
+      unsubscribe();
+    };
+  }, [storeKey, clientMessageId, onSettle]);
+
+  // Local 30s timeout — purely component-scoped, no global state.
+  useEffect(() => {
+    if (timedOut) return;
+    const id = window.setTimeout(() => {
+      if (settledRef.current) return;
+      setTimedOut(true);
+    }, GHOST_SETTLE_TIMEOUT_MS);
+    return () => {
+      window.clearTimeout(id);
+    };
+  }, [timedOut]);
+
+  const handleRetry = useCallback(() => {
+    if (!onRetry) return;
+    // Reset timeout so the retry gets a fresh 30s budget. Settling is
+    // still gated on the projection capturing our cmid.
+    setTimedOut(false);
+    setAttachedAt(Date.now());
+    onRetry();
+  }, [onRetry]);
+
+  const visibleText = text;
+  const showFiles = files.length > 0;
+
+  // Visual structure mirrors `ThreadUserBubble` in `chat-thread.tsx`
+  // (right-aligned, same `message-card-user` glass classes, same
+  // timestamp footer). The only deviations are:
+  //   - the outer test id (`ghost-bubble`) so harness specs can target
+  //     the optimistic overlay specifically;
+  //   - the optional inline error + Retry button when the 30s timer
+  //     fires.
+  return (
+    <div
+      data-testid="ghost-bubble"
+      data-client-message-id={clientMessageId}
+      data-ghost-state={timedOut ? "timed-out" : "pending"}
+      className="flex justify-end px-4 py-3"
+    >
+      <div className="flex max-w-[74%] flex-col items-end">
+        {visibleText && (
+          <div
+            data-testid="ghost-bubble-text"
+            className="message-card message-card-user rounded-[14px] rounded-br-[4px] px-4 py-2.5 text-sm leading-relaxed text-text"
+          >
+            {visibleText}
+          </div>
+        )}
+        {showFiles && (
+          <div className={`${visibleText ? "mt-2" : ""} flex flex-wrap gap-2`}>
+            {files.map((f, idx) => (
+              <div
+                // `File` objects don't have a stable id; pair name + size
+                // + index so duplicate filenames in the same send still
+                // render distinct rows.
+                key={`${f.name}-${f.size}-${idx}`}
+                data-testid="ghost-bubble-file"
+                className="glass-pill inline-flex max-w-full items-center gap-1.5 overflow-hidden rounded-[10px] px-3 py-2 text-xs text-link"
+              >
+                <Download size={14} className="shrink-0" />
+                <span className="truncate">{f.name}</span>
+              </div>
+            ))}
+          </div>
+        )}
+        <div className="mt-1.5 px-1 text-[10px] text-muted/50 select-none">
+          {formatGhostTimestamp(attachedAt)}
+        </div>
+        {timedOut && (
+          <div
+            data-testid="ghost-bubble-error"
+            role="alert"
+            className="mt-1.5 flex items-center gap-2 rounded-[10px] border border-red-500/20 bg-red-500/12 px-3 py-1.5 text-[11px] text-red-400"
+          >
+            <span>Send not confirmed within 30s.</span>
+            {onRetry && (
+              <button
+                data-testid="ghost-bubble-retry"
+                type="button"
+                onClick={handleRetry}
+                className="rounded-md bg-red-600 px-2 py-0.5 text-[11px] font-medium text-white hover:bg-red-700"
+              >
+                Retry
+              </button>
+            )}
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/components/GhostBubble.tsx
+++ b/src/components/GhostBubble.tsx
@@ -13,10 +13,19 @@
  * sees a `UserView` with a matching `client_message_id`.
  *
  * The ghost is OUTSIDE `ThreadStore`. This component owns its own
- * presentation state (text, files, attached_at). On every
- * `ThreadStore.subscribe` notify (which the dual-write path triggers)
- * we inspect the projection-store's `UserView` for our cmid; when it
- * lands the ghost calls `onSettle` and the parent unmounts.
+ * presentation state (text, files, attached_at). On every projection
+ * `ingest()` (the only authoritative event that adds an envelope to
+ * the log) we ask the projection-store via the O(1) `hasCmid` index
+ * whether our cmid has landed; when it has, the ghost calls `onSettle`
+ * and the parent unmounts.
+ *
+ * Subscription model (codex BLOCK 1 fix): we subscribe to
+ * `ProjectionStore.subscribe`, NOT `ThreadStore.subscribe`. The
+ * thread-store's mutators call `notify()` BEFORE the projection
+ * dual-write — so a ThreadStore-only subscription would see the notify
+ * before the envelope is actually in the projection log, leaving us
+ * waiting for a later unrelated notify (or the 30s timeout). The
+ * projection-store fires AFTER `ingest()` commits, closing the race.
  *
  * Failure mode: if 30 seconds pass without settling, render an inline
  * error + retry button. The 30s timer is local to the component (no
@@ -26,11 +35,9 @@
 
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { Download } from "lucide-react";
-import * as ThreadStore from "@/store/thread-store";
-import {
-  getProjection,
-  projectionStoreKey,
-} from "@/store/projection-store";
+import * as ProjectionStore from "@/store/projection-store";
+import { projectionStoreKey } from "@/store/projection-store";
+import { UserBubbleShell } from "./user-bubble-shell";
 
 // ---------------------------------------------------------------------------
 // Tunables
@@ -84,21 +91,6 @@ function formatGhostTimestamp(ts: number): string {
   return `${d.getFullYear()}-${pad(d.getMonth() + 1)}-${pad(d.getDate())} ${pad(d.getHours())}:${pad(d.getMinutes())}:${pad(d.getSeconds())}`;
 }
 
-/** True iff the projection's view has a thread whose `user.client_message_id`
- *  matches the supplied cmid. Internal — kept as a named function (not
- *  inlined) so the predicate is a single, testable choke point if the
- *  match semantics ever need to widen. */
-function projectionHasUserCmid(
-  storeKey: string,
-  clientMessageId: string,
-): boolean {
-  const view = getProjection(storeKey);
-  for (const t of view.threads) {
-    if (t.user?.client_message_id === clientMessageId) return true;
-  }
-  return false;
-}
-
 // ---------------------------------------------------------------------------
 // Component
 // ---------------------------------------------------------------------------
@@ -118,11 +110,11 @@ export function GhostBubble({
   onRetry,
 }: GhostBubbleProps): React.ReactElement {
   // attached_at is captured ONCE at mount so re-renders (e.g. from a
-  // ThreadStore notify) don't bump the displayed timestamp. We use the
-  // lazy-init form of `useState` so `Date.now()` is invoked exactly
-  // once (the initializer fn runs only on first render — no impure
-  // call during subsequent renders, and ESLint's "impure function in
-  // render" rule passes).
+  // projection-store notify) don't bump the displayed timestamp. We
+  // use the lazy-init form of `useState` so `Date.now()` is invoked
+  // exactly once (the initializer fn runs only on first render — no
+  // impure call during subsequent renders, and ESLint's "impure
+  // function in render" rule passes).
   const [attachedAt, setAttachedAt] = useState<number>(() => Date.now());
   const [timedOut, setTimedOut] = useState<boolean>(false);
   const settledRef = useRef<boolean>(false);
@@ -132,27 +124,33 @@ export function GhostBubble({
     [sessionId, topic],
   );
 
-  // Subscribe to ThreadStore notifications. Each notify means an envelope
-  // was just dual-written into the projection — re-check whether our cmid
-  // has landed. We DON'T subscribe to a projection-store notify channel
-  // (γ-3 doesn't expose one); the dual-write fires `notify()` on every
-  // ingest, which is exactly what we need.
+  // Subscribe to projection-store ingests. The projection-store fires
+  // its listeners AFTER each `ingest()` commits — so our `hasCmid`
+  // check is guaranteed to see the new envelope. (Subscribing to
+  // `ThreadStore.subscribe` would be racy: the legacy thread-store
+  // mutators call `notify()` BEFORE the projection dual-write.)
+  //
+  // Cmid lookup is O(1) — backed by `projection-store`'s
+  // `cmidToThread` index, populated as a side effect of `ingest()`.
   useEffect(() => {
     if (settledRef.current) return;
 
     // Fast-path: the projection might already carry our cmid by the
     // time this effect runs (rare race: server reflection landed inside
-    // the same microtask as the send dispatch). Settling synchronously
-    // here is safe — the parent's unmount will tear down the timer below.
-    if (projectionHasUserCmid(storeKey, clientMessageId)) {
+    // the same microtask as the send dispatch, or — more commonly — the
+    // ThreadStore's `addUserMessage` shim already ingested a
+    // user-rooted envelope before the GhostBubble mounted). Settling
+    // synchronously here is safe — the parent's unmount will tear down
+    // the timer below.
+    if (ProjectionStore.hasCmid(storeKey, clientMessageId)) {
       settledRef.current = true;
       onSettle();
       return;
     }
 
-    const unsubscribe = ThreadStore.subscribe(() => {
+    const unsubscribe = ProjectionStore.subscribe(() => {
       if (settledRef.current) return;
-      if (projectionHasUserCmid(storeKey, clientMessageId)) {
+      if (ProjectionStore.hasCmid(storeKey, clientMessageId)) {
         settledRef.current = true;
         unsubscribe();
         onSettle();
@@ -184,72 +182,68 @@ export function GhostBubble({
     onRetry();
   }, [onRetry]);
 
-  const visibleText = text;
   const showFiles = files.length > 0;
 
-  // Visual structure mirrors `ThreadUserBubble` in `chat-thread.tsx`
-  // (right-aligned, same `message-card-user` glass classes, same
-  // timestamp footer). The only deviations are:
-  //   - the outer test id (`ghost-bubble`) so harness specs can target
-  //     the optimistic overlay specifically;
+  // Visual structure delegates to `<UserBubbleShell>` so the ghost and
+  // the canonical `<ThreadUserBubble>` share one source of truth for
+  // markup + classes. The only ghost-specific deviations are:
+  //   - the outer `data-testid="ghost-bubble"` so harness specs can
+  //     target the optimistic overlay specifically;
+  //   - file rendering: ghosts carry raw `File` objects (not yet
+  //     uploaded), so we render them as pending "Sending…" pills
+  //     rather than `<FileAttachment>` rows;
   //   - the optional inline error + Retry button when the 30s timer
-  //     fires.
-  return (
-    <div
-      data-testid="ghost-bubble"
-      data-client-message-id={clientMessageId}
-      data-ghost-state={timedOut ? "timed-out" : "pending"}
-      className="flex justify-end px-4 py-3"
-    >
-      <div className="flex max-w-[74%] flex-col items-end">
-        {visibleText && (
-          <div
-            data-testid="ghost-bubble-text"
-            className="message-card message-card-user rounded-[14px] rounded-br-[4px] px-4 py-2.5 text-sm leading-relaxed text-text"
-          >
-            {visibleText}
-          </div>
-        )}
-        {showFiles && (
-          <div className={`${visibleText ? "mt-2" : ""} flex flex-wrap gap-2`}>
-            {files.map((f, idx) => (
-              <div
-                // `File` objects don't have a stable id; pair name + size
-                // + index so duplicate filenames in the same send still
-                // render distinct rows.
-                key={`${f.name}-${f.size}-${idx}`}
-                data-testid="ghost-bubble-file"
-                className="glass-pill inline-flex max-w-full items-center gap-1.5 overflow-hidden rounded-[10px] px-3 py-2 text-xs text-link"
-              >
-                <Download size={14} className="shrink-0" />
-                <span className="truncate">{f.name}</span>
-              </div>
-            ))}
-          </div>
-        )}
-        <div className="mt-1.5 px-1 text-[10px] text-muted/50 select-none">
-          {formatGhostTimestamp(attachedAt)}
+  //     fires (passed via the shell's `trailing` slot).
+  const fileRows = showFiles ? (
+    <>
+      {files.map((f, idx) => (
+        <div
+          // `File` objects don't have a stable id; pair name + size
+          // + index so duplicate filenames in the same send still
+          // render distinct rows.
+          key={`${f.name}-${f.size}-${idx}`}
+          data-testid="ghost-bubble-file"
+          className="glass-pill inline-flex max-w-full items-center gap-1.5 overflow-hidden rounded-[10px] px-3 py-2 text-xs text-link"
+        >
+          <Download size={14} className="shrink-0" />
+          <span className="truncate">{f.name}</span>
         </div>
-        {timedOut && (
-          <div
-            data-testid="ghost-bubble-error"
-            role="alert"
-            className="mt-1.5 flex items-center gap-2 rounded-[10px] border border-red-500/20 bg-red-500/12 px-3 py-1.5 text-[11px] text-red-400"
-          >
-            <span>Send not confirmed within 30s.</span>
-            {onRetry && (
-              <button
-                data-testid="ghost-bubble-retry"
-                type="button"
-                onClick={handleRetry}
-                className="rounded-md bg-red-600 px-2 py-0.5 text-[11px] font-medium text-white hover:bg-red-700"
-              >
-                Retry
-              </button>
-            )}
-          </div>
-        )}
-      </div>
+      ))}
+    </>
+  ) : null;
+
+  const trailing = timedOut ? (
+    <div
+      data-testid="ghost-bubble-error"
+      role="alert"
+      className="mt-1.5 flex items-center gap-2 rounded-[10px] border border-red-500/20 bg-red-500/12 px-3 py-1.5 text-[11px] text-red-400"
+    >
+      <span>Send not confirmed within 30s.</span>
+      {onRetry && (
+        <button
+          data-testid="ghost-bubble-retry"
+          type="button"
+          onClick={handleRetry}
+          className="rounded-md bg-red-600 px-2 py-0.5 text-[11px] font-medium text-white hover:bg-red-700"
+        >
+          Retry
+        </button>
+      )}
     </div>
+  ) : null;
+
+  return (
+    <UserBubbleShell
+      text={text || null}
+      files={fileRows}
+      footer={formatGhostTimestamp(attachedAt)}
+      trailing={trailing}
+      outerTestId="ghost-bubble"
+      textTestId="ghost-bubble-text"
+      outerDataAttributes={{
+        "data-client-message-id": clientMessageId,
+        "data-ghost-state": timedOut ? "timed-out" : "pending",
+      }}
+    />
   );
 }

--- a/src/components/chat-thread.tsx
+++ b/src/components/chat-thread.tsx
@@ -48,6 +48,7 @@ import { MarkdownContent } from "./markdown-renderer";
 import { ThinkingIndicator } from "./thinking-indicator";
 import { ToolProgressIndicator } from "./tool-progress-indicator";
 import { GhostBubble } from "./GhostBubble";
+import { UserBubbleShell } from "./user-bubble-shell";
 import { buildAuthenticatedFileUrl, buildFileUrl } from "@/api/files";
 import { displayFilenameFromPath } from "@/lib/utils";
 import { nextTopicForCommand } from "@/lib/slash-commands";
@@ -440,30 +441,27 @@ const ThreadUserBubble = memo(function ThreadUserBubble({
   threadId: string;
 }) {
   const visibleText = threadMessageVisibleText(message);
+  // Visual layout is shared with `<GhostBubble>` via `<UserBubbleShell>`
+  // so the optimistic overlay and the canonical user bubble cannot drift
+  // (codex BLOCK 4 fix). Only the file-row content differs: the real
+  // bubble renders `<FileAttachment>` for server-resolved paths; the
+  // ghost renders pending pills for not-yet-uploaded `File` objects.
+  const fileRows =
+    message.files.length > 0 ? (
+      <>
+        {message.files.map((f) => (
+          <FileAttachment key={f.path} file={f} />
+        ))}
+      </>
+    ) : null;
   return (
-    <div className="flex justify-end px-4 py-3">
-      <div className="flex max-w-[74%] flex-col items-end">
-        {visibleText && (
-          <div
-            data-testid="user-message"
-            data-thread-id={threadId}
-            className="message-card message-card-user rounded-[14px] rounded-br-[4px] px-4 py-2.5 text-sm leading-relaxed text-text"
-          >
-            {visibleText}
-          </div>
-        )}
-        {message.files.length > 0 && (
-          <div className={`${visibleText ? "mt-2" : ""} flex flex-wrap gap-2`}>
-            {message.files.map((f) => (
-              <FileAttachment key={f.path} file={f} />
-            ))}
-          </div>
-        )}
-        <div className="mt-1.5 px-1 text-[10px] text-muted/50 select-none">
-          {formatTimestamp(message.timestamp)}
-        </div>
-      </div>
-    </div>
+    <UserBubbleShell
+      text={visibleText || null}
+      files={fileRows}
+      footer={formatTimestamp(message.timestamp)}
+      textTestId="user-message"
+      textDataAttributes={{ "data-thread-id": threadId }}
+    />
   );
 });
 
@@ -1121,38 +1119,25 @@ function Composer({ mountGhost, unmountGhost }: ComposerProps) {
     const trimmedInput = text.trim();
     const input = trimmedInput.startsWith("/") ? text.trimStart() : trimmedInput;
 
-    // M9-γ-4: under projection_v1, we mount a `<GhostBubble>` immediately
-    // and pin the same cmid through the entire send so the projection's
-    // first envelope on this thread can match-and-unmount the ghost.
-    // Outside the flag, behaviour is unchanged: `enqueueSendV1` mints
-    // its own cmid as before.
+    // M9-γ-4 (codex BLOCK 3): defer the ghost-bubble mount until AFTER
+    // every early-return path (slash interception, /help, upload
+    // failure, second beforeSend interception). A ghost mounted before
+    // those returns leaves a stale optimistic bubble on screen with no
+    // matching cmid in flight. We compute the cmid up-front (so the
+    // bridge call at the bottom can pin it) but only call `mountGhost`
+    // once we're past every return point and `bridgeSend` is about to
+    // fire.
+    //
+    // Snapshot the user-typed visible text + the raw files NOW, before
+    // upload mutates `pendingFiles`. The ghost's contents are frozen at
+    // send-click — exactly what the user sees in a live bubble — and
+    // the same snapshot powers retry (codex BLOCK 2).
     const projectionV1 = isProjectionV1Enabled();
     const pinnedClientMessageId = projectionV1
       ? crypto.randomUUID()
       : undefined;
-    let ghostMounted = false;
-    if (projectionV1 && pinnedClientMessageId) {
-      // Snapshot the user-typed visible text + the raw files BEFORE
-      // upload mutates `pendingFiles`. The ghost's contents are frozen
-      // at send-click — exactly what the user sees in a live bubble.
-      const ghostText = trimmedInput;
-      const ghostFiles = pendingFiles.map((pf) => pf.file);
-      const cmid = pinnedClientMessageId;
-      mountGhost({
-        clientMessageId: cmid,
-        text: ghostText,
-        files: ghostFiles,
-        // Retry: tear down THIS ghost and re-invoke handleSend. The
-        // Composer's own state has been cleared (`setText("")` at the
-        // bottom of the success path), so a real retry would need the
-        // user to retype. We surface the affordance anyway so the
-        // overlay isn't a dead-end; a follow-up can wire deeper retry.
-        retry: () => {
-          unmountGhost(cmid);
-        },
-      });
-      ghostMounted = true;
-    }
+    const ghostTextSnapshot = trimmedInput;
+    const ghostFilesSnapshot = pendingFiles.map((pf) => pf.file);
 
     let mediaPaths: string[] = [];
     let audioUploadMode: "recording" | "upload" | undefined;
@@ -1269,6 +1254,58 @@ function Composer({ mountGhost, unmountGhost }: ComposerProps) {
       setTimeout(() => setCmdFeedback(null), 4000);
       sendingRef.current = false;
       return;
+    }
+
+    // M9-γ-4 (codex BLOCK 3): we're now past every early-return path.
+    // Mount the ghost immediately before dispatching `bridgeSend` so
+    // the optimistic bubble only appears when the send is actually
+    // about to leave the client. Hold onto the original payload so the
+    // ghost's Retry button can re-issue the send with a NEW cmid
+    // (codex BLOCK 2 — Retry truly resends, not just dismisses).
+    let ghostMounted = false;
+    if (projectionV1 && pinnedClientMessageId) {
+      const cmid = pinnedClientMessageId;
+      const retryPayload = {
+        ...finalPayload,
+        historyTopic: requestedTopic,
+      };
+      const retryFiles = ghostFilesSnapshot;
+      const retryText = ghostTextSnapshot;
+      // Recursive-closure factory: each retry mints a fresh cmid and
+      // mounts a new ghost; the new ghost's `retry` closure captures
+      // the freshly minted cmid so an N-th retry stays consistent.
+      const buildRetry = (currentCmid: string): (() => void) => () => {
+        unmountGhost(currentCmid);
+        const retryCmid = crypto.randomUUID();
+        mountGhost({
+          clientMessageId: retryCmid,
+          text: retryText,
+          files: retryFiles,
+          retry: buildRetry(retryCmid),
+        });
+        // Re-issue the send with the new cmid + the same payload.
+        // The bridge re-registers the pending cmid so the projection's
+        // first envelope on the new thread captures it. Failure of
+        // this retry must NOT pollute ThreadStore — the ghost's
+        // contract is purely visual.
+        bridgeSend({
+          ...retryPayload,
+          clientMessageId: retryCmid,
+          skipOptimisticUserMessage: true,
+          onSessionActive: (firstMsg) => markSessionActive(firstMsg),
+          onComplete: () => {
+            sendingRef.current = false;
+            refreshSessions();
+          },
+        });
+      };
+      mountGhost({
+        clientMessageId: cmid,
+        text: retryText,
+        files: retryFiles,
+        retry: buildRetry(cmid),
+      });
+      ghostMounted = true;
     }
 
     // Send via SSE bridge (StreamManager queues if a stream is already active)

--- a/src/components/chat-thread.tsx
+++ b/src/components/chat-thread.tsx
@@ -39,6 +39,7 @@ import {
   type ThreadMessage,
   type ThreadToolCall,
 } from "@/store/thread-store";
+import { isProjectionV1Enabled } from "@/store/projection-store";
 import { uploadFiles } from "@/api/chat";
 import { sendMessage as bridgeSend } from "@/runtime/ui-protocol-send";
 import { getActiveBridge } from "@/runtime/ui-protocol-runtime";
@@ -46,6 +47,7 @@ import * as StreamManager from "@/runtime/stream-manager";
 import { MarkdownContent } from "./markdown-renderer";
 import { ThinkingIndicator } from "./thinking-indicator";
 import { ToolProgressIndicator } from "./tool-progress-indicator";
+import { GhostBubble } from "./GhostBubble";
 import { buildAuthenticatedFileUrl, buildFileUrl } from "@/api/files";
 import { displayFilenameFromPath } from "@/lib/utils";
 import { nextTopicForCommand } from "@/lib/slash-commands";
@@ -367,6 +369,33 @@ interface PendingFile {
 }
 
 // ---------------------------------------------------------------------------
+// M9-γ-4: optimistic GhostBubble overlay
+//
+// Mounted by `Composer.handleSend` when `projection_v1` is on; lives in
+// the `ChatThreadV2` React tree (NOT in `ThreadStore`) and unmounts as
+// soon as the projection captures `UserView.client_message_id` matching
+// the ghost's cmid.
+// ---------------------------------------------------------------------------
+
+interface GhostSpec {
+  /** Pinned `client_message_id` — same value the send dispatches with. */
+  clientMessageId: string;
+  /** What the user typed (visible bubble text). */
+  text: string;
+  /** Raw files at send time — purely for the ghost row's display. */
+  files: File[];
+  /** Closure that re-issues the original send. The GhostBubble surfaces
+   *  it via the Retry button after the 30s timeout. Invoked at most
+   *  once per ghost. */
+  retry: () => void;
+}
+
+/** Stable empty-array reference for the per-bucket ghost lookup so
+ *  `useThreads`-style identity comparisons in downstream consumers
+ *  don't churn when the current bucket has no ghosts. */
+const EMPTY_GHOSTS: ReadonlyArray<GhostSpec> = Object.freeze([]);
+
+// ---------------------------------------------------------------------------
 // Main ChatThread component
 // ---------------------------------------------------------------------------
 
@@ -656,9 +685,17 @@ function ThreadView({
 
 function ThreadList({
   threads,
+  ghosts,
+  sessionId,
+  topic,
+  onSettleGhost,
   hideFileOnlyAssistantMessages,
 }: {
   threads: Thread[];
+  ghosts: ReadonlyArray<GhostSpec>;
+  sessionId: string;
+  topic?: string;
+  onSettleGhost: (clientMessageId: string) => void;
   hideFileOnlyAssistantMessages: boolean;
 }) {
   const viewportRef = useRef<HTMLDivElement>(null);
@@ -676,12 +713,13 @@ function ThreadList({
     return () => el.removeEventListener("scroll", handleScroll);
   }, []);
 
-  // Auto-scroll when threads update
+  // Auto-scroll when threads OR ghosts update — a fresh ghost on send
+  // should pull the viewport down just like a real user bubble would.
   useEffect(() => {
     if (stickToBottomRef.current && viewportRef.current) {
       viewportRef.current.scrollTop = viewportRef.current.scrollHeight;
     }
-  }, [threads]);
+  }, [threads, ghosts]);
 
   return (
     <div
@@ -698,6 +736,18 @@ function ThreadList({
             hideFileOnlyAssistantMessages={hideFileOnlyAssistantMessages}
           />
         ))}
+        {ghosts.map((g) => (
+          <GhostBubble
+            key={g.clientMessageId}
+            clientMessageId={g.clientMessageId}
+            text={g.text}
+            files={g.files}
+            sessionId={sessionId}
+            topic={topic}
+            onSettle={() => onSettleGhost(g.clientMessageId)}
+            onRetry={g.retry}
+          />
+        ))}
       </div>
     </div>
   );
@@ -708,7 +758,53 @@ function ChatThreadV2({
 }: ChatThreadProps) {
   const { currentSessionId, historyTopic } = useSession();
   const threads = useThreads(currentSessionId, historyTopic);
+  // M9-γ-4: optimistic ghost overlay state. Lives here (NOT in
+  // ThreadStore) so the renderer can mount/unmount rows without
+  // polluting the durable thread reducer. Composer pushes new ghosts
+  // via `mountGhost`; GhostBubble fires `onSettle` once the projection
+  // captures the matching cmid, which calls `unmountGhost`.
+  //
+  // Ghosts are bucketed by `(sessionId, historyTopic)` so a session
+  // switch doesn't bleed an in-flight optimistic bubble across to the
+  // next view. We render only the ghosts for the current bucket; stale
+  // entries in other buckets are dropped lazily by `mountGhost` when
+  // the same cmid re-enters, or via `__resetForTests`. No `useEffect`
+  // resets a bucket — that's exactly the cascading-rerender pattern the
+  // `react-hooks/set-state-in-effect` rule blocks.
+  const ghostBucketKey = `${currentSessionId}::${historyTopic ?? ""}`;
+  const [ghostsByBucket, setGhostsByBucket] = useState<
+    Record<string, GhostSpec[]>
+  >({});
+  const ghosts = ghostsByBucket[ghostBucketKey] ?? EMPTY_GHOSTS;
+  const mountGhost = useCallback(
+    (spec: GhostSpec) => {
+      setGhostsByBucket((prev) => {
+        const cur = prev[ghostBucketKey] ?? [];
+        // Idempotent: re-mounting the same cmid (e.g. a retry that mints
+        // the same id) replaces the existing entry instead of
+        // duplicating.
+        const filtered = cur.filter(
+          (g) => g.clientMessageId !== spec.clientMessageId,
+        );
+        return { ...prev, [ghostBucketKey]: [...filtered, spec] };
+      });
+    },
+    [ghostBucketKey],
+  );
+  const unmountGhost = useCallback(
+    (clientMessageId: string) => {
+      setGhostsByBucket((prev) => {
+        const cur = prev[ghostBucketKey];
+        if (!cur || cur.length === 0) return prev;
+        const next = cur.filter((g) => g.clientMessageId !== clientMessageId);
+        if (next.length === cur.length) return prev;
+        return { ...prev, [ghostBucketKey]: next };
+      });
+    },
+    [ghostBucketKey],
+  );
   const hasThreads = threads.length > 0;
+  const hasGhosts = ghosts.length > 0;
 
   // M8.10 follow-up (#633): rehydrate thread store from server history on mount
   // and on session/topic change. The flat-list path loads history via
@@ -749,9 +845,13 @@ function ChatThreadV2({
 
   return (
     <div className="flex h-full min-h-0 flex-col bg-transparent">
-      {hasThreads ? (
+      {hasThreads || hasGhosts ? (
         <ThreadList
           threads={threads}
+          ghosts={ghosts}
+          sessionId={currentSessionId}
+          topic={historyTopic}
+          onSettleGhost={unmountGhost}
           hideFileOnlyAssistantMessages={hideFileOnlyAssistantMessages}
         />
       ) : (
@@ -768,7 +868,7 @@ function ChatThreadV2({
         </div>
       )}
       <div className="shrink-0">
-        <Composer />
+        <Composer mountGhost={mountGhost} unmountGhost={unmountGhost} />
       </div>
     </div>
   );
@@ -778,7 +878,17 @@ function ChatThreadV2({
 // Composer
 // ---------------------------------------------------------------------------
 
-function Composer() {
+interface ComposerProps {
+  /** M9-γ-4: mount a `<GhostBubble>` overlay for the current send.
+   *  Composer calls this when `projection_v1` is on; otherwise the
+   *  legacy `addUserMessage` path keeps producing the optimistic row. */
+  mountGhost: (spec: GhostSpec) => void;
+  /** Tear down a ghost (used by the Retry path to clear a stale
+   *  overlay before re-issuing the send). */
+  unmountGhost: (clientMessageId: string) => void;
+}
+
+function Composer({ mountGhost, unmountGhost }: ComposerProps) {
   const {
     currentSessionId,
     historyTopic,
@@ -1011,6 +1121,39 @@ function Composer() {
     const trimmedInput = text.trim();
     const input = trimmedInput.startsWith("/") ? text.trimStart() : trimmedInput;
 
+    // M9-γ-4: under projection_v1, we mount a `<GhostBubble>` immediately
+    // and pin the same cmid through the entire send so the projection's
+    // first envelope on this thread can match-and-unmount the ghost.
+    // Outside the flag, behaviour is unchanged: `enqueueSendV1` mints
+    // its own cmid as before.
+    const projectionV1 = isProjectionV1Enabled();
+    const pinnedClientMessageId = projectionV1
+      ? crypto.randomUUID()
+      : undefined;
+    let ghostMounted = false;
+    if (projectionV1 && pinnedClientMessageId) {
+      // Snapshot the user-typed visible text + the raw files BEFORE
+      // upload mutates `pendingFiles`. The ghost's contents are frozen
+      // at send-click — exactly what the user sees in a live bubble.
+      const ghostText = trimmedInput;
+      const ghostFiles = pendingFiles.map((pf) => pf.file);
+      const cmid = pinnedClientMessageId;
+      mountGhost({
+        clientMessageId: cmid,
+        text: ghostText,
+        files: ghostFiles,
+        // Retry: tear down THIS ghost and re-invoke handleSend. The
+        // Composer's own state has been cleared (`setText("")` at the
+        // bottom of the success path), so a real retry would need the
+        // user to retype. We surface the affordance anyway so the
+        // overlay isn't a dead-end; a follow-up can wire deeper retry.
+        retry: () => {
+          unmountGhost(cmid);
+        },
+      });
+      ghostMounted = true;
+    }
+
     let mediaPaths: string[] = [];
     let audioUploadMode: "recording" | "upload" | undefined;
 
@@ -1132,6 +1275,18 @@ function Composer() {
     bridgeSend({
       ...finalPayload,
       historyTopic: requestedTopic,
+      // M9-γ-4: pin the cmid through the send so the ghost's
+      // projection-match predicate sees an envelope tagged with the
+      // exact same value. When `pinnedClientMessageId` is undefined
+      // (projection_v1 OFF) the bridge mints its own as before.
+      ...(pinnedClientMessageId !== undefined
+        ? { clientMessageId: pinnedClientMessageId }
+        : {}),
+      // M9-γ-4: tell the bridge to skip the optimistic
+      // `ThreadStore.addUserMessage` mirror — we've already mounted a
+      // visual `<GhostBubble>` instead. The bridge still registers the
+      // pending cmid so the projection's first envelope captures it.
+      skipOptimisticUserMessage: ghostMounted,
       onSessionActive: (firstMsg) => markSessionActive(firstMsg),
       onComplete: () => {
         sendingRef.current = false;
@@ -1149,6 +1304,8 @@ function Composer() {
     refreshSessions,
     markSessionActive,
     beforeSend,
+    mountGhost,
+    unmountGhost,
   ]);
 
   const handleCancel = useCallback(() => {

--- a/src/components/user-bubble-shell.tsx
+++ b/src/components/user-bubble-shell.tsx
@@ -1,0 +1,112 @@
+/**
+ * Shared visual shell for user-rooted message bubbles.
+ *
+ * Lives outside `chat-thread.tsx` so both the real `ThreadUserBubble`
+ * (rendered from `Thread.userMsg`) and the M9-γ-4 `<GhostBubble>`
+ * overlay (purely visual optimistic UI) hang the same layout and CSS
+ * classes off a single source of truth.
+ *
+ * Why a shell rather than direct reuse of `ThreadUserBubble`?
+ *   • A `<GhostBubble>` carries raw `File` objects (not-yet-uploaded
+ *     attachments), while `<ThreadUserBubble>` carries `MessageFile`
+ *     records (server-resolved paths). The two file-row renderings are
+ *     different by necessity — a pending file has no `/api/files/...`
+ *     URL yet.
+ *   • All other markup (outer flex, `message-card-user` glass classes,
+ *     timestamp footer) is identical. Putting it here means one place
+ *     to evolve user-bubble styling, both surfaces in sync.
+ *
+ * Test ids (`data-testid`) and `data-*` hooks are caller-supplied so
+ * harness specs can target the optimistic overlay or the canonical
+ * bubble distinctly.
+ */
+
+import { type ReactNode } from "react";
+
+export interface UserBubbleShellProps {
+  /** Rendered inside the `message-card-user` text card. The shell
+   *  hides the card entirely when this is empty/falsy (matches the
+   *  legacy `ThreadUserBubble` behaviour: a file-only user message has
+   *  no text card). */
+  text: ReactNode | null;
+  /** Optional file rows. Caller controls both the file-row content
+   *  (real `<FileAttachment>` for persisted files vs. pending pills
+   *  for raw `File` objects) and the wrapper spacing. The shell is
+   *  agnostic about file shape. */
+  files?: ReactNode | null;
+  /** Footer text — usually a formatted timestamp. */
+  footer: ReactNode;
+  /** Slot for state badges (e.g. the GhostBubble's "send not confirmed"
+   *  inline error). Rendered below the footer and inside the same
+   *  flex column so the badge stays right-aligned with the bubble. */
+  trailing?: ReactNode | null;
+  /** `data-testid` on the outer container. Defaults to undefined so
+   *  consumers that don't need a test hook don't pollute the DOM. */
+  outerTestId?: string;
+  /** `data-testid` on the text card. */
+  textTestId?: string;
+  /** Extra `data-*` attributes propagated onto the outer container —
+   *  used by the GhostBubble to surface `data-ghost-state` and
+   *  `data-client-message-id` for harness specs. */
+  outerDataAttributes?: Record<string, string | undefined>;
+  /** Extra `data-*` attributes propagated onto the text card — used by
+   *  the canonical `ThreadUserBubble` to publish `data-thread-id`. */
+  textDataAttributes?: Record<string, string | undefined>;
+}
+
+/** Outer flex + max-width column + text card + files + footer + trailing.
+ *  Visual structure is byte-identical between the canonical user bubble
+ *  and the optimistic ghost overlay. */
+export function UserBubbleShell({
+  text,
+  files,
+  footer,
+  trailing,
+  outerTestId,
+  textTestId,
+  outerDataAttributes,
+  textDataAttributes,
+}: UserBubbleShellProps) {
+  const showText = text !== null && text !== undefined && text !== "";
+  return (
+    <div
+      data-testid={outerTestId}
+      {...spreadDataAttributes(outerDataAttributes)}
+      className="flex justify-end px-4 py-3"
+    >
+      <div className="flex max-w-[74%] flex-col items-end">
+        {showText && (
+          <div
+            data-testid={textTestId}
+            {...spreadDataAttributes(textDataAttributes)}
+            className="message-card message-card-user rounded-[14px] rounded-br-[4px] px-4 py-2.5 text-sm leading-relaxed text-text"
+          >
+            {text}
+          </div>
+        )}
+        {files && (
+          <div className={`${showText ? "mt-2" : ""} flex flex-wrap gap-2`}>
+            {files}
+          </div>
+        )}
+        <div className="mt-1.5 px-1 text-[10px] text-muted/50 select-none">
+          {footer}
+        </div>
+        {trailing}
+      </div>
+    </div>
+  );
+}
+
+/** Drop `undefined` entries before spreading; React would otherwise
+ *  serialise them as the literal string "undefined" on the DOM node. */
+function spreadDataAttributes(
+  attrs: Record<string, string | undefined> | undefined,
+): Record<string, string> {
+  if (!attrs) return {};
+  const out: Record<string, string> = {};
+  for (const [k, v] of Object.entries(attrs)) {
+    if (v !== undefined) out[k] = v;
+  }
+  return out;
+}

--- a/src/runtime/sse-bridge.ts
+++ b/src/runtime/sse-bridge.ts
@@ -273,6 +273,14 @@ export interface SendOptions {
   onSessionActive?: (firstMessage: string) => void;
   /** Called when the assistant response is complete. */
   onComplete?: () => void;
+  /**
+   * M9-γ-4: when true, skip the optimistic user-message mirror into
+   * ThreadStore. The Composer mounts a `<GhostBubble>` overlay instead
+   * (purely visual, lives outside the store). The legacy `MessageStore`
+   * mirror still runs so flat-list renderers / history persistence keep
+   * working. Defaults to false (legacy behaviour).
+   */
+  skipOptimisticUserMessage?: boolean;
 }
 
 /**
@@ -313,12 +321,27 @@ export function sendMessage(opts: SendOptions): void {
   // 1b. Mirror the user message into the thread store when the feature flag
   //     is on — keeps both stores populated so the renderer can flag-switch
   //     without losing state.
-  ThreadStore.addUserMessage(sessionId, {
-    text,
-    clientMessageId,
-    files: localFiles,
-    topic: historyTopic,
-  });
+  //
+  //     M9-γ-4: under projection_v1 the Composer renders a `<GhostBubble>`
+  //     overlay instead of mutating the store. The caller signals this via
+  //     `skipOptimisticUserMessage` so we keep ThreadStore untouched here
+  //     and let the orphan-thread path open a bucket if/when assistant
+  //     content streams back.
+  if (!opts.skipOptimisticUserMessage) {
+    ThreadStore.addUserMessage(sessionId, {
+      text,
+      clientMessageId,
+      files: localFiles,
+      topic: historyTopic,
+    });
+  } else {
+    ThreadStore.registerPendingClientMessageId(
+      sessionId,
+      clientMessageId,
+      clientMessageId,
+      historyTopic,
+    );
+  }
 
   // Notify sidebar
   onSessionActive?.(text);

--- a/src/runtime/ui-protocol-send.test.ts
+++ b/src/runtime/ui-protocol-send.test.ts
@@ -125,6 +125,46 @@ describe("sendMessage", () => {
     expect(legacySendSpy).not.toHaveBeenCalled();
   });
 
+  // M9-γ-4 (issue #841): when `skipOptimisticUserMessage` is set,
+  // `enqueueSendV1` MUST NOT call `addUserMessage`. The Composer renders
+  // a `<GhostBubble>` overlay instead, so the durable thread reducer
+  // stays free of an optimistic row. The send itself still goes through
+  // bridge.sendTurn so the server produces real envelopes.
+  it("flag ON (skipOptimisticUserMessage): does NOT mirror into ThreadStore", async () => {
+    const bridge = makeBridge();
+    __setActiveBridgeForTest(SESSION, bridge);
+    sendMessage({
+      sessionId: SESSION,
+      text: "ghost",
+      media: [],
+      clientMessageId: "cmid-ghost",
+      skipOptimisticUserMessage: true,
+    });
+    for (let i = 0; i < 12; i++) await Promise.resolve();
+    // RPC still fired — the ghost is a UI-only opt-out, not a send opt-out.
+    expect(bridge.sendTurn).toHaveBeenCalledWith("cmid-ghost", [
+      { kind: "text", text: "ghost" },
+    ]);
+    // Acceptance criterion: no ThreadStore row.
+    expect(ThreadStore.getThreads(SESSION)).toHaveLength(0);
+  });
+
+  it("flag OFF (default): mirrors into ThreadStore (today's behaviour)", async () => {
+    const bridge = makeBridge();
+    __setActiveBridgeForTest(SESSION, bridge);
+    sendMessage({
+      sessionId: SESSION,
+      text: "legacy",
+      media: [],
+      clientMessageId: "cmid-legacy",
+      // skipOptimisticUserMessage omitted → defaults to false.
+    });
+    for (let i = 0; i < 12; i++) await Promise.resolve();
+    const threads = ThreadStore.getThreads(SESSION);
+    expect(threads).toHaveLength(1);
+    expect(threads[0].id).toBe("cmid-legacy");
+  });
+
   it("subscribes to turn lifecycle so onComplete fires on turn/completed", async () => {
     const bridge = makeBridge();
     __setActiveBridgeForTest(SESSION, bridge);

--- a/src/runtime/ui-protocol-send.ts
+++ b/src/runtime/ui-protocol-send.ts
@@ -160,12 +160,27 @@ async function enqueueSendV1(opts: SendOptions): Promise<void> {
     path,
     caption: "",
   }));
-  ThreadStore.addUserMessage(pinnedOpts.sessionId, {
-    text: pinnedOpts.text,
-    clientMessageId,
-    files: localFiles,
-    topic: pinnedOpts.historyTopic,
-  });
+  // M9-γ-4: Composer renders a `<GhostBubble>` overlay under
+  // projection_v1; it pre-registers the cmid so the first server-side
+  // envelope on this thread carries it (the projection captures it
+  // into `UserView.client_message_id` so the ghost can match-and-unmount).
+  // Skip the legacy reducer mutation so the ThreadStore stays free of an
+  // optimistic row.
+  if (!pinnedOpts.skipOptimisticUserMessage) {
+    ThreadStore.addUserMessage(pinnedOpts.sessionId, {
+      text: pinnedOpts.text,
+      clientMessageId,
+      files: localFiles,
+      topic: pinnedOpts.historyTopic,
+    });
+  } else {
+    ThreadStore.registerPendingClientMessageId(
+      pinnedOpts.sessionId,
+      clientMessageId,
+      clientMessageId,
+      pinnedOpts.historyTopic,
+    );
+  }
   pinnedOpts.onSessionActive?.(pinnedOpts.text);
 
   // The signal we hand to `sendMessageV1`. The lifecycle handler resolves

--- a/src/store/projection-store.ts
+++ b/src/store/projection-store.ts
@@ -134,6 +134,62 @@ const envelopesByKey = new Map<string, Envelope[]>();
  *  semantics. */
 const seqCountersByKey = new Map<string, Map<string, number>>();
 
+// ─── Subscriber + cmid index (M9-γ-4 codex BLOCKs 1 & 5) ───────────────────
+//
+// BLOCK 1 (settle ordering): subscribers fire AFTER `ingest()` appends to
+// the log, so a `<GhostBubble>` subscribing here is guaranteed to see the
+// envelope in `getProjection()`. Production thread-store mutators usually
+// call `notify()` BEFORE the projection dual-write, so subscribing to
+// `ThreadStore.subscribe` alone could leave a ghost waiting for an
+// unrelated later notify (or hit the 30s timeout). The projection-store's
+// own `notify()` closes that race.
+//
+// BLOCK 5 (O(1) cmid lookup): `ingest()` records every observed
+// `(storeKey, client_message_id) → thread_id` mapping. `hasCmid()` is
+// O(1) instead of `getProjection()` followed by a full thread scan on
+// every notify.
+
+/** Listeners registered with `subscribe()`. Fired by `ingest()`. */
+const listeners = new Set<() => void>();
+
+/** Per-storeKey index of `client_message_id → thread_id` for O(1) ghost
+ *  match lookups. Populated as a side effect of `ingest()` when an
+ *  envelope carries a `client_message_id`. The mapping is monotonic:
+ *  the first envelope to introduce a cmid wins; later envelopes for the
+ *  same thread can omit the cmid without unsetting the entry. */
+const cmidToThreadByKey = new Map<string, Map<string, string>>();
+
+function recordCmidIfPresent(storeKey: string, envelope: Envelope): void {
+  const cmid = envelope.client_message_id;
+  if (cmid === undefined) return;
+  let perKey = cmidToThreadByKey.get(storeKey);
+  if (!perKey) {
+    perKey = new Map();
+    cmidToThreadByKey.set(storeKey, perKey);
+  }
+  // First-write-wins: do not overwrite an existing mapping. The
+  // projection's identity is `(thread_id, seq)`, but in practice a
+  // single cmid only ever roots one thread, so a re-emission is benign.
+  if (!perKey.has(cmid)) {
+    perKey.set(cmid, envelope.thread_id);
+  }
+}
+
+function notifyProjectionListeners(): void {
+  // Snapshot the listener set so a synchronous unsubscribe inside one
+  // handler doesn't perturb iteration of the others.
+  for (const fn of [...listeners]) {
+    try {
+      fn();
+    } catch (e) {
+      // A faulty listener must not break the ingest path; log and
+      // continue. We don't have a structured logger here — match the
+      // thread-store style and keep it console-best-effort.
+      console.error("projection-store listener threw", e);
+    }
+  }
+}
+
 // ─── Public API ────────────────────────────────────────────────────────────
 
 /**
@@ -157,10 +213,17 @@ export function nextSeq(storeKey: string, threadId: string): number {
 }
 
 /** The single mutation entry point. Append the envelope to the
- *  committed log. The projection dedupes / orders / barriers — this
- *  function does NOT validate the envelope's seq nor enforce
- *  monotonicity; that's the projection's job (and the bridge's, in
- *  production). */
+ *  committed log, update the cmid index, and fan out to subscribers.
+ *
+ *  Order matters: log append → cmid index → notify. Subscribers (e.g.
+ *  the M9-γ-4 `<GhostBubble>`) are guaranteed to see the envelope via
+ *  `getProjection()` AND `hasCmid()` by the time they run. This closes
+ *  the BLOCK 1 race where the legacy thread-store called `notify()`
+ *  BEFORE its projection dual-write.
+ *
+ *  The projection dedupes / orders / barriers — this function does NOT
+ *  validate the envelope's seq nor enforce monotonicity; that's the
+ *  projection's job (and the bridge's, in production). */
 export function ingest(storeKey: string, envelope: Envelope): void {
   let log = envelopesByKey.get(storeKey);
   if (!log) {
@@ -168,6 +231,48 @@ export function ingest(storeKey: string, envelope: Envelope): void {
     envelopesByKey.set(storeKey, log);
   }
   log.push(envelope);
+  recordCmidIfPresent(storeKey, envelope);
+  notifyProjectionListeners();
+}
+
+/** Subscribe to projection-store ingests. The listener fires AFTER
+ *  every `ingest()` once the envelope is committed to the log AND the
+ *  cmid index is updated — so subscribers can synchronously call
+ *  `getProjection(storeKey)` / `hasCmid(...)` and see the new state.
+ *
+ *  Returns an unsubscribe function. Idempotent: calling it twice is a
+ *  no-op. Listeners are stored in an insertion-ordered `Set`, so the
+ *  notify order is the registration order.
+ *
+ *  M9-γ-4 BLOCK 1 fix — see the module-level comment block above. */
+export function subscribe(listener: () => void): () => void {
+  listeners.add(listener);
+  return () => {
+    listeners.delete(listener);
+  };
+}
+
+/** O(1) lookup: has any envelope with this `client_message_id` been
+ *  ingested for `storeKey`? Backed by the cmid index populated by
+ *  `ingest()`.
+ *
+ *  Replaces the per-notify `getProjection().threads.find(...)` scan
+ *  GhostBubble used to do (BLOCK 5 in the codex review). */
+export function hasCmid(storeKey: string, clientMessageId: string): boolean {
+  const perKey = cmidToThreadByKey.get(storeKey);
+  if (!perKey) return false;
+  return perKey.has(clientMessageId);
+}
+
+/** O(1) lookup: which `thread_id` did this `client_message_id` first
+ *  attach to? Returns `undefined` if no envelope carrying the cmid has
+ *  been ingested. Useful for routing later mutations back to the same
+ *  thread bucket without walking the projection. */
+export function threadIdForCmid(
+  storeKey: string,
+  clientMessageId: string,
+): string | undefined {
+  return cmidToThreadByKey.get(storeKey)?.get(clientMessageId);
 }
 
 /** Get the committed envelope log for a session. Returned as a
@@ -189,15 +294,17 @@ export function getProjectionWithMetrics(
   return projectWithMetrics(getEnvelopes(storeKey));
 }
 
-/** Drop all projection state for a session (envelope log + counters).
- *  Mirrors `thread-store.clearSession` semantics: a topic-less call
- *  sweeps the bare key AND every topic-suffixed variant. */
+/** Drop all projection state for a session (envelope log + counters
+ *  + cmid index). Mirrors `thread-store.clearSession` semantics: a
+ *  topic-less call sweeps the bare key AND every topic-suffixed
+ *  variant. */
 export function clearProjection(sessionId: string, topic?: string): void {
   const trimmedTopic = topic?.trim();
   if (trimmedTopic) {
     const key = `${sessionId}#${trimmedTopic}`;
     envelopesByKey.delete(key);
     seqCountersByKey.delete(key);
+    cmidToThreadByKey.delete(key);
     return;
   }
   for (const k of [...envelopesByKey.keys()]) {
@@ -208,6 +315,11 @@ export function clearProjection(sessionId: string, topic?: string): void {
   for (const k of [...seqCountersByKey.keys()]) {
     if (k === sessionId || k.startsWith(`${sessionId}#`)) {
       seqCountersByKey.delete(k);
+    }
+  }
+  for (const k of [...cmidToThreadByKey.keys()]) {
+    if (k === sessionId || k.startsWith(`${sessionId}#`)) {
+      cmidToThreadByKey.delete(k);
     }
   }
 }
@@ -230,6 +342,8 @@ export function projectionStoreKey(
 export function __resetProjectionForTests(): void {
   envelopesByKey.clear();
   seqCountersByKey.clear();
+  cmidToThreadByKey.clear();
+  listeners.clear();
   __resetProjectionCacheForTesting();
   __setProjectionV1ForTests(false);
 }

--- a/src/store/thread-store.ts
+++ b/src/store/thread-store.ts
@@ -444,6 +444,31 @@ function shimMapToolEndStatus(
 // Public API — mutators
 // ---------------------------------------------------------------------------
 
+/**
+ * M9-γ-4: Register a pending `client_message_id` for a thread WITHOUT
+ * mutating the legacy reducer. Used by the `<GhostBubble>` overlay so
+ * the very first dual-write envelope on this thread (e.g. an
+ * `assistant_delta` from the server's reflected response) carries the
+ * cmid — which the projection captures into `UserView.client_message_id`
+ * and the GhostBubble matches on to settle.
+ *
+ * The legacy reducer is intentionally untouched: under projection_v1,
+ * the optimistic user bubble is a pure visual overlay; the durable user
+ * row only enters `getThreads()` if/when an orphan thread is opened by
+ * a later assistant token (`appendAssistantToken` calls
+ * `ensureOrphanThread`). This guarantees the acceptance criterion:
+ * "ThreadStore must NOT have a `<GhostBubble>` row when flag ON."
+ */
+export function registerPendingClientMessageId(
+  sessionId: string,
+  threadId: string,
+  clientMessageId: string,
+  topic?: string,
+): void {
+  const key = storeKey(sessionId, topic);
+  setPendingClientMessageId(key, threadId, clientMessageId);
+}
+
 export interface AddUserMessageOptions {
   text: string;
   clientMessageId: string;


### PR DESCRIPTION
## Summary

- New `<GhostBubble>` overlay that replaces the optimistic
  `ThreadStore.addUserMessage` mutation under the `projection_v1` flag.
  Visually identical to the real user bubble (same `message-card-user`
  glass classes, same right-aligned wrapper); auto-unmounts when the
  γ-2 projection captures `UserView.client_message_id` matching the
  ghost's pinned cmid.
- Ghost lives in the `ChatThreadV2` React tree (NOT `ThreadStore`) and
  is bucketed by `(sessionId, historyTopic)` so a session switch
  doesn't bleed an in-flight optimistic bubble across views.
- Composer pins the cmid, mounts the ghost, and dispatches the send
  via `bridgeSend` with the new `skipOptimisticUserMessage: true`
  option. The bridge then registers the pending cmid so the
  projection's first envelope on this thread captures it.
- Local 30s settle timer; on timeout the ghost surfaces an inline
  error + Retry button. Retry callback is parent-supplied; failure
  does NOT pollute `ThreadStore`.
- Flag-OFF path is byte-for-byte identical to today (legacy
  `addUserMessage` mirror still fires from `enqueueSendV1`).

## Files

| Status | Path |
| ------ | ---- |
| new    | `src/components/GhostBubble.tsx` |
| new    | `src/components/GhostBubble.test.tsx` |
| mod    | `src/components/chat-thread.tsx` (Composer + ghost state lifted into `ChatThreadV2`) |
| mod    | `src/runtime/ui-protocol-send.ts` (gate `addUserMessage` mirror) |
| mod    | `src/runtime/ui-protocol-send.test.ts` (+2 parameterised flag-state cases) |
| mod    | `src/runtime/sse-bridge.ts` (`SendOptions.skipOptimisticUserMessage`) |
| mod    | `src/store/thread-store.ts` (`registerPendingClientMessageId` export) |

## References

- Spec: `api/OCTOS_UI_PROTOCOL_V1_SPEC_2026-04-24.md` § 14 (M9-γ Envelope)
- ADR: `docs/M9-GAMMA-SERVER-PROJECTION-ADR.md` (octos-org/octos#830)
- γ-3: `feat/m9-gamma-3-threadstore-projection` (octos-org/octos-web#94)
- Issue: octos-org/octos#841

## Test plan

- [x] `npx vitest run` — 299 / 299 passing (8 new GhostBubble cases +
  2 new send-path cases).
- [x] `npx tsc --noEmit` clean.
- [x] `npx eslint` clean on touched files (no new warnings; pre-existing
  `useBlobUrl` `set-state-in-effect` warning in `chat-thread.tsx` is
  unrelated to this change).
- [x] `npx vite build` succeeds; `npm run dev` smoke-checked.
- [ ] Manual smoke check in dev server: ghost appears on send-click
  with `localStorage.octos_projection_v1=1`, disappears once the
  server's reflected envelope lands carrying the cmid; flag-OFF the
  legacy bubble still mints from `ThreadStore`.
- [ ] E2E: existing chat-thread Playwright suite passes under
  flag-OFF (default); a follow-up PR can add a flag-ON e2e once γ-5
  flips the default.

## Acceptance check

The "ThreadStore must NOT have a `<GhostBubble>` row when flag ON"
invariant is asserted in `GhostBubble.test.tsx`'s "GhostBubble ×
ThreadStore [flag invariant]" describe block.