### PR TITLE
fix(composer): release send-lock after bridge handoff, not turn completion

### DIFF
--- a/src/components/chat-thread.tsx
+++ b/src/components/chat-thread.tsx
@@ -1287,10 +1287,15 @@ function Composer({ mountGhost, unmountGhost }: ComposerProps) {
           skipOptimisticUserMessage: true,
           onSessionActive: (firstMsg) => markSessionActive(firstMsg),
           onComplete: () => {
-            releaseSending();
             refreshSessions();
           },
         });
+        // Release synchronously after the bridge has the request:
+        // `bridgeSend` is fire-and-forget and `ui-protocol-send.ts`
+        // already serializes via a per-session FIFO. Holding `sending`
+        // until `onComplete` (turn/completed) locked the composer for
+        // the whole turn — see issue #112.3 follow-up.
+        releaseSending();
       };
       mountGhost({
         clientMessageId: cmid,
@@ -1321,10 +1326,17 @@ function Composer({ mountGhost, unmountGhost }: ComposerProps) {
       skipOptimisticUserMessage: ghostMounted,
       onSessionActive: (firstMsg) => markSessionActive(firstMsg),
       onComplete: () => {
-        releaseSending();
         refreshSessions();
       },
     });
+    // Release synchronously after the bridge has the request. The
+    // per-session FIFO at `ui-protocol-send.ts:163-291` serializes
+    // turn/start RPCs, so the composer can accept a follow-up while
+    // the prior turn is still in flight — the bridge queues it. The
+    // ~10ms double-tap guard #112.3 intended remains via `sendingRef`
+    // being set before `bridgeSend`. Holding it past handoff was
+    // overscoped — see issue #112.3 follow-up.
+    releaseSending();
 
     setText("");
   }, [


### PR DESCRIPTION
## Summary

Closes the UX regression where typing/sending a follow-up message was blocked while the previous turn was still in flight.

Root cause: issue #112.3 added a `sendingRef` double-tap guard but tied `releaseSending()` to `onComplete` (fires on `turn/completed`/`turn/error`). Result: composer locked for the whole turn lifetime, not the ~10ms upload+RPC-ack window the guard was meant to cover.

## Fix

2 sites in `src/components/chat-thread.tsx` (Composer.handleSend): move `releaseSending()` out of `onComplete` and call it synchronously after `bridgeSend(...)` returns. The per-session FIFO at `src/runtime/ui-protocol-send.ts:163-291` already serializes `turn/start` RPCs end-to-end, so the local lock past bridge handoff was redundant.

Double-tap guard semantics preserved: `sendingRef` is set synchronously before `bridgeSend`, so a same-tick second Enter still sees `sendingRef.current === true` and bails. The bridge's own dedup (server rejects concurrent `turn/start` for the same session) is the second line of defense.

## Diagnostic credit

Confirmed via read-only investigation agent: server is single-turn-per-session (octos `ui_protocol.rs:4482-4518`), client bridge has per-session FIFO (`ui-protocol-send.ts:163-291`), commit `5ec021e` (#112) introduced the over-scoped lock today.

## Test plan

- [x] `tsc --noEmit` clean
- [ ] CI build
- [ ] Live smoke on mini5: send message, type follow-up while assistant streams, hit Enter, second message queues and fires on first `turn/completed`
- [ ] Double-Enter same-tick: only one `turn/start` fires
