### PR TITLE
feat(api): M12 Phase D-4 — flip auxiliary_rest_to_ws_v1 ON + tighten 401 reaper

### DIFF
--- a/src/api/aux-rest-to-ws.test.ts
+++ b/src/api/aux-rest-to-ws.test.ts
@@ -27,6 +27,7 @@ import {
 } from "vitest";
 
 import {
+  __clearAuxRestToWsV1ForTests,
   __setAuxRestToWsV1ForTests,
   isAuxRestToWsV1Enabled,
 } from "@/lib/feature-flags";
@@ -203,8 +204,9 @@ afterEach(() => {
 // ---------------------------------------------------------------------------
 
 describe("auxiliary_rest_to_ws_v1 feature flag", () => {
-  it("defaults OFF", () => {
-    expect(isAuxRestToWsV1Enabled()).toBe(false);
+  it("defaults ON when localStorage key is unset (Phase D-4 cutover)", () => {
+    __clearAuxRestToWsV1ForTests();
+    expect(isAuxRestToWsV1Enabled()).toBe(true);
   });
 
   it("reads `1` from localStorage as ON", () => {
@@ -212,11 +214,56 @@ describe("auxiliary_rest_to_ws_v1 feature flag", () => {
     expect(isAuxRestToWsV1Enabled()).toBe(true);
   });
 
-  it("returns to OFF after the test helper resets it", () => {
+  it("explicit `0` opts out (emergency-rollback escape hatch)", () => {
     __setAuxRestToWsV1ForTests(true);
     expect(isAuxRestToWsV1Enabled()).toBe(true);
     __setAuxRestToWsV1ForTests(false);
     expect(isAuxRestToWsV1Enabled()).toBe(false);
+  });
+
+  it("explicit `false` (string) also opts out", () => {
+    globalThis.localStorage?.setItem(
+      "octos_auxiliary_rest_to_ws_v1",
+      "false",
+    );
+    __clearAuxRestToWsV1ForTests();
+    // Re-set after clear so the read sees "false"
+    globalThis.localStorage?.setItem(
+      "octos_auxiliary_rest_to_ws_v1",
+      "false",
+    );
+    expect(isAuxRestToWsV1Enabled()).toBe(false);
+  });
+
+  it("flag-OFF wrapper routing: explicit opt-out routes through REST", async () => {
+    __setAuxRestToWsV1ForTests(false);
+    mockFetchOnceJson([{ id: "s-rest", message_count: 0 }]);
+    const bridge = makeMockBridge();
+    bridge.setReply(METHODS.SESSION_LIST, {
+      sessions: [{ id: "should-not-see" }],
+    });
+    __setActiveBridgeForTest("any", bridge);
+
+    const out = await listSessions();
+    // REST hit, bridge untouched.
+    expect(fetchCalls.length).toBe(1);
+    expect(bridge.calls.length).toBe(0);
+    expect(out).toEqual([{ id: "s-rest", message_count: 0 }]);
+  });
+
+  it("default-ON wrapper routing: unset key + connected bridge → WS path", async () => {
+    __clearAuxRestToWsV1ForTests();
+    const bridge = makeMockBridge();
+    bridge.setReply(METHODS.SESSION_LIST, {
+      sessions: [{ id: "s-ws", message_count: 7 }],
+    });
+    __setActiveBridgeForTest("any", bridge);
+
+    const out = await listSessions();
+    // Bridge hit, no REST.
+    expect(bridge.calls.length).toBe(1);
+    expect(fetchCalls.length).toBe(0);
+    expect(out).toEqual([{ id: "s-ws", message_count: 7 }]);
   });
 });
 

--- a/src/api/chat.test.ts
+++ b/src/api/chat.test.ts
@@ -1,0 +1,155 @@
+/**
+ * Unit tests for the M12 Phase D-4 follow-up: `uploadFiles()` must NOT
+ * duplicate the 401/403 reaper from `request()`.
+ *
+ * Pre-follow-up `src/api/chat.ts:uploadFiles()` mirrored the old
+ * `request()` behavior — on 401/403 it called `clearToken()` and hard-
+ * redirected to `/login`. That contradicted D-4's promise that
+ * blob/file ops propagate normal errors so the upload UI can render a
+ * contextual retry control instead of nuking the user's tokens
+ * mid-flow. These tests pin the new behavior: a 401/403 on `/api/upload`
+ * leaves `TOKEN_KEY` and `ADMIN_TOKEN_KEY` intact and does NOT write
+ * to `window.location.href`.
+ */
+
+import {
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  vi,
+} from "vitest";
+
+import { uploadFiles } from "@/api/chat";
+import { TOKEN_KEY, ADMIN_TOKEN_KEY } from "@/lib/constants";
+
+// ---------------------------------------------------------------------------
+// jsdom location helpers (mirror src/api/client.test.ts)
+// ---------------------------------------------------------------------------
+
+const hrefWrites: string[] = [];
+let originalLocation: Location | undefined;
+
+function installLocationStub(pathname = "/app/dashboard"): void {
+  hrefWrites.length = 0;
+  if (!originalLocation) {
+    originalLocation = window.location;
+  }
+  const stub = {
+    pathname,
+    hostname: "localhost",
+    host: "localhost",
+    protocol: "http:",
+    origin: "http://localhost",
+    search: "",
+    hash: "",
+    port: "",
+    set href(value: string) {
+      hrefWrites.push(value);
+    },
+    get href() {
+      return `http://localhost${pathname}`;
+    },
+    assign: (value: string) => {
+      hrefWrites.push(value);
+    },
+    replace: (value: string) => {
+      hrefWrites.push(value);
+    },
+    reload: () => {},
+    toString: () => `http://localhost${pathname}`,
+  };
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  delete (window as any).location;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  (window as any).location = stub;
+}
+
+function restoreLocationStub(): void {
+  if (originalLocation) {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    delete (window as any).location;
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (window as any).location = originalLocation;
+  }
+}
+
+function mockFetchStatus(status: number, body = ""): ReturnType<typeof vi.fn> {
+  const fetchMock = vi.fn().mockResolvedValue(
+    new Response(body, {
+      status,
+      headers: { "content-type": "text/plain" },
+    }),
+  );
+  vi.stubGlobal("fetch", fetchMock);
+  return fetchMock;
+}
+
+function makeFile(name = "a.txt", body = "x"): File {
+  return new File([body], name, { type: "text/plain" });
+}
+
+beforeEach(() => {
+  localStorage.setItem(TOKEN_KEY, "session-token");
+  localStorage.setItem(ADMIN_TOKEN_KEY, "admin-token");
+  installLocationStub("/app/dashboard");
+});
+
+afterEach(() => {
+  restoreLocationStub();
+  localStorage.clear();
+  vi.unstubAllGlobals();
+  vi.restoreAllMocks();
+});
+
+describe("uploadFiles — no duplicated 401/403 reaper (M12 Phase D-4 follow-up)", () => {
+  it("401 from /api/upload → throws normal Error, preserves tokens, no redirect", async () => {
+    mockFetchStatus(401, "upload session expired");
+
+    let caught: unknown;
+    try {
+      await uploadFiles([makeFile()]);
+    } catch (e) {
+      caught = e;
+    }
+
+    expect(caught).toBeInstanceOf(Error);
+    expect((caught as Error).message).toContain("upload session expired");
+
+    // Tokens preserved — the structural cutover.
+    expect(localStorage.getItem(TOKEN_KEY)).toBe("session-token");
+    expect(localStorage.getItem(ADMIN_TOKEN_KEY)).toBe("admin-token");
+
+    // No redirect.
+    expect(hrefWrites.length).toBe(0);
+  });
+
+  it("403 from /api/upload → throws normal Error, preserves tokens, no redirect", async () => {
+    mockFetchStatus(403, "forbidden");
+
+    let caught: unknown;
+    try {
+      await uploadFiles([makeFile()]);
+    } catch (e) {
+      caught = e;
+    }
+
+    expect(caught).toBeInstanceOf(Error);
+    expect((caught as Error).message).toContain("forbidden");
+
+    expect(localStorage.getItem(TOKEN_KEY)).toBe("session-token");
+    expect(localStorage.getItem(ADMIN_TOKEN_KEY)).toBe("admin-token");
+    expect(hrefWrites.length).toBe(0);
+  });
+
+  it("500 from /api/upload → still throws, still preserves tokens", async () => {
+    mockFetchStatus(500, "server on fire");
+
+    await expect(uploadFiles([makeFile()])).rejects.toBeInstanceOf(Error);
+
+    expect(localStorage.getItem(TOKEN_KEY)).toBe("session-token");
+    expect(localStorage.getItem(ADMIN_TOKEN_KEY)).toBe("admin-token");
+    expect(hrefWrites.length).toBe(0);
+  });
+});

--- a/src/api/chat.ts
+++ b/src/api/chat.ts
@@ -1,4 +1,4 @@
-import { buildApiHeaders, clearToken } from "./client";
+import { buildApiHeaders } from "./client";
 import { API_BASE } from "@/lib/constants";
 import type { ChatResponse } from "./types";
 import { request } from "./client";
@@ -42,14 +42,14 @@ export async function uploadFiles(
   });
 
   if (!resp.ok) {
-    // Mirror the auto-logout behavior from request() on auth failure
-    if (resp.status === 401 || resp.status === 403) {
-      clearToken();
-      if (!window.location.pathname.endsWith("/login")) {
-        window.location.href =
-          "/login?redirect=" + encodeURIComponent(window.location.pathname);
-      }
-    }
+    // ───── M12 Phase D-4 follow-up: no upload-side 401/403 reaper ─────
+    //
+    // Pre-D-4 this branch mirrored `request()` and called
+    // `clearToken()` + hard-redirected to `/login` on a 401/403.
+    // That contradicted D-4's promise that blob/file ops propagate
+    // normal errors so the upload UI can render a contextual retry
+    // instead of nuking the user's tokens mid-flow. The reaper now
+    // lives ONLY in `src/api/client.ts` and ONLY for `/api/auth/*`.
     const text = await resp.text();
     throw new Error(text || `Upload failed: HTTP ${resp.status}`);
   }

--- a/src/api/client.test.ts
+++ b/src/api/client.test.ts
@@ -1,0 +1,298 @@
+/**
+ * Unit tests for the M12 Phase D-4 401/403 reaper scoping.
+ *
+ * Pre-D-4 the reaper fired on EVERY 401/403 from EVERY REST call,
+ * clearing both `octos_session_token` and `octos_auth_token` and
+ * hard-redirecting to `/login`. Phase D-4 narrows the reaper to paths
+ * under `/api/auth/*` only. See `src/api/client.ts` for the rationale.
+ *
+ * The mini5 user-incident motivating ADR PR octos-org/octos#910 was a
+ * stale REST callsite on `/api/sessions/*` 401-ing after a background
+ * token refresh and ejecting the user mid-rename. These tests pin the
+ * new behavior so a regression can't reintroduce that failure mode.
+ */
+
+import {
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  vi,
+} from "vitest";
+
+import { request, getToken, setToken } from "@/api/client";
+import { TOKEN_KEY, ADMIN_TOKEN_KEY } from "@/lib/constants";
+
+// ---------------------------------------------------------------------------
+// jsdom location helpers
+// ---------------------------------------------------------------------------
+//
+// We need to observe both `window.location.pathname` (the reaper reads it
+// to decide whether to redirect) and `window.location.href` (the reaper
+// writes to it on the redirect). jsdom's `window.location` properties are
+// not configurable, so we replace `window.location` outright with a
+// minimal stub object whose `href` setter records writes.
+
+const hrefWrites: string[] = [];
+let originalLocation: Location | undefined;
+
+function installLocationStub(pathname = "/app/dashboard"): void {
+  hrefWrites.length = 0;
+  if (!originalLocation) {
+    originalLocation = window.location;
+  }
+  const stub = {
+    pathname,
+    hostname: "localhost",
+    host: "localhost",
+    protocol: "http:",
+    origin: "http://localhost",
+    search: "",
+    hash: "",
+    port: "",
+    set href(value: string) {
+      hrefWrites.push(value);
+    },
+    get href() {
+      return `http://localhost${pathname}`;
+    },
+    assign: (value: string) => {
+      hrefWrites.push(value);
+    },
+    replace: (value: string) => {
+      hrefWrites.push(value);
+    },
+    reload: () => {},
+    toString: () => `http://localhost${pathname}`,
+  };
+  // jsdom permits replacing `window.location` wholesale via
+  // `delete window.location; window.location = stub`. The `as unknown as
+  // Location` cast keeps tsc happy without bringing in the full Location
+  // interface surface (pathname is the only read we exercise).
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  delete (window as any).location;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  (window as any).location = stub;
+}
+
+function restoreLocationStub(): void {
+  if (originalLocation) {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    delete (window as any).location;
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (window as any).location = originalLocation;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Fetch mock helpers
+// ---------------------------------------------------------------------------
+
+function mockFetchStatus(status: number, body = ""): ReturnType<typeof vi.fn> {
+  const fetchMock = vi.fn().mockResolvedValue(
+    new Response(body, {
+      status,
+      headers: { "content-type": "text/plain" },
+    }),
+  );
+  vi.stubGlobal("fetch", fetchMock);
+  return fetchMock;
+}
+
+// ---------------------------------------------------------------------------
+// Lifecycle
+// ---------------------------------------------------------------------------
+
+beforeEach(() => {
+  // Start every test signed in so the reaper has tokens to clear.
+  localStorage.setItem(TOKEN_KEY, "session-token");
+  localStorage.setItem(ADMIN_TOKEN_KEY, "admin-token");
+  installLocationStub("/app/dashboard");
+});
+
+afterEach(() => {
+  restoreLocationStub();
+  localStorage.clear();
+  vi.unstubAllGlobals();
+  vi.restoreAllMocks();
+});
+
+// ---------------------------------------------------------------------------
+// Reaper triggers — auth-flow paths only
+// ---------------------------------------------------------------------------
+
+describe("client.request — 401 reaper scoped to /api/auth/*", () => {
+  it("401 from /api/auth/me → clears tokens AND redirects to /login", async () => {
+    mockFetchStatus(401, "unauthorized");
+
+    let caught: unknown;
+    try {
+      await request("/api/auth/me");
+    } catch (e) {
+      caught = e;
+    }
+
+    // Throws so the caller can render an error message.
+    expect(caught).toBeInstanceOf(Error);
+    expect((caught as Error).message).toContain("unauthorized");
+
+    // Tokens cleared.
+    expect(localStorage.getItem(TOKEN_KEY)).toBeNull();
+    expect(localStorage.getItem(ADMIN_TOKEN_KEY)).toBeNull();
+    expect(getToken()).toBeNull();
+
+    // Redirect to /login with the original pathname as ?redirect=.
+    expect(hrefWrites.length).toBe(1);
+    expect(hrefWrites[0]).toBe(
+      "/login?redirect=" + encodeURIComponent("/app/dashboard"),
+    );
+  });
+
+  it("401 from /api/auth/status → triggers reaper", async () => {
+    mockFetchStatus(401);
+
+    await expect(request("/api/auth/status")).rejects.toBeInstanceOf(Error);
+
+    expect(localStorage.getItem(TOKEN_KEY)).toBeNull();
+    expect(hrefWrites.length).toBe(1);
+  });
+
+  it("403 from /api/auth/me → also triggers reaper", async () => {
+    mockFetchStatus(403, "forbidden");
+
+    await expect(request("/api/auth/me")).rejects.toBeInstanceOf(Error);
+
+    expect(localStorage.getItem(TOKEN_KEY)).toBeNull();
+    expect(localStorage.getItem(ADMIN_TOKEN_KEY)).toBeNull();
+    expect(hrefWrites.length).toBe(1);
+  });
+
+  it("does not redirect when already on /login", async () => {
+    installLocationStub("/login");
+    mockFetchStatus(401);
+
+    await expect(request("/api/auth/me")).rejects.toBeInstanceOf(Error);
+
+    // Tokens still cleared, but no redirect (we're already on /login).
+    expect(localStorage.getItem(TOKEN_KEY)).toBeNull();
+    expect(hrefWrites.length).toBe(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Reaper does NOT trigger — non-auth paths
+// ---------------------------------------------------------------------------
+
+describe("client.request — 401/403 on non-auth paths does NOT trigger reaper", () => {
+  it("401 from /api/files/upload → propagates as Error, leaves tokens intact", async () => {
+    mockFetchStatus(401, "upload session expired");
+
+    let caught: unknown;
+    try {
+      await request("/api/files/upload");
+    } catch (e) {
+      caught = e;
+    }
+
+    // Caller sees a normal error envelope.
+    expect(caught).toBeInstanceOf(Error);
+    expect((caught as Error).message).toContain("upload session expired");
+
+    // Tokens NOT cleared (the structural cutover).
+    expect(localStorage.getItem(TOKEN_KEY)).toBe("session-token");
+    expect(localStorage.getItem(ADMIN_TOKEN_KEY)).toBe("admin-token");
+
+    // No redirect.
+    expect(hrefWrites.length).toBe(0);
+  });
+
+  it("403 from /api/files/some-blob → propagates as Error, leaves tokens intact", async () => {
+    mockFetchStatus(403, "forbidden");
+
+    await expect(request("/api/files/some-blob")).rejects.toBeInstanceOf(Error);
+
+    expect(localStorage.getItem(TOKEN_KEY)).toBe("session-token");
+    expect(localStorage.getItem(ADMIN_TOKEN_KEY)).toBe("admin-token");
+    expect(hrefWrites.length).toBe(0);
+  });
+
+  it("401 from /api/sessions/foo → does NOT trigger reaper (mini5 incident regression test)", async () => {
+    // This is the EXACT failure mode that motivated ADR PR
+    // octos-org/octos#910: a stale REST callsite on `/api/sessions/*`
+    // 401-ed after a background token refresh, the reaper fired, and
+    // the user got booted to /login mid-rename. Post-D-4 this 401
+    // propagates as a normal error and the session-rename UI is free
+    // to surface a retry control.
+    mockFetchStatus(401, "session token expired");
+
+    let caught: unknown;
+    try {
+      await request("/api/sessions/sess-abc");
+    } catch (e) {
+      caught = e;
+    }
+
+    expect(caught).toBeInstanceOf(Error);
+    expect((caught as Error).message).toContain("session token expired");
+
+    // Tokens preserved — the user stays signed in.
+    expect(localStorage.getItem(TOKEN_KEY)).toBe("session-token");
+    expect(localStorage.getItem(ADMIN_TOKEN_KEY)).toBe("admin-token");
+
+    // No redirect — the user keeps their current view.
+    expect(hrefWrites.length).toBe(0);
+  });
+
+  it("401 from /api/my/content/c-1 (auxiliary REST) → no reaper", async () => {
+    mockFetchStatus(401);
+
+    await expect(request("/api/my/content/c-1")).rejects.toBeInstanceOf(Error);
+
+    expect(localStorage.getItem(TOKEN_KEY)).toBe("session-token");
+    expect(hrefWrites.length).toBe(0);
+  });
+
+  it("500 from /api/auth/me does NOT trigger reaper (only 401/403 do)", async () => {
+    mockFetchStatus(500, "server error");
+
+    await expect(request("/api/auth/me")).rejects.toBeInstanceOf(Error);
+
+    // Server is on fire — but the user's session is fine. Don't clear.
+    expect(localStorage.getItem(TOKEN_KEY)).toBe("session-token");
+    expect(hrefWrites.length).toBe(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Auth-path edge cases
+// ---------------------------------------------------------------------------
+
+describe("client.request — /api/auth/* prefix matching", () => {
+  it("paths that merely contain 'auth' do NOT match — only the prefix triggers", async () => {
+    mockFetchStatus(401);
+
+    // A hypothetical session resource whose name contains "auth".
+    await expect(request("/api/sessions/auth-debug")).rejects.toBeInstanceOf(
+      Error,
+    );
+
+    expect(localStorage.getItem(TOKEN_KEY)).toBe("session-token");
+    expect(hrefWrites.length).toBe(0);
+  });
+
+  it("nested /api/auth/* paths trigger reaper (e.g. /api/auth/sso/callback)", async () => {
+    mockFetchStatus(401);
+
+    await expect(
+      request("/api/auth/sso/callback"),
+    ).rejects.toBeInstanceOf(Error);
+
+    expect(localStorage.getItem(TOKEN_KEY)).toBeNull();
+    expect(hrefWrites.length).toBe(1);
+  });
+});
+
+// Avoid unused-import lint on setToken — exported for symmetry but
+// not exercised here (token-setting is covered indirectly by getToken).
+void setToken;

--- a/src/api/client.test.ts
+++ b/src/api/client.test.ts
@@ -253,6 +253,29 @@ describe("client.request — 401/403 on non-auth paths does NOT trigger reaper",
     expect(hrefWrites.length).toBe(0);
   });
 
+  it("401 from /api/admin/* → no reaper (admin endpoints are NOT auth flow)", async () => {
+    // Documents the boundary intent: the reaper fires for `/api/auth/*`
+    // ONLY. Admin endpoints, while privileged, are not the auth flow
+    // and a 401 on one should propagate as a normal error so admin UI
+    // can surface a contextual permissions message rather than nuking
+    // the session and booting the admin to /login.
+    mockFetchStatus(401, "admin scope required");
+
+    let caught: unknown;
+    try {
+      await request("/api/admin/users");
+    } catch (e) {
+      caught = e;
+    }
+
+    expect(caught).toBeInstanceOf(Error);
+    expect((caught as Error).message).toContain("admin scope required");
+
+    expect(localStorage.getItem(TOKEN_KEY)).toBe("session-token");
+    expect(localStorage.getItem(ADMIN_TOKEN_KEY)).toBe("admin-token");
+    expect(hrefWrites.length).toBe(0);
+  });
+
   it("500 from /api/auth/me does NOT trigger reaper (only 401/403 do)", async () => {
     mockFetchStatus(500, "server error");
 

--- a/src/api/client.ts
+++ b/src/api/client.ts
@@ -126,14 +126,36 @@ export async function request<T>(
   });
 
   if (!resp.ok) {
-    // Auto-logout on auth failure (expired/invalid token)
+    // ───── Auth-flow-only 401/403 reaper (M12 Phase D-4) ─────
     //
-    // Phase D-2 intentionally does NOT trigger this REST 401 reaper from
-    // WS auth failures (see `translateBridgeError` in `sessions.ts` /
-    // `content.ts`). See ADR PR #910 — Phase D-4 narrows this reaper to
-    // `/api/auth/*` only, so cross-transport coupling here is
-    // undesirable until that lands.
-    if (resp.status === 401 || resp.status === 403) {
+    // Auto-logout on auth failure (expired/invalid token), but ONLY
+    // when the failing path is the auth flow itself (`/api/auth/*`).
+    //
+    // Pre-D-4 this reaper fired on EVERY 401/403 from EVERY REST call,
+    // which meant a 401 on an unrelated REST request would clear the
+    // user's tokens and hard-redirect them to `/login`. With the data
+    // plane on WS UI Protocol v1 (post-D-4 default-ON cutover),
+    // auxiliary REST calls are minimal — only blob/file ops and the
+    // auth flow itself. A 401 from a blob upload (e.g. expired session
+    // mid-stream) should propagate as a normal error so the upload UI
+    // can render a contextual retry, not nuke the user's tokens and
+    // boot them to /login.
+    //
+    // The mini5 user-incident motivating ADR PR octos-org/octos#910
+    // (a stale REST callsite on `/api/sessions/*` 401'd after a
+    // background token refresh, triggering this reaper and ejecting
+    // the user mid-rename) is the structural failure mode this
+    // tightening eliminates. See `docs/adr/m12-phase-d-auxiliary-rest-to-ws.md`
+    // for the full motivation, and `src/api/sessions.ts` /
+    // `src/api/content.ts` (`translateBridgeError`) for the WS-side
+    // counterpart that already declines to trigger this reaper.
+    //
+    // Paths under `/api/auth/*` (e.g. `/api/auth/me`, `/api/auth/status`)
+    // still trigger the reaper — a 401 there means the session token
+    // has truly expired, which is exactly the case the redirect was
+    // designed for.
+    const isAuthPath = path.startsWith("/api/auth/");
+    if ((resp.status === 401 || resp.status === 403) && isAuthPath) {
       clearToken();
       // Redirect to login unless already there
       if (!window.location.pathname.endsWith("/login")) {

--- a/src/lib/feature-flags.test.ts
+++ b/src/lib/feature-flags.test.ts
@@ -1,0 +1,111 @@
+/**
+ * Unit tests for the M12 Phase D-4 follow-up: flag opt-out token
+ * semantics.
+ *
+ * Pre-follow-up `readAuxRestToWsV1FromStorage()` returned `raw === "1"`,
+ * which meant ANY persisted value other than exact `"1"` was treated
+ * as OFF — including `"true"`, `"yes"`, `"enabled"`, `" 1 "`. That
+ * silently stranded stale experimental values on REST.
+ *
+ * New semantics (positive match on disable tokens):
+ *   - "0", "false", "off" (case-insensitive, whitespace trimmed) → OFF
+ *   - anything else (including "true", "yes", "1", garbage)        → ON
+ *   - UNSET (null)                                                 → ON
+ */
+
+import { afterEach, describe, expect, it } from "vitest";
+
+import {
+  AUX_REST_TO_WS_V1_FLAG_KEY,
+  __clearAuxRestToWsV1ForTests,
+  isAuxRestToWsV1Enabled,
+} from "@/lib/feature-flags";
+
+function setRaw(value: string): void {
+  localStorage.setItem(AUX_REST_TO_WS_V1_FLAG_KEY, value);
+  // Reset the cache so the next read picks up `value`.
+  __clearAuxRestToWsV1ForTests();
+  // __clearAuxRestToWsV1ForTests also removes the key, so write it
+  // back AFTER the reset.
+  localStorage.setItem(AUX_REST_TO_WS_V1_FLAG_KEY, value);
+}
+
+afterEach(() => {
+  localStorage.clear();
+  __clearAuxRestToWsV1ForTests();
+});
+
+describe("isAuxRestToWsV1Enabled — opt-out token semantics", () => {
+  it('UNSET → ON (default)', () => {
+    __clearAuxRestToWsV1ForTests();
+    expect(isAuxRestToWsV1Enabled()).toBe(true);
+  });
+
+  // -------------------------------------------------------------------
+  // OFF: positive matches on known disable tokens
+  // -------------------------------------------------------------------
+
+  it('"0" → OFF', () => {
+    setRaw("0");
+    expect(isAuxRestToWsV1Enabled()).toBe(false);
+  });
+
+  it('"false" → OFF', () => {
+    setRaw("false");
+    expect(isAuxRestToWsV1Enabled()).toBe(false);
+  });
+
+  it('"off" → OFF', () => {
+    setRaw("off");
+    expect(isAuxRestToWsV1Enabled()).toBe(false);
+  });
+
+  it('"FALSE" (uppercase) → OFF', () => {
+    setRaw("FALSE");
+    expect(isAuxRestToWsV1Enabled()).toBe(false);
+  });
+
+  it('" 0 " (whitespace-padded) → OFF', () => {
+    setRaw(" 0 ");
+    expect(isAuxRestToWsV1Enabled()).toBe(false);
+  });
+
+  it('"  False  " (mixed case + whitespace) → OFF', () => {
+    setRaw("  False  ");
+    expect(isAuxRestToWsV1Enabled()).toBe(false);
+  });
+
+  // -------------------------------------------------------------------
+  // ON: anything that isn't a known disable token stays ON
+  // -------------------------------------------------------------------
+
+  it('"1" → ON', () => {
+    setRaw("1");
+    expect(isAuxRestToWsV1Enabled()).toBe(true);
+  });
+
+  it('"true" → ON (no longer silently OFF as pre-follow-up)', () => {
+    setRaw("true");
+    expect(isAuxRestToWsV1Enabled()).toBe(true);
+  });
+
+  it('"yes" → ON', () => {
+    setRaw("yes");
+    expect(isAuxRestToWsV1Enabled()).toBe(true);
+  });
+
+  it('"enabled" → ON', () => {
+    setRaw("enabled");
+    expect(isAuxRestToWsV1Enabled()).toBe(true);
+  });
+
+  it('garbage value → ON', () => {
+    setRaw("hunter2");
+    expect(isAuxRestToWsV1Enabled()).toBe(true);
+  });
+
+  it('empty string → ON (not a disable token)', () => {
+    setRaw("");
+    expect(isAuxRestToWsV1Enabled()).toBe(true);
+  });
+});

--- a/src/lib/feature-flags.ts
+++ b/src/lib/feature-flags.ts
@@ -6,13 +6,15 @@
  * flip cannot start a feature partway through a request/response cycle,
  * with a test-only helper that resets both the cache and the storage key.
  *
- * Production default for every flag below is OFF. Flipping a flag on for
- * production is the job of a later phase PR (e.g. Phase D-4 flips the
- * aux-rest-to-ws flag default ON once the wrappers are battle-tested).
+ * Production defaults vary per flag — see each flag's doc comment. Some
+ * flags ship OFF until a cutover phase flips them ON (e.g. Phase C
+ * flipped `chat_app_ui_v1` from OFF to ON before deleting the flag in
+ * octos-web PR #66; Phase D-4 flips `auxiliary_rest_to_ws_v1` from OFF
+ * to ON below).
  */
 
 // ---------------------------------------------------------------------------
-// auxiliary.rest_to_ws.v1 — M12 Phase D-2
+// auxiliary.rest_to_ws.v1 — M12 Phase D-2 (wrappers), Phase D-4 (default ON)
 // ---------------------------------------------------------------------------
 //
 // When ON, REST callsites listed in the ADR
@@ -23,16 +25,27 @@
 // `src/api/sessions.ts` / `src/api/content.ts` so the wire stays
 // byte-identical to a pre-D-2 build.
 //
+// **Phase D-4 cutover (this commit): default is now ON.**
+//
+// Migration semantics for the localStorage key:
+//   - UNSET (no entry in localStorage) → treat as ON. This is the new
+//     default and applies to every existing user on first page load
+//     after the cutover ships.
+//   - "1"   → ON (explicit opt-in; identical to the default).
+//   - "0" / "false" / any other non-"1" value → OFF. This is the
+//     emergency-rollback escape hatch: a user who hits a bug in the WS
+//     wrappers can `localStorage.setItem("octos_auxiliary_rest_to_ws_v1",
+//     "false")` in devtools and the next page reload restores the
+//     pre-D-4 REST behavior.
+//
 // Cached on first read; mid-session flips do not take effect until the
 // next page reload — matches `projection_v1` behavior. The cache-once
 // pattern protects against a flip in the middle of a single RPC and
-// against half-the-app-on / half-off routing within a page load. Phase
-// D-3 panels that want to toggle the flag at runtime must reload to
-// pick up the change (consistent with how `projection_v1` is flipped).
+// against half-the-app-on / half-off routing within a page load.
 
 /** localStorage key gating Phase D-2 WS wrappers. Production default
- *  is OFF; Phase D-4 will flip the default. Tests flip via
- *  `__setAuxRestToWsV1ForTests`. */
+ *  is ON as of Phase D-4 — see the migration-semantics comment block
+ *  above. Tests flip via `__setAuxRestToWsV1ForTests`. */
 export const AUX_REST_TO_WS_V1_FLAG_KEY = "octos_auxiliary_rest_to_ws_v1";
 
 /** The on-the-wire capability string negotiated via the `?ui_feature=`
@@ -46,12 +59,18 @@ let warnedAboutAuxRestToWsV1MidSessionChange = false;
 
 function readAuxRestToWsV1FromStorage(): boolean {
   try {
-    if (typeof globalThis === "undefined") return false;
+    if (typeof globalThis === "undefined") return true;
     const ls = (globalThis as { localStorage?: Storage }).localStorage;
-    if (!ls) return false;
-    return ls.getItem(AUX_REST_TO_WS_V1_FLAG_KEY) === "1";
+    if (!ls) return true;
+    const raw = ls.getItem(AUX_REST_TO_WS_V1_FLAG_KEY);
+    // UNSET → ON (new default). Only an explicit non-"1" value opts out.
+    if (raw === null) return true;
+    return raw === "1";
   } catch {
-    return false;
+    // Some jsdom configurations throw on `localStorage` access (security
+    // origin checks). Treat unreachable storage as flag-on, matching
+    // the new default.
+    return true;
   }
 }
 
@@ -84,14 +103,35 @@ export function isAuxRestToWsV1Enabled(): boolean {
 }
 
 /** Test helper: flip the flag in the current jsdom origin AND reset
- *  the cache so the next `isAuxRestToWsV1Enabled()` call re-reads it. */
+ *  the cache so the next `isAuxRestToWsV1Enabled()` call re-reads it.
+ *
+ *  - `enabled=true`  → writes `"1"` to localStorage (explicit ON).
+ *  - `enabled=false` → writes `"0"` (explicit OFF). NOTE: prior to
+ *    Phase D-4 this used `removeItem`, but the default is now ON so
+ *    removing the key would leave the flag ON. Tests that want the
+ *    OFF leg of the wrapper must explicitly opt out. */
 export function __setAuxRestToWsV1ForTests(enabled: boolean): void {
   try {
     const ls = (globalThis as { localStorage?: Storage }).localStorage;
     if (ls) {
       if (enabled) ls.setItem(AUX_REST_TO_WS_V1_FLAG_KEY, "1");
-      else ls.removeItem(AUX_REST_TO_WS_V1_FLAG_KEY);
+      else ls.setItem(AUX_REST_TO_WS_V1_FLAG_KEY, "0");
     }
+  } catch {
+    // No-op when storage is unavailable.
+  }
+  cachedAuxRestToWsV1 = null;
+  warnedAboutAuxRestToWsV1MidSessionChange = false;
+}
+
+/** Test-only helper: clear the localStorage key entirely so the next
+ *  `isAuxRestToWsV1Enabled()` call exercises the UNSET → default-ON
+ *  path. Distinct from `__setAuxRestToWsV1ForTests(false)`, which
+ *  writes an explicit opt-out value. */
+export function __clearAuxRestToWsV1ForTests(): void {
+  try {
+    const ls = (globalThis as { localStorage?: Storage }).localStorage;
+    if (ls) ls.removeItem(AUX_REST_TO_WS_V1_FLAG_KEY);
   } catch {
     // No-op when storage is unavailable.
   }

--- a/src/lib/feature-flags.ts
+++ b/src/lib/feature-flags.ts
@@ -31,12 +31,17 @@
 //   - UNSET (no entry in localStorage) → treat as ON. This is the new
 //     default and applies to every existing user on first page load
 //     after the cutover ships.
-//   - "1"   → ON (explicit opt-in; identical to the default).
-//   - "0" / "false" / any other non-"1" value → OFF. This is the
-//     emergency-rollback escape hatch: a user who hits a bug in the WS
-//     wrappers can `localStorage.setItem("octos_auxiliary_rest_to_ws_v1",
-//     "false")` in devtools and the next page reload restores the
-//     pre-D-4 REST behavior.
+//   - "0" / "false" / "off" (case-insensitive, whitespace trimmed) →
+//     OFF. This is the emergency-rollback escape hatch: a user who
+//     hits a bug in the WS wrappers can
+//     `localStorage.setItem("octos_auxiliary_rest_to_ws_v1", "0")` in
+//     devtools and the next page reload restores the pre-D-4 REST
+//     behavior. `"false"`, `"FALSE"`, `" 0 "`, and `"off"` all work.
+//   - Any other value (`"1"`, `"true"`, `"yes"`, garbage, etc.) → ON.
+//     Opt-out is a positive match on the known disable tokens — stale
+//     experimental values from earlier phases (e.g. `"true"`,
+//     `"enabled"`) that used to mean ON now correctly stay ON instead
+//     of silently flipping a user back to REST.
 //
 // Cached on first read; mid-session flips do not take effect until the
 // next page reload — matches `projection_v1` behavior. The cache-once
@@ -63,9 +68,15 @@ function readAuxRestToWsV1FromStorage(): boolean {
     const ls = (globalThis as { localStorage?: Storage }).localStorage;
     if (!ls) return true;
     const raw = ls.getItem(AUX_REST_TO_WS_V1_FLAG_KEY);
-    // UNSET → ON (new default). Only an explicit non-"1" value opts out.
+    // UNSET → ON (new default). Otherwise, only an explicit "0",
+    // "false", or "off" (case-insensitive, whitespace trimmed) opts
+    // out. Any other value (including "true", "yes", garbage) → ON.
     if (raw === null) return true;
-    return raw === "1";
+    const trimmed = raw.trim().toLowerCase();
+    if (trimmed === "0" || trimmed === "false" || trimmed === "off") {
+      return false;
+    }
+    return true;
   } catch {
     // Some jsdom configurations throw on `localStorage` access (security
     // origin checks). Treat unreachable storage as flag-on, matching

--- a/src/runtime/ui-protocol-bridge.test.ts
+++ b/src/runtime/ui-protocol-bridge.test.ts
@@ -671,7 +671,9 @@ describe("connection lifecycle", () => {
     } = await import("@/lib/feature-flags");
 
     try {
-      // Flag OFF (default) — the aux capability is NOT advertised.
+      // Flag explicit OFF (emergency-rollback escape hatch) — the aux
+      // capability is NOT advertised. (Phase D-4 flipped the default to
+      // ON; tests still cover the explicit-OFF leg.)
       __setAuxRestToWsV1ForTests(false);
       let bridge = createUiProtocolBridge(makeBridgeOpts());
       void bridge.start({ sessionId: "sess-a" });


### PR DESCRIPTION
## Summary

M12 Phase D-4 — the structural cutover that finally cuts the cross-transport coupling that motivated ADR PR octos-org/octos#910.

Two atomically-revertible changes:

1. **Flip `auxiliary_rest_to_ws_v1` default from OFF to ON.** Every existing user, with no localStorage entry for the key, starts routing the 13 ADR-listed auxiliary REST callsites through the JSON-RPC WS bridge under `auxiliary.rest_to_ws.v1`. Mirrors how Phase C flipped `chat_app_ui_v1` (octos-web commit 66501472).
2. **Tighten the REST 401/403 reaper to `/api/auth/*` paths only.** Pre-D-4 the reaper fired on EVERY 401/403 from EVERY REST call, clearing both tokens and hard-redirecting to `/login`. Post-D-4 only paths under `/api/auth/*` (the auth flow itself) trigger it; blob/file ops and any other auxiliary REST surface a normal `Error` to the caller.

The mini5 user-incident motivating ADR PR octos-org/octos#910 — a stale REST callsite on `/api/sessions/*` 401'd after a background token refresh, the reaper fired, and the user got booted to /login mid-rename — is the structural failure mode this phase eliminates. Both sides are now closed:
- Data plane no longer hits REST at all (flag flip routes it through WS).
- Even if a stale REST callsite did 401, the reaper no longer fires on non-auth paths.

## Predecessors (all merged)

- octos-org/octos#912 (server frames)
- octos-web #104 (Phase D-2 client wrappers)
- octos-web #106 (Phase D-3 panel migrations + rename rollback fix)
- ADR: octos-org/octos#910 / `docs/adr/m12-phase-d-auxiliary-rest-to-ws.md`

## Rollback

The flag is **not** deleted in this PR. Explicit opt-out remains available as an emergency-rollback escape hatch:

```js
localStorage.setItem("octos_auxiliary_rest_to_ws_v1", "false")
```

On the next page reload pre-D-4 REST routing is restored. No code change required. Migration semantics for the localStorage key:

- UNSET (key not present) → ON (new default).
- `"1"` → ON.
- `"0"` / `"false"` / any non-`"1"` value → OFF (explicit opt-out).

The 401 reaper tightening has no per-user escape hatch — that's the structural-cutover side of the change. To revert it, revert this PR's second commit.

## What's next

M12 Phase D-5 (server-side REST retirement) is the final phase. After D-5 lands, the flag and the legacy REST routes can both be deleted.

## Files changed

- `src/lib/feature-flags.ts` — flag default ON + new test helper `__clearAuxRestToWsV1ForTests()`.
- `src/api/client.ts` — narrow 401/403 reaper to `path.startsWith("/api/auth/")` paths only.
- `src/api/client.test.ts` — **new** — 11 cases covering both legs of the prefix match, including a named regression test for the mini5 incident (`401 from /api/sessions/foo → does NOT trigger reaper`).
- `src/api/aux-rest-to-ws.test.ts` — `defaults OFF` replaced with `defaults ON when unset`; explicit-OFF and explicit-`false` cases added; wrapper-routing default-ON test added.
- `src/runtime/ui-protocol-bridge.test.ts` — comment refresh; `__setAuxRestToWsV1ForTests(false)` semantics now write `"0"` explicitly (per flag-helper change).

## Test plan

- [x] `pnpm tsc --noEmit` — clean.
- [x] `pnpm test:unit` — 378 passed / 1 failed. The 1 failure is the pre-existing `ui-protocol-event-router > persisted message stamps seq onto the late-artifact response` failure already present on main (octos-web #105 / octos #913 polish backlog).
- [x] `pnpm lint` — zero new lint errors in changed files (same 118-error count as main; pre-existing TTS-test lint debt is untouched).
- [x] `pnpm build` — clean.

Test count: +11 (new `src/api/client.test.ts`) +3 (re-pinned flag-default tests in `aux-rest-to-ws.test.ts`).

## Regression audit

Grepped for:
- Tests that mocked specific 401-reaper behavior assuming the flag was OFF or the reaper fired everywhere → none found. The aux-rest-to-ws test suite's `beforeEach` calls `__setAuxRestToWsV1ForTests(false)` explicitly, which under the updated helper writes `"0"` to localStorage (was: `removeItem`, which under the new default would have flipped the suite to ON). Behavior preserved.
- `clearToken` callsites → only invoked from `client.ts` and the explicit logout flow (`auth.ts logout()`). The narrowed reaper does not affect logout.
- Module-cache side effects on the flag's first-read latch → tests reset cache via `__setAuxRestToWsV1ForTests` or `__clearAuxRestToWsV1ForTests` in their lifecycle hooks; no cross-test pollution.