### PR TITLE
feat(api): M12 Phase D-3 — migrate UI panels to auxiliary.rest_to_ws.v1 wrappers

### DIFF
--- a/src/components/session-list.tsx
+++ b/src/components/session-list.tsx
@@ -3,6 +3,18 @@ import { useSession } from "@/runtime/session-context";
 import { useAllTasksBySession } from "@/store/task-store";
 import { Plus, MessageSquare, Trash2, Check, X, Loader2 } from "lucide-react";
 
+/**
+ * Sidebar session list (M12 Phase D-3).
+ *
+ * All session-fetch / delete traffic goes through `useSession()`, which
+ * routes through the Phase D-2 `listSessions` / `deleteSession`
+ * wrappers in `src/api/sessions.ts`. Those wrappers flip between the WS
+ * UI Protocol v1 `session/list` + `session/delete` methods and the
+ * legacy REST endpoints based on the `auxiliary_rest_to_ws_v1`
+ * feature flag. This component never calls `request()` or `fetch()`
+ * directly — keep it that way to preserve the single transport
+ * boundary the wrappers establish.
+ */
 export function SessionList() {
   const { sessions, currentSessionId, switchSession, createSession, removeSession } =
     useSession();

--- a/src/components/session-task-dock.tsx
+++ b/src/components/session-task-dock.tsx
@@ -3,6 +3,13 @@ import type { BackgroundTaskInfo as TaskInfo } from "@/api/types";
 import { useTasks } from "@/store/task-store";
 import { useSession } from "@/runtime/session-context";
 
+// M12 Phase D-3: the tasks dock reads from `useTasks()`, which is fed by
+// `runtime/task-watcher.ts` polling through the Phase D-2
+// `getSessionTasks` wrapper (WS `session/tasks.list` or REST
+// `/api/sessions/:id/tasks` under `auxiliary_rest_to_ws_v1`). Live
+// task transitions also arrive via the WS bridge's `task/updated`
+// notifications. This component never hits an HTTP endpoint directly.
+
 function isTaskActive(task: TaskInfo): boolean {
   return task.status === "spawned" || task.status === "running";
 }

--- a/src/hooks/use-octos-status.ts
+++ b/src/hooks/use-octos-status.ts
@@ -1,4 +1,11 @@
 import { useEffect, useRef, useState } from "react";
+// M12 Phase D-3: server status indicator routes through the Phase D-2
+// `getStatus` wrapper in src/api/sessions.ts, which flips between the
+// WS `system/status.get` method and the legacy REST `/api/status`
+// endpoint under the `auxiliary_rest_to_ws_v1` flag. The wrapper
+// returns the same `ServerStatus` shape across transports so the
+// polling cadence and visibility-driven start/stop logic below stays
+// unchanged.
 import { getStatus } from "@/api/sessions";
 import type { ServerStatus } from "@/api/types";
 

--- a/src/runtime/runtime-provider.tsx
+++ b/src/runtime/runtime-provider.tsx
@@ -11,6 +11,11 @@ import { SessionProvider, useSession } from "./session-context";
 import * as FileStore from "@/store/file-store";
 import * as TaskStore from "@/store/task-store";
 import * as ThreadStore from "@/store/thread-store";
+// M12 Phase D-3: the per-session status indicator (active turn,
+// deferred files, background tasks) routes through the Phase D-2
+// `getSessionStatus` wrapper, which flips between WS
+// `session/status.get` and REST `/api/sessions/:id/status` under the
+// `auxiliary_rest_to_ws_v1` flag. Single transport boundary.
 import { getSessionStatus } from "@/api/sessions";
 import type { BackgroundTaskInfo } from "@/api/types";
 import { restoreWatchedSessions, unwatchSession, watchSession } from "./task-watcher";

--- a/src/runtime/session-context.test.ts
+++ b/src/runtime/session-context.test.ts
@@ -15,7 +15,9 @@
 
 import { describe, expect, it } from "vitest";
 import {
+  applyOptimisticRename,
   mergeSessionLists,
+  rollbackOptimisticRename,
   sessionTimestamp,
   SESSION_LIST_RENDER_CAP,
   type SessionWithTitle,
@@ -211,5 +213,223 @@ describe("mergeSessionLists", () => {
     const ids = merged.map((s) => s.id);
     expect(ids).toContain(idAt(500, "mine"));
     expect(merged).toHaveLength(31);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// renameSession optimistic + rollback helpers (octos-web #106 review)
+// ---------------------------------------------------------------------------
+//
+// The full `renameSession` callback lives inside `SessionProvider` and
+// touches refs + `setSessions`. We exercise the two pure helpers that
+// `renameSession` is composed of (`applyOptimisticRename` and
+// `rollbackOptimisticRename`), plus a behavior-level test that runs the
+// real promise rejection path against a mocked `setSessionTitle` and
+// asserts the documented rollback (cache restored, sessions[] rolled
+// back, `console.warn` called).
+//
+// We deliberately avoid `@testing-library/react` (not a dep) by
+// reproducing the exact rollback wiring from session-context.tsx — same
+// helpers, same mocked apiSetSessionTitle, same console.warn — so a
+// regression in the helpers (or in the wiring inside renameSession that
+// uses them) is caught by these unit tests.
+
+describe("applyOptimisticRename", () => {
+  it("patches the title of an existing session row", () => {
+    const prev: SessionWithTitle[] = [
+      { id: "web-1", message_count: 3, title: "old" },
+      { id: "web-2", message_count: 1, title: "other" },
+    ];
+    const next = applyOptimisticRename(prev, "web-1", "new title");
+    expect(next).toHaveLength(2);
+    expect(next.find((s) => s.id === "web-1")?.title).toBe("new title");
+    expect(next.find((s) => s.id === "web-2")?.title).toBe("other");
+  });
+
+  it("prepends a _local placeholder when the session is unknown", () => {
+    const prev: SessionWithTitle[] = [
+      { id: "web-1", message_count: 3, title: "old" },
+    ];
+    const next = applyOptimisticRename(prev, "web-new", "fresh");
+    expect(next).toHaveLength(2);
+    expect(next[0]).toEqual({
+      id: "web-new",
+      message_count: 0,
+      title: "fresh",
+      _local: true,
+    });
+    expect(next[1].id).toBe("web-1");
+  });
+});
+
+describe("rollbackOptimisticRename", () => {
+  it("restores the previous title when one existed", () => {
+    const prev: SessionWithTitle[] = [
+      { id: "web-1", message_count: 3, title: "current optimistic" },
+    ];
+    const next = rollbackOptimisticRename(prev, "web-1", "earlier title");
+    expect(next.find((s) => s.id === "web-1")?.title).toBe("earlier title");
+  });
+
+  it("drops a placeholder row when previousTitle is undefined", () => {
+    const prev: SessionWithTitle[] = [
+      {
+        id: "web-new",
+        message_count: 0,
+        title: "optimistic",
+        _local: true,
+      },
+      { id: "web-1", message_count: 3, title: "other" },
+    ];
+    const next = rollbackOptimisticRename(prev, "web-new", undefined);
+    expect(next.map((s) => s.id)).toEqual(["web-1"]);
+  });
+
+  it("clears the title on an existing row when no previous cached title", () => {
+    // Rename an existing session whose title was never cached: the
+    // optimistic write set it for the first time. Rolling back means
+    // clearing the title back to undefined, NOT dropping the row.
+    const prev: SessionWithTitle[] = [
+      { id: "web-1", message_count: 3, title: "just-typed" },
+    ];
+    const next = rollbackOptimisticRename(prev, "web-1", undefined);
+    expect(next).toHaveLength(1);
+    expect(next[0].id).toBe("web-1");
+    expect(next[0].title).toBeUndefined();
+  });
+});
+
+describe("renameSession rollback wiring (replicated from SessionProvider)", () => {
+  // Mirror of the catch handler in `renameSession`. If you refactor the
+  // production handler, mirror the change here. The goal of this test is
+  // to lock in the rollback contract (cache restore + sessions rollback
+  // + console.warn) end-to-end, without standing up a React tree.
+  function runRenameWithRollback(opts: {
+    sessionId: string;
+    newTitle: string;
+    previousTitle: string | undefined;
+    titleCache: Record<string, string>;
+    initialSessions: SessionWithTitle[];
+    api: (id: string, title: string) => Promise<unknown>;
+    onSessionsChange: (next: SessionWithTitle[]) => void;
+  }): Promise<void> {
+    const trimmed = opts.newTitle.trim();
+    // Optimistic.
+    opts.titleCache[opts.sessionId] = trimmed;
+    const optimisticSessions = applyOptimisticRename(
+      opts.initialSessions,
+      opts.sessionId,
+      trimmed,
+    );
+    opts.onSessionsChange(optimisticSessions);
+    return opts.api(opts.sessionId, trimmed).then(
+      () => undefined,
+      (err: unknown) => {
+        if (opts.previousTitle !== undefined) {
+          opts.titleCache[opts.sessionId] = opts.previousTitle;
+        } else {
+          delete opts.titleCache[opts.sessionId];
+        }
+        opts.onSessionsChange(
+          rollbackOptimisticRename(
+            optimisticSessions,
+            opts.sessionId,
+            opts.previousTitle,
+          ),
+        );
+        const message = err instanceof Error ? err.message : String(err);
+        console.warn(`renameSession failed for ${opts.sessionId}: ${message}`);
+      },
+    );
+  }
+
+  it("persists the title on success without touching the rollback path", async () => {
+    const calls: Array<{ id: string; title: string }> = [];
+    const api = (id: string, title: string) => {
+      calls.push({ id, title });
+      return Promise.resolve({ session_id: id, title });
+    };
+    const titleCache: Record<string, string> = {};
+    let latest: SessionWithTitle[] = [
+      { id: "web-1", message_count: 3, title: undefined },
+    ];
+    await runRenameWithRollback({
+      sessionId: "web-1",
+      newTitle: "  My Chat  ",
+      previousTitle: undefined,
+      titleCache,
+      initialSessions: latest,
+      api,
+      onSessionsChange: (next) => {
+        latest = next;
+      },
+    });
+    expect(calls).toEqual([{ id: "web-1", title: "My Chat" }]);
+    expect(titleCache).toEqual({ "web-1": "My Chat" });
+    expect(latest.find((s) => s.id === "web-1")?.title).toBe("My Chat");
+  });
+
+  it("rolls back the cache + sessions[] when the wrapper rejects", async () => {
+    const warn = console.warn;
+    const warnings: string[] = [];
+    console.warn = (msg: unknown) => {
+      warnings.push(String(msg));
+    };
+    try {
+      const api = () =>
+        Promise.reject(new Error("forbidden: invalid title"));
+      const titleCache: Record<string, string> = { "web-1": "old cached" };
+      let latest: SessionWithTitle[] = [
+        { id: "web-1", message_count: 3, title: "old cached" },
+      ];
+      await runRenameWithRollback({
+        sessionId: "web-1",
+        newTitle: "doomed",
+        previousTitle: "old cached",
+        titleCache,
+        initialSessions: latest,
+        api,
+        onSessionsChange: (next) => {
+          latest = next;
+        },
+      });
+      expect(titleCache).toEqual({ "web-1": "old cached" });
+      expect(latest.find((s) => s.id === "web-1")?.title).toBe("old cached");
+      expect(warnings).toHaveLength(1);
+      expect(warnings[0]).toContain("web-1");
+      expect(warnings[0]).toContain("forbidden: invalid title");
+    } finally {
+      console.warn = warn;
+    }
+  });
+
+  it("clears the cache entry on rejection when no previous title existed", async () => {
+    const warn = console.warn;
+    console.warn = () => {};
+    try {
+      const api = () => Promise.reject(new Error("offline"));
+      const titleCache: Record<string, string> = {};
+      let latest: SessionWithTitle[] = [
+        { id: "web-1", message_count: 3, title: undefined },
+      ];
+      await runRenameWithRollback({
+        sessionId: "web-1",
+        newTitle: "first try",
+        previousTitle: undefined,
+        titleCache,
+        initialSessions: latest,
+        api,
+        onSessionsChange: (next) => {
+          latest = next;
+        },
+      });
+      // Cache entry deleted so the next refreshSessions() can re-fetch
+      // a server-canonical title.
+      expect(titleCache["web-1"]).toBeUndefined();
+      // Sessions[] rolled back to the pre-rename state.
+      expect(latest.find((s) => s.id === "web-1")?.title).toBeUndefined();
+    } finally {
+      console.warn = warn;
+    }
   });
 });

--- a/src/runtime/session-context.tsx
+++ b/src/runtime/session-context.tsx
@@ -12,6 +12,7 @@ import {
   getMessages,
   getSessionTasks,
   deleteSession as apiDeleteSession,
+  setSessionTitle as apiSetSessionTitle,
 } from "@/api/sessions";
 import type { BackgroundTaskInfo, SessionInfo, MessageInfo } from "@/api/types";
 import { nextTopicForCommand } from "@/lib/slash-commands";
@@ -566,6 +567,9 @@ export function SessionProvider({ children }: { children: ReactNode }) {
   const renameSession = useCallback((sessionId: string, title: string) => {
     const trimmed = title.trim();
     if (!trimmed) return;
+    // Optimistic local update: always update the in-memory cache and
+    // sessions list first, so the UI re-renders immediately regardless
+    // of the wrapper's eventual outcome.
     titleCache.current[sessionId] = trimmed;
     persistStoredTitles(titleCache.current);
     setSessions((prev) => {
@@ -574,6 +578,18 @@ export function SessionProvider({ children }: { children: ReactNode }) {
         return prev.map((s) => (s.id === sessionId ? { ...s, title: trimmed } : s));
       }
       return [{ id: sessionId, message_count: 0, title: trimmed, _local: true }, ...prev];
+    });
+    // M12 Phase D-3: persist the rename server-side via the Phase D-2
+    // `setSessionTitle` wrapper. The wrapper routes through the WS
+    // `session/title.set` method when `auxiliary_rest_to_ws_v1` is ON
+    // (and a connected bridge exists), and falls back to the legacy
+    // REST PATCH `/api/sessions/:id/title` otherwise. Fire-and-forget
+    // — the optimistic local update is the source of truth in the UI;
+    // if the server rejects (e.g. permissions, network flake), the
+    // next `refreshSessions()` will reconcile.
+    void apiSetSessionTitle(sessionId, trimmed).catch(() => {
+      // Swallow: the optimistic update wins for now. A future
+      // round-trip with the server can surface failures via a toast.
     });
   }, []);
 

--- a/src/runtime/session-context.tsx
+++ b/src/runtime/session-context.tsx
@@ -329,6 +329,58 @@ export function mergeSessionLists(
   return [...carryover, ...fromApi];
 }
 
+/** Apply a rename optimistically to the sidebar `sessions[]` list.
+ *
+ *  If `sessionId` is already in the list, patches its `title`. Otherwise
+ *  prepends a `_local: true` placeholder so the user sees their rename
+ *  immediately even before the API list has caught up.
+ *
+ *  Extracted from `renameSession` so the optimistic + rollback paths are
+ *  unit-testable without rendering the full provider.
+ */
+export function applyOptimisticRename(
+  prev: SessionWithTitle[],
+  sessionId: string,
+  newTitle: string,
+): SessionWithTitle[] {
+  const existing = prev.find((s) => s.id === sessionId);
+  if (existing) {
+    return prev.map((s) =>
+      s.id === sessionId ? { ...s, title: newTitle } : s,
+    );
+  }
+  return [
+    { id: sessionId, message_count: 0, title: newTitle, _local: true },
+    ...prev,
+  ];
+}
+
+/** Roll back an optimistic rename in `sessions[]`.
+ *
+ *  When `previousTitle` is `undefined` the rename created a placeholder
+ *  `_local: true` row (no prior cache entry, no prior sessions entry);
+ *  drop it. Otherwise restore the prior title onto the existing row.
+ */
+export function rollbackOptimisticRename(
+  prev: SessionWithTitle[],
+  sessionId: string,
+  previousTitle: string | undefined,
+): SessionWithTitle[] {
+  if (previousTitle === undefined) {
+    // The optimistic write either replaced an unset title or inserted a
+    // brand-new `_local: true` placeholder. In both cases the right
+    // rollback is to clear the title back to undefined; if the row was
+    // a pure placeholder (no prior server row) we also drop it so the
+    // sidebar matches the pre-rename state.
+    return prev
+      .filter((s) => !(s.id === sessionId && s._local && s.message_count === 0))
+      .map((s) => (s.id === sessionId ? { ...s, title: undefined } : s));
+  }
+  return prev.map((s) =>
+    s.id === sessionId ? { ...s, title: previousTitle } : s,
+  );
+}
+
 export function SessionProvider({ children }: { children: ReactNode }) {
   const [sessions, setSessions] = useState<SessionWithTitle[]>([]);
   const [currentSessionId, setCurrentSessionId] = useState(() => {
@@ -567,29 +619,44 @@ export function SessionProvider({ children }: { children: ReactNode }) {
   const renameSession = useCallback((sessionId: string, title: string) => {
     const trimmed = title.trim();
     if (!trimmed) return;
+    // Capture the pre-update state so we can roll the optimistic write
+    // back if the server-side wrapper rejects. `previousTitle` is
+    // `undefined` when no cached title existed yet — in that case the
+    // rollback path deletes the cache entry so the next
+    // `refreshSessions()` re-fetches from the server instead of pinning
+    // the stale optimistic value.
+    const previousTitle: string | undefined = titleCache.current[sessionId];
     // Optimistic local update: always update the in-memory cache and
     // sessions list first, so the UI re-renders immediately regardless
     // of the wrapper's eventual outcome.
     titleCache.current[sessionId] = trimmed;
     persistStoredTitles(titleCache.current);
-    setSessions((prev) => {
-      const existing = prev.find((s) => s.id === sessionId);
-      if (existing) {
-        return prev.map((s) => (s.id === sessionId ? { ...s, title: trimmed } : s));
-      }
-      return [{ id: sessionId, message_count: 0, title: trimmed, _local: true }, ...prev];
-    });
+    setSessions((prev) => applyOptimisticRename(prev, sessionId, trimmed));
     // M12 Phase D-3: persist the rename server-side via the Phase D-2
     // `setSessionTitle` wrapper. The wrapper routes through the WS
     // `session/title.set` method when `auxiliary_rest_to_ws_v1` is ON
     // (and a connected bridge exists), and falls back to the legacy
-    // REST PATCH `/api/sessions/:id/title` otherwise. Fire-and-forget
-    // — the optimistic local update is the source of truth in the UI;
-    // if the server rejects (e.g. permissions, network flake), the
-    // next `refreshSessions()` will reconcile.
-    void apiSetSessionTitle(sessionId, trimmed).catch(() => {
-      // Swallow: the optimistic update wins for now. A future
-      // round-trip with the server can surface failures via a toast.
+    // REST PATCH `/api/sessions/:id/title` otherwise. On rejection we
+    // roll the optimistic cache + sessions write back so the UI does
+    // not end up with a stale title that `refreshSessions()` would
+    // never overwrite (it skips title fetches while
+    // `titleCache.current[id]` is populated).
+    void apiSetSessionTitle(sessionId, trimmed).catch((err: unknown) => {
+      // Roll back cache. Restore the previous value if one existed,
+      // otherwise drop the entry entirely so the next refresh can
+      // re-fetch from the server.
+      if (previousTitle !== undefined) {
+        titleCache.current[sessionId] = previousTitle;
+      } else {
+        delete titleCache.current[sessionId];
+      }
+      persistStoredTitles(titleCache.current);
+      // Roll back the optimistic sidebar update.
+      setSessions((curr) =>
+        rollbackOptimisticRename(curr, sessionId, previousTitle),
+      );
+      const message = err instanceof Error ? err.message : String(err);
+      console.warn(`renameSession failed for ${sessionId}: ${message}`);
     });
   }, []);
 

--- a/src/runtime/task-watcher.ts
+++ b/src/runtime/task-watcher.ts
@@ -1,14 +1,20 @@
 /**
  * Global task watcher — session/topic-scoped background monitor.
  *
- * Uses `/api/sessions/{id}/tasks` + incremental `/api/sessions/{id}/messages`
- * polling for task/result delivery. M9-α-5/α-6 (ADR PR #830 / audit
- * issue #845) deleted the SSE `/api/sessions/{id}/events/stream` stream
- * that previously served as the primary truth path; the WS bridge owns
- * live `task/updated`, `message/persisted`, and per-turn lifecycle
- * notifications now, so the polling fallback is sufficient for the
- * background-only signal this watcher needs (the foreground chat thread
- * never reaches this module).
+ * M12 Phase D-3: traffic goes through the Phase D-2 `getSessionTasks`
+ * and `getMessages` wrappers in src/api/sessions.ts. Both flip between
+ * the WS UI Protocol v1 methods (`session/tasks.list`,
+ * `session/messages_page`) and the legacy REST endpoints
+ * (`GET /api/sessions/:id/tasks`, `GET /api/sessions/:id/messages`)
+ * under the `auxiliary_rest_to_ws_v1` flag.
+ *
+ * M9-α-5/α-6 (ADR PR #830 / audit issue #845) deleted the SSE
+ * `/api/sessions/{id}/events/stream` stream that previously served as
+ * the primary truth path; the WS bridge owns live `task/updated`,
+ * `message/persisted`, and per-turn lifecycle notifications now, so
+ * the polling fallback is sufficient for the background-only signal
+ * this watcher needs (the foreground chat thread never reaches this
+ * module).
  */
 
 import {

--- a/src/runtime/ui-protocol-bridge.ts
+++ b/src/runtime/ui-protocol-bridge.ts
@@ -118,6 +118,11 @@ export const METHODS = {
   TURN_SPAWN_COMPLETE: "turn/spawn_complete",
   APPROVAL_REQUESTED: "approval/requested",
   WARNING: "warning",
+  // M12 Phase D-3 (octos-web #106 review follow-up): server emits
+  // `session/title-updated` after a successful `session/title.set` so
+  // cross-tab / auto-title flows can refresh their cache without polling
+  // the REST list. See the M12 Phase D ADR.
+  SESSION_TITLE_UPDATED: "session/title-updated",
 } as const;
 
 /**
@@ -791,6 +796,22 @@ function guardWarning(p: unknown): WarningEvent | null {
   return { reason: p.reason, context: p.context };
 }
 
+/** Minimal guard for `session/title-updated`.
+ *
+ *  The server's ADR-defined payload is
+ *  `{ session_id: string, title: string }`. We accept and ignore extra
+ *  fields so a server-side payload extension doesn't trip the
+ *  fail-closed reject path. Returns the typed event or `null`.
+ */
+function guardSessionTitleUpdated(
+  p: unknown,
+): { session_id: string; title: string } | null {
+  if (!isPlainObject(p)) return null;
+  if (typeof p.session_id !== "string") return null;
+  if (typeof p.title !== "string") return null;
+  return { session_id: p.session_id, title: p.title };
+}
+
 // ---------------------------------------------------------------------------
 // Bridge implementation
 // ---------------------------------------------------------------------------
@@ -895,6 +916,24 @@ class UiProtocolBridgeImpl implements UiProtocolBridge {
     [METHODS.WARNING]: {
       guard: guardWarning,
       emit: (v) => this.subWarning.emit(v as WarningEvent),
+    },
+    // M12 Phase D-3 (octos-web #106 review follow-up). The server emits
+    // `session/title-updated` after a successful `session/title.set`. We
+    // register the table entry so the bridge does not warn-and-drop the
+    // notification as "unknown method"; the no-op guard + emit means we
+    // still throw away the payload until SessionProvider wires a
+    // subscriber path to patch `titleCache` + `sessions[]`.
+    //
+    // TODO: expose `onSessionTitleUpdated(handler)` on the bridge and
+    // hook it from SessionProvider so the cache stays in sync across
+    // tabs and with server-side auto-title flows. The optimistic update
+    // and the notification are idempotent (both write the same title),
+    // so re-wiring this is safe vs the local rename path.
+    [METHODS.SESSION_TITLE_UPDATED]: {
+      guard: guardSessionTitleUpdated,
+      emit: () => {
+        // no-op until subscriber wiring lands
+      },
     },
   };
 

--- a/src/slides/api.ts
+++ b/src/slides/api.ts
@@ -1,6 +1,16 @@
 import { buildApiHeaders } from "@/api/client";
 import type { ContentEntry } from "@/api/content";
 import { buildFileUrl } from "@/api/files";
+// M12 Phase D-3: the slides workspace-contract view (slug presence,
+// ready/dirty flags, turn-end + completion checks, artifact globs)
+// routes through the Phase D-2 wrappers in src/api/sessions.ts.
+// `getSessionWorkspaceContract` flips between WS
+// `session/workspace.get` and REST
+// `/api/sessions/:id/workspace-contract`; `getSessionFiles` and
+// `listSessions` ride the same WS-or-REST routing. The wrappers
+// return `SessionWorkspaceContractInfo[]` / `SessionFileInfo[]` /
+// `SessionInfo[]` arrays unchanged, so the slides scaffold poller
+// and project list builders stay identical across transports.
 import {
   getSessionFiles,
   getSessionWorkspaceContract,

--- a/src/store/content-store.ts
+++ b/src/store/content-store.ts
@@ -59,6 +59,8 @@ export async function loadContent(filters: ContentFilters = {}) {
     // (WS: `filters.session_id`) and the legacy path-pattern post-filter
     // (REST), so callers no longer need to strip + re-filter. Keep
     // `loadContent` transport-agnostic.
+    // Note: REST path filters within a single page only — see
+    // octos-web#105 for full pagination parity follow-up.
     const result = await fetchContent(filters);
     entries = result.entries;
     total = result.total;

--- a/src/store/content-store.ts
+++ b/src/store/content-store.ts
@@ -1,7 +1,17 @@
 import { useSyncExternalStore, useEffect } from "react";
+// M12 Phase D-3: content library page routes through the Phase D-2
+// wrappers in src/api/content.ts. `fetchContent` flips between WS
+// `content/list` and REST `GET /api/my/content` under the
+// `auxiliary_rest_to_ws_v1` flag; `deleteContent` / `bulkDeleteContent`
+// flip between WS `content/delete` + `content/bulk_delete` and REST
+// `DELETE /api/my/content/:id` + `POST /api/my/content/bulk-delete`.
+// All three wrappers preserve their REST return shapes; the sessionId
+// filter is now applied INSIDE the wrapper (in REST mode the wrapper
+// post-filters via `matchesContentSession`, in WS mode the server
+// pre-filters via `filters.session_id`), so this store no longer
+// strips/re-applies the filter itself.
 import {
   fetchContent,
-  matchesContentSession,
   deleteContent as apiDelete,
   bulkDeleteContent as apiBulkDelete,
   type ContentEntry,
@@ -44,13 +54,14 @@ export async function loadContent(filters: ContentFilters = {}) {
   notify();
 
   try {
-    const { sessionId, ...serverFilters } = filters;
-    const result = await fetchContent(serverFilters);
-    const filteredEntries = sessionId
-      ? result.entries.filter((entry) => matchesContentSession(entry, sessionId))
-      : result.entries;
-    entries = filteredEntries;
-    total = filteredEntries.length;
+    // M12 Phase D-3: pass `filters` (including `sessionId`) straight to
+    // the wrapper. The wrapper now owns the sessionId-to-server mapping
+    // (WS: `filters.session_id`) and the legacy path-pattern post-filter
+    // (REST), so callers no longer need to strip + re-filter. Keep
+    // `loadContent` transport-agnostic.
+    const result = await fetchContent(filters);
+    entries = result.entries;
+    total = result.total;
     loading = false;
     notify();
   } catch (e) {

--- a/src/store/file-store.ts
+++ b/src/store/file-store.ts
@@ -1,6 +1,12 @@
 import { useSyncExternalStore } from "react";
 import { buildApiHeaders } from "@/api/client";
 import { buildFileUrl } from "@/api/files";
+// M12 Phase D-3: files panel routes through the Phase D-2
+// `getSessionFiles` wrapper in src/api/sessions.ts, which flips
+// between the WS `session/files.list` method and the legacy REST
+// `/api/sessions/:id/files` endpoint under the
+// `auxiliary_rest_to_ws_v1` flag. The wrapper returns a plain
+// `SessionFileInfo[]` array, matching what loadSessionFiles consumes.
 import { getSessionFiles } from "@/api/sessions";
 import { API_BASE } from "@/lib/constants";
 import { displayFilenameFromPath } from "@/lib/utils";

--- a/src/store/thread-store.ts
+++ b/src/store/thread-store.ts
@@ -18,6 +18,14 @@
  */
 
 import { useSyncExternalStore } from "react";
+// M12 Phase D-3: history panel routes through the Phase D-2
+// `getMessages` wrapper in src/api/sessions.ts, which flips between
+// the WS `session/messages_page` method and the legacy REST
+// `/api/sessions/:id/messages` endpoint under the
+// `auxiliary_rest_to_ws_v1` flag. The wrapper preserves the array
+// return shape that `replayHistory` consumes; pagination metadata
+// (`has_more` / `next_offset`) is available via `getMessagesPage`
+// for the future paged-history loader.
 import { getMessages as fetchMessages } from "@/api/sessions";
 import type { MessageInfo } from "@/api/types";
 import { displayFilenameFromPath } from "@/lib/utils";


### PR DESCRIPTION
## Summary

Migrate every UI panel in `octos-web` to route session / content auxiliary traffic through the Phase D-2 wrappers in `src/api/sessions.ts` and `src/api/content.ts`. The wrappers flip between WS UI Protocol v1 methods and the legacy REST endpoints under the `auxiliary_rest_to_ws_v1` localStorage flag (default **OFF** — Phase D-4 will flip it). After this PR, no panel calls `request()` or `fetch()` for any of the 13 aux methods directly — they all go through the wrapper boundary, so flipping the flag is a single point of change.

This unblocks Phase D-4 (default-flip + reaper scope narrowing) and Phase D-5 (REST endpoint retirement).

## Panels migrated

| Panel | Commit | Wrapper(s) used | Before → After |
|---|---|---|---|
| Sidebar session list | `9392ecd` | `listSessions`, `deleteSession` | `src/components/session-list.tsx:6` — already wrapper-routed via `useSession()`; stamp header now records this so future audits don't re-trace the import graph. |
| Session rename action | `edcf232` | `setSessionTitle` (new in D-2) | `src/runtime/session-context.tsx:566–578` (local-only cache update) → `src/runtime/session-context.tsx:566–595` (optimistic local update + fire-and-forget `setSessionTitle` persistence). This is the one **behavior-affecting** commit in the PR. |
| History / messages | `ed13d8d` | `getMessages` | `src/store/thread-store.ts:21` already imports `getMessages`; header comment now stamps the migration. `getMessagesPage` is available for future paged scroll. |
| Files panel | `0195479` | `getSessionFiles` | `src/store/file-store.ts:4` already imports `getSessionFiles`; header stamped. |
| Tasks panel (watcher + dock) | `3b1f2cc` | `getSessionTasks`, `getMessages` | `src/runtime/task-watcher.ts:14–17` + `src/components/session-task-dock.tsx:1–4` already wrapper-routed; module and component headers stamped. |
| Session status indicator | `6a1cad5` | `getStatus`, `getSessionStatus` | `src/hooks/use-octos-status.ts:2` (server status badge) + `src/runtime/runtime-provider.tsx:14` (per-session status) already wrapper-routed; headers stamped. |
| Workspace contract view | `56fbbe6` | `getSessionWorkspaceContract`, `getSessionFiles`, `listSessions` | `src/slides/api.ts:4–9` already wrapper-routed; header stamped. |
| Content library page | `9623f95` | `fetchContent`, `deleteContent`, `bulkDeleteContent` | `src/store/content-store.ts:40–61` used to strip `sessionId` from filters and re-apply `matchesContentSession` client-side. The D-2 wrapper now owns that filter (WS: `filters.session_id`; REST: post-filter via `matchesContentSession`). Forward filters whole; drop the double-filter. |

## Wrapper-shape adaptations

- **Content store double-filter** (commit `9623f95`): the legacy store applied `matchesContentSession` itself after stripping `sessionId` from the filter object passed to `fetchContent`. The D-2 wrapper now handles both transports (WS server pre-filters via `filters.session_id`; REST post-filters via `matchesContentSession`). Per the D-3 brief — adapt the panel to the wrapper — drop the strip-and-re-filter and forward the full filters object to `fetchContent`. The aux test `fetchContent({sessionId}) returns same filtered subset across transports` already pins both legs of this.

- **Rename action**: the legacy `renameSession()` only touched the local `titleCache` and `sessions[]`. It never persisted. The new D-2 `setSessionTitle` wrapper exposes both transports for the session-title PATCH that previously had no public REST helper. Wired in as **optimistic local update + fire-and-forget wrapper call**; if the server rejects, the next `refreshSessions()` reconciles. No error toast yet — `chat-layout` doesn't have a generic toast pipeline; surface as a Phase D-3 followup if rename-rejection UX matters.

## Panels not touched

- **`chat-thread` file blob preflight** (`src/components/chat-thread.tsx:94`): this `fetch()` is for `/api/files/:path` (auth blob preview), NOT one of the 13 auxiliary methods. Out of scope for D-3.
- **`chat-thread` send pipeline**: already goes through the WS bridge for `TurnStartInput`; no REST migration needed.
- **`/api/chat` legacy POST in slides/sites chat surfaces**: that endpoint is being retired by M9-β not D-3; tracked separately.

## Constraints respected

- Did NOT change `src/api/client.ts` 401 reaper — that's Phase D-4 territory.
- Did NOT retire any REST endpoint — that's Phase D-5.
- Did NOT alter the wrapper APIs (`src/api/sessions.ts` / `src/api/content.ts`) — D-2's surface is frozen.
- Flag remains default OFF; the rename PATCH still flows over REST today.

## Predecessors

- octos PR #912 — server-side WS frames (merged)
- octos-web PR #104 — client-side flagged wrappers (merged)
- ADR octos PR #910 — `docs/adr/m12-phase-d-auxiliary-rest-to-ws.md`
- Closes part of octos-web tracking issue #103

## Test plan

- [x] `pnpm tsc --noEmit` — passes
- [x] `pnpm test:unit` — 356 / 357 (the one pre-existing failure `ui-protocol-event-router > persisted message stamps seq onto the late-artifact response` is on main; not introduced here)
- [x] `pnpm lint` — 121 problems baseline preserved; no new errors
- [x] `pnpm build` — passes
- [ ] Manual smoke: with flag OFF, rename a session in the sidebar → confirm rename persists across a refresh (was a no-op pre-D-3)
- [ ] Manual smoke: with flag ON, rename a session → confirm WS `session/title.set` lands and reaches the persistent store
- [ ] Manual smoke: content library page with a `sessionId` filter returns the same entries with flag ON and OFF