### PR TITLE
feat(store): M9-γ-3 — ThreadStore projection-mode shim (closes #840)

### DIFF
--- a/src/store/projection-store.ts
+++ b/src/store/projection-store.ts
@@ -1,0 +1,235 @@
+/**
+ * M9-γ-3: Projection-mode store wrapper around γ-2's pure `project()` fn.
+ *
+ * Spec: `api/OCTOS_UI_PROTOCOL_V1_SPEC_2026-04-24.md` § 14 (M9-γ Envelope).
+ * ADR:  `docs/M9-GAMMA-SERVER-PROJECTION-ADR.md` (PR #830).
+ * γ-2:  `src/store/projection.ts` (PR #93, the pure projection function).
+ * Issue: octos-org/octos#840.
+ *
+ * Behind the `projection_v1` feature flag (window.localStorage
+ * `octos_projection_v1` === "1"), `ThreadStore` translates every legacy
+ * mutation entry point into an `Envelope` and ingests it here. This
+ * module owns the committed envelope log and exposes the projected
+ * `ChatViewModel` for projection-only tests / future renderers.
+ *
+ * Intentional split from `thread-store.ts`:
+ *   - The thread-store stays the migration-time facade (legacy reducer
+ *     remains the source of truth for `getThreads()` so 191 existing
+ *     tests pass under both flag states).
+ *   - This store accumulates the committed envelope log and provides
+ *     the projection-mode read surface for new tests + γ-4's optimistic
+ *     overlay + γ-5's full cutover.
+ *
+ * Single mutation entry point: `ingest(envelope)`. Identity is
+ * `(thread_id, seq)`.
+ *
+ * Sessions are addressed by an opaque "store key" — the same string
+ * `thread-store.ts` uses internally (`sessionId` or `sessionId#topic`).
+ * Keeping the addressing space identical avoids a (sessionId, topic)
+ * round-trip on every dual-write hot-path call.
+ *
+ * ─── Seq policy (gap-buffer canonical) ───────────────────────────────────
+ *
+ * The shim mints client-side seqs when the caller has no server seq
+ * (streamed deltas, in-flight tool starts, etc.). The shim's seqs are
+ * 0-based per-thread monotonic — matching the projection's gap-buffer
+ * `expectedNextSeq=0` initialization. Server-issued seqs (historySeq /
+ * committedSeq) flow through `ingest()` with the server's own seq value;
+ * the projection's gap-buffer drains in canonical order regardless of
+ * arrival order. Identity is `(thread_id, seq)`; same-seq arrivals are
+ * deduplicated, gap-buffered fills drain when the gap closes.
+ */
+
+import {
+  __resetProjectionCacheForTesting,
+  project,
+  projectWithMetrics,
+} from "./projection";
+import type { ChatViewModel, ProjectionMetrics } from "./projection";
+import type { Envelope } from "../runtime/ui-protocol-types";
+
+// ─── Feature flag ──────────────────────────────────────────────────────────
+
+/** localStorage key gating projection-mode dual-writes. Production
+ *  default is OFF; tests flip the flag in their setup. */
+const PROJECTION_V1_FLAG_KEY = "octos_projection_v1";
+
+/** Cached snapshot of the flag's value on first read. The flag is
+ *  intentionally locked in at first read so a mid-session flip can't
+ *  start the projection log from the next shimmed event with no prior
+ *  envelope history (codex round-1 BLOCK 5). A subsequent flip is a
+ *  one-shot `console.warn` and ignored until reload. */
+let cachedProjectionV1Enabled: boolean | null = null;
+let warnedAboutMidSessionChange = false;
+
+function readFlagFromStorage(): boolean {
+  try {
+    if (typeof globalThis === "undefined") return false;
+    const ls = (globalThis as { localStorage?: Storage }).localStorage;
+    if (!ls) return false;
+    return ls.getItem(PROJECTION_V1_FLAG_KEY) === "1";
+  } catch {
+    // Some jsdom configurations throw on `localStorage` access (security
+    // origin checks). Treat unreachable storage as flag-off.
+    return false;
+  }
+}
+
+/** Read the projection-mode flag. Cached on first call so a mid-session
+ *  flip can't start the projection log mid-stream. Subsequent flag
+ *  changes log a one-shot warning and are otherwise ignored until the
+ *  next reload. Tests reset the cache via `__setProjectionV1ForTests`. */
+export function isProjectionV1Enabled(): boolean {
+  if (cachedProjectionV1Enabled !== null) {
+    // Detect a mid-session flip and warn (once). The cache wins; the
+    // observed flag value at first read is the source of truth for the
+    // rest of the session.
+    if (!warnedAboutMidSessionChange) {
+      const live = readFlagFromStorage();
+      if (live !== cachedProjectionV1Enabled) {
+        warnedAboutMidSessionChange = true;
+        console.warn(
+          "[octos] octos_projection_v1 changed mid-session; the new " +
+            "value is ignored until reload to avoid starting the " +
+            "projection log mid-stream.",
+        );
+      }
+    }
+    return cachedProjectionV1Enabled;
+  }
+  cachedProjectionV1Enabled = readFlagFromStorage();
+  return cachedProjectionV1Enabled;
+}
+
+/** Test helper: flip the flag in the current jsdom origin AND reset the
+ *  cache so the next `isProjectionV1Enabled()` call re-reads it. Without
+ *  the cache reset, vitest-level flips would all see the value latched
+ *  from the very first read in the worker process. */
+export function __setProjectionV1ForTests(enabled: boolean): void {
+  try {
+    const ls = (globalThis as { localStorage?: Storage }).localStorage;
+    if (!ls) {
+      cachedProjectionV1Enabled = null;
+      warnedAboutMidSessionChange = false;
+      return;
+    }
+    if (enabled) ls.setItem(PROJECTION_V1_FLAG_KEY, "1");
+    else ls.removeItem(PROJECTION_V1_FLAG_KEY);
+  } catch {
+    // No-op when storage is unavailable.
+  }
+  cachedProjectionV1Enabled = null;
+  warnedAboutMidSessionChange = false;
+}
+
+// ─── Internal state ────────────────────────────────────────────────────────
+
+/** Committed envelope log per session storeKey. Append-only. */
+const envelopesByKey = new Map<string, Envelope[]>();
+
+/** Per-(storeKey, thread) monotonic counter for shim-minted seqs.
+ *  Counter advances by 1 on each call; first value returned is 0,
+ *  matching projection's `expectedNextSeq=0` initialization so the very
+ *  first envelope on a thread applies in-order under gap-buffer
+ *  semantics. */
+const seqCountersByKey = new Map<string, Map<string, number>>();
+
+// ─── Public API ────────────────────────────────────────────────────────────
+
+/**
+ * Synthesize the next client-side seq for a thread. Returns a
+ * non-negative integer (0, 1, 2, …) — per-thread monotonic, not
+ * `Date.now()`-based, so re-projecting the committed log is
+ * deterministic. The projection dedupes on `(thread_id, seq)`; the shim
+ * caller is responsible for not minting a synthetic seq when the server
+ * is going to assign its own (the migration shim only mints for
+ * pre-persistence in-flight events).
+ */
+export function nextSeq(storeKey: string, threadId: string): number {
+  let perThread = seqCountersByKey.get(storeKey);
+  if (!perThread) {
+    perThread = new Map();
+    seqCountersByKey.set(storeKey, perThread);
+  }
+  const next = perThread.get(threadId) ?? 0;
+  perThread.set(threadId, next + 1);
+  return next;
+}
+
+/** The single mutation entry point. Append the envelope to the
+ *  committed log. The projection dedupes / orders / barriers — this
+ *  function does NOT validate the envelope's seq nor enforce
+ *  monotonicity; that's the projection's job (and the bridge's, in
+ *  production). */
+export function ingest(storeKey: string, envelope: Envelope): void {
+  let log = envelopesByKey.get(storeKey);
+  if (!log) {
+    log = [];
+    envelopesByKey.set(storeKey, log);
+  }
+  log.push(envelope);
+}
+
+/** Get the committed envelope log for a session. Returned as a
+ *  read-only view; callers must NOT mutate. Useful for projection-only
+ *  tests that want to assert on the raw log shape. */
+export function getEnvelopes(storeKey: string): ReadonlyArray<Envelope> {
+  return envelopesByKey.get(storeKey) ?? [];
+}
+
+/** Compute and return the projected `ChatViewModel` for a session. */
+export function getProjection(storeKey: string): ChatViewModel {
+  return project(getEnvelopes(storeKey));
+}
+
+/** Variant that surfaces metrics counters alongside the view. */
+export function getProjectionWithMetrics(
+  storeKey: string,
+): { view: ChatViewModel; metrics: ProjectionMetrics } {
+  return projectWithMetrics(getEnvelopes(storeKey));
+}
+
+/** Drop all projection state for a session (envelope log + counters).
+ *  Mirrors `thread-store.clearSession` semantics: a topic-less call
+ *  sweeps the bare key AND every topic-suffixed variant. */
+export function clearProjection(sessionId: string, topic?: string): void {
+  const trimmedTopic = topic?.trim();
+  if (trimmedTopic) {
+    const key = `${sessionId}#${trimmedTopic}`;
+    envelopesByKey.delete(key);
+    seqCountersByKey.delete(key);
+    return;
+  }
+  for (const k of [...envelopesByKey.keys()]) {
+    if (k === sessionId || k.startsWith(`${sessionId}#`)) {
+      envelopesByKey.delete(k);
+    }
+  }
+  for (const k of [...seqCountersByKey.keys()]) {
+    if (k === sessionId || k.startsWith(`${sessionId}#`)) {
+      seqCountersByKey.delete(k);
+    }
+  }
+}
+
+/** Build the shared store-key string. Mirrors `thread-store`'s
+ *  internal `storeKey` so dual-writes target the same bucket. */
+export function projectionStoreKey(
+  sessionId: string,
+  topic?: string,
+): string {
+  const trimmedTopic = topic?.trim();
+  return trimmedTopic ? `${sessionId}#${trimmedTopic}` : sessionId;
+}
+
+/** Test-only helper: reset all projection-store state, including the
+ *  pure-function projection's per-thread ThreadView cache. The cache
+ *  lives in `projection.ts` module scope; without clearing it, a thread
+ *  whose `(appliedCount, lastSeq)` matches a stale entry from a previous
+ *  test would return the stale view. */
+export function __resetProjectionForTests(): void {
+  envelopesByKey.clear();
+  seqCountersByKey.clear();
+  __resetProjectionCacheForTesting();
+  __setProjectionV1ForTests(false);
+}

--- a/src/store/thread-store.test.ts
+++ b/src/store/thread-store.test.ts
@@ -14,13 +14,30 @@
  *  10. abort_marks_pending_assistant_as_complete_with_partial_text
  *  11. reordered_arrival_preserves_send_order
  *  12. subscribe_notifies_on_change
+ *
+ * M9-γ-3 (issue #840): every test in this file runs twice — once with
+ * the `projection_v1` flag OFF (legacy reducer is the source of truth)
+ * and once ON (the shim translates each entry point into a projection
+ * envelope and ingests it in parallel; legacy reducer continues to
+ * back `getThreads()`). Parametrising with `describe.each` keeps the
+ * test names distinguishable in the runner output.
  */
 
-import { afterEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import * as ThreadStore from "./thread-store";
+import {
+  __resetProjectionForTests,
+  __setProjectionV1ForTests,
+  getEnvelopes,
+  getProjection,
+  getProjectionWithMetrics,
+  ingest as projectionIngest,
+  projectionStoreKey,
+} from "./projection-store";
 
 afterEach(() => {
   ThreadStore.__resetForTests();
+  __resetProjectionForTests();
   vi.unstubAllGlobals();
 });
 
@@ -33,7 +50,16 @@ function makeUser(text: string, cmid: string) {
   });
 }
 
-describe("thread-store", () => {
+const FLAG_STATES = [
+  { label: "projectionV1=false", projectionV1: false },
+  { label: "projectionV1=true", projectionV1: true },
+] as const;
+
+describe.each(FLAG_STATES)("thread-store [$label]", ({ projectionV1 }) => {
+  beforeEach(() => {
+    __setProjectionV1ForTests(projectionV1);
+  });
+
   it("creates_thread_on_user_message", () => {
     makeUser("hello", "cmid-1");
     const threads = ThreadStore.getThreads(SESSION);
@@ -1763,7 +1789,12 @@ describe("thread-store", () => {
 // M10 Phase 6.2 (Bug C): WS session/hydrate dedup pass
 // ---------------------------------------------------------------------------
 
-describe("applyHydrateDedup (M10 Phase 6.2)", () => {
+describe.each(FLAG_STATES)(
+  "applyHydrateDedup (M10 Phase 6.2) [$label]",
+  ({ projectionV1 }) => {
+    beforeEach(() => {
+      __setProjectionV1ForTests(projectionV1);
+    });
   const SID = "sess-bug-c";
 
   it("drops the legacy spawn-ack row when an envelope's message_id matches it, then renders the envelope", () => {
@@ -2247,9 +2278,15 @@ describe("applyHydrateDedup (M10 Phase 6.2)", () => {
       "envelope final",
     ]);
   });
-});
+  },
+);
 
-describe("setHydrateSnapshot reload-mid-stream fallback (M10.5)", () => {
+describe.each(FLAG_STATES)(
+  "setHydrateSnapshot reload-mid-stream fallback (M10.5) [$label]",
+  ({ projectionV1 }) => {
+    beforeEach(() => {
+      __setProjectionV1ForTests(projectionV1);
+    });
   const SID = "sess-reload-mid-stream";
 
   /**
@@ -2765,5 +2802,502 @@ describe("setHydrateSnapshot reload-mid-stream fallback (M10.5)", () => {
     );
     expect(allFiles).toContain("pf/orphan.md");
     expect(allFiles).toContain("pf/different.md");
+  });
+  },
+);
+
+// ---------------------------------------------------------------------------
+// M9-γ-3 (issue #840): projection-mode-only behaviour.
+//
+// These tests run ONLY with `octos_projection_v1 === "1"` and exercise
+// the scenarios the legacy reducer handles imperfectly. Each one
+// asserts on `getProjection(...)` (the pure-function view computed from
+// the committed envelope log), NOT on `getThreads(...)` (the legacy
+// state). The projection-only invariants verified here are the ones
+// γ-5 will inherit when the legacy reducer is retired.
+// ---------------------------------------------------------------------------
+
+describe("ThreadStore projection-mode (M9-γ-3, octos#840)", () => {
+  const SID = "sess-projection";
+
+  beforeEach(() => {
+    __setProjectionV1ForTests(true);
+  });
+
+  it("phantom_bubble_repro_two_assistant_persisted_envelopes_at_seq_1_and_3_accumulate_without_phantom", () => {
+    // The 2026-05-09 production phantom-bubble pattern: two
+    // `assistant_persisted` events for the same thread land at seq 0
+    // and seq 2 (an interleaving tool_progress at seq 1 in between).
+    // Legacy `appendCompletionBubble` could spawn a phantom row at
+    // seq=0 and then a SECOND row at seq=2 because the historySeq
+    // dedup path fell through under specific media-merge donations.
+    // Under gap-buffer projection semantics, both seqs apply in
+    // canonical order; `assistant_persisted` REPLACES the assistant
+    // text/meta in-place, so seq=2 (the canonical replay) wins.
+    ThreadStore.addUserMessage(SID, {
+      text: "research X",
+      clientMessageId: "cmid-1",
+    });
+    const key = projectionStoreKey(SID);
+
+    // Inject the two persisted envelopes directly through the
+    // projection-store so we control the exact `seq` values. We use
+    // `projectionIngest` rather than the legacy entry points so the
+    // test pins the projection's own dedup contract — independent of
+    // what the legacy reducer would have done.
+    projectionIngest(key, {
+      thread_id: "cmid-1",
+      seq: 0,
+      payload: {
+        type: "assistant_persisted",
+        data: {
+          text: "first persisted",
+          meta: {
+            message_id: "msg-1",
+            persisted_at: "2026-05-09T10:00:01Z",
+          },
+        },
+      },
+    });
+    projectionIngest(key, {
+      thread_id: "cmid-1",
+      seq: 1,
+      payload: { type: "assistant_delta", data: { text: " (drift)" } },
+    });
+    projectionIngest(key, {
+      thread_id: "cmid-1",
+      seq: 2,
+      payload: {
+        type: "assistant_persisted",
+        data: {
+          text: "second persisted (canonical)",
+          meta: {
+            message_id: "msg-3",
+            persisted_at: "2026-05-09T10:00:03Z",
+          },
+        },
+      },
+    });
+
+    const view = getProjection(key);
+    // Exactly ONE thread, one assistant slot — no phantom row.
+    expect(view.threads).toHaveLength(1);
+    const thread = view.threads[0];
+    expect(thread.thread_id).toBe("cmid-1");
+    expect(thread.assistant?.persisted).toBe(true);
+    // Last persisted wins (canonical text).
+    expect(thread.assistant?.text).toBe("second persisted (canonical)");
+    expect(thread.assistant?.meta?.message_id).toBe("msg-3");
+  });
+
+  it("late_tool_progress_after_turn_completed_is_dropped_by_projection_hard_barrier", () => {
+    // Legacy `appendToolProgress` would re-open a `pendingAssistant`
+    // for a finalized thread (the spawn_only late-progress path); the
+    // projection's hard barrier on `turn_completed` drops the event
+    // and bumps `metrics.droppedAfterTurnCompleted` instead.
+    ThreadStore.addUserMessage(SID, {
+      text: "run pipeline",
+      clientMessageId: "cmid-1",
+    });
+    ThreadStore.addToolCall("cmid-1", "tc-1", "deep_research");
+    ThreadStore.finalizeAssistant("cmid-1", { committedSeq: 5 });
+
+    // After finalize → projection saw `turn_completed`. Late progress
+    // arrives for the same thread.
+    ThreadStore.appendToolProgress("cmid-1", "tc-1", "[late] still working");
+
+    const key = projectionStoreKey(SID);
+    const { view, metrics } = getProjectionWithMetrics(key);
+    const thread = view.threads.find((t) => t.thread_id === "cmid-1");
+    expect(thread?.completed).toBe(true);
+    // The late `tool_progress` envelope was emitted by the shim AND
+    // ingested into the log, BUT the projection's barrier dropped
+    // it — so the tool's `progress` array does NOT contain the late
+    // message.
+    const toolCall = thread?.toolCalls.find((tc) => tc.tool_call_id === "tc-1");
+    expect(toolCall?.progress).not.toContain("[late] still working");
+    // The projection counter records the drop.
+    expect(metrics.droppedAfterTurnCompleted).toBeGreaterThanOrEqual(1);
+  });
+
+  it("out_of_order_delivery_seq_2_then_seq_1_is_buffered_and_drained_in_canonical_order", () => {
+    // Inject envelopes in `seq=2, seq=1, seq=0` reverse order. Under
+    // γ-2's gap-buffer semantics, out-of-order envelopes are BUFFERED
+    // (not dropped) until the gap closes, then drained in canonical
+    // seq order. `metrics.outOfOrder` counts buffered-then-drained
+    // envelopes (back-compat name; not lost). The accumulated
+    // assistant text reflects canonical seq order: "zeroth firstthird"
+    // wait no — seqs 0,1,2 have text "zeroth", "first", "second"
+    // applied in that order, concatenated.
+    const key = projectionStoreKey(SID);
+    ThreadStore.addUserMessage(SID, {
+      text: "out of order",
+      clientMessageId: "cmid-1",
+    });
+    projectionIngest(key, {
+      thread_id: "cmid-1",
+      seq: 2,
+      payload: { type: "assistant_delta", data: { text: "second" } },
+    });
+    projectionIngest(key, {
+      thread_id: "cmid-1",
+      seq: 1,
+      payload: { type: "assistant_delta", data: { text: "first" } },
+    });
+    projectionIngest(key, {
+      thread_id: "cmid-1",
+      seq: 0,
+      payload: { type: "assistant_delta", data: { text: "zeroth" } },
+    });
+    const { view, metrics } = getProjectionWithMetrics(key);
+    // Two envelopes (seq=2, seq=1) were buffered; seq=0 closed the
+    // gap and drained both. The counter is back-compat-named
+    // `outOfOrder`.
+    expect(metrics.outOfOrder).toBeGreaterThanOrEqual(2);
+    expect(metrics.duplicates).toBe(0);
+    const thread = view.threads.find((t) => t.thread_id === "cmid-1");
+    // Canonical-order concatenation: 0 → "zeroth", 1 → "first",
+    // 2 → "second" — gap-buffer drains them in seq order regardless
+    // of arrival order.
+    expect(thread?.assistant?.text).toBe("zeroth" + "first" + "second");
+  });
+
+  it("cross_session_orphan_envelope_for_unknown_thread_is_appended_no_orphan_bucket_needed", () => {
+    // Legacy `findThreadById`/`ensureOrphanThread` allocates a
+    // placeholder bucket when a `tool_progress` arrives for an
+    // unknown thread. The projection just appends the envelope and
+    // the projected view exposes the orphan thread as its own row —
+    // no host-session-picking heuristic, no placeholder allocation.
+    const key = projectionStoreKey(SID);
+    projectionIngest(key, {
+      thread_id: "cmid-orphan",
+      seq: 0,
+      payload: {
+        type: "tool_progress",
+        data: { tool_call_id: "tc-orphan", message: "orphan log line" },
+      },
+    });
+    const view = getProjection(key);
+    const orphan = view.threads.find((t) => t.thread_id === "cmid-orphan");
+    expect(orphan).toBeDefined();
+    // The projection opens a tool-call card with empty `name` (per
+    // γ-2's "progress without a prior start" path) — exactly the
+    // shape γ-5's render layer keys off.
+    const tc = orphan?.toolCalls.find((tc) => tc.tool_call_id === "tc-orphan");
+    expect(tc).toBeDefined();
+    expect(tc?.progress).toContain("orphan log line");
+  });
+
+  it("identity_collapse_client_message_id_is_captured_on_envelope_but_projection_keys_on_seq", () => {
+    // The brief: an envelope's `client_message_id` field is captured
+    // but only used for the optimistic overlay (γ-4); the projection
+    // itself ignores it for identity. We verify both halves:
+    //
+    //   (1) The envelope log carries `client_message_id` on the
+    //       first envelope for a thread (γ-4's GhostBubble overlay
+    //       reads this).
+    //   (2) The projection's `(thread_id, seq)` dedup is unaffected
+    //       by `client_message_id`: two envelopes that share
+    //       `(thread_id, seq)` BUT differ on `client_message_id` are
+    //       still treated as duplicates (the second one is dropped).
+    ThreadStore.addUserMessage(SID, {
+      text: "identity collapse",
+      clientMessageId: "cmid-collapse",
+    });
+    const key = projectionStoreKey(SID);
+    // The shim should have associated `cmid-collapse` with the next
+    // envelope this thread emits. Trigger one by streaming a token.
+    ThreadStore.appendAssistantToken("cmid-collapse", "hi");
+
+    const log = getEnvelopes(key);
+    const firstForThread = log.find(
+      (e) => e.thread_id === "cmid-collapse",
+    );
+    expect(firstForThread).toBeDefined();
+    expect(firstForThread?.client_message_id).toBe("cmid-collapse");
+
+    // Now deliberately re-ingest the same `(thread_id, seq)` with a
+    // DIFFERENT `client_message_id` — the projection's idempotency
+    // guard drops it; `client_message_id` plays no role in identity.
+    const dupSeq = firstForThread!.seq;
+    projectionIngest(key, {
+      thread_id: "cmid-collapse",
+      seq: dupSeq,
+      client_message_id: "cmid-NOT-the-same",
+      payload: { type: "assistant_delta", data: { text: " stray" } },
+    });
+    const { metrics } = getProjectionWithMetrics(key);
+    expect(metrics.duplicates).toBeGreaterThanOrEqual(1);
+    // The projection's user view still carries the ORIGINAL cmid
+    // (set on first-seen envelope) — not the duplicate's cmid.
+    const view = getProjection(key);
+    const thread = view.threads.find((t) => t.thread_id === "cmid-collapse");
+    expect(thread?.user?.client_message_id).toBe("cmid-collapse");
+  });
+
+  it("shim_synthesizes_per_thread_monotonic_seqs_so_re_projection_is_deterministic", () => {
+    // Constraint from the brief: shim seq synthesis must be
+    // per-thread monotonic (NOT `Date.now()`) so that re-projecting
+    // the committed log is deterministic. Under gap-buffer projection
+    // semantics, the shim mints non-negative seqs starting at 0 to
+    // match `expectedNextSeq=0` initialization.
+    ThreadStore.addUserMessage(SID, { text: "Q1", clientMessageId: "cm-1" });
+    ThreadStore.addUserMessage(SID, { text: "Q2", clientMessageId: "cm-2" });
+    ThreadStore.appendAssistantToken("cm-1", "A1.1");
+    ThreadStore.appendAssistantToken("cm-2", "A2.1");
+    ThreadStore.appendAssistantToken("cm-1", "A1.2");
+    ThreadStore.appendAssistantToken("cm-2", "A2.2");
+
+    const key = projectionStoreKey(SID);
+    const log = getEnvelopes(key);
+    // Group by thread_id and verify monotonicity.
+    const byThread = new Map<string, number[]>();
+    for (const env of log) {
+      const arr = byThread.get(env.thread_id) ?? [];
+      arr.push(env.seq);
+      byThread.set(env.thread_id, arr);
+    }
+    for (const seqs of byThread.values()) {
+      // Shim mints non-negative seqs so the gap-buffer projection's
+      // expectedNextSeq=0 initialization fits the first arrival.
+      for (const s of seqs) expect(s).toBeGreaterThanOrEqual(0);
+      // Strictly increasing per-thread.
+      for (let i = 1; i < seqs.length; i += 1) {
+        expect(seqs[i]).toBeGreaterThan(seqs[i - 1]);
+      }
+    }
+    // Cross-thread independence: cm-1 and cm-2 each start their own
+    // counter — neither one's seqs are functions of the other's.
+    expect(byThread.get("cm-1")?.[0]).toBe(byThread.get("cm-2")?.[0]);
+  });
+
+  // ── codex round-1 BLOCK 1: synthetic / server seq namespaces ──────────
+
+  it("streamed_delta_then_persisted_envelope_apply_in_canonical_seq_order_under_gap_buffer", () => {
+    // Under gap-buffer semantics, the shim mints a non-negative
+    // synthetic seq for the streamed delta (seq=0) and a subsequent
+    // server-issued `assistant_persisted` carries the next seq (seq=1
+    // here). Both apply in canonical order; the persisted payload
+    // REPLACES the assistant text/meta in place, so the persisted
+    // canonical text wins.
+    ThreadStore.addUserMessage(SID, {
+      text: "stream then persist",
+      clientMessageId: "cmid-1",
+    });
+
+    // Synthetic delta — shim mints seq=0.
+    ThreadStore.appendAssistantToken("cmid-1", "streamed");
+
+    // Server-issued persisted envelope with seq=1 (next after the
+    // synthetic delta). The gap-buffer applies it in order.
+    const key = projectionStoreKey(SID);
+    projectionIngest(key, {
+      thread_id: "cmid-1",
+      seq: 1,
+      payload: {
+        type: "assistant_persisted",
+        data: {
+          text: "persisted-canonical",
+          meta: {
+            message_id: "msg-server-1",
+            persisted_at: "2026-05-09T11:00:01Z",
+          },
+        },
+      },
+    });
+
+    const { view, metrics } = getProjectionWithMetrics(key);
+    // Both applied in order — neither dropped as a duplicate.
+    expect(metrics.duplicates).toBe(0);
+    const thread = view.threads.find((t) => t.thread_id === "cmid-1");
+    // The persisted text wins (assistant_persisted REPLACES text).
+    expect(thread?.assistant?.persisted).toBe(true);
+    expect(thread?.assistant?.text).toBe("persisted-canonical");
+  });
+
+  it("late_arriving_envelope_with_seq_below_high_water_buffers_then_drains_under_gap_buffer", () => {
+    // Under the canonical gap-buffer projection (γ-2 fixup), an
+    // envelope arriving with `seq < expectedNextSeq` is BUFFERED for
+    // a possible canonical replay rather than dropped. The shim mints
+    // non-negative monotonic seqs so a streamed delta and a
+    // subsequent late-fill on a lower seq are reconciled by the
+    // projection's drain logic.
+    ThreadStore.addUserMessage(SID, {
+      text: "interleaved arrivals",
+      clientMessageId: "cmid-1",
+    });
+
+    // Two streamed tokens through the shim — synthetic seqs 0, 1.
+    ThreadStore.appendAssistantToken("cmid-1", "a");
+    ThreadStore.appendAssistantToken("cmid-1", "b");
+
+    // A late-arriving envelope at seq=3 (gap above expected=2). The
+    // gap-buffer holds it pending. seq=3 contributes a tool_start.
+    const key = projectionStoreKey(SID);
+    projectionIngest(key, {
+      thread_id: "cmid-1",
+      seq: 3,
+      payload: {
+        type: "tool_start",
+        data: { tool_call_id: "tc-srv", name: "external_tool" },
+      },
+    });
+    // seq=2 closes the gap; seq=3 drains immediately after.
+    projectionIngest(key, {
+      thread_id: "cmid-1",
+      seq: 2,
+      payload: { type: "assistant_delta", data: { text: "c" } },
+    });
+
+    const { view, metrics } = getProjectionWithMetrics(key);
+    // seq=3 was buffered then drained; counted in `outOfOrder`
+    // (back-compat name for buffered-then-applied).
+    expect(metrics.outOfOrder).toBeGreaterThanOrEqual(1);
+    expect(metrics.duplicates).toBe(0);
+    const thread = view.threads.find((t) => t.thread_id === "cmid-1");
+    expect(
+      thread?.toolCalls.find((tc) => tc.tool_call_id === "tc-srv"),
+    ).toBeDefined();
+    expect(thread?.assistant?.text).toBe("abc");
+  });
+
+  // ── codex round-1 BLOCK 2: retry-collapse emits tool_start ────────────
+
+  it("addToolCall_retry_collapse_emits_tool_start_for_new_tool_call_id", () => {
+    // The retry-collapse path mutates the existing legacy tool entry
+    // (incrementing retryCount) and returns early. Pre-fix, no
+    // `tool_start` envelope was emitted for the NEW tool_call_id, so
+    // the projection's tool card was either keyed on the OLD id (if
+    // legacy reused it via mutation) or never opened — and any
+    // subsequent `tool_progress` for the new id would synthesise an
+    // empty-name card. Post-fix: the retry-collapse path emits a
+    // fresh `tool_start { tool_call_id: NEW, name }` envelope so the
+    // projection opens a properly-named card under the new id.
+    ThreadStore.addUserMessage(SID, {
+      text: "retry me",
+      clientMessageId: "cmid-1",
+    });
+    ThreadStore.addToolCall("cmid-1", "tc-1", "fetch_thing");
+    ThreadStore.setToolCallStatus("cmid-1", "tc-1", "error");
+    // The retry: same name, NEW id. Legacy collapses; projection
+    // must still see a `tool_start` for tc-2.
+    ThreadStore.addToolCall("cmid-1", "tc-2", "fetch_thing");
+
+    const key = projectionStoreKey(SID);
+    const log = getEnvelopes(key);
+    const startsForTc2 = log.filter(
+      (e) =>
+        e.payload.type === "tool_start" &&
+        e.payload.data.tool_call_id === "tc-2",
+    );
+    expect(startsForTc2).toHaveLength(1);
+    expect(
+      startsForTc2[0].payload.type === "tool_start" &&
+        startsForTc2[0].payload.data.name,
+    ).toBe("fetch_thing");
+
+    // And the projected view: tc-2 has a card with the right name.
+    const view = getProjection(key);
+    const thread = view.threads.find((t) => t.thread_id === "cmid-1");
+    const tc2 = thread?.toolCalls.find((tc) => tc.tool_call_id === "tc-2");
+    expect(tc2).toBeDefined();
+    expect(tc2?.name).toBe("fetch_thing");
+  });
+
+  // ── codex round-1 BLOCK 3: finalizeAssistant emits tool_end on sweep ──
+
+  it("finalizeAssistant_emits_tool_end_for_swept_running_tool_calls_before_turn_completed", () => {
+    // Legacy `finalizeAssistant` sweeps any tool calls still in
+    // `"running"` to `"complete"` (the wire never delivered a
+    // `tool_end` for them). Pre-fix, the projection's tool card
+    // stayed in `status: null` because no `tool_end` envelope was
+    // emitted, AND the subsequent `turn_completed` envelope's hard
+    // barrier meant a late tool_end on the wire could never close
+    // the card. Post-fix: finalize emits a synthetic `tool_end`
+    // BEFORE `turn_completed` for every swept call.
+    ThreadStore.addUserMessage(SID, {
+      text: "run pipeline",
+      clientMessageId: "cmid-1",
+    });
+    ThreadStore.addToolCall("cmid-1", "tc-A", "step_one");
+    ThreadStore.addToolCall("cmid-1", "tc-B", "step_two");
+    // tc-B finishes explicitly via tool_end; tc-A is left running.
+    ThreadStore.setToolCallStatus("cmid-1", "tc-B", "complete");
+    // Now finalize — the sweep should close tc-A in the projection.
+    ThreadStore.finalizeAssistant("cmid-1", { committedSeq: 7 });
+
+    const key = projectionStoreKey(SID);
+    const log = getEnvelopes(key);
+
+    // Find the indices of tool_end events for tc-A and the
+    // turn_completed event — the tool_end MUST come first.
+    const tcAEndIdx = log.findIndex(
+      (e) =>
+        e.payload.type === "tool_end" &&
+        e.payload.data.tool_call_id === "tc-A",
+    );
+    const turnCompletedIdx = log.findIndex(
+      (e) => e.payload.type === "turn_completed",
+    );
+    expect(tcAEndIdx).toBeGreaterThanOrEqual(0);
+    expect(turnCompletedIdx).toBeGreaterThanOrEqual(0);
+    expect(tcAEndIdx).toBeLessThan(turnCompletedIdx);
+
+    // And the projected view: tc-A is closed with status=complete.
+    const view = getProjection(key);
+    const thread = view.threads.find((t) => t.thread_id === "cmid-1");
+    const tcA = thread?.toolCalls.find((tc) => tc.tool_call_id === "tc-A");
+    expect(tcA?.status).toBe("complete");
+    expect(thread?.completed).toBe(true);
+  });
+
+  // ── codex round-1 BLOCK 5: mid-session flag flip is ignored ───────────
+
+  it("mid_session_projection_v1_flag_flip_is_ignored_until_reload", () => {
+    // The flag is read once and cached on first call; a subsequent
+    // localStorage flip is logged as a one-shot warning and
+    // otherwise ignored — pre-fix, flipping the flag mid-session
+    // would start the projection log from the next shimmed event
+    // with no prior envelope history, leaving the projection in an
+    // inconsistent state.
+    //
+    // First read latches the cache at "true" (from the suite's
+    // `beforeEach`). Now flip localStorage to "0" WITHOUT calling
+    // `__setProjectionV1ForTests` (the test helper resets the
+    // cache); the cached value should win.
+    const warnSpy = vi
+      .spyOn(console, "warn")
+      .mockImplementation(() => undefined);
+    try {
+      // Prime the cache by issuing a mutation under projectionV1=true.
+      ThreadStore.addUserMessage(SID, {
+        text: "first",
+        clientMessageId: "cm-1",
+      });
+      ThreadStore.appendAssistantToken("cm-1", "hello");
+
+      const key = projectionStoreKey(SID);
+      expect(getEnvelopes(key).length).toBeGreaterThan(0);
+      const beforeFlipCount = getEnvelopes(key).length;
+
+      // Flip the raw flag bypassing the test helper.
+      globalThis.localStorage?.removeItem("octos_projection_v1");
+
+      // Subsequent mutation should STILL emit envelopes (the cached
+      // value wins), AND a single console.warn should fire.
+      ThreadStore.appendAssistantToken("cm-1", " world");
+      const afterFlipCount = getEnvelopes(key).length;
+      expect(afterFlipCount).toBeGreaterThan(beforeFlipCount);
+      expect(warnSpy).toHaveBeenCalledTimes(1);
+      expect(warnSpy.mock.calls[0][0]).toMatch(/octos_projection_v1/);
+
+      // Multiple subsequent mutations DO NOT spam the warning —
+      // it's a one-shot.
+      ThreadStore.appendAssistantToken("cm-1", "!");
+      ThreadStore.appendAssistantToken("cm-1", "?");
+      expect(warnSpy).toHaveBeenCalledTimes(1);
+    } finally {
+      warnSpy.mockRestore();
+    }
   });
 });

--- a/src/store/thread-store.ts
+++ b/src/store/thread-store.ts
@@ -22,6 +22,17 @@ import { getMessages as fetchMessages } from "@/api/sessions";
 import type { MessageInfo } from "@/api/types";
 import { displayFilenameFromPath } from "@/lib/utils";
 import { recordRuntimeCounter } from "@/runtime/observability";
+import type {
+  Envelope,
+  EnvelopeToolEndStatus,
+  Payload,
+} from "@/runtime/ui-protocol-types";
+import {
+  ingest as projectionIngest,
+  isProjectionV1Enabled,
+  nextSeq as projectionNextSeq,
+  projectionStoreKey,
+} from "./projection-store";
 
 // ---------------------------------------------------------------------------
 // Types
@@ -176,6 +187,20 @@ function findThreadById(
   return null;
 }
 
+/** Find the storeKey hosting the given thread. Used by the projection-mode
+ *  shim: legacy entry points like `appendAssistantToken` carry a
+ *  threadId without (sessionId, topic), so the shim walks
+ *  `sessionsByKey` to find the bucket — same lookup as `findThreadById`
+ *  but returning the key string for `projectionIngest()`. Returns null
+ *  when the thread is not yet hosted (caller should skip the dual-write
+ *  rather than silently invent a bucket). */
+function findStoreKeyForThread(threadId: string): string | null {
+  for (const [key, state] of sessionsByKey.entries()) {
+    if (state.byId.has(threadId)) return key;
+  }
+  return null;
+}
+
 /** Pick a "best guess" session to host a brand-new orphan thread bucket
  *  created in response to a late background event whose user message we
  *  never saw (page reload, multi-tab, etc.). Picks the session with the
@@ -318,6 +343,104 @@ function sortResponsesInThread(thread: Thread): void {
 }
 
 // ---------------------------------------------------------------------------
+// Projection-mode shim (M9-γ-3, issue #840)
+//
+// When the `octos_projection_v1` localStorage flag is `"1"`, every
+// legacy mutation entry point ALSO synthesizes an `Envelope` and
+// ingests it into the projection store (`./projection-store.ts`). The
+// legacy reducer continues to run unchanged so `getThreads()` keeps
+// returning the same `Thread[]` shape — that's why the existing 191
+// tests pass under both flag states. The projection log accumulates in
+// parallel; new projection-only tests assert against
+// `getProjection()`.
+//
+// Seq synthesis: per-(storeKey, threadId) monotonic counter inside
+// `projection-store`. Deterministic, NOT `Date.now()` — when γ-5 stops
+// using the legacy reducer, the projection re-projects the same log
+// and produces a byte-identical view.
+// ---------------------------------------------------------------------------
+
+/** Resolve the storeKey for a thread when only the threadId is in
+ *  hand. Walks live sessions; returns null when the thread has not yet
+ *  been routed (e.g. the very first call before `addUserMessage`). The
+ *  shim uses this to skip translating envelopes for un-routed threads —
+ *  no information is lost; the projection just doesn't see the event,
+ *  same as if the legacy reducer dropped it as orphan-without-host. */
+function shimResolveKey(threadId: string): string | null {
+  return findStoreKeyForThread(threadId);
+}
+
+/** Pending `client_message_id` per (storeKey, threadId). Set when
+ *  `addUserMessage` opens a thread; consumed (cleared) on the FIRST
+ *  envelope emitted for that thread so the cmid lands exactly once on
+ *  the wire. The projection captures the cmid into its `UserView` from
+ *  the first envelope it sees for a given thread. */
+const pendingClientMessageIds = new Map<string, Map<string, string>>();
+
+function setPendingClientMessageId(
+  storeKey: string,
+  threadId: string,
+  cmid: string,
+): void {
+  let perThread = pendingClientMessageIds.get(storeKey);
+  if (!perThread) {
+    perThread = new Map();
+    pendingClientMessageIds.set(storeKey, perThread);
+  }
+  perThread.set(threadId, cmid);
+}
+
+function consumePendingClientMessageId(
+  storeKey: string,
+  threadId: string,
+): string | undefined {
+  const perThread = pendingClientMessageIds.get(storeKey);
+  if (!perThread) return undefined;
+  const cmid = perThread.get(threadId);
+  if (cmid === undefined) return undefined;
+  perThread.delete(threadId);
+  return cmid;
+}
+
+/** Translate-and-ingest helper for the dual-write path. Handles the
+ *  pending-cmid handoff so a thread's first envelope carries the
+ *  client_message_id without callers having to thread it through every
+ *  shim site explicitly. */
+function shimIngest(
+  storeKey: string,
+  threadId: string,
+  payload: Payload,
+  options: { client_message_id?: string; seq?: number } = {},
+): void {
+  const seq = options.seq ?? projectionNextSeq(storeKey, threadId);
+  const cmid =
+    options.client_message_id !== undefined
+      ? options.client_message_id
+      : consumePendingClientMessageId(storeKey, threadId);
+  const envelope: Envelope = {
+    thread_id: threadId,
+    seq,
+    payload,
+    ...(cmid !== undefined ? { client_message_id: cmid } : {}),
+  };
+  projectionIngest(storeKey, envelope);
+}
+
+/** Map a legacy `ThreadToolCall.status` (which carries `"running"` for
+ *  in-flight calls) to the projection's `tool_end` status enum
+ *  (`"complete" | "error"`). The projection has no concept of a
+ *  running/in-flight tool — `tool_start` opens, `tool_end` closes.
+ *  `"running"` is a no-op signal that does not warrant a `tool_end`
+ *  envelope; the shim returns null and the caller skips emission. */
+function shimMapToolEndStatus(
+  status: "running" | "complete" | "error",
+): EnvelopeToolEndStatus | null {
+  if (status === "complete") return "complete";
+  if (status === "error") return "error";
+  return null;
+}
+
+// ---------------------------------------------------------------------------
 // Public API — mutators
 // ---------------------------------------------------------------------------
 
@@ -422,6 +545,18 @@ export function addUserMessage(
   };
   insertThreadInTimestampOrder(state, thread);
   notify();
+
+  // M9-γ-3 dual-write: a fresh user message roots the thread. The
+  // projection has no `user_message` payload variant — user identity
+  // is captured implicitly from the FIRST envelope that names a given
+  // `thread_id` (per γ-2 `projection.ts` § "Capture user identity").
+  // We register the cmid in the pending-cmid map so the next envelope
+  // for this thread carries `client_message_id` on the wire — that's
+  // what γ-4's GhostBubble overlay matches against.
+  if (isProjectionV1Enabled()) {
+    setPendingClientMessageId(key, thread.id, opts.clientMessageId);
+  }
+
   return {
     threadId: thread.id,
     pendingAssistantId: pendingAssistant.id,
@@ -457,6 +592,17 @@ export function appendAssistantToken(threadId: string, token: string): void {
   const slot = ensurePendingAssistant(found.thread);
   slot.text += token;
   notify();
+
+  // M9-γ-3 dual-write: streamed token → assistant_delta envelope.
+  if (isProjectionV1Enabled()) {
+    const key = shimResolveKey(threadId);
+    if (key) {
+      shimIngest(key, threadId, {
+        type: "assistant_delta",
+        data: { text: token },
+      });
+    }
+  }
 }
 
 export function replaceAssistantText(threadId: string, text: string): void {
@@ -472,6 +618,24 @@ export function replaceAssistantText(threadId: string, text: string): void {
   const slot = ensurePendingAssistant(found.thread);
   slot.text = text;
   notify();
+
+  // M9-γ-3 dual-write: legacy `replace` semantics has no direct
+  // projection counterpart (projection accumulates deltas + finalises
+  // on `assistant_persisted`). Emit the full replacement text as an
+  // `assistant_delta`. This is OK for the migration window: projection
+  // and legacy disagree on accumulated text shape, but legacy is the
+  // current truth source for `getThreads()`. γ-5 will retire the legacy
+  // path entirely; by then the SSE bridge no longer emits `replace`
+  // events (only deltas + persisted), so the drift goes away.
+  if (isProjectionV1Enabled()) {
+    const key = shimResolveKey(threadId);
+    if (key) {
+      shimIngest(key, threadId, {
+        type: "assistant_delta",
+        data: { text },
+      });
+    }
+  }
 }
 
 /**
@@ -549,6 +713,24 @@ export function addToolCall(
       progress: last.progress,
     };
     notify();
+
+    // M9-γ-3 dual-write (codex round-1 BLOCK 2): the retry-collapse
+    // path mutates legacy state in place but the wire still receives a
+    // fresh `tool_start` for the NEW `tool_call_id`. The projection
+    // keys tool cards on `tool_call_id`, so without this emission a
+    // retry would never open a card for the new id and any subsequent
+    // `tool_progress` / `tool_end` envelope would synthesise an
+    // empty-name placeholder card (γ-2's "progress without a prior
+    // start" path) — mismatching the legacy reducer's view.
+    if (isProjectionV1Enabled() && toolCallId) {
+      const key = shimResolveKey(threadId);
+      if (key) {
+        shimIngest(key, threadId, {
+          type: "tool_start",
+          data: { tool_call_id: toolCallId, name },
+        });
+      }
+    }
     return;
   }
 
@@ -560,6 +742,21 @@ export function addToolCall(
     retryCount: 0,
   });
   notify();
+
+  // M9-γ-3 dual-write: tool_start envelope. The projection requires a
+  // non-empty `tool_call_id` for routing (it keys on `tool_call_id`);
+  // legacy supports the empty-id fallback for legacy daemons. Skip the
+  // dual-write for empty-id calls — the projection isn't responsible
+  // for legacy compat, γ-5 cleanup makes the server's id mandatory.
+  if (isProjectionV1Enabled() && toolCallId) {
+    const key = shimResolveKey(threadId);
+    if (key) {
+      shimIngest(key, threadId, {
+        type: "tool_start",
+        data: { tool_call_id: toolCallId, name },
+      });
+    }
+  }
 }
 
 /** Maximum runtime progress entries kept per tool call. Old entries are
@@ -629,6 +826,21 @@ export function appendToolProgress(
     );
   }
   notify();
+
+  // M9-γ-3 dual-write: tool_progress envelope. Per the brief, the
+  // projection drops late tool_progress events that arrive after a
+  // `turn_completed` for the same thread (see the projection's hard
+  // barrier). The shim emits unconditionally; the projection itself
+  // enforces the barrier and bumps `metrics.droppedAfterTurnCompleted`.
+  if (isProjectionV1Enabled() && toolCallId) {
+    const key = shimResolveKey(threadId);
+    if (key) {
+      shimIngest(key, threadId, {
+        type: "tool_progress",
+        data: { tool_call_id: toolCallId, message },
+      });
+    }
+  }
 }
 
 export function setToolCallStatus(
@@ -657,6 +869,23 @@ export function setToolCallStatus(
   if (idx === -1) return;
   tcs[idx] = { ...tcs[idx], status };
   notify();
+
+  // M9-γ-3 dual-write: setToolCallStatus → tool_end envelope. Skip
+  // the `"running"` flavour (projection has no in-flight status —
+  // tool_start opens, tool_end closes); only `"complete"` and
+  // `"error"` translate to a wire-level `tool_end`.
+  if (isProjectionV1Enabled() && toolCallId) {
+    const endStatus = shimMapToolEndStatus(status);
+    if (endStatus !== null) {
+      const key = shimResolveKey(threadId);
+      if (key) {
+        shimIngest(key, threadId, {
+          type: "tool_end",
+          data: { tool_call_id: toolCallId, status: endStatus },
+        });
+      }
+    }
+  }
 }
 
 /**
@@ -846,6 +1075,37 @@ export function appendCompletionBubble(
   thread.responses.push(completion);
   sortResponsesInThread(thread);
   notify();
+
+  // M9-γ-3 dual-write: completion bubble → assistant_persisted envelope.
+  // The projection enforces text/meta finalisation here. Use the
+  // server-authoritative `historySeq` as the projection seq when the
+  // caller supplied one (matches the wire-level seq on a replay) so
+  // late re-emissions of the same row dedup cleanly via the
+  // projection's `(thread_id, seq)` idempotency.
+  if (isProjectionV1Enabled()) {
+    const key =
+      shimResolveKey(threadId) ??
+      (opts.sessionId
+        ? projectionStoreKey(opts.sessionId, opts.topic)
+        : null);
+    if (key) {
+      const messageId = opts.messageId ?? completion.id;
+      shimIngest(key, threadId, {
+        type: "assistant_persisted",
+        data: {
+          text: opts.text,
+          meta: {
+            message_id: messageId,
+            persisted_at:
+              opts.persistedAt ??
+              new Date(completion.timestamp).toISOString(),
+            ...(opts.media.length > 0 ? { media: opts.media.slice() } : {}),
+          },
+        },
+      }, opts.historySeq !== undefined ? { seq: opts.historySeq } : undefined);
+    }
+  }
+
   return true;
 }
 
@@ -919,6 +1179,25 @@ export function appendAssistantFile(
   if (slot.files.some((f) => f.path === file.path)) return true;
   slot.files = [...slot.files, file];
   notify();
+
+  // M9-γ-3 dual-write: file delivery → file_attached envelope. Legacy
+  // `MessageFile` doesn't carry `mime` / `size_bytes`; use defensible
+  // defaults that the projection accepts (the wire-level event always
+  // carries both, this is only the migration-time shim).
+  if (isProjectionV1Enabled()) {
+    const key = shimResolveKey(threadId);
+    if (key) {
+      shimIngest(key, threadId, {
+        type: "file_attached",
+        data: {
+          path: file.path,
+          mime: "",
+          size_bytes: 0,
+        },
+      });
+    }
+  }
+
   return true;
 }
 
@@ -948,6 +1227,21 @@ export function stampPendingHistorySeq(
       found.thread.pendingAssistant.intra_thread_seq ?? historySeq,
   };
   notify();
+
+  // M9-γ-3 dual-write: stamp-only operation has no projection
+  // counterpart. The projection finalises bubbles on
+  // `assistant_persisted` (which carries `meta.message_id` +
+  // `persisted_at`); a bare seq-stamp without text/meta is purely a
+  // legacy bookkeeping fix the v1 router needs to acknowledge a
+  // `message/persisted` that arrived BEFORE its `message/delta`.
+  // Intentionally no envelope emission here.
+  //
+  // Why this no-op is safe under the projection: the `historySeq`
+  // stamp is purely a legacy reducer detail. The projection's gap-
+  // buffer applies envelopes in canonical `(thread_id, seq)` order on
+  // arrival; the eventual `assistant_persisted` / `turn_completed`
+  // envelope is what finalises the bubble. A bare stamp without
+  // text/meta carries no projection-relevant payload, so we elide it.
 }
 
 export interface FinalizeAssistantOptions {
@@ -977,9 +1271,17 @@ export function finalizeAssistant(
     // lost over the wire would otherwise leave the chip spinning forever.
     // Only flip running → complete; preserve "error" and existing
     // "complete" entries (tool_end already arrived for those).
-    const sweptToolCalls = thread.pendingAssistant.toolCalls.map((tc) =>
-      tc.status === "running" ? { ...tc, status: "complete" as const } : tc,
-    );
+    // Also remember which ids were swept so the projection dual-write
+    // below can emit synthetic `tool_end` envelopes for them BEFORE
+    // `turn_completed` (codex round-1 BLOCK 3).
+    const sweptToolCallIds: string[] = [];
+    const sweptToolCalls = thread.pendingAssistant.toolCalls.map((tc) => {
+      if (tc.status === "running") {
+        if (tc.id) sweptToolCallIds.push(tc.id);
+        return { ...tc, status: "complete" as const };
+      }
+      return tc;
+    });
 
     const finalized: ThreadMessage = {
       ...thread.pendingAssistant,
@@ -994,6 +1296,51 @@ export function finalizeAssistant(
     sortResponsesInThread(thread);
     thread.pendingAssistant = null;
     notify();
+
+    // M9-γ-3 dual-write: finalize → turn_completed envelope (the
+    // projection's hard barrier). Maps token usage best-effort from
+    // the legacy `meta` (which carries `tokens_in` / `tokens_out` —
+    // we mirror them onto the projection's `input_tokens` /
+    // `output_tokens`). The barrier is what the brief's projection-
+    // only test "Late `tool_progress` after `turn_completed`"
+    // exercises.
+    if (isProjectionV1Enabled()) {
+      const key = shimResolveKey(threadId);
+      if (key) {
+        // codex round-1 BLOCK 3: emit a synthetic `tool_end` for every
+        // tool call that legacy `finalizeAssistant` swept from
+        // `running` → `complete` (the wire never delivered an explicit
+        // tool_end). MUST happen BEFORE `turn_completed` since the
+        // projection's hard barrier drops anything after a thread is
+        // marked complete — a late tool_end on the wire would never
+        // reach the projection's tool card. Empty-id calls (legacy
+        // daemon path) are skipped at sweep-collection time.
+        for (const sweptId of sweptToolCallIds) {
+          shimIngest(key, threadId, {
+            type: "tool_end",
+            data: { tool_call_id: sweptId, status: "complete" },
+          });
+        }
+
+        const meta = opts.meta ?? finalized.meta;
+        const usage =
+          meta !== undefined
+            ? {
+                ...(meta.tokens_in
+                  ? { input_tokens: meta.tokens_in }
+                  : {}),
+                ...(meta.tokens_out
+                  ? { output_tokens: meta.tokens_out }
+                  : {}),
+              }
+            : {};
+        shimIngest(key, threadId, {
+          type: "turn_completed",
+          data: { token_usage: usage },
+        });
+      }
+    }
+
     return;
   }
 }
@@ -2065,6 +2412,32 @@ export function appendPersistedMessage(
   thread.responses.push(built);
   sortResponsesInThread(thread);
   notify();
+
+  // M9-γ-3 dual-write: a persisted assistant row corresponds to an
+  // `assistant_persisted` envelope. Tool/system rows have no projection
+  // counterpart in γ-2 (the projection's payload tagged-union doesn't
+  // carry tool-result rows — they live as `tool_end` + per-tool
+  // progress). Limit the dual-write to assistant rows for now; γ-5
+  // will fold tool persistence into the projection's surface.
+  if (isProjectionV1Enabled() && built.role === "assistant") {
+    const key = projectionStoreKey(sessionId, topic);
+    const messageId = built.id;
+    const persistedAt = message.timestamp
+      ? new Date(message.timestamp).toISOString()
+      : new Date().toISOString();
+    const media = (message.media ?? []).slice();
+    shimIngest(key, threadId, {
+      type: "assistant_persisted",
+      data: {
+        text: built.text,
+        meta: {
+          message_id: messageId,
+          persisted_at: persistedAt,
+          ...(media.length > 0 ? { media } : {}),
+        },
+      },
+    }, built.historySeq !== undefined ? { seq: built.historySeq } : undefined);
+  }
 }
 
 // ---------------------------------------------------------------------------
@@ -2132,6 +2505,7 @@ export function clearSession(sessionId: string, topic?: string): void {
     loadedSessions.delete(key);
     loadingPromises.delete(key);
     hydrateSnapshotByKey.delete(key);
+    pendingClientMessageIds.delete(key);
   } else {
     for (const k of [...sessionsByKey.keys()]) {
       if (k === sessionId || k.startsWith(`${sessionId}#`)) {
@@ -2139,6 +2513,7 @@ export function clearSession(sessionId: string, topic?: string): void {
         loadedSessions.delete(k);
         loadingPromises.delete(k);
         hydrateSnapshotByKey.delete(k);
+        pendingClientMessageIds.delete(k);
       }
     }
     // Codex round-5 P3: a hydrate snapshot may exist without a
@@ -2249,6 +2624,7 @@ export function __resetForTests(): void {
   loadingPromises.clear();
   snapshotCache.clear();
   hydrateSnapshotByKey.clear();
+  pendingClientMessageIds.clear();
   version = 0;
   idCounter = 0;
 }


### PR DESCRIPTION
Re-targets #94 (which was merged into a stale gamma-2 branch instead of main). Same squashed commit, now applied directly onto main.

Closes #840.