### PR TITLE
fix(history): paint sidebar titles from session/list directly

### DIFF
--- a/src/api/types.ts
+++ b/src/api/types.ts
@@ -17,6 +17,12 @@ export interface ChatResponse {
 export interface SessionInfo {
   id: string;
   message_count: number;
+  /// Server-computed title (from session JSONL metadata or a stored
+  /// rename). May be missing or empty for legacy sessions — when
+  /// present, the SPA uses it directly and skips the per-session
+  /// `messages_page` round-trip used to derive a title from the first
+  /// user message.
+  title?: string | null;
 }
 
 export interface MessageInfo {

--- a/src/runtime/session-context.tsx
+++ b/src/runtime/session-context.tsx
@@ -512,6 +512,24 @@ export function SessionProvider({ children }: { children: ReactNode }) {
     try {
       const deletedIds = loadDeletedSessionIds();
       const list = await listSessions();
+      // Server-supplied title wins: populate the title cache from
+      // `session/list` directly so the sidebar paints with real titles
+      // on first render — no per-session `messages_page` round-trip
+      // needed. Pre-fix, `SessionInfo` had no `title` field so the
+      // server's title was silently discarded and the SPA derived
+      // titles from the first user message via N (≤10) serial
+      // `messages_page` calls, adding 1–5 s of latency on `/chat` load.
+      let titleCacheDirty = false;
+      for (const s of list) {
+        const t = s.title?.trim();
+        if (t && titleCache.current[s.id] !== t) {
+          titleCache.current[s.id] = t;
+          titleCacheDirty = true;
+        }
+      }
+      if (titleCacheDirty) {
+        persistStoredTitles(titleCache.current);
+      }
       // Pre-merge filter + sort just to decide which sessions need a title
       // fetch. The actual merge runs again inside `setSessions` so it sees
       // the latest `prev`.


### PR DESCRIPTION
Closes the SessionInfo `title` field gap. PR #114's history fixes capped the title N+1 at 10/refresh but didn't eliminate it. Server already returns the title in `session/list`, but `SessionInfo` had no field for it so the SPA fetched messages anyway. Empirical mini5 verification: 107 → 69 WS frames on /chat boot, zero `messages_page` calls.

🤖 Generated with [Claude Code](https://claude.com/claude-code)