### PR TITLE
fix(runtime): qualify bare WS session IDs with profile prefix

### DIFF
--- a/src/runtime/ui-protocol-bridge.ts
+++ b/src/runtime/ui-protocol-bridge.ts
@@ -866,8 +866,20 @@ class UiProtocolBridgeImpl implements UiProtocolBridge {
       throw new Error("ui-protocol-bridge: start requires sessionId");
     }
     this.stopped = false;
-    this.sessionId = opts.sessionId;
     this.profileId = opts.profileId ?? this.cfg.getProfileId();
+    // Auto-qualify bare session IDs (e.g. `web-1778...-abc123`) with the
+    // `<profile>:api:` prefix. The server's authenticated WS session-scope
+    // validator rejects bare IDs with `-32602 session_id must include the
+    // authenticated profile` and that RPC error never surfaces in the UI —
+    // it just leaves the ghost bubble stuck forever. Empirically reproduced
+    // 2026-05-10: bare `web-XXX` is rejected; `dspfac:api:web-XXX` is
+    // accepted. Admin-token connections bypass the check, which masked the
+    // bug in e2e harness runs.
+    let sid = opts.sessionId;
+    if (this.profileId && !sid.includes(":")) {
+      sid = `${this.profileId}:api:${sid}`;
+    }
+    this.sessionId = sid;
     this.reconnectAttempts = 0;
     this.reconnectAbandoned = false;
     await this.openSocket();


### PR DESCRIPTION
## Summary

- Bundle's `generateSessionId()` produced bare `web-{Date.now()}-{rand}` IDs.
- Server's `validate_authenticated_session_scope` rejects bare IDs from OTP-authenticated WS connections with `rpc-error[-32602] session_id must include the authenticated profile` — and the error path emits **no server log**, so the UI just left a stuck ghost bubble.
- Admin-token connections short-circuit the check (`AuthIdentity::Admin` → `connection_profile_id = None`), which is exactly why the entire M9-α/γ e2e harness — built around `octos-admin-2026` — passed while real OTP users silently failed.
- Fix: prepend `<profileId>:api:` to bare sessionIds at the WS bridge boundary in `start()`. Already-qualified IDs (containing `:`) pass through untouched.

## Repro / Verification

Empirical reproduction on mini1 (2026-05-10) using the user's real session token:

| session_id form | Result |
| --- | --- |
| `web-1778435423175-8upkb5` (bare) | REJECTED `-32602 session_id must include the authenticated profile` |
| `dspfac:api:web-1778435423333-p021pa` (profile-prefixed) | ACCEPTED, turn/completed at seq=17 |

Post-fix end-to-end via headless Playwright with the same real token:
- WS sends `turn/start` with `session_id: "dspfac:api:web-..."` ✓
- Server replies `message/persisted` for user/tool/assistant + `turn/completed` ✓
- Assistant bubble rendered with full weather answer ✓

## Test plan

- [x] Manual: deployed to mini1/mini2/mini3 (`index-BB3tNG6o.js`), verified mini1 in user's browser.
- [ ] Add a non-admin e2e probe to the chatWS harness so this bug class can't recur.