### PR TITLE
fix(build): post-M9-α-5/6 merge cleanup

### DIFF
--- a/src/components/session-list.tsx
+++ b/src/components/session-list.tsx
@@ -4,7 +4,7 @@ import { useAllTasksBySession } from "@/store/task-store";
 import { Plus, MessageSquare, Trash2, Check, X, Loader2 } from "lucide-react";
 
 export function SessionList() {
-  const { sessions, currentSessionId, activeTaskOnServer, switchSession, createSession, removeSession } =
+  const { sessions, currentSessionId, switchSession, createSession, removeSession } =
     useSession();
   const taskEntries = useAllTasksBySession();
   const [confirmingDelete, setConfirmingDelete] = useState<string | null>(null);
@@ -13,9 +13,18 @@ export function SessionList() {
   // (driven by SSE) is gone. The WS bridge owns the active-turn signal
   // via `task/updated` + `turn/started/completed`, which feed
   // `useAllTasksBySession` above; the per-session "currently streaming"
-  // pill follows from `backgroundTaskSessions` until the WS bridge
+  // pill follows from background task entries until the WS bridge
   // exposes a turn-active selector directly.
   const streamingSessions: Set<string> = useMemo(() => new Set<string>(), []);
+  const backgroundTaskSessions: Set<string> = useMemo(() => {
+    const s = new Set<string>();
+    for (const [sessionId, tasks] of taskEntries) {
+      if (tasks.some((t) => t.status === "spawned" || t.status === "running")) {
+        s.add(sessionId);
+      }
+    }
+    return s;
+  }, [taskEntries]);
 
   const handleDelete = useCallback(async (id: string) => {
     setDeletingId(id);

--- a/src/runtime/task-watcher.ts
+++ b/src/runtime/task-watcher.ts
@@ -15,8 +15,6 @@ import {
   getSessionTasks,
   getMessages as fetchSessionMessages,
 } from "@/api/sessions";
-import { buildApiHeaders } from "@/api/client";
-import { API_BASE } from "@/lib/constants";
 import * as ThreadStore from "@/store/thread-store";
 import * as TaskStore from "@/store/task-store";
 import * as FileStore from "@/store/file-store";
@@ -175,19 +173,6 @@ function updateActiveIds(entry: WatchedSession, tasks: BackgroundTaskInfo[]): vo
   }
 }
 
-function applyTaskUpdate(entry: WatchedSession, task: BackgroundTaskInfo): void {
-  if (isTaskActive(task)) {
-    entry.activeIds.add(task.id);
-    entry.terminalSince = null;
-    dispatchBgTasksEvent(entry.sessionId, entry.topic);
-  } else {
-    entry.activeIds.delete(task.id);
-    if (entry.replayComplete && entry.activeIds.size === 0) {
-      entry.terminalSince = Date.now();
-    }
-  }
-}
-
 function emitNewFileEvents(
   sessionId: string,
   topic: string | undefined,
@@ -228,23 +213,6 @@ function applyCommittedMessages(
     entry.terminalSince = Date.now();
   }
   persistWatchedSessions();
-}
-
-async function backfillCommittedGap(
-  entry: WatchedSession,
-  previousSeq: number,
-  observedSeq: number,
-): Promise<void> {
-  if (observedSeq <= previousSeq + 1) return;
-
-  const backfill = await fetchSessionMessages(
-    entry.sessionId,
-    500,
-    0,
-    previousSeq >= 0 ? previousSeq : undefined,
-    entry.topic,
-  );
-  applyCommittedMessages(entry.sessionId, entry, backfill);
 }
 
 /** Register a session for background monitoring. */


### PR DESCRIPTION
Two minor build breakages from squash merging #96 onto main:
- session-list.tsx: `backgroundTaskSessions` symbol lost in merge.
- task-watcher.ts: dead imports/functions.

Restores `npm run build`.