### PR TITLE
feat(api): M12 Phase D-2 — flagged client wrappers for auxiliary.rest_to_ws.v1

### DIFF
--- a/src/api/aux-rest-to-ws.test.ts
+++ b/src/api/aux-rest-to-ws.test.ts
@@ -330,6 +330,52 @@ describe("getMessagesPage", () => {
     expect(page.next_offset).toBe(100);
     expect(page.messages.length).toBe(100);
   });
+
+  // M12 Phase D-2 codex review (MEDIUM 1): the WS transport clamps
+  // limit→500 and offset→10000 server-side. The REST fallback used to
+  // synthesize `next_offset` from the caller's raw args, so
+  // `getMessagesPage(id, 1000)` reported different metadata across
+  // transports. The wrapper now clamps once up-front so the metadata
+  // is identical regardless of transport.
+  it("clamps over-limit and over-offset args to the same caps on both transports", async () => {
+    // First leg: flag OFF, REST path with limit=1000 (clamped to 500),
+    // offset=20000 (clamped to 10000). REST returns 500 rows → has_more.
+    const oversized = Array.from({ length: 500 }, (_, i) => ({
+      role: "user" as const,
+      content: `m${i}`,
+      timestamp: "2026-05-12T00:00:00Z",
+    }));
+    mockFetchOnceJson(oversized);
+    const restPage = await getMessagesPage("sess-clamp", 1000, 20000);
+    // REST URL should embed the CLAMPED values, not the raw ones.
+    expect(fetchCalls[0].url).toContain("limit=500");
+    expect(fetchCalls[0].url).toContain("offset=10000");
+    expect(restPage.has_more).toBe(true);
+    expect(restPage.next_offset).toBe(10500); // 10000 + 500
+
+    // Second leg: flag ON, WS path with the same args. The bridge must
+    // see the clamped values, not the raw ones. The server returns
+    // metadata derived from clamped values too.
+    resetFetchCalls();
+    __setAuxRestToWsV1ForTests(true);
+    const bridge = makeMockBridge();
+    bridge.setReply(METHODS.SESSION_MESSAGES_PAGE, {
+      messages: [],
+      has_more: true,
+      next_offset: 10500,
+    });
+    __setActiveBridgeForTest("any", bridge);
+
+    const wsPage = await getMessagesPage("sess-clamp", 1000, 20000);
+    expect(bridge.calls[0].params).toEqual({
+      session_id: "sess-clamp",
+      limit: 500,
+      offset: 10000,
+    });
+    // Both transports report the same next_offset for the same caller args.
+    expect(wsPage.next_offset).toBe(restPage.next_offset);
+    expect(wsPage.has_more).toBe(restPage.has_more);
+  });
 });
 
 describe("getSessionStatus [session/status.get]", () => {

--- a/src/api/aux-rest-to-ws.test.ts
+++ b/src/api/aux-rest-to-ws.test.ts
@@ -664,6 +664,66 @@ describe("fetchContent [content/list]", () => {
       filters: { session_id: "abc" },
     });
   });
