### PR TITLE
feat(runtime): M9-β-1 — wire TurnStartInput media/topic/rewrite_for; remove WS-only stubs

### DIFF
--- a/src/runtime/ui-protocol-bridge.ts
+++ b/src/runtime/ui-protocol-bridge.ts
@@ -33,6 +33,7 @@ import type {
   TurnErrorEvent,
   TurnInterruptResult,
   TurnSpawnCompleteEvent,
+  TurnStartExtras,
   TurnStartInput,
   TurnStartResult,
   TurnStartedEvent,
@@ -59,7 +60,9 @@ export type {
   TurnErrorEvent,
   TurnInterruptResult,
   TurnSpawnCompleteEvent,
+  TurnStartExtras,
   TurnStartInput,
+  TurnStartMediaRef,
   TurnStartResult,
   TurnStartedEvent,
   UiCursor,
@@ -170,7 +173,16 @@ export interface UiProtocolBridge {
   start(opts: { sessionId: string; profileId?: string }): Promise<void>;
   stop(): Promise<void>;
 
-  sendTurn(turn_id: string, input: TurnStartInput[]): Promise<TurnStartResult>;
+  sendTurn(
+    turn_id: string,
+    input: TurnStartInput[],
+    /** UPCR-2026-015 (M9-β-1): optional `media`, `topic`,
+     *  `rewrite_for` extras carried alongside `input`. Each is
+     *  forwarded onto the wire only when populated; omitted entirely
+     *  for legacy text-only sends so the on-wire shape stays
+     *  byte-identical to a pre-β-1 build. */
+    extras?: TurnStartExtras,
+  ): Promise<TurnStartResult>;
   interruptTurn(turn_id: string, reason?: string): Promise<TurnInterruptResult>;
   respondToApproval(
     approval_id: string,
@@ -889,15 +901,35 @@ class UiProtocolBridgeImpl implements UiProtocolBridge {
     this.subState.clear();
   }
 
-  sendTurn(turn_id: string, input: TurnStartInput[]): Promise<TurnStartResult> {
+  sendTurn(
+    turn_id: string,
+    input: TurnStartInput[],
+    extras?: TurnStartExtras,
+  ): Promise<TurnStartResult> {
     if (!isString(turn_id)) {
       return Promise.reject(new Error("ui-protocol-bridge: sendTurn requires turn_id"));
     }
-    return this.request<TurnStartResult>(METHODS.TURN_START, {
+    // UPCR-2026-015 (M9-β-1): the three optional `media` / `topic` /
+    // `rewrite_for` params land on the wire only when populated. The
+    // server's serde shape skip-when-empty / skip-when-None on the
+    // matching Rust struct, so an old server (or this client without
+    // β-1 callers) sees byte-identical bytes to the legacy text-only
+    // shape.
+    const params: Record<string, unknown> = {
       session_id: this.requireSessionId(),
       turn_id,
       input,
-    });
+    };
+    if (extras?.media && extras.media.length > 0) {
+      params.media = extras.media;
+    }
+    if (extras?.topic && extras.topic.trim().length > 0) {
+      params.topic = extras.topic;
+    }
+    if (extras?.rewrite_for && extras.rewrite_for.length > 0) {
+      params.rewrite_for = extras.rewrite_for;
+    }
+    return this.request<TurnStartResult>(METHODS.TURN_START, params);
   }
 
   interruptTurn(

--- a/src/runtime/ui-protocol-send.test.ts
+++ b/src/runtime/ui-protocol-send.test.ts
@@ -4,13 +4,21 @@
  * M9-α-5/α-6 (ADR PR #830 / audit issue #845): the legacy SSE bridge has
  * been deleted; `/api/ui-protocol/ws` is the sole chat transport.
  *
+ * M9-β-1 (UPCR-2026-015 / server PR #860): the WS turn/start envelope
+ * gained three optional fields (`media`, `topic`, `rewrite_for`). The
+ * tests below assert the bridge dispatches them through unchanged for
+ * each variant.
+ *
  * Coverage:
  *   - active bridge: dispatches via `bridge.sendTurn` and mirrors the
  *     user message into the thread store
  *   - no active bridge: surfaces an error on the assistant bubble (no
  *     legacy fallback exists anymore)
- *   - media / requestText / topic-scoped sends: surface an error
- *     (`TurnStartInput` is text-only today; M9-β extension follow-up)
+ *   - β-1 media-bearing sends: `bridge.sendTurn` called with `extras.media`
+ *     populated (`FileRef`-shaped entries)
+ *   - β-1 topic-scoped sends: `bridge.sendTurn` called with `extras.topic`
+ *   - β-1 /queue rewrites: `bridge.sendTurn` called with `extras.rewrite_for`
+ *     carrying the original `client_message_id`
  *   - per-session FIFO turn queue contract from M10 follow-up Bug B
  *     (rapid sends serialise behind `turn/completed`/`turn/error`)
  */
@@ -109,9 +117,11 @@ describe("sendMessage", () => {
       clientMessageId: "cmid-on",
     });
     for (let i = 0; i < 12; i++) await Promise.resolve();
-    expect(bridge.sendTurn).toHaveBeenCalledWith("cmid-on", [
-      { kind: "text", text: "hello" },
-    ]);
+    expect(bridge.sendTurn).toHaveBeenCalledWith(
+      "cmid-on",
+      [{ kind: "text", text: "hello" }],
+      undefined,
+    );
     const threads = ThreadStore.getThreads(SESSION);
     expect(threads).toHaveLength(1);
     expect(threads[0].userMsg.text).toBe("hello");
@@ -134,9 +144,11 @@ describe("sendMessage", () => {
       skipOptimisticUserMessage: true,
     });
     for (let i = 0; i < 12; i++) await Promise.resolve();
-    expect(bridge.sendTurn).toHaveBeenCalledWith("cmid-ghost", [
-      { kind: "text", text: "ghost" },
-    ]);
+    expect(bridge.sendTurn).toHaveBeenCalledWith(
+      "cmid-ghost",
+      [{ kind: "text", text: "ghost" }],
+      undefined,
+    );
     expect(ThreadStore.getThreads(SESSION)).toHaveLength(0);
   });
 
@@ -192,28 +204,38 @@ describe("sendMessage", () => {
     expect(onComplete).toHaveBeenCalledTimes(1);
   });
 
-  // M9-α-5/α-6: media-bearing turns no longer have a legacy SSE
-  // fallback. The send surfaces an error instead of silently dropping;
-  // the assistant bubble is finalised as errored and the queue advances.
-  it("errors the bubble when media is present (WS path is text-only)", async () => {
+  // M9-β-1 (UPCR-2026-015): media-bearing turns now ride the WS path.
+  // The bridge is called with `extras.media` populated as
+  // `FileRef`-shaped entries; the user bubble carries the local files.
+  it("forwards media on bridge.sendTurn extras when media is present", async () => {
     const bridge = makeBridge();
     __setActiveBridgeForTest(SESSION, bridge);
     sendMessage({
       sessionId: SESSION,
       text: "with image",
-      media: ["/tmp/foo.png"],
+      media: ["/tmp/foo.png", "/tmp/bar.mp3"],
       clientMessageId: "cmid-media",
     });
-    await Promise.resolve();
-    expect(ThreadStore.getThreads(SESSION)).toHaveLength(1);
     for (let i = 0; i < 12; i++) await Promise.resolve();
-    expect(bridge.sendTurn).not.toHaveBeenCalled();
+    expect(bridge.sendTurn).toHaveBeenCalledTimes(1);
+    const call = bridge.sendTurn.mock.calls[0];
+    expect(call[0]).toBe("cmid-media");
+    expect(call[1]).toEqual([{ kind: "text", text: "with image" }]);
+    const extras = call[2];
+    expect(extras).toBeDefined();
+    expect(extras.media).toHaveLength(2);
+    expect(extras.media[0]).toMatchObject({ path: "/tmp/foo.png" });
+    expect(extras.media[1]).toMatchObject({ path: "/tmp/bar.mp3" });
+    // No error finalisation — the optimistic user bubble is still
+    // pending an assistant response.
     const threads = ThreadStore.getThreads(SESSION);
-    expect(threads[0].responses[0]?.status).toBe("error");
+    expect(threads[0].responses[0]?.status).not.toBe("error");
   });
 
-  // M9-α-5/α-6: `/queue interrupt` style rewrites also surface an error.
-  it("errors the bubble when requestText differs from text", async () => {
+  // M9-β-1: `/queue` rewrites carry the original cmid via
+  // `extras.rewrite_for` so the server can replace the queued user
+  // message in place rather than appending.
+  it("forwards rewrite_for on bridge.sendTurn extras when requestText differs from text", async () => {
     const bridge = makeBridge();
     __setActiveBridgeForTest(SESSION, bridge);
     sendMessage({
@@ -224,15 +246,24 @@ describe("sendMessage", () => {
       clientMessageId: "cmid-rewrite",
     });
     for (let i = 0; i < 12; i++) await Promise.resolve();
-    expect(bridge.sendTurn).not.toHaveBeenCalled();
-    const threads = ThreadStore.getThreads(SESSION);
-    expect(threads[0].responses[0]?.status).toBe("error");
+    expect(bridge.sendTurn).toHaveBeenCalledTimes(1);
+    const call = bridge.sendTurn.mock.calls[0];
+    expect(call[0]).toBe("cmid-rewrite");
+    const extras = call[2];
+    expect(extras).toBeDefined();
+    expect(extras.rewrite_for).toBe("cmid-rewrite");
+    expect(extras.media).toBeUndefined();
+    expect(extras.topic).toBeUndefined();
   });
 
-  // M9-α-5/α-6: topic-scoped sends surface an error too.
-  it("errors the bubble when historyTopic is set", async () => {
+  // M9-β-1: topic-scoped sends carry `extras.topic` so the server
+  // folds it into the resolved SessionKey before scope validation.
+  // The active bridge is registered against the same `(sessionId,
+  // topic)` scope the SPA's runtime would publish — `getActiveBridge`
+  // gates by scope, so the test mirrors production wiring.
+  it("forwards topic on bridge.sendTurn extras when historyTopic is set", async () => {
     const bridge = makeBridge();
-    __setActiveBridgeForTest(SESSION, bridge);
+    __setActiveBridgeForTest(SESSION, bridge, "slides");
     sendMessage({
       sessionId: SESSION,
       historyTopic: "slides",
@@ -241,9 +272,55 @@ describe("sendMessage", () => {
       clientMessageId: "cmid-topic",
     });
     for (let i = 0; i < 12; i++) await Promise.resolve();
-    expect(bridge.sendTurn).not.toHaveBeenCalled();
-    const threads = ThreadStore.getThreads(SESSION, "slides");
-    expect(threads[0].responses[0]?.status).toBe("error");
+    expect(bridge.sendTurn).toHaveBeenCalledTimes(1);
+    const call = bridge.sendTurn.mock.calls[0];
+    expect(call[0]).toBe("cmid-topic");
+    const extras = call[2];
+    expect(extras).toBeDefined();
+    expect(extras.topic).toBe("slides");
+    expect(extras.media).toBeUndefined();
+    expect(extras.rewrite_for).toBeUndefined();
+  });
+
+  // M9-β-1: text-only sends produce NO extras envelope so the on-wire
+  // shape stays byte-identical to a pre-β-1 build (back-compat).
+  it("omits the extras envelope for plain text-only sends", async () => {
+    const bridge = makeBridge();
+    __setActiveBridgeForTest(SESSION, bridge);
+    sendMessage({
+      sessionId: SESSION,
+      text: "plain text",
+      media: [],
+      clientMessageId: "cmid-plain",
+    });
+    for (let i = 0; i < 12; i++) await Promise.resolve();
+    expect(bridge.sendTurn).toHaveBeenCalledTimes(1);
+    const call = bridge.sendTurn.mock.calls[0];
+    expect(call[2]).toBeUndefined();
+  });
+
+  // M9-β-1: when all three β-1 surfaces are populated together (a
+  // /queue rewrite under a topic-scoped session that swaps in new
+  // media), every extra rides through.
+  it("forwards all three β-1 extras when populated together", async () => {
+    const bridge = makeBridge();
+    __setActiveBridgeForTest(SESSION, bridge, "research");
+    sendMessage({
+      sessionId: SESSION,
+      historyTopic: "research",
+      text: "redo with this image",
+      requestText: "edited prompt",
+      media: ["/tmp/replacement.png"],
+      clientMessageId: "cmid-all",
+    });
+    for (let i = 0; i < 12; i++) await Promise.resolve();
+    expect(bridge.sendTurn).toHaveBeenCalledTimes(1);
+    const extras = bridge.sendTurn.mock.calls[0][2];
+    expect(extras).toBeDefined();
+    expect(extras.media).toHaveLength(1);
+    expect(extras.media[0]).toMatchObject({ path: "/tmp/replacement.png" });
+    expect(extras.topic).toBe("research");
+    expect(extras.rewrite_for).toBe("cmid-all");
   });
 
   // Codex review must-fix #5B: the lifecycle subscription must be
@@ -361,23 +438,29 @@ describe("sendMessage", () => {
 
     for (let i = 0; i < 12; i++) await Promise.resolve();
     expect(bridge.sendTurn).toHaveBeenCalledTimes(1);
-    expect(bridge.sendTurn).toHaveBeenLastCalledWith("cmid-Q1", [
-      { kind: "text", text: "Q1" },
-    ]);
+    expect(bridge.sendTurn).toHaveBeenLastCalledWith(
+      "cmid-Q1",
+      [{ kind: "text", text: "Q1" }],
+      undefined,
+    );
 
     lifecycleHandler?.({ turn_id: "cmid-Q1", reason: "stop" });
     for (let i = 0; i < 12; i++) await Promise.resolve();
     expect(bridge.sendTurn).toHaveBeenCalledTimes(2);
-    expect(bridge.sendTurn).toHaveBeenLastCalledWith("cmid-Q2", [
-      { kind: "text", text: "Q2" },
-    ]);
+    expect(bridge.sendTurn).toHaveBeenLastCalledWith(
+      "cmid-Q2",
+      [{ kind: "text", text: "Q2" }],
+      undefined,
+    );
 
     lifecycleHandler?.({ turn_id: "cmid-Q2", reason: "stop" });
     for (let i = 0; i < 12; i++) await Promise.resolve();
     expect(bridge.sendTurn).toHaveBeenCalledTimes(3);
-    expect(bridge.sendTurn).toHaveBeenLastCalledWith("cmid-Q3", [
-      { kind: "text", text: "Q3" },
-    ]);
+    expect(bridge.sendTurn).toHaveBeenLastCalledWith(
+      "cmid-Q3",
+      [{ kind: "text", text: "Q3" }],
+      undefined,
+    );
   });
 
   // Codex P2 round 7 (M10 follow-up Bug B): a `bridge.sendTurn`
@@ -456,9 +539,11 @@ describe("sendMessage", () => {
     expect(threads[1].userMsg.text).toBe("Q2");
     for (let i = 0; i < 12; i++) await Promise.resolve();
     expect(bridge.sendTurn).toHaveBeenCalledTimes(1);
-    expect(bridge.sendTurn).toHaveBeenLastCalledWith("cmid-Q1", [
-      { kind: "text", text: "Q1" },
-    ]);
+    expect(bridge.sendTurn).toHaveBeenLastCalledWith(
+      "cmid-Q1",
+      [{ kind: "text", text: "Q1" }],
+      undefined,
+    );
 
     lifecycleHandler?.({ turn_id: "cmid-Q1", reason: "stop" });
     for (let i = 0; i < 12; i++) await Promise.resolve();
@@ -512,9 +597,11 @@ describe("sendMessage", () => {
     expect(onCompleteThrowing).toHaveBeenCalledTimes(1);
     for (let i = 0; i < 12; i++) await Promise.resolve();
     expect(bridge.sendTurn).toHaveBeenCalledTimes(2);
-    expect(bridge.sendTurn).toHaveBeenLastCalledWith("cmid-Q2", [
-      { kind: "text", text: "Q2" },
-    ]);
+    expect(bridge.sendTurn).toHaveBeenLastCalledWith(
+      "cmid-Q2",
+      [{ kind: "text", text: "Q2" }],
+      undefined,
+    );
   });
 
   // Codex P2 round 2 (M10 follow-up Bug B): when the bridge transitions

--- a/src/runtime/ui-protocol-send.ts
+++ b/src/runtime/ui-protocol-send.ts
@@ -8,33 +8,43 @@
  * (`sse-bridge.ts`) has been deleted along with the server-side SSE
  * chat transport. `/api/ui-protocol/ws` is now the sole chat transport.
  *
- * **Known follow-up**: the WS bridge's `TurnStartInput` only accepts
- * `kind: "text"` today, so media uploads, `/queue` rewrites, and
- * topic-scoped sends are temporarily blocked here — `sendMessage`
- * surfaces an explicit error on the assistant bubble and emits a
- * `console.warn` instead of falling back to a deleted SSE path. The
- * follow-up to extend `TurnStartInput` lives in M9-β.
+ * M9-β-1 (UPCR-2026-015 / server PR #860): `TurnStartParams` gained
+ * three optional fields — `media: FileRef[]`, `topic: string`,
+ * `rewrite_for: client_message_id`. The web client populates them
+ * from the existing `SendOptions.media` / `historyTopic` /
+ * `requestText` fields; the bridge serialises only the populated
+ * extras onto the wire so the on-wire shape stays byte-identical to
+ * a pre-β-1 build for text-only sends.
  */
 
 import * as ThreadStore from "@/store/thread-store";
 import { displayFilenameFromPath } from "@/lib/utils";
 import { getActiveBridge } from "./ui-protocol-runtime";
+import type { TurnStartExtras, TurnStartMediaRef } from "./ui-protocol-types";
 import { request } from "@/api/client";
 
 /** Per-turn send options. The legacy SSE bridge previously re-exported
  *  this type; with that file deleted, the canonical home is here. */
 export interface SendOptions {
   sessionId: string;
-  /** Topic ('/new <slug>' surfaces). Currently unsupported by the WS
-   *  bridge — sends with a non-empty topic surface an error. */
+  /** Sub-topic suffix (`/new <slug>` surfaces, slides/sites scoping).
+   *  M9-β-1 (UPCR-2026-015): forwarded to the server as `topic` on
+   *  `turn/start` so history / ledger / `task/list` see the per-topic
+   *  bucket. Empty / undefined sends to the default-topic bucket. */
   historyTopic?: string;
   text: string;
-  /** Optional rewrite (e.g. `/queue` slash-commands). Currently
-   *  unsupported by the WS bridge — sends where `requestText !== text`
-   *  surface an error. */
+  /** Optional rewrite (e.g. `/queue` slash-commands). M9-β-1:
+   *  forwarded as `rewrite_for: <client_message_id>` so the server
+   *  can replace the queued user message in place rather than
+   *  appending. (β-1 server logs the field; durable in-place ledger
+   *  replace lands in a follow-up — the wire field is forward-
+   *  compatible.) Sends where `requestText === text` (or undefined)
+   *  carry no `rewrite_for`. */
   requestText?: string;
-  /** Pre-uploaded media paths from `/api/upload`. Currently unsupported
-   *  by the WS bridge — sends with non-empty media surface an error. */
+  /** Pre-uploaded media paths from `/api/upload`. M9-β-1: forwarded
+   *  as `media: FileRef[]` on `turn/start`. The server feeds the
+   *  paths to `Agent::process_message`, the same entry the
+   *  gateway-mode `ApiChannel` and `octos chat` CLI use. */
   media: string[];
   clientMessageId?: string;
   /** Recording vs upload (audio surface). Unused on the WS path today. */
@@ -74,21 +84,56 @@ export function sendMessage(opts: SendOptions): void {
   void enqueueSendV1(opts);
 }
 
-/** Return a human-readable reason when this send is unsupported by the
- *  WS-only path, else `null`. M9-α-5/α-6 deleted the legacy SSE
- *  fallback — when this returns non-null, the send fails fast with an
- *  errored assistant bubble rather than silently dropping. */
-function unsupportedSendReason(opts: SendOptions): string | null {
+/** UPCR-2026-015 (M9-β-1): build the `TurnStartParams` extras envelope
+ *  from `SendOptions`. Returns `undefined` when no extras are
+ *  populated so the bridge omits all three fields and the on-wire
+ *  shape stays byte-identical to a pre-β-1 text-only send. */
+function buildTurnStartExtras(opts: SendOptions): TurnStartExtras | undefined {
+  const extras: TurnStartExtras = {};
+
   if (opts.media.length > 0) {
-    return "media uploads are not yet supported on the WS chat transport (follow-up: M9-β extension to `TurnStartInput`)";
+    // The `/api/upload` endpoint returns paths only — `mime` and
+    // `size_bytes` are not propagated through `SendOptions.media`
+    // (the legacy SSE path also had this limitation). Surface what
+    // we know and let the server resolve metadata at consume time.
+    // The wire-shape requires the fields, so synthesise placeholders
+    // (mirroring the legacy SSE behaviour); the server's
+    // `process_message` only reads `path`, so the placeholders never
+    // leak into render.
+    const media: TurnStartMediaRef[] = opts.media.map((path) => ({
+      path,
+      mime: "application/octet-stream",
+      size_bytes: 0,
+    }));
+    extras.media = media;
   }
-  if (opts.requestText !== undefined && opts.requestText !== opts.text) {
-    return "`/queue`-style rewrites are not yet supported on the WS chat transport (follow-up: M9-β extension to `TurnStartInput`)";
+
+  const topic = opts.historyTopic?.trim();
+  if (topic && topic.length > 0) {
+    extras.topic = topic;
   }
-  if ((opts.historyTopic?.trim().length ?? 0) > 0) {
-    return "topic-scoped sends are not yet supported on the WS chat transport (follow-up: M9-β extension to `session/open` / `TurnStartInput`)";
+
+  // `rewrite_for` carries the client_message_id of the original
+  // queued send. The Composer's `/queue` slash-command flow stashes
+  // the user-edited prompt in `requestText` while `text` keeps the
+  // original-with-attached-files form. When the two diverge, treat
+  // it as a rewrite and pass the cmid for the original turn.
+  if (
+    opts.requestText !== undefined &&
+    opts.requestText !== opts.text &&
+    opts.clientMessageId !== undefined
+  ) {
+    extras.rewrite_for = opts.clientMessageId;
   }
-  return null;
+
+  if (
+    (extras.media === undefined || extras.media.length === 0) &&
+    (extras.topic === undefined || extras.topic.length === 0) &&
+    extras.rewrite_for === undefined
+  ) {
+    return undefined;
+  }
+  return extras;
 }
 
 // ---------------------------------------------------------------------------
@@ -189,21 +234,14 @@ async function enqueueSendV1(opts: SendOptions): Promise<void> {
 
   try {
     await prev;
-    // M9-α-5/α-6: legacy SSE fallback removed. If the send is
-    // unsupported by the WS path (media, /queue rewrite, topic-scoped),
-    // surface an error on the assistant bubble and release the gate
-    // immediately so subsequent sends drain.
-    const reason = unsupportedSendReason(pinnedOpts);
-    if (reason !== null) {
-      if (typeof console !== "undefined" && console.warn) {
-        console.warn(`ui-protocol-send: ${reason}`);
-      }
-      ThreadStore.finalizeAssistant(clientMessageId, { status: "error" });
-      pinnedOpts.onComplete?.();
-      release();
-    } else {
-      await sendMessageV1(pinnedOpts, release);
-    }
+    // M9-β-1 (UPCR-2026-015 / server PR #860): the three previously
+    // unsupported variants — media-bearing, /queue-rewrite, and
+    // topic-scoped sends — are now first-class on the WS path.
+    // `sendMessageV1` builds a `TurnStartExtras` envelope from the
+    // populated `SendOptions` fields and the bridge serialises only
+    // the populated extras onto the wire (so the on-wire shape stays
+    // byte-identical to a pre-β-1 build for text-only sends).
+    await sendMessageV1(pinnedOpts, release);
     // Wait for the lifecycle to complete before we let the chain advance.
     // `sendMessageV1` always calls `release()` — on success via the
     // `turn/completed`/`turn/error` listener, on early fallback or RPC
@@ -358,12 +396,16 @@ async function sendMessageV1(
   );
 
   try {
-    const result = await bridge.sendTurn(clientMessageId, [
-      { kind: "text", text },
-      // File / voice attachments stay on REST — see fallback above. The
-      // bridge schema already accepts a TurnStartInput[] so a future PR
-      // can add file references here without changing this call site.
-    ]);
+    // M9-β-1 (UPCR-2026-015): build the `TurnStartExtras` envelope
+    // from the populated `SendOptions` fields. The bridge serialises
+    // only the populated extras onto the wire, so a text-only send
+    // produces the same bytes a pre-β-1 build did.
+    const extras = buildTurnStartExtras(opts);
+    const result = await bridge.sendTurn(
+      clientMessageId,
+      [{ kind: "text", text }],
+      extras,
+    );
     // Codex round 7 P2: if the server's RPC reply is structurally
     // valid but reports `{ accepted: false }`, no `turn/started` will
     // ever fire — the lifecycle gate would otherwise wait the full

--- a/src/runtime/ui-protocol-types.ts
+++ b/src/runtime/ui-protocol-types.ts
@@ -28,6 +28,50 @@ export interface TurnStartInput {
   text: string;
 }
 
+/**
+ * UPCR-2026-015 (M9-β-1): wire-form file reference carried on
+ * `TurnStartParams.media`. Mirrors the Rust `FileRef` reused from
+ * UPCR-2026-014 (γ-1) — `path` is the durable filesystem handle
+ * returned from `POST /api/upload`; `mime` and `size_bytes` are
+ * captured at upload time. The web client populates all three.
+ *
+ * Note: the projection-side `FileRef` (lower in this file) leaves
+ * `mime` and `size_bytes` optional to tolerate envelopes the server
+ * emits with bare paths. The send-side shape here keeps them required
+ * because the upload endpoint always returns them.
+ */
+export interface TurnStartMediaRef {
+  path: string;
+  mime: string;
+  size_bytes: number;
+}
+
+/**
+ * UPCR-2026-015 (M9-β-1): the full `turn/start` params envelope the
+ * bridge serialises onto the wire. Strict-additive on top of the legacy
+ * `{ session_id, turn_id, input }` shape — every new field is optional
+ * and serialised only when populated.
+ *
+ * Mirrors the Rust `TurnStartParams` struct in
+ * `crates/octos-core/src/ui_protocol.rs`. Keep these in lockstep —
+ * `tsc --noEmit` is the only structural check; a drift between the
+ * two is a wire bug.
+ */
+export interface TurnStartExtras {
+  /** Pre-uploaded media references the user attached. Empty / omitted
+   *  for text-only sends. */
+  media?: TurnStartMediaRef[];
+  /** Sub-topic suffix that scopes this send to a per-topic session
+   *  bucket (`<session>#<topic>` form). Server folds it into the
+   *  resolved `SessionKey` before scope validation. */
+  topic?: string;
+  /** When set, this turn rewrites an existing queued user message
+   *  identified by its `client_message_id` (the `/queue` slash-command
+   *  flow). β-1 server logs the field; durable in-place ledger
+   *  replace lands in a follow-up. */
+  rewrite_for?: string;
+}
+
 export interface SessionOpenedResult {
   session_id: string;
   active_profile_id?: string;
@@ -273,6 +317,45 @@ export interface ApprovalRequestedEvent {
 export interface WarningEvent {
   reason: string;
   context?: unknown;
+}
+
+/**
+ * UPCR-2026-016 (M9-β-2) `session/closed` notification.
+ *
+ * Server emits this after `DELETE /api/sessions/:id` clears at least
+ * one entry from the standalone session store. Web clients use it to
+ * remove the row from the sidebar in real time so a delete action on
+ * one tab reflects on every other open tab without polling.
+ *
+ * `reason` is a free-form discriminator; the canonical value today is
+ * `"deleted"`. Future producers may emit `"expired"`, `"forked"`, etc.
+ * Treat unknown values as opaque so a server upgrade does not break
+ * the client.
+ */
+export interface SessionClosedEvent {
+  session_id: string;
+  reason?: string;
+  timestamp?: string;
+  cursor?: UiCursor;
+}
+
+/**
+ * UPCR-2026-016 (M9-β-2) `session/title-updated` notification.
+ *
+ * Server emits this after a successful `PATCH /api/sessions/:id/title`.
+ * Web clients re-render the sidebar row in place — the auto-titler
+ * fires the same REST PATCH from its caller, so this event covers both
+ * manual rename and auto-naming flows the user perceives.
+ *
+ * `reason` is `"manual"` for direct PATCH calls today. Future producers
+ * may emit `"auto"`, `"bulk_rename"`, etc.
+ */
+export interface SessionTitleUpdatedEvent {
+  session_id: string;
+  title: string;
+  reason?: string;
+  timestamp?: string;
+  cursor?: UiCursor;
 }
 
 export interface RpcErrorPayload {

--- a/src/store/projection.test.ts
+++ b/src/store/projection.test.ts
@@ -509,6 +509,31 @@ describe("project — user_message variant (codex BLOCK 3)", () => {
     const view = project(log);
     expect(view.threads[0].user?.text).toBe("first");
   });
+
+  // M9-β-1 (UPCR-2026-015): a user_message envelope server-mirrored
+  // from a turn/start that carried `media: FileRef[]` must surface
+  // those files on the projection's `UserView.files`. This is the
+  // end-to-end contract: client uploads → POST /api/upload returns
+  // path → SPA pins it on `SendOptions.media` → bridge serialises as
+  // `extras.media` on `turn/start` → server projects into the
+  // `user_message` envelope's `files` field → projection populates
+  // `UserView.files`. Test asserts the projection-side observable.
+  it("should populate UserView.files non-empty when β-1 turn/start carried media", () => {
+    const files: FileRef[] = [
+      { path: "/tmp/upload-1.png", mime: "image/png", size_bytes: 4096 },
+      { path: "/tmp/voice.mp3", mime: "audio/mpeg", size_bytes: 32_768 },
+    ];
+    const log: Envelope[] = [
+      env("t1", 0, uMsg("look at this", files), "cmid-beta1"),
+      env("t1", 1, aDelta("noted")),
+    ];
+    const view = project(log);
+    const u = view.threads[0].user!;
+    expect(u.files.length).toBeGreaterThan(0);
+    expect(u.files).toEqual(files);
+    expect(u.client_message_id).toBe("cmid-beta1");
+    expect(u.text).toBe("look at this");
+  });
 });
 
 // ─── BLOCK 4: referential stability across project() calls ───────────────


### PR DESCRIPTION
## Summary

- Pairs with octos PR #860 (UPCR-2026-015): `turn/start` params on
  `/api/ui-protocol/ws` gained three optional fields — `media`,
  `topic`, `rewrite_for`. This PR wires the web client onto them and
  deletes the three WS-only error strings the α-5/α-6 SSE-deletion
  series left behind in `ui-protocol-send.ts`.
- `ui-protocol-types.ts` extended; `ui-protocol-bridge.ts.sendTurn`
  accepts an optional `TurnStartExtras` envelope and serialises only
  populated fields onto the wire (text-only sends stay byte-identical
  to pre-β-1).
- Vitest covers media-bearing, `/queue`-rewrite, and topic-scoped
  variants plus the unchanged text-only baseline.

## Test plan

- [x] `npm run test:unit -- src/runtime/ui-protocol-send.test.ts src/store/projection.test.ts` — 44 / 44 green.
- [x] `npm run build` — clean (only pre-existing chunk-size warnings).
- [x] Full `npm run test:unit` — 1 unrelated pre-existing failure on `ui-protocol-event-router.test.ts` (also fails on main); all 17 send tests + 27 projection tests + the rest pass.
- [ ] Manual probe via `/Users/yuechen/home/octos-deploy-wave2/e2e/tests/_oneoff-beta1-media.spec.ts` (image attach -> assistant-bubble content) — runs after both PRs merge + mini1 redeploy.