+
+  // M12 Phase D-2 codex review (MEDIUM 2): the WS path filters by
+  // `filters.session_id` server-side. The REST GET endpoint has no
+  // equivalent query param, so direct `fetchContent({sessionId})`
+  // callers used to see UNFILTERED results when the flag was OFF
+  // (the store worked around it by client-filtering, but only
+  // `loadContent` did so). The REST fallback now applies the same
+  // client-side filter so caller-observable behavior is byte-identical
+  // across transports.
+  it("fetchContent({sessionId}) returns same filtered subset across transports", async () => {
+    const backendEntries = [
+      {
+        id: "a",
+        filename: "a.txt",
+        path: "/api/sessions/sess-x/files/a.txt",
+        category: "report" as const,
+        size_bytes: 1,
+        created_at: "2026-05-12T00:00:00Z",
+        thumbnail_path: null,
+        session_id: "sess-x",
+        tool_name: null,
+        caption: null,
+      },
+      {
+        id: "b",
+        filename: "b.txt",
+        path: "/api/sessions/sess-y/files/b.txt",
+        category: "report" as const,
+        size_bytes: 1,
+        created_at: "2026-05-12T00:00:00Z",
+        thumbnail_path: null,
+        session_id: "sess-y",
+        tool_name: null,
+        caption: null,
+      },
+    ];
+
+    // Leg 1: flag OFF (REST) — the server returns all entries, the
+    // wrapper filters client-side to those matching session_id.
+    mockFetchOnceJson({ entries: backendEntries, total: 2 });
+    const restOut = await fetchContent({ sessionId: "sess-x" });
+    expect(restOut.entries.map((e) => e.id)).toEqual(["a"]);
+    expect(restOut.total).toBe(1);
+
+    // Leg 2: flag ON (WS) — the server pre-filters; wrapper passes
+    // result through unchanged. Same caller-observable shape.
+    __setAuxRestToWsV1ForTests(true);
+    const bridge = makeMockBridge();
+    bridge.setReply(METHODS.CONTENT_LIST, {
+      entries: [backendEntries[0]],
+      total: 1,
+    });
+    __setActiveBridgeForTest("any", bridge);
+    const wsOut = await fetchContent({ sessionId: "sess-x" });
+    expect(wsOut.entries.map((e) => e.id)).toEqual(["a"]);
+    expect(wsOut.total).toBe(1);
+
+    // Equal under both transports.
+    expect(wsOut).toEqual(restOut);
+  });
 });
 
 describe("deleteContent [content/delete]", () => {

--- a/src/api/aux-rest-to-ws.test.ts
+++ b/src/api/aux-rest-to-ws.test.ts
@@ -767,6 +767,137 @@ describe("bulkDeleteContent [content/bulk_delete]", () => {
     expect(bridge.calls[0].method).toBe(METHODS.CONTENT_BULK_DELETE);
     expect(bridge.calls[0].params).toEqual({ ids: ["c-1", "c-2"] });
   });
+
+  // M12 Phase D-2 codex review (MEDIUM 3): the WS dispatcher caps
+  // `content/bulk_delete` at 256 IDs server-side. The REST endpoint
+  // has no equivalent cap, so a 300-ID delete used to succeed with
+  // the flag OFF and fail with the flag ON. The wrapper now chunks
+  // client-side to BATCH_SIZE on both transports so 300 IDs succeed
+  // regardless of flag state.
+  it("chunks 300 IDs into 2 batches (256 + 44) on the WS transport", async () => {
+    __setAuxRestToWsV1ForTests(true);
+    const bridge = makeMockBridge();
+    bridge.setReply(METHODS.CONTENT_BULK_DELETE, { deleted: 256 });
+    __setActiveBridgeForTest("any", bridge);
+
+    const ids = Array.from({ length: 300 }, (_, i) => `c-${i}`);
+    const out = await bulkDeleteContent(ids);
+
+    // Two chunks: 256 + 44.
+    expect(bridge.calls.length).toBe(2);
+    expect((bridge.calls[0].params as { ids: string[] }).ids.length).toBe(256);
+    expect((bridge.calls[1].params as { ids: string[] }).ids.length).toBe(44);
+    // First chunk's first ID is the array's first ID.
+    expect((bridge.calls[0].params as { ids: string[] }).ids[0]).toBe("c-0");
+    // Second chunk starts at index 256.
+    expect((bridge.calls[1].params as { ids: string[] }).ids[0]).toBe("c-256");
+    // Aggregated count tracks per-chunk replies.
+    expect(out.deleted_count).toBe(512); // both replies returned `deleted: 256`
+    expect(out.failed_ids).toEqual([]);
+  });
+
+  it("chunks 300 IDs into 2 batches on the REST transport too", async () => {
+    // Default fetchMock returns 200 OK for every call. The wrapper
+    // counts each chunk's length when no `deleted` body is returned.
+    const ids = Array.from({ length: 300 }, (_, i) => `c-${i}`);
+    const out = await bulkDeleteContent(ids);
+
+    // Two REST POSTs.
+    expect(fetchCalls.length).toBe(2);
+    const body1 = JSON.parse(fetchCalls[0].init?.body as string);
+    const body2 = JSON.parse(fetchCalls[1].init?.body as string);
+    expect(body1.ids.length).toBe(256);
+    expect(body2.ids.length).toBe(44);
+    expect(out.deleted_count).toBe(300);
+    expect(out.failed_ids).toEqual([]);
+  });
+
+  it("handles edge sizes 0, 1, 256, 257 correctly", async () => {
+    // 0 IDs → no transport call.
+    const empty = await bulkDeleteContent([]);
+    expect(fetchCalls.length).toBe(0);
+    expect(empty).toEqual({ deleted_count: 0, failed_ids: [] });
+
+    // 1 ID → exactly one chunk of 1.
+    const one = await bulkDeleteContent(["c-only"]);
+    expect(fetchCalls.length).toBe(1);
+    expect(JSON.parse(fetchCalls[0].init?.body as string).ids).toEqual([
+      "c-only",
+    ]);
+    expect(one.deleted_count).toBe(1);
+
+    // 256 IDs → exactly one chunk.
+    resetFetchCalls();
+    await bulkDeleteContent(Array.from({ length: 256 }, (_, i) => `c-${i}`));
+    expect(fetchCalls.length).toBe(1);
+    expect(JSON.parse(fetchCalls[0].init?.body as string).ids.length).toBe(256);
+
+    // 257 IDs → two chunks (256 + 1).
+    resetFetchCalls();
+    await bulkDeleteContent(Array.from({ length: 257 }, (_, i) => `c-${i}`));
+    expect(fetchCalls.length).toBe(2);
+    expect(JSON.parse(fetchCalls[0].init?.body as string).ids.length).toBe(256);
+    expect(JSON.parse(fetchCalls[1].init?.body as string).ids.length).toBe(1);
+  });
+
+  it("returns aggregated failed_ids when a chunk fails (REST)", async () => {
+    // First chunk: 256 IDs succeed (default fetchMock returns 200).
+    // Second chunk: forced 500. The wrapper aggregates failed_ids
+    // instead of throwing so callers can see partial-success.
+    currentFetchMock?.mockImplementationOnce(
+      async (url: string, init?: RequestInit) => {
+        currentCalls?.push({ url, init });
+        return new Response("{}", {
+          status: 200,
+          headers: { "content-type": "application/json" },
+        });
+      },
+    );
+    currentFetchMock?.mockImplementationOnce(
+      async (url: string, init?: RequestInit) => {
+        currentCalls?.push({ url, init });
+        return new Response("server boom", { status: 500 });
+      },
+    );
+
+    const ids = Array.from({ length: 300 }, (_, i) => `c-${i}`);
+    const out = await bulkDeleteContent(ids);
+
+    // Chunk 1 (256 IDs) succeeded; chunk 2 (44 IDs) failed.
+    expect(out.deleted_count).toBe(256);
+    expect(out.failed_ids.length).toBe(44);
+    expect(out.failed_ids[0]).toBe("c-256");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Feature flag — mid-session flip is ignored (NIT 1)
+// ---------------------------------------------------------------------------
+describe("auxiliary_rest_to_ws_v1 mid-session flip semantics", () => {
+  it("flipping the flag mid-session does NOT change subsequent wrapper routing", async () => {
+    // Initial read latches the flag value to OFF.
+    expect(isAuxRestToWsV1Enabled()).toBe(false);
+
+    // Flip storage directly WITHOUT calling the test reset helper, so
+    // the cached value stays. This mirrors a user toggling the flag in
+    // localStorage from devtools mid-session.
+    globalThis.localStorage?.setItem("octos_auxiliary_rest_to_ws_v1", "1");
+
+    // Cached value still wins. (One-shot warn fires once and is then
+    // suppressed.)
+    expect(isAuxRestToWsV1Enabled()).toBe(false);
+
+    // Wrapper routing must follow the latched value — REST path, not WS.
+    mockFetchOnceJson([]);
+    const bridge = makeMockBridge();
+    bridge.setReply(METHODS.SESSION_LIST, { sessions: [{ id: "should-not-see" }] });
+    __setActiveBridgeForTest("any", bridge);
+    const out = await listSessions();
+    // Routed through REST because the cached flag is still OFF.
+    expect(fetchCalls.length).toBe(1);
+    expect(bridge.calls.length).toBe(0);
+    expect(out).toEqual([]);
+  });
 });
 
 // ---------------------------------------------------------------------------

--- a/src/api/aux-rest-to-ws.test.ts
+++ b/src/api/aux-rest-to-ws.test.ts
@@ -1,0 +1,690 @@
+/**
+ * Unit tests for the M12 Phase D-2 auxiliary REST-to-WS wrappers.
+ *
+ * Each of the 13 wrappers in `src/api/sessions.ts` / `src/api/content.ts`
+ * routes one of two ways based on:
+ *   - `octos_auxiliary_rest_to_ws_v1` localStorage flag (on / off)
+ *   - presence of a connected bridge in the UI Protocol v1 runtime
+ *
+ * These tests pin both legs:
+ *   - flag OFF → flag-off REST path runs the existing `fetch` against
+ *     the legacy REST handler.
+ *   - flag ON + connected bridge → wrapper calls `bridge.callMethod()`
+ *     with the JSON-RPC params the server expects (golden shape from
+ *     `aux_rest_to_ws_v1_request_dtos_match_json_goldens` in
+ *     `crates/octos-core/src/ui_protocol.rs`).
+ *   - flag ON + no bridge → graceful fallback to REST so panels that
+ *     load before a chat session is open still work.
+ */
+
+import {
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  vi,
+} from "vitest";
+
+import {
+  __setAuxRestToWsV1ForTests,
+  isAuxRestToWsV1Enabled,
+} from "@/lib/feature-flags";
+import { __resetUiProtocolRuntimeForTest, __setActiveBridgeForTest } from "@/runtime/ui-protocol-runtime";
+import { METHODS, type UiProtocolBridge } from "@/runtime/ui-protocol-bridge";
+import { TOKEN_KEY } from "@/lib/constants";
+
+// SUT
+import {
+  bulkDeleteContent,
+  deleteContent,
+  fetchContent,
+} from "@/api/content";
+import {
+  deleteSession,
+  getMessages,
+  getMessagesPage,
+  getSessionFiles,
+  getSessionSnapshot,
+  getSessionStatus,
+  getSessionTasks,
+  getSessionWorkspaceContract,
+  getStatus,
+  listSessions,
+  setSessionTitle,
+} from "@/api/sessions";
+
+// ---------------------------------------------------------------------------
+// Mock bridge factory
+// ---------------------------------------------------------------------------
+
+interface MockBridge extends UiProtocolBridge {
+  calls: Array<{ method: string; params: unknown }>;
+  replies: Map<string, unknown>;
+  setReply(method: string, value: unknown): void;
+}
+
+function makeMockBridge(): MockBridge {
+  const calls: Array<{ method: string; params: unknown }> = [];
+  const replies = new Map<string, unknown>();
+
+  const stub: Partial<UiProtocolBridge> = {
+    callMethod: async <T,>(method: string, params?: unknown): Promise<T> => {
+      calls.push({ method, params: params ?? null });
+      if (!replies.has(method)) {
+        throw new Error(`mock bridge: no reply queued for ${method}`);
+      }
+      return replies.get(method) as T;
+    },
+    // Methods we don't exercise in this suite — stubs that satisfy the
+    // interface but throw if accidentally invoked.
+    start: async () => {},
+    stop: async () => {},
+    sendTurn: () => Promise.reject(new Error("not used in this test")),
+    interruptTurn: () => Promise.reject(new Error("not used")),
+    respondToApproval: () => Promise.reject(new Error("not used")),
+    hydrateSession: () => Promise.resolve(null),
+    onMessageDelta: () => () => {},
+    onMessagePersisted: () => () => {},
+    onSpawnComplete: () => () => {},
+    onTaskUpdated: () => () => {},
+    onTaskOutputDelta: () => () => {},
+    onTurnLifecycle: () => () => {},
+    onApprovalRequested: () => () => {},
+    onConnectionStateChange: () => () => {},
+    onWarning: () => () => {},
+  };
+
+  return Object.assign(stub as MockBridge, {
+    calls,
+    replies,
+    setReply(method: string, value: unknown) {
+      replies.set(method, value);
+    },
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Fetch mock helpers (REST fallback path)
+// ---------------------------------------------------------------------------
+
+interface FetchCapture {
+  url: string;
+  init: RequestInit | undefined;
+}
+
+let currentFetchMock: ReturnType<typeof vi.fn> | null = null;
+let currentCalls: FetchCapture[] | null = null;
+
+function installFetchMock(): { calls: FetchCapture[]; reset: () => void } {
+  const calls: FetchCapture[] = [];
+  const reset = () => {
+    calls.length = 0;
+  };
+
+  const fetchMock = vi
+    .fn()
+    .mockImplementation(async (url: string, init?: RequestInit) => {
+      calls.push({ url, init });
+      // Default success body for all REST stubs — each test overrides
+      // via `mockResolvedValueOnce` BEFORE invoking the wrapper.
+      return new Response(JSON.stringify({}), {
+        status: 200,
+        headers: { "content-type": "application/json" },
+      });
+    });
+  vi.stubGlobal("fetch", fetchMock);
+  currentFetchMock = fetchMock;
+  currentCalls = calls;
+
+  return { calls, reset };
+}
+
+function mockFetchOnceJson(body: unknown): void {
+  // Wrap the body in a `mockImplementationOnce` that ALSO logs into the
+  // shared `calls` array — otherwise the queued one-shot impl bypasses
+  // the default impl's bookkeeping and `fetchCalls` stays empty.
+  const capture = currentCalls;
+  currentFetchMock?.mockImplementationOnce(
+    async (url: string, init?: RequestInit) => {
+      capture?.push({ url, init });
+      return new Response(JSON.stringify(body), {
+        status: 200,
+        headers: { "content-type": "application/json" },
+      });
+    },
+  );
+}
+
+function mockFetchOnce204(): void {
+  const capture = currentCalls;
+  currentFetchMock?.mockImplementationOnce(
+    async (url: string, init?: RequestInit) => {
+      capture?.push({ url, init });
+      return new Response(null, { status: 204 });
+    },
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Shared lifecycle
+// ---------------------------------------------------------------------------
+
+let fetchCalls: FetchCapture[];
+let resetFetchCalls: () => void;
+
+beforeEach(() => {
+  __resetUiProtocolRuntimeForTest();
+  __setAuxRestToWsV1ForTests(false);
+  // Auth bookkeeping — `request()` reads the token from localStorage to
+  // build the Authorization header on the REST fallback.
+  try {
+    globalThis.localStorage?.setItem(TOKEN_KEY, "test-token");
+  } catch {
+    // jsdom always provides localStorage
+  }
+  const installed = installFetchMock();
+  fetchCalls = installed.calls;
+  resetFetchCalls = installed.reset;
+});
+
+afterEach(() => {
+  __setAuxRestToWsV1ForTests(false);
+  __resetUiProtocolRuntimeForTest();
+  resetFetchCalls();
+  vi.unstubAllGlobals();
+  vi.restoreAllMocks();
+  currentFetchMock = null;
+  currentCalls = null;
+});
+
+// ---------------------------------------------------------------------------
+// Flag plumbing
+// ---------------------------------------------------------------------------
+
+describe("auxiliary_rest_to_ws_v1 feature flag", () => {
+  it("defaults OFF", () => {
+    expect(isAuxRestToWsV1Enabled()).toBe(false);
+  });
+
+  it("reads `1` from localStorage as ON", () => {
+    __setAuxRestToWsV1ForTests(true);
+    expect(isAuxRestToWsV1Enabled()).toBe(true);
+  });
+
+  it("returns to OFF after the test helper resets it", () => {
+    __setAuxRestToWsV1ForTests(true);
+    expect(isAuxRestToWsV1Enabled()).toBe(true);
+    __setAuxRestToWsV1ForTests(false);
+    expect(isAuxRestToWsV1Enabled()).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Session wrappers
+// ---------------------------------------------------------------------------
+
+describe("listSessions [session/list]", () => {
+  it("flag OFF → calls REST /api/sessions", async () => {
+    mockFetchOnceJson([{ id: "s-1", message_count: 0 }]);
+    const result = await listSessions();
+    expect(fetchCalls[0].url).toBe("/api/sessions");
+    expect(result).toEqual([{ id: "s-1", message_count: 0 }]);
+  });
+
+  it("flag ON + connected bridge → calls WS session/list", async () => {
+    __setAuxRestToWsV1ForTests(true);
+    const bridge = makeMockBridge();
+    bridge.setReply(METHODS.SESSION_LIST, {
+      sessions: [{ id: "s-2", message_count: 5 }],
+    });
+    __setActiveBridgeForTest("any", bridge);
+
+    const result = await listSessions();
+    expect(bridge.calls).toEqual([
+      { method: METHODS.SESSION_LIST, params: {} },
+    ]);
+    expect(fetchCalls).toEqual([]); // no REST hit
+    expect(result).toEqual([{ id: "s-2", message_count: 5 }]);
+  });
+
+  it("flag ON + no bridge → falls back to REST", async () => {
+    __setAuxRestToWsV1ForTests(true);
+    mockFetchOnceJson([{ id: "s-3", message_count: 1 }]);
+    const result = await listSessions();
+    expect(fetchCalls[0].url).toBe("/api/sessions");
+    expect(result).toEqual([{ id: "s-3", message_count: 1 }]);
+  });
+});
+
+describe("getMessages [session/messages_page]", () => {
+  it("flag OFF → calls REST with paginated query string", async () => {
+    mockFetchOnceJson([
+      { role: "user", content: "hello", timestamp: "2026-05-12T00:00:00Z" },
+    ]);
+    const msgs = await getMessages("sess-x", 100, 0, 42, "topic-a");
+    expect(fetchCalls[0].url).toContain(
+      "/api/sessions/sess-x/messages?",
+    );
+    expect(fetchCalls[0].url).toContain("limit=100");
+    expect(fetchCalls[0].url).toContain("offset=0");
+    expect(fetchCalls[0].url).toContain("source=full");
+    expect(fetchCalls[0].url).toContain("since_seq=42");
+    expect(fetchCalls[0].url).toContain("topic=topic-a");
+    expect(msgs.length).toBe(1);
+  });
+
+  it("flag ON → calls WS session/messages_page with golden params", async () => {
+    __setAuxRestToWsV1ForTests(true);
+    const bridge = makeMockBridge();
+    bridge.setReply(METHODS.SESSION_MESSAGES_PAGE, {
+      messages: [
+        {
+          role: "assistant",
+          content: "hi",
+          timestamp: "2026-05-12T00:00:00Z",
+        },
+      ],
+      has_more: false,
+      next_offset: 1,
+    });
+    __setActiveBridgeForTest("any", bridge);
+
+    const msgs = await getMessages("sess-2", 50, 10, 100);
+    expect(bridge.calls[0].method).toBe(METHODS.SESSION_MESSAGES_PAGE);
+    expect(bridge.calls[0].params).toEqual({
+      session_id: "sess-2",
+      limit: 50,
+      offset: 10,
+      since_seq: 100,
+    });
+    expect(msgs.length).toBe(1);
+  });
+});
+
+describe("getMessagesPage", () => {
+  it("flag ON → returns WS page metadata verbatim", async () => {
+    __setAuxRestToWsV1ForTests(true);
+    const bridge = makeMockBridge();
+    bridge.setReply(METHODS.SESSION_MESSAGES_PAGE, {
+      messages: [],
+      has_more: true,
+      next_offset: 200,
+    });
+    __setActiveBridgeForTest("any", bridge);
+
+    const page = await getMessagesPage("sess-3", 100, 100);
+    expect(page).toEqual({ messages: [], has_more: true, next_offset: 200 });
+  });
+
+  it("flag OFF → synthesizes has_more from page length", async () => {
+    // Page returns exactly `limit` rows → has_more=true, next_offset=limit
+    const messages = Array.from({ length: 100 }, (_, i) => ({
+      role: "user" as const,
+      content: `m${i}`,
+      timestamp: "2026-05-12T00:00:00Z",
+    }));
+    mockFetchOnceJson(messages);
+    const page = await getMessagesPage("sess-3", 100, 0);
+    expect(page.has_more).toBe(true);
+    expect(page.next_offset).toBe(100);
+    expect(page.messages.length).toBe(100);
+  });
+});
+
+describe("getSessionStatus [session/status.get]", () => {
+  it("flag OFF → calls REST /status with optional topic", async () => {
+    mockFetchOnceJson({
+      active: true,
+      has_deferred_files: false,
+      has_bg_tasks: false,
+    });
+    const s = await getSessionStatus("sess-a", "t1");
+    expect(fetchCalls[0].url).toBe("/api/sessions/sess-a/status?topic=t1");
+    expect(s.active).toBe(true);
+  });
+
+  it("flag ON → calls WS session/status.get and unwraps `status`", async () => {
+    __setAuxRestToWsV1ForTests(true);
+    const bridge = makeMockBridge();
+    bridge.setReply(METHODS.SESSION_STATUS_GET, {
+      status: {
+        active: false,
+        has_deferred_files: true,
+        has_bg_tasks: true,
+      },
+    });
+    __setActiveBridgeForTest("any", bridge);
+
+    const s = await getSessionStatus("sess-a");
+    expect(bridge.calls[0].params).toEqual({ session_id: "sess-a" });
+    expect(s).toEqual({
+      active: false,
+      has_deferred_files: true,
+      has_bg_tasks: true,
+    });
+  });
+});
+
+describe("getSessionFiles [session/files.list]", () => {
+  it("flag OFF → REST /files", async () => {
+    mockFetchOnceJson([
+      {
+        filename: "a.txt",
+        path: "p/a.txt",
+        size_bytes: 1,
+        modified_at: "2026-05-12T00:00:00Z",
+      },
+    ]);
+    const files = await getSessionFiles("sess-b");
+    expect(fetchCalls[0].url).toBe("/api/sessions/sess-b/files");
+    expect(files.length).toBe(1);
+  });
+
+  it("flag ON → WS session/files.list, unwraps `files`", async () => {
+    __setAuxRestToWsV1ForTests(true);
+    const bridge = makeMockBridge();
+    bridge.setReply(METHODS.SESSION_FILES_LIST, {
+      files: [
+        {
+          filename: "b.txt",
+          path: "p/b.txt",
+          size_bytes: 2,
+          modified_at: "2026-05-12T00:00:00Z",
+        },
+      ],
+    });
+    __setActiveBridgeForTest("any", bridge);
+
+    const files = await getSessionFiles("sess-b");
+    expect(bridge.calls[0].params).toEqual({ session_id: "sess-b" });
+    expect(files.length).toBe(1);
+    expect(files[0].filename).toBe("b.txt");
+  });
+});
+
+describe("getSessionTasks [session/tasks.list]", () => {
+  it("flag OFF → REST /tasks", async () => {
+    mockFetchOnceJson([]);
+    const tasks = await getSessionTasks("sess-c", "t");
+    expect(fetchCalls[0].url).toBe("/api/sessions/sess-c/tasks?topic=t");
+    expect(tasks).toEqual([]);
+  });
+
+  it("flag ON → WS session/tasks.list with topic", async () => {
+    __setAuxRestToWsV1ForTests(true);
+    const bridge = makeMockBridge();
+    bridge.setReply(METHODS.SESSION_TASKS_LIST, { tasks: [] });
+    __setActiveBridgeForTest("any", bridge);
+
+    await getSessionTasks("sess-c", "t");
+    expect(bridge.calls[0].params).toEqual({
+      session_id: "sess-c",
+      topic: "t",
+    });
+  });
+});
+
+describe("getSessionWorkspaceContract [session/workspace.get]", () => {
+  it("flag OFF → REST /workspace-contract", async () => {
+    mockFetchOnceJson([]);
+    await getSessionWorkspaceContract("sess-d");
+    expect(fetchCalls[0].url).toBe(
+      "/api/sessions/sess-d/workspace-contract",
+    );
+  });
+
+  it("flag ON → WS session/workspace.get, unwraps `contracts`", async () => {
+    __setAuxRestToWsV1ForTests(true);
+    const bridge = makeMockBridge();
+    bridge.setReply(METHODS.SESSION_WORKSPACE_GET, { contracts: [] });
+    __setActiveBridgeForTest("any", bridge);
+
+    const out = await getSessionWorkspaceContract("sess-d");
+    expect(bridge.calls[0].params).toEqual({ session_id: "sess-d" });
+    expect(out).toEqual([]);
+  });
+});
+
+describe("getSessionSnapshot [session/snapshot]", () => {
+  it("flag OFF → issues 3 parallel REST calls", async () => {
+    // status, files, tasks (in unspecified order; the wrapper uses Promise.all)
+    mockFetchOnceJson({
+      active: true,
+      has_deferred_files: false,
+      has_bg_tasks: false,
+    });
+    mockFetchOnceJson([]);
+    mockFetchOnceJson([]);
+    const snap = await getSessionSnapshot("sess-e");
+    expect(fetchCalls.length).toBe(3);
+    expect(snap.status.active).toBe(true);
+    expect(snap.files).toEqual([]);
+    expect(snap.tasks).toEqual([]);
+  });
+
+  it("flag ON → one WS session/snapshot call", async () => {
+    __setAuxRestToWsV1ForTests(true);
+    const bridge = makeMockBridge();
+    bridge.setReply(METHODS.SESSION_SNAPSHOT, {
+      status: {
+        active: false,
+        has_deferred_files: false,
+        has_bg_tasks: false,
+      },
+      files: [],
+      tasks: [],
+    });
+    __setActiveBridgeForTest("any", bridge);
+
+    const snap = await getSessionSnapshot("sess-e", "topic-z");
+    expect(bridge.calls.length).toBe(1);
+    expect(bridge.calls[0].method).toBe(METHODS.SESSION_SNAPSHOT);
+    expect(bridge.calls[0].params).toEqual({
+      session_id: "sess-e",
+      topic: "topic-z",
+    });
+    expect(snap.status.active).toBe(false);
+  });
+});
+
+describe("setSessionTitle [session/title.set]", () => {
+  it("flag OFF → REST PATCH /title", async () => {
+    mockFetchOnce204();
+    const out = await setSessionTitle("sess-f", "New title");
+    expect(fetchCalls[0].url).toBe("/api/sessions/sess-f/title");
+    expect(fetchCalls[0].init?.method).toBe("PATCH");
+    expect(JSON.parse(fetchCalls[0].init?.body as string)).toEqual({
+      title: "New title",
+    });
+    expect(out).toEqual({ session_id: "sess-f", title: "New title" });
+  });
+
+  it("flag ON → WS session/title.set echoes the rename", async () => {
+    __setAuxRestToWsV1ForTests(true);
+    const bridge = makeMockBridge();
+    bridge.setReply(METHODS.SESSION_TITLE_SET, {
+      session_id: "sess-f",
+      title: "Better title",
+    });
+    __setActiveBridgeForTest("any", bridge);
+
+    const out = await setSessionTitle("sess-f", "Better title");
+    expect(bridge.calls[0].params).toEqual({
+      session_id: "sess-f",
+      title: "Better title",
+    });
+    expect(out).toEqual({ session_id: "sess-f", title: "Better title" });
+  });
+});
+
+describe("deleteSession [session/delete]", () => {
+  it("flag OFF → REST DELETE", async () => {
+    mockFetchOnce204();
+    await deleteSession("sess-g");
+    expect(fetchCalls[0].url).toBe("/api/sessions/sess-g");
+    expect(fetchCalls[0].init?.method).toBe("DELETE");
+  });
+
+  it("flag ON → WS session/delete", async () => {
+    __setAuxRestToWsV1ForTests(true);
+    const bridge = makeMockBridge();
+    bridge.setReply(METHODS.SESSION_DELETE, {});
+    __setActiveBridgeForTest("any", bridge);
+
+    await deleteSession("sess-g");
+    expect(bridge.calls[0].method).toBe(METHODS.SESSION_DELETE);
+    expect(bridge.calls[0].params).toEqual({ session_id: "sess-g" });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// System wrappers
+// ---------------------------------------------------------------------------
+
+describe("getStatus [system/status.get]", () => {
+  it("flag OFF → REST /api/status", async () => {
+    mockFetchOnceJson({
+      version: "0.1.0",
+      model: "x",
+      provider: "y",
+      uptime_secs: 42,
+      agent_configured: true,
+    });
+    const s = await getStatus();
+    expect(fetchCalls[0].url).toBe("/api/status");
+    expect(s.version).toBe("0.1.0");
+  });
+
+  it("flag ON → WS system/status.get, unwraps `status`", async () => {
+    __setAuxRestToWsV1ForTests(true);
+    const bridge = makeMockBridge();
+    bridge.setReply(METHODS.SYSTEM_STATUS_GET, {
+      status: {
+        version: "0.2.0",
+        model: "m",
+        provider: "p",
+        uptime_secs: 7,
+        agent_configured: false,
+      },
+    });
+    __setActiveBridgeForTest("any", bridge);
+
+    const s = await getStatus();
+    expect(bridge.calls[0].method).toBe(METHODS.SYSTEM_STATUS_GET);
+    expect(bridge.calls[0].params).toEqual({});
+    expect(s.version).toBe("0.2.0");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Content wrappers
+// ---------------------------------------------------------------------------
+
+describe("fetchContent [content/list]", () => {
+  it("flag OFF → REST /api/my/content with query string", async () => {
+    mockFetchOnceJson({ entries: [], total: 0 });
+    await fetchContent({ category: "image", limit: 50 });
+    expect(fetchCalls[0].url).toBe(
+      "/api/my/content?category=image&limit=50",
+    );
+  });
+
+  it("flag ON → WS content/list with `filters` wrapper", async () => {
+    __setAuxRestToWsV1ForTests(true);
+    const bridge = makeMockBridge();
+    bridge.setReply(METHODS.CONTENT_LIST, {
+      entries: [{ id: "c-1" }],
+      total: 1,
+    });
+    __setActiveBridgeForTest("any", bridge);
+
+    const out = await fetchContent({ category: "image", limit: 50 });
+    expect(bridge.calls[0].method).toBe(METHODS.CONTENT_LIST);
+    expect(bridge.calls[0].params).toEqual({
+      filters: { category: "image", limit: 50 },
+    });
+    expect(out.total).toBe(1);
+  });
+
+  it("flag ON + sessionId filter → maps to session_id on the wire", async () => {
+    __setAuxRestToWsV1ForTests(true);
+    const bridge = makeMockBridge();
+    bridge.setReply(METHODS.CONTENT_LIST, { entries: [], total: 0 });
+    __setActiveBridgeForTest("any", bridge);
+
+    await fetchContent({ sessionId: "abc" });
+    expect(bridge.calls[0].params).toEqual({
+      filters: { session_id: "abc" },
+    });
+  });
+});
+
+describe("deleteContent [content/delete]", () => {
+  it("flag OFF → REST DELETE /api/my/content/:id", async () => {
+    mockFetchOnce204();
+    await deleteContent("c-1");
+    expect(fetchCalls[0].url).toBe("/api/my/content/c-1");
+    expect(fetchCalls[0].init?.method).toBe("DELETE");
+  });
+
+  it("flag ON → WS content/delete", async () => {
+    __setAuxRestToWsV1ForTests(true);
+    const bridge = makeMockBridge();
+    bridge.setReply(METHODS.CONTENT_DELETE, { deleted: true });
+    __setActiveBridgeForTest("any", bridge);
+
+    await deleteContent("c-1");
+    expect(bridge.calls[0].method).toBe(METHODS.CONTENT_DELETE);
+    expect(bridge.calls[0].params).toEqual({ id: "c-1" });
+  });
+});
+
+describe("bulkDeleteContent [content/bulk_delete]", () => {
+  it("flag OFF → REST POST /bulk-delete", async () => {
+    mockFetchOnce204();
+    await bulkDeleteContent(["c-1", "c-2"]);
+    expect(fetchCalls[0].url).toBe("/api/my/content/bulk-delete");
+    expect(fetchCalls[0].init?.method).toBe("POST");
+    expect(JSON.parse(fetchCalls[0].init?.body as string)).toEqual({
+      ids: ["c-1", "c-2"],
+    });
+  });
+
+  it("flag ON → WS content/bulk_delete with `ids` array", async () => {
+    __setAuxRestToWsV1ForTests(true);
+    const bridge = makeMockBridge();
+    bridge.setReply(METHODS.CONTENT_BULK_DELETE, { deleted: 2 });
+    __setActiveBridgeForTest("any", bridge);
+
+    await bulkDeleteContent(["c-1", "c-2"]);
+    expect(bridge.calls[0].method).toBe(METHODS.CONTENT_BULK_DELETE);
+    expect(bridge.calls[0].params).toEqual({ ids: ["c-1", "c-2"] });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Error translation
+// ---------------------------------------------------------------------------
+
+describe("error envelope translation", () => {
+  it("flag ON + bridge RPC error → throws plain Error with server message", async () => {
+    __setAuxRestToWsV1ForTests(true);
+    const bridge = makeMockBridge();
+    // Inject a callMethod that throws BridgeRpcError-style failure.
+    bridge.callMethod = (async (): Promise<never> => {
+      const { BridgeRpcError } = await import("@/runtime/ui-protocol-bridge");
+      throw new BridgeRpcError(-32601, "method_not_supported", null);
+    }) as UiProtocolBridge["callMethod"];
+    __setActiveBridgeForTest("any", bridge);
+
+    let caught: unknown;
+    try {
+      await listSessions();
+    } catch (e) {
+      caught = e;
+    }
+    expect(caught).toBeInstanceOf(Error);
+    expect((caught as Error).message).toContain("method_not_supported");
+  });
+});

--- a/src/api/client.ts
+++ b/src/api/client.ts
@@ -127,6 +127,12 @@ export async function request<T>(
 
   if (!resp.ok) {
     // Auto-logout on auth failure (expired/invalid token)
+    //
+    // Phase D-2 intentionally does NOT trigger this REST 401 reaper from
+    // WS auth failures (see `translateBridgeError` in `sessions.ts` /
+    // `content.ts`). See ADR PR #910 — Phase D-4 narrows this reaper to
+    // `/api/auth/*` only, so cross-transport coupling here is
+    // undesirable until that lands.
     if (resp.status === 401 || resp.status === 403) {
       clearToken();
       // Redirect to login unless already there

--- a/src/api/content.ts
+++ b/src/api/content.ts
@@ -1,6 +1,14 @@
 import { request, getSelectedProfileId, getToken } from "@/api/client";
 import { API_BASE } from "@/lib/constants";
 import { buildFileUrl } from "@/api/files";
+import {
+  BridgeRpcError,
+  BridgeStoppedError,
+  BridgeTimeoutError,
+  METHODS,
+} from "@/runtime/ui-protocol-bridge";
+import { getAnyConnectedBridge } from "@/runtime/ui-protocol-runtime";
+import { isAuxRestToWsV1Enabled } from "@/lib/feature-flags";
 
 // --- Types ---
 
@@ -33,11 +41,68 @@ export interface ContentFilters {
   sessionId?: string;
 }
 
+// ---------------------------------------------------------------------------
+// M12 Phase D-2 wrapper helpers — see header in `src/api/sessions.ts`.
+// ---------------------------------------------------------------------------
+
+function shouldUseWs(): boolean {
+  if (!isAuxRestToWsV1Enabled()) return false;
+  return getAnyConnectedBridge() !== null;
+}
+
+function translateBridgeError(err: unknown): Error {
+  if (err instanceof BridgeRpcError) return new Error(err.message);
+  if (err instanceof BridgeTimeoutError) return new Error(err.message);
+  if (err instanceof BridgeStoppedError) return new Error(err.message);
+  if (err instanceof Error) return err;
+  return new Error(String(err));
+}
+
+async function callAuxWs<T>(method: string, params: unknown): Promise<T> {
+  const bridge = getAnyConnectedBridge();
+  if (!bridge) {
+    throw new Error("ui-protocol-bridge: no connected bridge for " + method);
+  }
+  try {
+    return await bridge.callMethod<T>(method, params);
+  } catch (err) {
+    throw translateBridgeError(err);
+  }
+}
+
 // --- API ---
+
+function filtersToWsParams(filters: ContentFilters): Record<string, unknown> {
+  // Server-side `ContentListParams.filters` is a free-form JSON object
+  // mirrored 1:1 onto the existing REST `ContentQuery` shape (snake_case
+  // server-side; the UI passes camelCase `sessionId`, which the REST
+  // query param flattener has historically not used — the REST `GET`
+  // accepts no sessionId at all). For WS we pass through the keys the
+  // server actually consumes.
+  const filterObj: Record<string, unknown> = {};
+  if (filters.category) filterObj.category = filters.category;
+  if (filters.search) filterObj.search = filters.search;
+  if (filters.from) filterObj.from = filters.from;
+  if (filters.to) filterObj.to = filters.to;
+  if (filters.sort) filterObj.sort = filters.sort;
+  if (filters.limit !== undefined) filterObj.limit = filters.limit;
+  if (filters.offset !== undefined) filterObj.offset = filters.offset;
+  if (filters.sessionId) filterObj.session_id = filters.sessionId;
+  return filterObj;
+}
+
+// ---------------------------------------------------------------------------
+// content/list — `GET /api/my/content`
+// ---------------------------------------------------------------------------
 
 export async function fetchContent(
   filters: ContentFilters = {},
 ): Promise<ContentQueryResult> {
+  if (shouldUseWs()) {
+    return callAuxWs<ContentQueryResult>(METHODS.CONTENT_LIST, {
+      filters: filtersToWsParams(filters),
+    });
+  }
   const params = new URLSearchParams();
   if (filters.category) params.set("category", filters.category);
   if (filters.search) params.set("search", filters.search);
@@ -82,11 +147,29 @@ export function matchesContentSession(
   });
 }
 
+// ---------------------------------------------------------------------------
+// content/delete — `DELETE /api/my/content/:id`
+// ---------------------------------------------------------------------------
+
 export async function deleteContent(id: string): Promise<void> {
+  if (shouldUseWs()) {
+    await callAuxWs<{ deleted: boolean }>(METHODS.CONTENT_DELETE, { id });
+    return;
+  }
   await request(`/api/my/content/${id}`, { method: "DELETE" });
 }
 
+// ---------------------------------------------------------------------------
+// content/bulk_delete — `POST /api/my/content/bulk-delete`
+// ---------------------------------------------------------------------------
+
 export async function bulkDeleteContent(ids: string[]): Promise<void> {
+  if (shouldUseWs()) {
+    await callAuxWs<{ deleted: number }>(METHODS.CONTENT_BULK_DELETE, {
+      ids,
+    });
+    return;
+  }
   await request("/api/my/content/bulk-delete", {
     method: "POST",
     body: JSON.stringify({ ids }),

--- a/src/api/content.ts
+++ b/src/api/content.ts
@@ -1,5 +1,5 @@
 import { request, getSelectedProfileId, getToken } from "@/api/client";
-import { API_BASE } from "@/lib/constants";
+import { API_BASE, CONTENT_BULK_DELETE_BATCH_SIZE } from "@/lib/constants";
 import { buildFileUrl } from "@/api/files";
 import {
   BridgeRpcError,
@@ -51,6 +51,9 @@ function shouldUseWs(): boolean {
 }
 
 function translateBridgeError(err: unknown): Error {
+  // Phase D-2 intentionally does NOT trigger the REST 401 reaper on WS
+  // auth failures. See ADR PR #910 — Phase D-4 narrows the reaper scope,
+  // so cross-transport coupling here is undesirable.
   if (err instanceof BridgeRpcError) return new Error(err.message);
   if (err instanceof BridgeTimeoutError) return new Error(err.message);
   if (err instanceof BridgeStoppedError) return new Error(err.message);
@@ -113,9 +116,25 @@ export async function fetchContent(
   if (filters.offset) params.set("offset", String(filters.offset));
 
   const qs = params.toString();
-  return request<ContentQueryResult>(
+  const result = await request<ContentQueryResult>(
     `/api/my/content${qs ? `?${qs}` : ""}`,
   );
+
+  // M12 Phase D-2: the WS path maps `sessionId` → `filters.session_id`
+  // server-side. The REST `GET /api/my/content` query string has no
+  // equivalent parameter, so we apply the same filter client-side here
+  // to keep caller-observable behavior byte-identical across transports.
+  // `content-store.ts` historically performed this filtering itself; we
+  // also keep that copy for back-compat so flag-OFF callers that bypass
+  // the store still get filtered results.
+  if (filters.sessionId) {
+    const sid = filters.sessionId;
+    const entries = (result.entries ?? []).filter((entry) =>
+      matchesContentSession(entry, sid),
+    );
+    return { entries, total: entries.length };
+  }
+  return result;
 }
 
 export function matchesContentSession(
@@ -163,17 +182,70 @@ export async function deleteContent(id: string): Promise<void> {
 // content/bulk_delete — `POST /api/my/content/bulk-delete`
 // ---------------------------------------------------------------------------
 
-export async function bulkDeleteContent(ids: string[]): Promise<void> {
-  if (shouldUseWs()) {
-    await callAuxWs<{ deleted: number }>(METHODS.CONTENT_BULK_DELETE, {
-      ids,
-    });
-    return;
+export interface BulkDeleteResult {
+  deleted_count: number;
+  failed_ids: string[];
+}
+
+/**
+ * Delete a batch of content entries, chunked client-side to
+ * `CONTENT_BULK_DELETE_BATCH_SIZE` (256) per request.
+ *
+ * The server-side WS dispatcher caps `content/bulk_delete` at 256 IDs,
+ * while the REST endpoint has no equivalent visible cap. Chunking in
+ * both transports keeps behavior consistent regardless of the flag
+ * state and lets large bulk-deletes succeed under either path.
+ *
+ * Returns a `BulkDeleteResult` so callers can surface partial-failure
+ * semantics — earlier chunks may have committed even if a later one
+ * threw. The legacy `void` return is preserved at the call sites that
+ * don't care via discarding.
+ */
+export async function bulkDeleteContent(
+  ids: string[],
+): Promise<BulkDeleteResult> {
+  if (ids.length === 0) {
+    return { deleted_count: 0, failed_ids: [] };
   }
-  await request("/api/my/content/bulk-delete", {
-    method: "POST",
-    body: JSON.stringify({ ids }),
-  });
+
+  const chunks: string[][] = [];
+  for (let i = 0; i < ids.length; i += CONTENT_BULK_DELETE_BATCH_SIZE) {
+    chunks.push(ids.slice(i, i + CONTENT_BULK_DELETE_BATCH_SIZE));
+  }
+
+  let deletedCount = 0;
+  const failedIds: string[] = [];
+
+  for (const chunk of chunks) {
+    try {
+      if (shouldUseWs()) {
+        const out = await callAuxWs<{ deleted?: number }>(
+          METHODS.CONTENT_BULK_DELETE,
+          { ids: chunk },
+        );
+        deletedCount += out?.deleted ?? chunk.length;
+      } else {
+        await request("/api/my/content/bulk-delete", {
+          method: "POST",
+          body: JSON.stringify({ ids: chunk }),
+        });
+        // REST endpoint returns 204 with no body — assume full success
+        // for the chunk on a 2xx response.
+        deletedCount += chunk.length;
+      }
+    } catch (err) {
+      // Aggregate failures so partially-successful batches still report
+      // useful progress to the caller. Don't rethrow mid-loop: chunks
+      // after a failure are also recorded as failed to preserve the
+      // caller's view of "these IDs were not deleted".
+      failedIds.push(...chunk);
+      // Best-effort: drop the error onto the console so callers that
+      // ignore the return shape still see something in the devtools.
+      console.warn("[octos] bulkDeleteContent chunk failed", err);
+    }
+  }
+
+  return { deleted_count: deletedCount, failed_ids: failedIds };
 }
 
 export function thumbnailUrl(id: string): string {

--- a/src/api/sessions.ts
+++ b/src/api/sessions.ts
@@ -1,5 +1,18 @@
 import { request } from "./client";
-import type { SessionInfo, MessageInfo, BackgroundTaskInfo } from "./types";
+import type {
+  SessionInfo,
+  MessageInfo,
+  BackgroundTaskInfo,
+  ServerStatus,
+} from "./types";
+import {
+  BridgeRpcError,
+  BridgeStoppedError,
+  BridgeTimeoutError,
+  METHODS,
+} from "@/runtime/ui-protocol-bridge";
+import { getAnyConnectedBridge } from "@/runtime/ui-protocol-runtime";
+import { isAuxRestToWsV1Enabled } from "@/lib/feature-flags";
 
 export interface SessionFileInfo {
   filename: string;
@@ -35,9 +48,95 @@ export interface SessionWorkspaceContractInfo {
   artifacts: SessionWorkspaceArtifactInfo[];
 }
 
+export interface SessionStatusInfo {
+  active: boolean;
+  has_deferred_files: boolean;
+  has_bg_tasks: boolean;
+}
+
+export interface SessionMessagesPage {
+  messages: MessageInfo[];
+  has_more: boolean;
+  next_offset: number;
+}
+
+export interface SessionSnapshot {
+  status: SessionStatusInfo;
+  files: SessionFileInfo[];
+  tasks: BackgroundTaskInfo[];
+}
+
+// ---------------------------------------------------------------------------
+// M12 Phase D-2: WS-or-REST wrappers under `auxiliary.rest_to_ws.v1`.
+//
+// Each wrapper checks the `auxiliary_rest_to_ws_v1` feature flag. When ON
+// AND there is a live, `connected` UI Protocol v1 bridge, the call routes
+// through the bridge's `callMethod()` and returns the result of the
+// matching JSON-RPC method. When OFF or there is no live bridge, the
+// wrapper falls through to the existing REST helper unchanged.
+//
+// Return types and error envelopes are identical across the two paths —
+// WS `BridgeRpcError` / `BridgeTimeoutError` / `BridgeStoppedError` are
+// translated into the same `Error` shape the REST `request()` helper
+// throws on a non-OK response. Callers must not branch on the transport.
+// ---------------------------------------------------------------------------
+
+function shouldUseWs(): boolean {
+  if (!isAuxRestToWsV1Enabled()) return false;
+  return getAnyConnectedBridge() !== null;
+}
+
+function translateBridgeError(err: unknown): Error {
+  // Match the existing REST helper's error envelope: a plain `Error`
+  // whose `message` is the server-provided text (or a `HTTP NNN`
+  // string). Codex review M9-β-2 prefers a single `Error` subclass at
+  // the wrapper boundary so panels can drop both code paths into one
+  // `try { ... } catch (e: any) { setError(e.message) }`.
+  if (err instanceof BridgeRpcError) {
+    return new Error(err.message);
+  }
+  if (err instanceof BridgeTimeoutError) {
+    return new Error(err.message);
+  }
+  if (err instanceof BridgeStoppedError) {
+    return new Error(err.message);
+  }
+  if (err instanceof Error) return err;
+  return new Error(String(err));
+}
+
+async function callAuxWs<T>(method: string, params: unknown): Promise<T> {
+  const bridge = getAnyConnectedBridge();
+  if (!bridge) {
+    // shouldUseWs() guarantees this is unreachable at the call sites
+    // below, but a defensive throw keeps the type narrow.
+    throw new Error("ui-protocol-bridge: no connected bridge for " + method);
+  }
+  try {
+    return await bridge.callMethod<T>(method, params);
+  } catch (err) {
+    throw translateBridgeError(err);
+  }
+}
+
+// ---------------------------------------------------------------------------
+// session/list — `GET /api/sessions`
+// ---------------------------------------------------------------------------
+
 export async function listSessions(): Promise<SessionInfo[]> {
+  if (shouldUseWs()) {
+    const result = await callAuxWs<{ sessions: SessionInfo[] }>(
+      METHODS.SESSION_LIST,
+      {},
+    );
+    return result.sessions ?? [];
+  }
   return request("/api/sessions");
 }
+
+// ---------------------------------------------------------------------------
+// session/messages_page — `GET /api/sessions/:id/messages`
+// ---------------------------------------------------------------------------
 
 export async function getMessages(
   sessionId: string,
@@ -46,6 +145,28 @@ export async function getMessages(
   sinceSeq?: number,
   topic?: string,
 ): Promise<MessageInfo[]> {
+  if (shouldUseWs()) {
+    const params: Record<string, unknown> = {
+      session_id: sessionId,
+      limit,
+      offset,
+    };
+    if (
+      typeof sinceSeq === "number" &&
+      Number.isFinite(sinceSeq) &&
+      sinceSeq >= 0
+    ) {
+      params.since_seq = sinceSeq;
+    }
+    const trimmedTopic = topic?.trim();
+    if (trimmedTopic) params.topic = trimmedTopic;
+    const result = await callAuxWs<SessionMessagesPage>(
+      METHODS.SESSION_MESSAGES_PAGE,
+      params,
+    );
+    return result.messages ?? [];
+  }
+
   const params = new URLSearchParams({
     limit: String(limit),
     offset: String(offset),
@@ -66,20 +187,87 @@ export async function getMessages(
   );
 }
 
+/**
+ * M12 Phase D-2: the WS variant of `getMessages` also returns the
+ * `has_more` / `next_offset` pagination metadata, useful for the future
+ * paged history loader. Phase D-3 panels can call this directly when
+ * they want pagination state; the legacy REST array shape is
+ * preserved by `getMessages` for back-compat.
+ */
+export async function getMessagesPage(
+  sessionId: string,
+  limit = 500,
+  offset = 0,
+  sinceSeq?: number,
+  topic?: string,
+): Promise<SessionMessagesPage> {
+  if (shouldUseWs()) {
+    const params: Record<string, unknown> = {
+      session_id: sessionId,
+      limit,
+      offset,
+    };
+    if (
+      typeof sinceSeq === "number" &&
+      Number.isFinite(sinceSeq) &&
+      sinceSeq >= 0
+    ) {
+      params.since_seq = sinceSeq;
+    }
+    const trimmedTopic = topic?.trim();
+    if (trimmedTopic) params.topic = trimmedTopic;
+    return callAuxWs<SessionMessagesPage>(
+      METHODS.SESSION_MESSAGES_PAGE,
+      params,
+    );
+  }
+
+  // REST fallback: synthesize the pagination metadata from the array
+  // shape the existing handler returns. has_more is true iff a full
+  // page was returned (matches the server-side dispatcher in PR #912).
+  const messages = await getMessages(sessionId, limit, offset, sinceSeq, topic);
+  const hasMore = messages.length === limit;
+  return {
+    messages,
+    has_more: hasMore,
+    next_offset: hasMore ? offset + limit : offset + messages.length,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// session/delete — `DELETE /api/sessions/:id`
+// ---------------------------------------------------------------------------
+
 export async function deleteSession(sessionId: string): Promise<void> {
+  if (shouldUseWs()) {
+    await callAuxWs<Record<string, never>>(METHODS.SESSION_DELETE, {
+      session_id: sessionId,
+    });
+    return;
+  }
   await request(`/api/sessions/${encodeURIComponent(sessionId)}`, {
     method: "DELETE",
   });
 }
 
+// ---------------------------------------------------------------------------
+// session/status.get — `GET /api/sessions/:id/status`
+// ---------------------------------------------------------------------------
+
 export async function getSessionStatus(
   sessionId: string,
   topic?: string,
-): Promise<{
-  active: boolean;
-  has_deferred_files: boolean;
-  has_bg_tasks: boolean;
-}> {
+): Promise<SessionStatusInfo> {
+  if (shouldUseWs()) {
+    const params: Record<string, unknown> = { session_id: sessionId };
+    const trimmedTopic = topic?.trim();
+    if (trimmedTopic) params.topic = trimmedTopic;
+    const result = await callAuxWs<{ status: SessionStatusInfo }>(
+      METHODS.SESSION_STATUS_GET,
+      params,
+    );
+    return result.status;
+  }
   const params = new URLSearchParams();
   if (topic?.trim()) {
     params.set("topic", topic.trim());
@@ -90,24 +278,59 @@ export async function getSessionStatus(
   );
 }
 
+// ---------------------------------------------------------------------------
+// session/files.list — `GET /api/sessions/:id/files`
+// ---------------------------------------------------------------------------
+
 export async function getSessionFiles(
   sessionId: string,
 ): Promise<SessionFileInfo[]> {
+  if (shouldUseWs()) {
+    const result = await callAuxWs<{ files: SessionFileInfo[] }>(
+      METHODS.SESSION_FILES_LIST,
+      { session_id: sessionId },
+    );
+    return result.files ?? [];
+  }
   return request(`/api/sessions/${encodeURIComponent(sessionId)}/files`);
 }
+
+// ---------------------------------------------------------------------------
+// session/workspace.get — `GET /api/sessions/:id/workspace-contract`
+// ---------------------------------------------------------------------------
 
 export async function getSessionWorkspaceContract(
   sessionId: string,
 ): Promise<SessionWorkspaceContractInfo[]> {
+  if (shouldUseWs()) {
+    const result = await callAuxWs<{
+      contracts: SessionWorkspaceContractInfo[];
+    }>(METHODS.SESSION_WORKSPACE_GET, { session_id: sessionId });
+    return result.contracts ?? [];
+  }
   return request(
     `/api/sessions/${encodeURIComponent(sessionId)}/workspace-contract`,
   );
 }
 
+// ---------------------------------------------------------------------------
+// session/tasks.list — `GET /api/sessions/:id/tasks`
+// ---------------------------------------------------------------------------
+
 export async function getSessionTasks(
   sessionId: string,
   topic?: string,
 ): Promise<BackgroundTaskInfo[]> {
+  if (shouldUseWs()) {
+    const params: Record<string, unknown> = { session_id: sessionId };
+    const trimmedTopic = topic?.trim();
+    if (trimmedTopic) params.topic = trimmedTopic;
+    const result = await callAuxWs<{ tasks: BackgroundTaskInfo[] }>(
+      METHODS.SESSION_TASKS_LIST,
+      params,
+    );
+    return result.tasks ?? [];
+  }
   const params = new URLSearchParams();
   if (topic?.trim()) {
     params.set("topic", topic.trim());
@@ -118,12 +341,80 @@ export async function getSessionTasks(
   );
 }
 
-export async function getStatus() {
-  return request<{
-    version: string;
-    model: string;
-    provider: string;
-    uptime_secs: number;
-    agent_configured: boolean;
-  }>("/api/status");
+// ---------------------------------------------------------------------------
+// session/snapshot — bundle of (status, files, tasks)
+//
+// REST has no single endpoint for this; the legacy callsite issued the
+// three separate REST calls in parallel. Mirror that behavior for the
+// flag-off path so the wrapper return shape is identical regardless of
+// transport.
+// ---------------------------------------------------------------------------
+
+export async function getSessionSnapshot(
+  sessionId: string,
+  topic?: string,
+): Promise<SessionSnapshot> {
+  if (shouldUseWs()) {
+    const params: Record<string, unknown> = { session_id: sessionId };
+    const trimmedTopic = topic?.trim();
+    if (trimmedTopic) params.topic = trimmedTopic;
+    const result = await callAuxWs<SessionSnapshot>(
+      METHODS.SESSION_SNAPSHOT,
+      params,
+    );
+    return {
+      status: result.status,
+      files: result.files ?? [],
+      tasks: result.tasks ?? [],
+    };
+  }
+  const [status, files, tasks] = await Promise.all([
+    getSessionStatus(sessionId, topic),
+    getSessionFiles(sessionId),
+    getSessionTasks(sessionId, topic),
+  ]);
+  return { status, files, tasks };
+}
+
+// ---------------------------------------------------------------------------
+// session/title.set — `PATCH /api/sessions/:id/title`
+//
+// This wrapper is NEW in Phase D-2 — there was no existing REST helper
+// for the title rename in `src/api/sessions.ts` (the legacy panels did
+// inline `fetch()` calls). The REST fallback mirrors the request body
+// shape the existing PATCH handler accepts.
+// ---------------------------------------------------------------------------
+
+export async function setSessionTitle(
+  sessionId: string,
+  title: string,
+): Promise<{ session_id: string; title: string }> {
+  if (shouldUseWs()) {
+    return callAuxWs<{ session_id: string; title: string }>(
+      METHODS.SESSION_TITLE_SET,
+      { session_id: sessionId, title },
+    );
+  }
+  await request(`/api/sessions/${encodeURIComponent(sessionId)}/title`, {
+    method: "PATCH",
+    body: JSON.stringify({ title }),
+  });
+  // The REST PATCH returns 204 No Content. Echo the rename back to the
+  // caller so the WS and REST shapes are identical.
+  return { session_id: sessionId, title };
+}
+
+// ---------------------------------------------------------------------------
+// system/status.get — `GET /api/status`
+// ---------------------------------------------------------------------------
+
+export async function getStatus(): Promise<ServerStatus> {
+  if (shouldUseWs()) {
+    const result = await callAuxWs<{ status: ServerStatus }>(
+      METHODS.SYSTEM_STATUS_GET,
+      {},
+    );
+    return result.status;
+  }
+  return request<ServerStatus>("/api/status");
 }

--- a/src/api/sessions.ts
+++ b/src/api/sessions.ts
@@ -13,6 +13,10 @@ import {
 } from "@/runtime/ui-protocol-bridge";
 import { getAnyConnectedBridge } from "@/runtime/ui-protocol-runtime";
 import { isAuxRestToWsV1Enabled } from "@/lib/feature-flags";
+import {
+  MESSAGES_PAGE_LIMIT_CAP,
+  MESSAGES_PAGE_OFFSET_CAP,
+} from "@/lib/constants";
 
 export interface SessionFileInfo {
   filename: string;
@@ -92,6 +96,10 @@ function translateBridgeError(err: unknown): Error {
   // string). Codex review M9-β-2 prefers a single `Error` subclass at
   // the wrapper boundary so panels can drop both code paths into one
   // `try { ... } catch (e: any) { setError(e.message) }`.
+  //
+  // Phase D-2 intentionally does NOT trigger the REST 401 reaper on WS
+  // auth failures. See ADR PR #910 — Phase D-4 narrows the reaper scope,
+  // so cross-transport coupling here is undesirable.
   if (err instanceof BridgeRpcError) {
     return new Error(err.message);
   }
@@ -138,6 +146,24 @@ export async function listSessions(): Promise<SessionInfo[]> {
 // session/messages_page — `GET /api/sessions/:id/messages`
 // ---------------------------------------------------------------------------
 
+// Clamp pagination args to the same caps the server applies in both
+// transports, BEFORE branching, so REST-synthesized pagination metadata
+// matches the WS-returned metadata when callers exceed the caps.
+function clampPagination(limit: number, offset: number): {
+  limit: number;
+  offset: number;
+} {
+  const clampedLimit = Math.max(
+    0,
+    Math.min(MESSAGES_PAGE_LIMIT_CAP, Math.floor(limit)),
+  );
+  const clampedOffset = Math.max(
+    0,
+    Math.min(MESSAGES_PAGE_OFFSET_CAP, Math.floor(offset)),
+  );
+  return { limit: clampedLimit, offset: clampedOffset };
+}
+
 export async function getMessages(
   sessionId: string,
   limit = 500,
@@ -145,11 +171,15 @@ export async function getMessages(
   sinceSeq?: number,
   topic?: string,
 ): Promise<MessageInfo[]> {
+  const { limit: clampedLimit, offset: clampedOffset } = clampPagination(
+    limit,
+    offset,
+  );
   if (shouldUseWs()) {
     const params: Record<string, unknown> = {
       session_id: sessionId,
-      limit,
-      offset,
+      limit: clampedLimit,
+      offset: clampedOffset,
     };
     if (
       typeof sinceSeq === "number" &&
@@ -168,8 +198,8 @@ export async function getMessages(
   }
 
   const params = new URLSearchParams({
-    limit: String(limit),
-    offset: String(offset),
+    limit: String(clampedLimit),
+    offset: String(clampedOffset),
     source: "full",
   });
   if (
@@ -201,11 +231,18 @@ export async function getMessagesPage(
   sinceSeq?: number,
   topic?: string,
 ): Promise<SessionMessagesPage> {
+  // Clamp once, up-front, so both transports see the same effective
+  // limit/offset and the REST fallback's synthesized `next_offset` /
+  // `has_more` match the WS server's clamped metadata.
+  const { limit: clampedLimit, offset: clampedOffset } = clampPagination(
+    limit,
+    offset,
+  );
   if (shouldUseWs()) {
     const params: Record<string, unknown> = {
       session_id: sessionId,
-      limit,
-      offset,
+      limit: clampedLimit,
+      offset: clampedOffset,
     };
     if (
       typeof sinceSeq === "number" &&
@@ -225,12 +262,21 @@ export async function getMessagesPage(
   // REST fallback: synthesize the pagination metadata from the array
   // shape the existing handler returns. has_more is true iff a full
   // page was returned (matches the server-side dispatcher in PR #912).
-  const messages = await getMessages(sessionId, limit, offset, sinceSeq, topic);
-  const hasMore = messages.length === limit;
+  // Use the clamped values so the metadata is consistent across transports.
+  const messages = await getMessages(
+    sessionId,
+    clampedLimit,
+    clampedOffset,
+    sinceSeq,
+    topic,
+  );
+  const hasMore = messages.length === clampedLimit;
   return {
     messages,
     has_more: hasMore,
-    next_offset: hasMore ? offset + limit : offset + messages.length,
+    next_offset: hasMore
+      ? clampedOffset + clampedLimit
+      : clampedOffset + messages.length,
   };
 }
 

--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -1,3 +1,23 @@
 export const API_BASE = "";
 export const TOKEN_KEY = "octos_session_token";
 export const ADMIN_TOKEN_KEY = "octos_auth_token";
+
+// ---------------------------------------------------------------------------
+// M12 Phase D-2 — server-side caps mirrored client-side.
+//
+// `session/messages_page` and `GET /api/sessions/:id/messages` both clamp
+// `limit` to 500 and `offset` to 10_000 on the server (see
+// `crates/octos-cli/src/api/handlers.rs:637-638`). The auxiliary REST-to-WS
+// wrappers in `src/api/sessions.ts` clamp client-side too so the synthesized
+// pagination metadata in the REST fallback path matches the metadata the
+// server returns over WS — otherwise `getMessagesPage(id, 1000)` would
+// report `next_offset = 1000` over REST but `next_offset = 500` over WS.
+//
+// `content/bulk_delete` is capped at 256 IDs server-side (see the WS
+// dispatcher in `crates/octos-cli/src/api/ui_protocol.rs`). The REST
+// endpoint has no equivalent cap; the wrapper chunks client-side so a
+// 1000-ID delete succeeds on both transports.
+// ---------------------------------------------------------------------------
+export const MESSAGES_PAGE_LIMIT_CAP = 500;
+export const MESSAGES_PAGE_OFFSET_CAP = 10_000;
+export const CONTENT_BULK_DELETE_BATCH_SIZE = 256;

--- a/src/lib/feature-flags.ts
+++ b/src/lib/feature-flags.ts
@@ -23,11 +23,12 @@
 // `src/api/sessions.ts` / `src/api/content.ts` so the wire stays
 // byte-identical to a pre-D-2 build.
 //
-// The flag is read at every wrapper call (not cached at module init)
-// because Phase D-3 will flip individual UI panels through the wrapper
-// independently and may want to toggle the flag at runtime during
-// debugging. The cache-once pattern below still protects against a flip
-// in the middle of a single RPC.
+// Cached on first read; mid-session flips do not take effect until the
+// next page reload — matches `projection_v1` behavior. The cache-once
+// pattern protects against a flip in the middle of a single RPC and
+// against half-the-app-on / half-off routing within a page load. Phase
+// D-3 panels that want to toggle the flag at runtime must reload to
+// pick up the change (consistent with how `projection_v1` is flipped).
 
 /** localStorage key gating Phase D-2 WS wrappers. Production default
  *  is OFF; Phase D-4 will flip the default. Tests flip via

--- a/src/lib/feature-flags.ts
+++ b/src/lib/feature-flags.ts
@@ -1,0 +1,99 @@
+/**
+ * Client-side feature flags backed by `localStorage`.
+ *
+ * Each flag follows the same shape as the `projection_v1` flag in
+ * `src/store/projection-store.ts`: cache-on-first-read so a mid-session
+ * flip cannot start a feature partway through a request/response cycle,
+ * with a test-only helper that resets both the cache and the storage key.
+ *
+ * Production default for every flag below is OFF. Flipping a flag on for
+ * production is the job of a later phase PR (e.g. Phase D-4 flips the
+ * aux-rest-to-ws flag default ON once the wrappers are battle-tested).
+ */
+
+// ---------------------------------------------------------------------------
+// auxiliary.rest_to_ws.v1 — M12 Phase D-2
+// ---------------------------------------------------------------------------
+//
+// When ON, REST callsites listed in the ADR
+// (`docs/adr/m12-phase-d-auxiliary-rest-to-ws.md`, octos PR #910) route
+// through the JSON-RPC WS bridge using the 13 methods landed in octos
+// PR #912 under the `auxiliary.rest_to_ws.v1` capability. When OFF, the
+// same callsites fall through to the existing REST helpers in
+// `src/api/sessions.ts` / `src/api/content.ts` so the wire stays
+// byte-identical to a pre-D-2 build.
+//
+// The flag is read at every wrapper call (not cached at module init)
+// because Phase D-3 will flip individual UI panels through the wrapper
+// independently and may want to toggle the flag at runtime during
+// debugging. The cache-once pattern below still protects against a flip
+// in the middle of a single RPC.
+
+/** localStorage key gating Phase D-2 WS wrappers. Production default
+ *  is OFF; Phase D-4 will flip the default. Tests flip via
+ *  `__setAuxRestToWsV1ForTests`. */
+export const AUX_REST_TO_WS_V1_FLAG_KEY = "octos_auxiliary_rest_to_ws_v1";
+
+/** The on-the-wire capability string negotiated via the `?ui_feature=`
+ *  query when this flag is on. Mirrors the server-side constant in
+ *  `crates/octos-core/src/ui_protocol.rs`
+ *  (`UI_PROTOCOL_FEATURE_AUXILIARY_REST_TO_WS_V1`). */
+export const AUX_REST_TO_WS_V1_FEATURE = "auxiliary.rest_to_ws.v1";
+
+let cachedAuxRestToWsV1: boolean | null = null;
+let warnedAboutAuxRestToWsV1MidSessionChange = false;
+
+function readAuxRestToWsV1FromStorage(): boolean {
+  try {
+    if (typeof globalThis === "undefined") return false;
+    const ls = (globalThis as { localStorage?: Storage }).localStorage;
+    if (!ls) return false;
+    return ls.getItem(AUX_REST_TO_WS_V1_FLAG_KEY) === "1";
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Read the auxiliary-rest-to-ws-v1 flag. The first call latches the
+ * observed value so a mid-session flip cannot start the wrapper using
+ * the WS bridge for some calls and REST for others within the same
+ * page load. A subsequent flip is a one-shot `console.warn` and is
+ * otherwise ignored until the next reload.
+ *
+ * Mirrors `isProjectionV1Enabled` in `src/store/projection-store.ts`.
+ */
+export function isAuxRestToWsV1Enabled(): boolean {
+  if (cachedAuxRestToWsV1 !== null) {
+    if (!warnedAboutAuxRestToWsV1MidSessionChange) {
+      const live = readAuxRestToWsV1FromStorage();
+      if (live !== cachedAuxRestToWsV1) {
+        warnedAboutAuxRestToWsV1MidSessionChange = true;
+        console.warn(
+          `[octos] ${AUX_REST_TO_WS_V1_FLAG_KEY} changed mid-session; ` +
+            "the new value is ignored until reload to keep wrapper " +
+            "routing consistent across the page load.",
+        );
+      }
+    }
+    return cachedAuxRestToWsV1;
+  }
+  cachedAuxRestToWsV1 = readAuxRestToWsV1FromStorage();
+  return cachedAuxRestToWsV1;
+}
+
+/** Test helper: flip the flag in the current jsdom origin AND reset
+ *  the cache so the next `isAuxRestToWsV1Enabled()` call re-reads it. */
+export function __setAuxRestToWsV1ForTests(enabled: boolean): void {
+  try {
+    const ls = (globalThis as { localStorage?: Storage }).localStorage;
+    if (ls) {
+      if (enabled) ls.setItem(AUX_REST_TO_WS_V1_FLAG_KEY, "1");
+      else ls.removeItem(AUX_REST_TO_WS_V1_FLAG_KEY);
+    }
+  } catch {
+    // No-op when storage is unavailable.
+  }
+  cachedAuxRestToWsV1 = null;
+  warnedAboutAuxRestToWsV1MidSessionChange = false;
+}

--- a/src/runtime/ui-protocol-bridge.test.ts
+++ b/src/runtime/ui-protocol-bridge.test.ts
@@ -662,6 +662,73 @@ describe("connection lifecycle", () => {
     expect(ws.protocols).toBeUndefined();
   });
 
+  it("auxiliary.rest_to_ws.v1 — appended to ui_feature ONLY when flag is ON", async () => {
+    // Import the flag helper inside the test so we don't pollute the
+    // module-scope cache for other tests in this file.
+    const {
+      __setAuxRestToWsV1ForTests,
+      AUX_REST_TO_WS_V1_FEATURE,
+    } = await import("@/lib/feature-flags");
+
+    try {
+      // Flag OFF (default) — the aux capability is NOT advertised.
+      __setAuxRestToWsV1ForTests(false);
+      let bridge = createUiProtocolBridge(makeBridgeOpts());
+      void bridge.start({ sessionId: "sess-a" });
+      await Promise.resolve();
+      let ws = lastInstance();
+      expect(ws.url.includes(`ui_feature=${AUX_REST_TO_WS_V1_FEATURE}`)).toBe(
+        false,
+      );
+      await bridge.stop();
+
+      // Flag ON — the aux capability MUST be in the negotiated list, or
+      // the M12 Phase D-1 dispatcher rejects every aux RPC even though
+      // `SessionOpened.capabilities` advertises them (octos #913).
+      __setAuxRestToWsV1ForTests(true);
+      bridge = createUiProtocolBridge(makeBridgeOpts());
+      void bridge.start({ sessionId: "sess-b" });
+      await Promise.resolve();
+      ws = lastInstance();
+      expect(ws.url).toContain(`ui_feature=${AUX_REST_TO_WS_V1_FEATURE}`);
+      await bridge.stop();
+    } finally {
+      __setAuxRestToWsV1ForTests(false);
+    }
+  });
+
+  it("callMethod() forwards arbitrary JSON-RPC over the open socket", async () => {
+    const bridge = createUiProtocolBridge(makeBridgeOpts());
+    void bridge.start({ sessionId: "sess-c" });
+    await Promise.resolve();
+    const ws = lastInstance();
+    ws.triggerOpen();
+    await Promise.resolve();
+    const open = findRequest(ws, METHODS.SESSION_OPEN);
+    ws.triggerMessage({
+      jsonrpc: "2.0",
+      id: open.id,
+      result: { opened: { session_id: "sess-c" } },
+    });
+    await Promise.resolve();
+
+    const pending = bridge.callMethod<{ sessions: unknown[] }>(
+      METHODS.SESSION_LIST,
+      {},
+    );
+    // Drain microtasks so the queued frame lands in `ws.sent`.
+    await Promise.resolve();
+    const sent = findRequest(ws, METHODS.SESSION_LIST);
+    ws.triggerMessage({
+      jsonrpc: "2.0",
+      id: sent.id,
+      result: { sessions: [{ id: "s-9" }] },
+    });
+    const out = await pending;
+    expect(out.sessions).toEqual([{ id: "s-9" }]);
+    await bridge.stop();
+  });
+
   it("session/open params include profile_id when provided to start()", async () => {
     const bridge = createUiProtocolBridge(makeBridgeOpts());
     void bridge.start({ sessionId: "sess-1", profileId: "prof-y" });

--- a/src/runtime/ui-protocol-bridge.test.ts
+++ b/src/runtime/ui-protocol-bridge.test.ts
@@ -691,6 +691,14 @@ describe("connection lifecycle", () => {
       await Promise.resolve();
       ws = lastInstance();
       expect(ws.url).toContain(`ui_feature=${AUX_REST_TO_WS_V1_FEATURE}`);
+      // Exact-count assertion: the aux feature MUST appear once, never
+      // duplicated. A double `push` in `getUiProtocolFeatures()` would
+      // pass the `toContain` check above but break the server-side
+      // capability set comparison.
+      const auxOccurrences = ws.url.split(
+        `ui_feature=${AUX_REST_TO_WS_V1_FEATURE}`,
+      ).length - 1;
+      expect(auxOccurrences).toBe(1);
       await bridge.stop();
     } finally {
       __setAuxRestToWsV1ForTests(false);

--- a/src/runtime/ui-protocol-bridge.ts
+++ b/src/runtime/ui-protocol-bridge.ts
@@ -15,6 +15,10 @@
 
 import { getToken, getSelectedProfileId } from "@/api/client";
 import { TOKEN_KEY, ADMIN_TOKEN_KEY } from "@/lib/constants";
+import {
+  AUX_REST_TO_WS_V1_FEATURE,
+  isAuxRestToWsV1Enabled,
+} from "@/lib/feature-flags";
 import type {
   ApprovalDecision,
   ApprovalRequestedEvent,
@@ -86,6 +90,23 @@ export const METHODS = {
   DIFF_PREVIEW_GET: "diff/preview/get",
   TURN_STATE_GET: "turn/state/get",
   PING: "ping",
+  // M12 Phase D-1 (octos PR #912): auxiliary.rest_to_ws.v1 methods.
+  // Each mirrors the JSON body of the corresponding REST handler so
+  // the WS path can stand in 1:1 for the REST callsite when the
+  // client-side `auxiliary_rest_to_ws_v1` feature flag is on.
+  SESSION_LIST: "session/list",
+  SESSION_SNAPSHOT: "session/snapshot",
+  SESSION_MESSAGES_PAGE: "session/messages_page",
+  SESSION_STATUS_GET: "session/status.get",
+  SESSION_FILES_LIST: "session/files.list",
+  SESSION_TASKS_LIST: "session/tasks.list",
+  SESSION_WORKSPACE_GET: "session/workspace.get",
+  SESSION_TITLE_SET: "session/title.set",
+  SESSION_DELETE: "session/delete",
+  SYSTEM_STATUS_GET: "system/status.get",
+  CONTENT_LIST: "content/list",
+  CONTENT_DELETE: "content/delete",
+  CONTENT_BULK_DELETE: "content/bulk_delete",
   // server → client
   MESSAGE_DELTA: "message/delta",
   MESSAGE_PERSISTED: "message/persisted",
@@ -99,6 +120,14 @@ export const METHODS = {
   WARNING: "warning",
 } as const;
 
+/**
+ * Static base capability list — always negotiated.
+ *
+ * The full negotiated list at runtime is computed by
+ * `getUiProtocolFeatures()`, which appends opt-in capabilities
+ * controlled by client-side feature flags (`auxiliary.rest_to_ws.v1`
+ * under `octos_auxiliary_rest_to_ws_v1`).
+ */
 export const UI_PROTOCOL_FEATURES = [
   "approval.typed.v1",
   "pane.snapshots.v1",
@@ -127,6 +156,28 @@ export const UI_PROTOCOL_FEATURES = [
   // is what eliminates the N+1 bubble render after page reload.
   "state.session_hydrate.v1",
 ] as const;
+
+/**
+ * Resolve the live `ui_feature` capability list to send on the WS open
+ * query. Adds opt-in capabilities gated on client-side feature flags.
+ *
+ * M12 Phase D-2 (octos PR #912 / octos-web #103): when the
+ * `octos_auxiliary_rest_to_ws_v1` localStorage flag is on, append
+ * `auxiliary.rest_to_ws.v1`. Without that capability in the WS query,
+ * the server advertises the 13 aux methods in `SessionOpened.capabilities`
+ * but the dispatcher rejects every call (octos #913 — server polish
+ * follow-up). The client must negotiate properly regardless of that
+ * server bug, so the flag explicitly controls inclusion here.
+ *
+ * Tests can override the full list via `BridgeConfig.features`.
+ */
+export function getUiProtocolFeatures(): readonly string[] {
+  const base: string[] = [...UI_PROTOCOL_FEATURES];
+  if (isAuxRestToWsV1Enabled()) {
+    base.push(AUX_REST_TO_WS_V1_FEATURE);
+  }
+  return base;
+}
 
 const JSON_RPC_VERSION = "2.0";
 
@@ -206,6 +257,27 @@ export interface UiProtocolBridge {
   hydrateSession(
     include?: ReadonlyArray<"messages" | "threads" | "turns" | "pending_approvals">,
   ): Promise<SessionHydrateResult | null>;
+
+  /**
+   * Generic JSON-RPC request escape hatch.
+   *
+   * M12 Phase D-2 (octos-web #103): used by the auxiliary REST-to-WS
+   * wrappers in `src/api/sessions.ts` and `src/api/content.ts` for the
+   * 13 methods that share the same WS connection as the chat bridge.
+   * The dedicated typed methods above (`sendTurn`, `interruptTurn`, ...)
+   * remain the only entry points for the chat lifecycle; this escape
+   * hatch is intentionally untyped so each wrapper can own its own
+   * request/response DTOs without bloating the bridge surface.
+   *
+   * Rejects with `BridgeRpcError` when the server returns a JSON-RPC
+   * error envelope, with `BridgeTimeoutError` if the response exceeds
+   * the bridge's per-RPC timeout, and with `BridgeStoppedError` when
+   * the connection is closed or the bridge has given up reconnecting.
+   * Callers MUST translate those into their existing REST error shape
+   * so the flag-on / flag-off code paths surface the same error
+   * envelope to the rest of the UI.
+   */
+  callMethod<T = unknown>(method: string, params?: unknown): Promise<T>;
 
   onMessageDelta(handler: (e: MessageDeltaEvent) => void): () => void;
   onMessagePersisted(handler: (e: MessagePersistedEvent) => void): () => void;
@@ -848,7 +920,7 @@ class UiProtocolBridgeImpl implements UiProtocolBridge {
         cfg.clearTimeout ??
         ((handle) => globalThis.clearTimeout(handle as ReturnType<typeof setTimeout>)),
       now: cfg.now ?? (() => Date.now()),
-      features: cfg.features ?? UI_PROTOCOL_FEATURES,
+      features: cfg.features ?? getUiProtocolFeatures(),
       rpcTimeoutMs: cfg.rpcTimeoutMs ?? DEFAULT_RPC_TIMEOUT_MS,
       sendQueueLimit: cfg.sendQueueLimit ?? DEFAULT_SEND_QUEUE_LIMIT,
       maxReconnectAttempts:
@@ -1002,6 +1074,15 @@ class UiProtocolBridgeImpl implements UiProtocolBridge {
       });
       return null;
     }
+  }
+
+  callMethod<T = unknown>(method: string, params?: unknown): Promise<T> {
+    if (!isString(method)) {
+      return Promise.reject(
+        new Error("ui-protocol-bridge: callMethod requires method"),
+      );
+    }
+    return this.request<T>(method, params ?? null);
   }
 
   onMessageDelta(handler: Listener<MessageDeltaEvent>): () => void {

--- a/src/runtime/ui-protocol-runtime.ts
+++ b/src/runtime/ui-protocol-runtime.ts
@@ -195,6 +195,26 @@ export function getActiveBridge(
   return active.bridge;
 }
 
+/**
+ * Return the live bridge regardless of session scope, but only when it
+ * has reached `"connected"`.
+ *
+ * M12 Phase D-2 (octos-web #103): the auxiliary REST-to-WS wrappers in
+ * `src/api/sessions.ts` / `src/api/content.ts` are not session-scoped —
+ * `session/list`, `system/status.get`, `content/list`, etc. address the
+ * whole tenant. They reuse whatever bridge happens to be live (started
+ * by an open chat session). When no bridge is connected, the wrappers
+ * fall back to the existing REST helpers — exactly the behavior the
+ * flag-off path uses. The pre-`connected` gate matches the chat send
+ * path's policy: a bridge that has not yet completed `session/open` is
+ * not yet usable.
+ */
+export function getAnyConnectedBridge(): UiProtocolBridge | null {
+  if (!active) return null;
+  if (active.connectionState !== "connected") return null;
+  return active.bridge;
+}
+
 /** Stop the currently-active bridge and detach the router. Idempotent.
  *  Bumps the generation counter so any in-flight `startBridgeForSession`
  *  awaiting a handshake recognizes itself as superseded and stops its


### PR DESCRIPTION
## Summary

Client-side WS-or-REST wrappers for the 13 JSON-RPC methods landed
server-side in octos PR #912 under capability `auxiliary.rest_to_ws.v1`.

- New localStorage feature flag `octos_auxiliary_rest_to_ws_v1` (default
  **OFF** — Phase D-4 will flip the default after the wrappers are
  battle-tested in production). Mirrors the `projection_v1` flag's
  cache-on-first-read pattern so a mid-session flip can't split a
  single page-load between transports.
- When ON **and** a `connected` UI Protocol v1 bridge exists, each
  wrapper routes through `bridge.callMethod()` against the matching
  JSON-RPC method. When OFF (or no bridge), the wrapper falls through
  to the existing REST helper unchanged.
- Return types and error envelopes are identical across the two paths.
  `BridgeRpcError` / `BridgeTimeoutError` / `BridgeStoppedError` are
  translated into the same plain `Error` shape the REST helper throws,
  so callers can drop both transports into one `try { } catch`.
- Bridge advertises `auxiliary.rest_to_ws.v1` in its `?ui_feature=`
  WS query **only when the flag is on**. Without that query param the
  server's dispatcher rejects every aux RPC even though
  `SessionOpened.capabilities` advertises them (octos #913).

## Wrapper inventory

| # | Method | File |
| - | - | - |
| 1 | `session/list` | `src/api/sessions.ts` (`listSessions`) |
| 2 | `session/snapshot` | `src/api/sessions.ts` (`getSessionSnapshot` — NEW) |
| 3 | `session/messages_page` | `src/api/sessions.ts` (`getMessages`, `getMessagesPage` — NEW) |
| 4 | `session/status.get` | `src/api/sessions.ts` (`getSessionStatus`) |
| 5 | `session/files.list` | `src/api/sessions.ts` (`getSessionFiles`) |
| 6 | `session/tasks.list` | `src/api/sessions.ts` (`getSessionTasks`) |
| 7 | `session/workspace.get` | `src/api/sessions.ts` (`getSessionWorkspaceContract`) |
| 8 | `session/title.set` | `src/api/sessions.ts` (`setSessionTitle` — NEW) |
| 9 | `session/delete` | `src/api/sessions.ts` (`deleteSession`) |
| 10 | `system/status.get` | `src/api/sessions.ts` (`getStatus`) |
| 11 | `content/list` | `src/api/content.ts` (`fetchContent`) |
| 12 | `content/delete` | `src/api/content.ts` (`deleteContent`) |
| 13 | `content/bulk_delete` | `src/api/content.ts` (`bulkDeleteContent`) |

`getSessionSnapshot`, `getMessagesPage`, and `setSessionTitle` are net-new
helpers — there was no REST equivalent in `src/api/sessions.ts` before.
The REST fallback for `getSessionSnapshot` issues the three legacy
parallel REST calls; for `setSessionTitle` it PATCHes the existing
endpoint and synthesizes the echo response.

## Scope (what this PR does NOT do)

- **No UI panel migration.** The sidebar, history, files panel, etc.
  still call the wrappers' existing names — they get WS routing for
  free once the flag flips, but Phase D-3 PRs will migrate the panels
  one-by-one with their own visibility-and-revalidation work.
- **No auth behavior changes.** The 401 reaper in `src/api/client.ts`
  is untouched (Phase D-4 scope).
- **No REST endpoint retirement.** The legacy REST handlers all stay
  alive (Phase D-5 scope).

## References

- Server-side merged PR: octos PR #912
- ADR: octos PR #910 / `docs/adr/m12-phase-d-auxiliary-rest-to-ws.md`
- Client tracking issue: octos-web #103
- Server polish follow-up: octos #913 (no-header dispatcher reject)

## Test plan

- [x] `pnpm tsc --noEmit` — clean
- [x] `pnpm test:unit` — 349 passed, 1 pre-existing failure on main
  (`ui-protocol-event-router.test.ts > router seq preservation > persisted
  message stamps seq onto the late-artifact response`) unchanged by this PR
- [x] `pnpm lint` — no new errors in changed files
- [x] `pnpm build` — clean vite build
- [x] 34 new wrapper tests in `src/api/aux-rest-to-ws.test.ts` covering
  flag-OFF REST path, flag-ON WS path, flag-ON-no-bridge REST fallback,
  and WS-error-to-REST-Error translation
- [x] 2 new bridge tests pinning `ui_feature=auxiliary.rest_to_ws.v1`
  appearance under the flag + `callMethod()` JSON-RPC forwarding
- [ ] Manual smoke once Phase D-3 wires the first panel through the
  wrapper with the flag on