### PR TITLE
fix(runtime): restore tool-progress / cost / message-meta DOM events

### DIFF
--- a/src/components/tool-progress-indicator.test.tsx
+++ b/src/components/tool-progress-indicator.test.tsx
@@ -1,0 +1,170 @@
+/**
+ * `ToolProgressIndicator` unit tests.
+ *
+ * PR fix/restore-progress-cost-meta-events regression A:
+ *
+ * After PR #96 deleted `src/runtime/sse-bridge.ts` (the sole dispatcher
+ * of `crew:tool_progress`), the streaming-bubble spinner stopped
+ * firing — the listener in this component was still bound but nobody
+ * fired the event. The fix lifts `tool/started`, `tool/progress`, and
+ * `tool/completed` UI Protocol v1 notifications onto the same DOM
+ * event via `ui-protocol-event-router.ts`.
+ *
+ * These tests exercise the component directly:
+ *   1. Dispatching a `crew:tool_progress` window event shows the
+ *      spinner row with the tool name + cleaned message.
+ *   2. A subsequent `crew:thinking { thinking: false }` clears the row.
+ *   3. Scope mismatch (different session id) does NOT show anything.
+ */
+
+import { afterEach, describe, expect, it } from "vitest";
+import * as React from "react";
+import { act } from "react";
+import { createRoot, type Root } from "react-dom/client";
+
+(globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT =
+  true;
+
+import { ToolProgressIndicator } from "./tool-progress-indicator";
+import { SessionContext } from "@/runtime/session-context";
+import type { SessionContextValue } from "@/runtime/session-context";
+
+const SESSION = "sess-tool-progress";
+
+interface MountedHarness {
+  container: HTMLDivElement;
+  root: Root;
+  unmount: () => void;
+}
+
+function makeSessionCtx(): SessionContextValue {
+  return {
+    sessions: [],
+    currentSessionId: SESSION,
+    historyTopic: undefined,
+    currentSessionTitle: "",
+    currentSessionStats: null,
+    initialMessages: [],
+    activeTaskOnServer: false,
+    queueMode: null,
+    adaptiveMode: null,
+    setServerTaskActive: () => {},
+    renameSession: () => {},
+    updateSessionStats: () => {},
+    switchSession: () => {},
+    goBack: async () => false,
+    createSession: () => SESSION,
+    removeSession: async () => {},
+    refreshSessions: async () => {},
+    markSessionActive: () => {},
+  };
+}
+
+function mount(node: React.ReactElement): MountedHarness {
+  const container = document.createElement("div");
+  document.body.appendChild(container);
+  const root = createRoot(container);
+  act(() => {
+    root.render(node);
+  });
+  return {
+    container,
+    root,
+    unmount: () => {
+      act(() => root.unmount());
+      container.remove();
+    },
+  };
+}
+
+afterEach(() => {
+  for (const node of [...document.body.children]) {
+    node.remove();
+  }
+});
+
+describe("ToolProgressIndicator", () => {
+  it("renders the spinner row when a scoped crew:tool_progress event fires", () => {
+    const ctx = makeSessionCtx();
+    const harness = mount(
+      <SessionContext.Provider value={ctx}>
+        <ToolProgressIndicator />
+      </SessionContext.Provider>,
+    );
+    expect(harness.container.querySelector("[data-testid='tool-progress']"))
+      .toBeNull();
+
+    act(() => {
+      window.dispatchEvent(
+        new CustomEvent("crew:tool_progress", {
+          detail: {
+            tool: "shell",
+            message: "[info] running cargo test",
+            sessionId: SESSION,
+          },
+        }),
+      );
+    });
+
+    const row = harness.container.querySelector("[data-testid='tool-progress']");
+    expect(row).not.toBeNull();
+    expect(row!.textContent).toContain("shell");
+    // The component strips `[info]/[debug]/[warn]` prefixes — we wrote
+    // `[info] running cargo test`, expect `running cargo test`.
+    expect(row!.textContent).toContain("running cargo test");
+    expect(row!.textContent).not.toContain("[info]");
+    harness.unmount();
+  });
+
+  it("clears the row when crew:thinking { thinking: false } fires", () => {
+    const ctx = makeSessionCtx();
+    const harness = mount(
+      <SessionContext.Provider value={ctx}>
+        <ToolProgressIndicator />
+      </SessionContext.Provider>,
+    );
+    act(() => {
+      window.dispatchEvent(
+        new CustomEvent("crew:tool_progress", {
+          detail: { tool: "shell", message: "running", sessionId: SESSION },
+        }),
+      );
+    });
+    expect(harness.container.querySelector("[data-testid='tool-progress']"))
+      .not.toBeNull();
+
+    act(() => {
+      window.dispatchEvent(
+        new CustomEvent("crew:thinking", {
+          detail: { thinking: false, sessionId: SESSION },
+        }),
+      );
+    });
+    expect(harness.container.querySelector("[data-testid='tool-progress']"))
+      .toBeNull();
+    harness.unmount();
+  });
+
+  it("ignores crew:tool_progress events scoped to a different session", () => {
+    const ctx = makeSessionCtx();
+    const harness = mount(
+      <SessionContext.Provider value={ctx}>
+        <ToolProgressIndicator />
+      </SessionContext.Provider>,
+    );
+    act(() => {
+      window.dispatchEvent(
+        new CustomEvent("crew:tool_progress", {
+          detail: {
+            tool: "shell",
+            message: "running",
+            sessionId: "some-other-session",
+          },
+        }),
+      );
+    });
+    expect(harness.container.querySelector("[data-testid='tool-progress']"))
+      .toBeNull();
+    harness.unmount();
+  });
+});

--- a/src/runtime/session-context.tsx
+++ b/src/runtime/session-context.tsx
@@ -141,7 +141,7 @@ export function useModeState() {
   return { queueMode, adaptiveMode };
 }
 
-interface SessionContextValue {
+export interface SessionContextValue {
   sessions: SessionWithTitle[];
   currentSessionId: string;
   historyTopic?: string;

--- a/src/runtime/ui-protocol-bridge.test.ts
+++ b/src/runtime/ui-protocol-bridge.test.ts
@@ -601,6 +601,77 @@ describe("type guards (fail-closed)", () => {
       guards.guardTurnError({ session_id: "s", turn_id: "t" }),
     ).toBeNull();
   });
+
+  // PR fix/restore-progress-cost-meta-events guards (regression A / B)
+  it("accepts a well-formed tool/started event", () => {
+    const ok = guards.guardToolStarted({
+      session_id: "s",
+      turn_id: "t",
+      tool_call_id: "tc-1",
+      tool_name: "shell",
+      arguments: { command: "ls" },
+    });
+    expect(ok?.tool_call_id).toBe("tc-1");
+    expect(ok?.tool_name).toBe("shell");
+  });
+
+  it("rejects tool/started missing tool_name", () => {
+    expect(
+      guards.guardToolStarted({
+        session_id: "s",
+        turn_id: "t",
+        tool_call_id: "tc-1",
+      }),
+    ).toBeNull();
+  });
+
+  it("accepts tool/progress with optional message + progress_pct", () => {
+    const ok = guards.guardToolProgress({
+      session_id: "s",
+      turn_id: "t",
+      tool_call_id: "tc-2",
+      message: "running",
+      progress_pct: 42,
+    });
+    expect(ok?.message).toBe("running");
+    expect(ok?.progress_pct).toBe(42);
+  });
+
+  it("accepts tool/completed and lifts success + duration_ms", () => {
+    const ok = guards.guardToolCompleted({
+      session_id: "s",
+      turn_id: "t",
+      tool_call_id: "tc-3",
+      tool_name: "shell",
+      success: true,
+      duration_ms: 1250,
+    });
+    expect(ok?.success).toBe(true);
+    expect(ok?.duration_ms).toBe(1250);
+  });
+
+  it("accepts progress/updated and lifts token_cost.input_tokens", () => {
+    const ok = guards.guardProgressUpdated({
+      session_id: "s",
+      turn_id: "t",
+      metadata: {
+        kind: "token_cost_update",
+        token_cost: { input_tokens: 100, output_tokens: 20, session_cost: 0.01 },
+      },
+    });
+    expect(ok?.metadata.kind).toBe("token_cost_update");
+    expect(ok?.metadata.token_cost?.input_tokens).toBe(100);
+    expect(ok?.metadata.token_cost?.session_cost).toBe(0.01);
+  });
+
+  it("rejects progress/updated missing metadata.kind", () => {
+    expect(
+      guards.guardProgressUpdated({
+        session_id: "s",
+        metadata: { token_cost: { input_tokens: 100 } },
+      }),
+    ).toBeNull();
+  });
 });
 
 // ---------------------------------------------------------------------------
@@ -1192,6 +1263,71 @@ describe("notification dispatch", () => {
     expect(
       warnings.some((w) => w.reason === "invalid_event:turn/spawn_complete"),
     ).toBe(true);
+  });
+
+  it("routes tool/started, tool/progress, tool/completed, progress/updated through the new subscribers", async () => {
+    // PR fix/restore-progress-cost-meta-events: end-to-end bridge dispatch
+    // test for the four notification methods restored after the SSE
+    // bridge deletion in PR #96.
+    const { bridge, ws } = await freshConnected();
+    const started: unknown[] = [];
+    const progressed: unknown[] = [];
+    const completed: unknown[] = [];
+    const updates: unknown[] = [];
+    bridge.onToolStarted((e) => started.push(e));
+    bridge.onToolProgress((e) => progressed.push(e));
+    bridge.onToolCompleted((e) => completed.push(e));
+    bridge.onProgressUpdated((e) => updates.push(e));
+
+    ws.triggerMessage({
+      jsonrpc: "2.0",
+      method: METHODS.TOOL_STARTED,
+      params: {
+        session_id: "sess-1",
+        turn_id: "t1",
+        tool_call_id: "tc-1",
+        tool_name: "shell",
+      },
+    });
+    ws.triggerMessage({
+      jsonrpc: "2.0",
+      method: METHODS.TOOL_PROGRESS,
+      params: {
+        session_id: "sess-1",
+        turn_id: "t1",
+        tool_call_id: "tc-1",
+        message: "running",
+      },
+    });
+    ws.triggerMessage({
+      jsonrpc: "2.0",
+      method: METHODS.TOOL_COMPLETED,
+      params: {
+        session_id: "sess-1",
+        turn_id: "t1",
+        tool_call_id: "tc-1",
+        tool_name: "shell",
+        success: true,
+        duration_ms: 100,
+      },
+    });
+    ws.triggerMessage({
+      jsonrpc: "2.0",
+      method: METHODS.PROGRESS_UPDATED,
+      params: {
+        session_id: "sess-1",
+        turn_id: "t1",
+        metadata: {
+          kind: "token_cost_update",
+          label: "moonshot@autodl/kimi-k2.5",
+          token_cost: { input_tokens: 1, output_tokens: 2, session_cost: 0.001 },
+        },
+      },
+    });
+    expect(started).toHaveLength(1);
+    expect(progressed).toHaveLength(1);
+    expect(completed).toHaveLength(1);
+    expect(updates).toHaveLength(1);
   });
 
   it("routes turn lifecycle and approval/requested", async () => {

--- a/src/runtime/ui-protocol-bridge.ts
+++ b/src/runtime/ui-protocol-bridge.ts
@@ -28,11 +28,15 @@ import type {
   HydratedMessage,
   MessageDeltaEvent,
   MessagePersistedEvent,
+  ProgressUpdatedEvent,
   RpcErrorPayload,
   SessionHydrateResult,
   SessionOpenResult,
   TaskOutputDeltaEvent,
   TaskUpdatedEvent,
+  ToolCompletedEvent,
+  ToolProgressEvent,
+  ToolStartedEvent,
   TurnCompletedEvent,
   TurnErrorEvent,
   TurnInterruptResult,
@@ -41,6 +45,10 @@ import type {
   TurnStartInput,
   TurnStartResult,
   TurnStartedEvent,
+  UiProgressMetadata,
+  UiRetryBackoff,
+  UiTokenCostUpdate,
+  UiFileMutationNotice,
   WarningEvent,
 } from "./ui-protocol-types";
 
@@ -55,11 +63,15 @@ export type {
   MessagePersistedEvent,
   PersistedMessage,
   PersistedMessageFile,
+  ProgressUpdatedEvent,
   SessionHydrateResult,
   SessionOpenResult,
   SessionOpenedResult,
   TaskOutputDeltaEvent,
   TaskUpdatedEvent,
+  ToolCompletedEvent,
+  ToolProgressEvent,
+  ToolStartedEvent,
   TurnCompletedEvent,
   TurnErrorEvent,
   TurnInterruptResult,
@@ -70,6 +82,10 @@ export type {
   TurnStartResult,
   TurnStartedEvent,
   UiCursor,
+  UiFileMutationNotice,
+  UiProgressMetadata,
+  UiRetryBackoff,
+  UiTokenCostUpdate,
   WarningEvent,
 } from "./ui-protocol-types";
 
@@ -118,6 +134,22 @@ export const METHODS = {
   TURN_SPAWN_COMPLETE: "turn/spawn_complete",
   APPROVAL_REQUESTED: "approval/requested",
   WARNING: "warning",
+  // Synchronous tool-call lifecycle. Server emits these as
+  // `UiNotification::ToolStarted/Progress/Completed` for non-spawn tool
+  // calls. The event-router fans them out into the legacy
+  // `crew:tool_progress` DOM event so the streaming-bubble spinner
+  // (`ToolProgressIndicator`) lights up — the SSE bridge predecessor of
+  // this surface was the sole dispatcher prior to PR #96. See
+  // `crates/octos-cli/src/api/ui_protocol_progress.rs:99-363`.
+  TOOL_STARTED: "tool/started",
+  TOOL_PROGRESS: "tool/progress",
+  TOOL_COMPLETED: "tool/completed",
+  /// Generic progress envelope — server uses this for cost / status /
+  /// retry / file-mutation frames. The event-router fans `kind ===
+  /// "token_cost_update"` notifications out into `crew:cost` (header
+  /// model + cost badge) and, when model + duration are populated, also
+  /// `crew:message_meta` (assistant bubble footer).
+  PROGRESS_UPDATED: "progress/updated",
   // M12 Phase D-3 (octos-web #106 review follow-up): server emits
   // `session/title-updated` after a successful `session/title.set` so
   // cross-tab / auto-title flows can refresh their cache without polling
@@ -310,6 +342,19 @@ export interface UiProtocolBridge {
     ) => void,
   ): () => void;
   onApprovalRequested(handler: (e: ApprovalRequestedEvent) => void): () => void;
+  /** Synchronous tool-call lifecycle event surface. The event-router
+   *  attaches a handler that re-emits each variant as a
+   *  `crew:tool_progress` DOM event so the streaming-bubble spinner keeps
+   *  firing post-PR-#96 SSE-bridge deletion. */
+  onToolStarted(handler: (e: ToolStartedEvent) => void): () => void;
+  onToolProgress(handler: (e: ToolProgressEvent) => void): () => void;
+  onToolCompleted(handler: (e: ToolCompletedEvent) => void): () => void;
+  /** Generic progress envelope subscriber. The event-router fans
+   *  `metadata.kind === "token_cost_update"` notifications out into the
+   *  legacy `crew:cost` and (model + duration permitting) `crew:message_meta`
+   *  DOM events so the header cost badge and assistant-bubble footer
+   *  keep firing post-PR-#96 SSE-bridge deletion. */
+  onProgressUpdated(handler: (e: ProgressUpdatedEvent) => void): () => void;
   onConnectionStateChange(handler: (state: ConnectionState) => void): () => void;
   /** Codex BLOCK F: synchronous read of the bridge's current
    *  connection state. The `onConnectionStateChange` listener fires on
@@ -835,6 +880,162 @@ function guardWarning(p: unknown): WarningEvent | null {
   return { reason: p.reason, context: p.context };
 }
 
+function guardToolStarted(p: unknown): ToolStartedEvent | null {
+  if (!isPlainObject(p)) return null;
+  if (
+    !isString(p.session_id) ||
+    !isString(p.turn_id) ||
+    !isString(p.tool_call_id) ||
+    !isString(p.tool_name)
+  ) {
+    return null;
+  }
+  return {
+    session_id: p.session_id,
+    turn_id: p.turn_id,
+    tool_call_id: p.tool_call_id,
+    tool_name: p.tool_name,
+    arguments: p.arguments,
+  };
+}
+
+function guardToolProgress(p: unknown): ToolProgressEvent | null {
+  if (!isPlainObject(p)) return null;
+  if (
+    !isString(p.session_id) ||
+    !isString(p.turn_id) ||
+    !isString(p.tool_call_id)
+  ) {
+    return null;
+  }
+  return {
+    session_id: p.session_id,
+    turn_id: p.turn_id,
+    tool_call_id: p.tool_call_id,
+    message: typeof p.message === "string" ? p.message : undefined,
+    progress_pct:
+      typeof p.progress_pct === "number" && Number.isFinite(p.progress_pct)
+        ? p.progress_pct
+        : undefined,
+  };
+}
+
+function guardToolCompleted(p: unknown): ToolCompletedEvent | null {
+  if (!isPlainObject(p)) return null;
+  if (
+    !isString(p.session_id) ||
+    !isString(p.turn_id) ||
+    !isString(p.tool_call_id) ||
+    !isString(p.tool_name)
+  ) {
+    return null;
+  }
+  return {
+    session_id: p.session_id,
+    turn_id: p.turn_id,
+    tool_call_id: p.tool_call_id,
+    tool_name: p.tool_name,
+    success: typeof p.success === "boolean" ? p.success : undefined,
+    output_preview:
+      typeof p.output_preview === "string" ? p.output_preview : undefined,
+    duration_ms:
+      typeof p.duration_ms === "number" && Number.isFinite(p.duration_ms)
+        ? p.duration_ms
+        : undefined,
+  };
+}
+
+function guardUiTokenCost(p: unknown): UiTokenCostUpdate | undefined {
+  if (!isPlainObject(p)) return undefined;
+  const out: UiTokenCostUpdate = {};
+  if (typeof p.input_tokens === "number") out.input_tokens = p.input_tokens;
+  if (typeof p.output_tokens === "number") out.output_tokens = p.output_tokens;
+  if (typeof p.reasoning_tokens === "number")
+    out.reasoning_tokens = p.reasoning_tokens;
+  if (typeof p.cache_read_tokens === "number")
+    out.cache_read_tokens = p.cache_read_tokens;
+  if (typeof p.cache_write_tokens === "number")
+    out.cache_write_tokens = p.cache_write_tokens;
+  if (typeof p.total_tokens === "number") out.total_tokens = p.total_tokens;
+  if (typeof p.response_cost === "number") out.response_cost = p.response_cost;
+  if (typeof p.session_cost === "number") out.session_cost = p.session_cost;
+  if (typeof p.currency === "string") out.currency = p.currency;
+  return out;
+}
+
+function guardUiRetryBackoff(p: unknown): UiRetryBackoff | undefined {
+  if (!isPlainObject(p)) return undefined;
+  const out: UiRetryBackoff = {};
+  if (typeof p.attempt === "number") out.attempt = p.attempt;
+  if (typeof p.max_attempts === "number") out.max_attempts = p.max_attempts;
+  if (typeof p.backoff_ms === "number") out.backoff_ms = p.backoff_ms;
+  if (typeof p.reason === "string") out.reason = p.reason;
+  if (typeof p.provider === "string") out.provider = p.provider;
+  if (typeof p.next_provider === "string") out.next_provider = p.next_provider;
+  return out;
+}
+
+function guardUiFileMutationNotice(
+  p: unknown,
+): UiFileMutationNotice | undefined {
+  if (!isPlainObject(p)) return undefined;
+  if (!isString(p.path) || !isString(p.operation)) return undefined;
+  const out: UiFileMutationNotice = {
+    path: p.path,
+    operation: p.operation,
+  };
+  if (typeof p.tool_call_id === "string") out.tool_call_id = p.tool_call_id;
+  if (typeof p.bytes_written === "number") out.bytes_written = p.bytes_written;
+  return out;
+}
+
+function guardProgressUpdated(p: unknown): ProgressUpdatedEvent | null {
+  if (!isPlainObject(p)) return null;
+  if (!isString(p.session_id)) return null;
+  if (!isPlainObject(p.metadata)) return null;
+  const m = p.metadata;
+  if (!isString(m.kind)) return null;
+  const metadata: UiProgressMetadata = {
+    kind: m.kind,
+  };
+  if (typeof m.label === "string") metadata.label = m.label;
+  if (typeof m.message === "string") metadata.message = m.message;
+  if (typeof m.detail === "string") metadata.detail = m.detail;
+  if (typeof m.iteration === "number") metadata.iteration = m.iteration;
+  if (typeof m.progress_pct === "number") metadata.progress_pct = m.progress_pct;
+  const retry = guardUiRetryBackoff(m.retry);
+  if (retry) metadata.retry = retry;
+  const fileMutation = guardUiFileMutationNotice(m.file_mutation);
+  if (fileMutation) metadata.file_mutation = fileMutation;
+  const tokenCost = guardUiTokenCost(m.token_cost);
+  if (tokenCost) metadata.token_cost = tokenCost;
+  // Pass through any unknown `extra` fields verbatim so a server-side
+  // schema extension doesn't trip the fail-closed reject path. Skips the
+  // known keys we already lifted above.
+  const known = new Set([
+    "kind",
+    "label",
+    "message",
+    "detail",
+    "iteration",
+    "progress_pct",
+    "retry",
+    "file_mutation",
+    "token_cost",
+  ]);
+  for (const key of Object.keys(m)) {
+    if (!known.has(key)) metadata[key] = m[key];
+  }
+  return {
+    session_id: p.session_id,
+    turn_id:
+      typeof p.turn_id === "string" && p.turn_id.length > 0
+        ? p.turn_id
+        : undefined,
+    metadata,
+  };
+}
+
 /** Minimal guard for `session/title-updated`.
  *
  *  The server's ADR-defined payload is
@@ -928,6 +1129,10 @@ class UiProtocolBridgeImpl implements UiProtocolBridge {
     TurnStartedEvent | TurnCompletedEvent | TurnErrorEvent
   >();
   private readonly subApprovalRequested = new Subscribers<ApprovalRequestedEvent>();
+  private readonly subToolStarted = new Subscribers<ToolStartedEvent>();
+  private readonly subToolProgress = new Subscribers<ToolProgressEvent>();
+  private readonly subToolCompleted = new Subscribers<ToolCompletedEvent>();
+  private readonly subProgressUpdated = new Subscribers<ProgressUpdatedEvent>();
   private readonly subWarning = new Subscribers<WarningEvent>();
   private readonly subState = new Subscribers<ConnectionState>();
   private readonly subSessionTitleUpdated = new Subscribers<{
@@ -977,6 +1182,22 @@ class UiProtocolBridgeImpl implements UiProtocolBridge {
     [METHODS.APPROVAL_REQUESTED]: {
       guard: guardApprovalRequested,
       emit: (v) => this.subApprovalRequested.emit(v as ApprovalRequestedEvent),
+    },
+    [METHODS.TOOL_STARTED]: {
+      guard: guardToolStarted,
+      emit: (v) => this.subToolStarted.emit(v as ToolStartedEvent),
+    },
+    [METHODS.TOOL_PROGRESS]: {
+      guard: guardToolProgress,
+      emit: (v) => this.subToolProgress.emit(v as ToolProgressEvent),
+    },
+    [METHODS.TOOL_COMPLETED]: {
+      guard: guardToolCompleted,
+      emit: (v) => this.subToolCompleted.emit(v as ToolCompletedEvent),
+    },
+    [METHODS.PROGRESS_UPDATED]: {
+      guard: guardProgressUpdated,
+      emit: (v) => this.subProgressUpdated.emit(v as ProgressUpdatedEvent),
     },
     [METHODS.WARNING]: {
       guard: guardWarning,
@@ -1079,6 +1300,10 @@ class UiProtocolBridgeImpl implements UiProtocolBridge {
     this.subTaskOutputDelta.clear();
     this.subTurnLifecycle.clear();
     this.subApprovalRequested.clear();
+    this.subToolStarted.clear();
+    this.subToolProgress.clear();
+    this.subToolCompleted.clear();
+    this.subProgressUpdated.clear();
     this.subWarning.clear();
     this.subState.clear();
     this.subSessionTitleUpdated.clear();
@@ -1218,6 +1443,18 @@ class UiProtocolBridgeImpl implements UiProtocolBridge {
   }
   onApprovalRequested(handler: Listener<ApprovalRequestedEvent>): () => void {
     return this.subApprovalRequested.add(handler);
+  }
+  onToolStarted(handler: Listener<ToolStartedEvent>): () => void {
+    return this.subToolStarted.add(handler);
+  }
+  onToolProgress(handler: Listener<ToolProgressEvent>): () => void {
+    return this.subToolProgress.add(handler);
+  }
+  onToolCompleted(handler: Listener<ToolCompletedEvent>): () => void {
+    return this.subToolCompleted.add(handler);
+  }
+  onProgressUpdated(handler: Listener<ProgressUpdatedEvent>): () => void {
+    return this.subProgressUpdated.add(handler);
   }
   onConnectionStateChange(handler: Listener<ConnectionState>): () => void {
     return this.subState.add(handler);
@@ -1820,5 +2057,9 @@ export const __INTERNAL_GUARDS_FOR_TEST__ = {
   guardTurnCompleted,
   guardTurnError,
   guardApprovalRequested,
+  guardToolStarted,
+  guardToolProgress,
+  guardToolCompleted,
+  guardProgressUpdated,
   guardWarning,
 };

--- a/src/runtime/ui-protocol-event-router.test.ts
+++ b/src/runtime/ui-protocol-event-router.test.ts
@@ -1392,7 +1392,9 @@ describe("regression C: turn/completed stamps per-turn meta snapshot onto the fi
       { sessionId: SESSION },
       { session_id: SESSION, turn_id: "cmid-C1" },
     );
-    // A cost frame mid-turn populates the snapshot.
+    // TWO cost frames so we get a real delta (the first frame just
+    // sets the baseline per codex round-3 P2 — see the multi-frame
+    // turn test below for the rationale).
     handleProgressUpdated(
       { sessionId: SESSION },
       {
@@ -1401,7 +1403,19 @@ describe("regression C: turn/completed stamps per-turn meta snapshot onto the fi
         metadata: {
           kind: "token_cost_update",
           label: "moonshot@autodl/kimi-k2.5",
-          token_cost: { input_tokens: 100, output_tokens: 20 },
+          token_cost: { input_tokens: 50, output_tokens: 5 },
+        },
+      },
+    );
+    handleProgressUpdated(
+      { sessionId: SESSION },
+      {
+        session_id: SESSION,
+        turn_id: "cmid-C1",
+        metadata: {
+          kind: "token_cost_update",
+          label: "moonshot@autodl/kimi-k2.5",
+          token_cost: { input_tokens: 150, output_tokens: 25 },
         },
       },
     );
@@ -1414,19 +1428,30 @@ describe("regression C: turn/completed stamps per-turn meta snapshot onto the fi
     const meta = thread.responses[0].meta;
     expect(meta).toBeDefined();
     expect(meta!.model).toBe("moonshot@autodl/kimi-k2.5");
-    expect(meta!.tokens_in).toBe(100);
-    expect(meta!.tokens_out).toBe(20);
+    expect(meta!.tokens_in).toBe(100); // 150 - 50 baseline
+    expect(meta!.tokens_out).toBe(20); // 25 - 5 baseline
     // duration_s is computed from `nowMs() - firstSeenAtMs`; under
     // synchronous test execution it should be a tiny non-negative
     // number. Asserting `>= 0` keeps the test stable across hosts.
     expect(meta!.duration_s).toBeGreaterThanOrEqual(0);
   });
 
-  it("codex round-2 P2: per-turn meta tokens are the DELTA, not session cumulative totals", () => {
-    // Wire ordering: turn-1 emits one cost frame; turn-2 emits another
-    // whose `input_tokens` / `output_tokens` reflect the
-    // session-cumulative growth. The finalised bubble for turn-2 must
-    // show DELTA tokens (turn-2 alone), not session totals.
+  it("codex round-2 + 3 P2: per-turn meta tokens are the DELTA, not session cumulative totals", () => {
+    // Wire ordering: turn-1 emits one cost frame, then turn-2's
+    // frame whose `input_tokens` / `output_tokens` reflect
+    // session-cumulative growth across both turns. The finalised
+    // bubble for turn-2 must show the DELTA (turn-2 alone), not the
+    // session-total.
+    //
+    // Codex round-3 P2 follow-up: the FIRST turn after a fresh
+    // session/restore has no baseline yet, so the snapshot self-seeds
+    // from the first observed cumulative — turn-1's footer shows
+    // tokens_in/out=0 (delta against itself). This is the conservative
+    // fallback for the restored-session case the codex review flagged;
+    // a fresh session does the same thing because the runtime can't
+    // distinguish the two. The PR description explains the trade-off
+    // and links a follow-up issue for a per-turn rather than
+    // cumulative counter on the server surface.
     seedThread("cmid-T1", "first ask");
     ThreadStore.appendAssistantToken("cmid-T1", "first reply");
     handleTurnStarted(
@@ -1449,11 +1474,13 @@ describe("regression C: turn/completed stamps per-turn meta snapshot onto the fi
       { sessionId: SESSION },
       { session_id: SESSION, turn_id: "cmid-T1", reason: "stop" },
     );
+    // Turn-1: cumulative=(100,20), baseline self-seeded to (100,20),
+    // delta=(0,0). Footer text effectively omits tokens.
     let [thread] = ThreadStore.getThreads(SESSION);
-    expect(thread.responses[0].meta?.tokens_in).toBe(100);
-    expect(thread.responses[0].meta?.tokens_out).toBe(20);
+    expect(thread.responses[0].meta?.tokens_in).toBe(0);
+    expect(thread.responses[0].meta?.tokens_out).toBe(0);
 
-    // Turn 2: cumulative is 250 / 60. Per-turn delta is 150 / 40.
+    // Turn 2: cumulative is (250, 60); per-turn delta is (150, 40).
     seedThread("cmid-T2", "second ask");
     ThreadStore.appendAssistantToken("cmid-T2", "second reply");
     handleTurnStarted(
@@ -1484,6 +1511,52 @@ describe("regression C: turn/completed stamps per-turn meta snapshot onto the fi
     expect(turn2.meta?.tokens_out).toBe(40); // 60 - 20 baseline
   });
 
+  it("codex round-3 P2: multi-frame turn within a session computes delta against baseline correctly", () => {
+    // Within a single turn, multiple `progress/updated` frames carry
+    // the same cumulative growing across the turn. The DELTA should
+    // always be against the per-session baseline, not the first frame
+    // we saw this turn.
+    seedThread("cmid-multi", "ask");
+    ThreadStore.appendAssistantToken("cmid-multi", "reply");
+    handleTurnStarted(
+      { sessionId: SESSION },
+      { session_id: SESSION, turn_id: "cmid-multi" },
+    );
+    // Two frames in this turn — first sets the baseline self-seed,
+    // second should derive a non-zero delta against that baseline.
+    handleProgressUpdated(
+      { sessionId: SESSION },
+      {
+        session_id: SESSION,
+        turn_id: "cmid-multi",
+        metadata: {
+          kind: "token_cost_update",
+          label: "test",
+          token_cost: { input_tokens: 1000, output_tokens: 100 },
+        },
+      },
+    );
+    handleProgressUpdated(
+      { sessionId: SESSION },
+      {
+        session_id: SESSION,
+        turn_id: "cmid-multi",
+        metadata: {
+          kind: "token_cost_update",
+          label: "test",
+          token_cost: { input_tokens: 1050, output_tokens: 130 },
+        },
+      },
+    );
+    handleTurnCompleted(
+      { sessionId: SESSION },
+      { session_id: SESSION, turn_id: "cmid-multi", reason: "stop" },
+    );
+    const [thread] = ThreadStore.getThreads(SESSION);
+    expect(thread.responses[0].meta?.tokens_in).toBe(50); // 1050 - 1000
+    expect(thread.responses[0].meta?.tokens_out).toBe(30); // 130 - 100
+  });
+
   it("turn/completed without any cost snapshot still finalises the bubble (no meta)", () => {
     seedThread("cmid-C2", "ask");
     ThreadStore.appendAssistantToken("cmid-C2", "Hello.");
@@ -1509,6 +1582,8 @@ describe("regression C: turn/completed stamps per-turn meta snapshot onto the fi
       { sessionId: SESSION },
       { session_id: SESSION, turn_id: cmid },
     );
+    // TWO frames (codex round-3 P2: first frame seeds baseline, second
+    // gives the real delta).
     handleProgressUpdated(
       { sessionId: SESSION },
       {
@@ -1517,7 +1592,19 @@ describe("regression C: turn/completed stamps per-turn meta snapshot onto the fi
         metadata: {
           kind: "token_cost_update",
           label: "moonshot@autodl/kimi-k2.5",
-          token_cost: { input_tokens: 9000, output_tokens: 300 },
+          token_cost: { input_tokens: 4000, output_tokens: 100 },
+        },
+      },
+    );
+    handleProgressUpdated(
+      { sessionId: SESSION },
+      {
+        session_id: SESSION,
+        turn_id: cmid,
+        metadata: {
+          kind: "token_cost_update",
+          label: "moonshot@autodl/kimi-k2.5",
+          token_cost: { input_tokens: 13000, output_tokens: 400 },
         },
       },
     );
@@ -1554,8 +1641,94 @@ describe("regression C: turn/completed stamps per-turn meta snapshot onto the fi
     );
     const [thread] = ThreadStore.getThreads(SESSION);
     expect(thread.responses[0].meta?.model).toBe("moonshot@autodl/kimi-k2.5");
-    expect(thread.responses[0].meta?.tokens_in).toBe(9000);
-    expect(thread.responses[0].meta?.tokens_out).toBe(300);
+    expect(thread.responses[0].meta?.tokens_in).toBe(9000); // 13000 - 4000
+    expect(thread.responses[0].meta?.tokens_out).toBe(300); // 400 - 100
+  });
+
+  it("codex round-3 P2: patchLastResponseMeta targets the assistant row, not a tool/media tail", () => {
+    // After `message/persisted` promotes the text assistant, a
+    // subsequent tool result or media companion can land as the new
+    // tail of `responses`. The naive tail-stamp would put the meta
+    // on the wrong row and leave the visible answer blank. The fix
+    // walks the responses tail-to-head looking for an assistant row.
+    const cmid = "cmid-Ptail";
+    seedThread(cmid, "ask");
+    handleTurnStarted(
+      { sessionId: SESSION },
+      { session_id: SESSION, turn_id: cmid },
+    );
+    handleProgressUpdated(
+      { sessionId: SESSION },
+      {
+        session_id: SESSION,
+        turn_id: cmid,
+        metadata: {
+          kind: "token_cost_update",
+          label: "claude",
+          token_cost: { input_tokens: 50, output_tokens: 10 },
+        },
+      },
+    );
+    handleProgressUpdated(
+      { sessionId: SESSION },
+      {
+        session_id: SESSION,
+        turn_id: cmid,
+        metadata: {
+          kind: "token_cost_update",
+          label: "claude",
+          token_cost: { input_tokens: 120, output_tokens: 25 },
+        },
+      },
+    );
+    handleMessageDelta(
+      { sessionId: SESSION },
+      { session_id: SESSION, turn_id: cmid, text: "answer text" },
+    );
+    handleMessagePersisted(
+      { sessionId: SESSION },
+      {
+        session_id: SESSION,
+        turn_id: cmid,
+        thread_id: cmid,
+        seq: 50,
+        role: "assistant",
+        message_id: "msg-assistant",
+        source: "assistant",
+        cursor: { stream: SESSION, seq: 50 },
+        persisted_at: "2026-05-04T00:00:00Z",
+      },
+    );
+    // Inject a tool row after the assistant promotion. The tail of
+    // responses is now this tool row, NOT the assistant answer.
+    ThreadStore.appendPersistedMessage(SESSION, undefined, {
+      role: "tool",
+      content: "tool output",
+      thread_id: cmid,
+      timestamp: "2026-05-04T00:00:01Z",
+      seq: 51,
+    });
+    const beforeCompleted = ThreadStore.getThreads(SESSION)[0];
+    // The assistant row is responses[0]; some tool row is responses[1].
+    expect(beforeCompleted.responses.length).toBeGreaterThanOrEqual(2);
+    const tailRoleBefore =
+      beforeCompleted.responses[beforeCompleted.responses.length - 1].role;
+    expect(tailRoleBefore).toBe("tool");
+
+    handleTurnCompleted(
+      { sessionId: SESSION },
+      { session_id: SESSION, turn_id: cmid, reason: "stop" },
+    );
+    const [thread] = ThreadStore.getThreads(SESSION);
+    // Find the assistant response by role — that's the one that
+    // should now carry the meta.
+    const assistant = thread.responses.find((r) => r.role === "assistant");
+    expect(assistant).toBeDefined();
+    expect(assistant!.meta?.model).toBe("claude");
+    expect(assistant!.meta?.tokens_in).toBe(70); // 120 - 50 baseline
+    // The tool row must NOT have been stamped.
+    const tool = thread.responses.find((r) => r.role === "tool");
+    expect(tool?.meta).toBeUndefined();
   });
 
   it("turn/error also stamps the snapshot so the bubble's meta survives errored turns", () => {

--- a/src/runtime/ui-protocol-event-router.test.ts
+++ b/src/runtime/ui-protocol-event-router.test.ts
@@ -1645,6 +1645,54 @@ describe("regression C: turn/completed stamps per-turn meta snapshot onto the fi
     expect(thread.responses[0].meta?.tokens_out).toBe(300); // 400 - 100
   });
 
+  it("codex round-4 P2: counter baselines seed independently per-counter", () => {
+    // Frame 1 carries only output_tokens. Round-3 self-seed pinned
+    // inputTokens baseline to 0; a later frame's first input_tokens
+    // value of 9000 was then attributed in full to this turn. Round-4
+    // fix: each counter seeds INDEPENDENTLY when first observed.
+    seedThread("cmid-RT4", "ask");
+    handleTurnStarted(
+      { sessionId: SESSION },
+      { session_id: SESSION, turn_id: "cmid-RT4" },
+    );
+    // Frame 1: output_tokens only.
+    handleProgressUpdated(
+      { sessionId: SESSION },
+      {
+        session_id: SESSION,
+        turn_id: "cmid-RT4",
+        metadata: {
+          kind: "token_cost_update",
+          label: "test",
+          token_cost: { output_tokens: 80 },
+        },
+      },
+    );
+    // Frame 2: introduces input_tokens for the first time. Its
+    // baseline must self-seed here (not be pinned to 0 by frame 1).
+    handleProgressUpdated(
+      { sessionId: SESSION },
+      {
+        session_id: SESSION,
+        turn_id: "cmid-RT4",
+        metadata: {
+          kind: "token_cost_update",
+          label: "test",
+          token_cost: { input_tokens: 9000, output_tokens: 90 },
+        },
+      },
+    );
+    handleTurnCompleted(
+      { sessionId: SESSION },
+      { session_id: SESSION, turn_id: "cmid-RT4", reason: "stop" },
+    );
+    const [thread] = ThreadStore.getThreads(SESSION);
+    // tokens_in must be 0 (frame 2 = self-seed baseline for input),
+    // NOT 9000 (the historical cumulative).
+    expect(thread.responses[0].meta?.tokens_in).toBe(0);
+    expect(thread.responses[0].meta?.tokens_out).toBe(10); // 90 - 80
+  });
+
   it("codex round-3 P2: patchLastResponseMeta targets the assistant row, not a tool/media tail", () => {
     // After `message/persisted` promotes the text assistant, a
     // subsequent tool result or media companion can land as the new

--- a/src/runtime/ui-protocol-event-router.test.ts
+++ b/src/runtime/ui-protocol-event-router.test.ts
@@ -15,13 +15,18 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 import * as ThreadStore from "@/store/thread-store";
 import {
   __resetRouterStateForTest,
+  __resetTurnMetaForTest,
   attachRouter,
   handleApprovalRequested,
   handleMessageDelta,
   handleMessagePersisted,
+  handleProgressUpdated,
   handleSpawnComplete,
   handleTaskOutputDelta,
   handleTaskUpdated,
+  handleToolCompleted,
+  handleToolProgress,
+  handleToolStarted,
   handleTurnCompleted,
   handleTurnError,
   handleTurnStarted,
@@ -30,8 +35,12 @@ import type {
   ApprovalRequestedEvent,
   MessageDeltaEvent,
   MessagePersistedEvent,
+  ProgressUpdatedEvent,
   TaskOutputDeltaEvent,
   TaskUpdatedEvent,
+  ToolCompletedEvent,
+  ToolProgressEvent,
+  ToolStartedEvent,
   TurnCompletedEvent,
   TurnErrorEvent,
   TurnSpawnCompleteEvent,
@@ -51,6 +60,7 @@ function seedThread(cmid: string, text = "hi") {
 afterEach(() => {
   ThreadStore.__resetForTests();
   __resetRouterStateForTest();
+  __resetTurnMetaForTest();
 });
 
 describe("router event mapping", () => {
@@ -963,6 +973,10 @@ class FakeBridge implements UiProtocolBridge {
     e: TurnStartedEvent | TurnCompletedEvent | TurnErrorEvent,
   ) => void;
   emitApprovalRequested?: (e: ApprovalRequestedEvent) => void;
+  emitToolStarted?: (e: ToolStartedEvent) => void;
+  emitToolProgress?: (e: ToolProgressEvent) => void;
+  emitToolCompleted?: (e: ToolCompletedEvent) => void;
+  emitProgressUpdated?: (e: ProgressUpdatedEvent) => void;
 
   start = vi.fn(async () => {});
   stop = vi.fn(async () => {});
@@ -973,6 +987,8 @@ class FakeBridge implements UiProtocolBridge {
     accepted: true,
     status: "ok",
   }));
+  hydrateSession = vi.fn(async () => null);
+  callMethod = vi.fn(async () => null);
 
   onMessageDelta(h: (e: MessageDeltaEvent) => void) {
     this.emitMessageDelta = h;
@@ -1018,6 +1034,30 @@ class FakeBridge implements UiProtocolBridge {
       this.emitApprovalRequested = undefined;
     };
   }
+  onToolStarted(h: (e: ToolStartedEvent) => void) {
+    this.emitToolStarted = h;
+    return () => {
+      this.emitToolStarted = undefined;
+    };
+  }
+  onToolProgress(h: (e: ToolProgressEvent) => void) {
+    this.emitToolProgress = h;
+    return () => {
+      this.emitToolProgress = undefined;
+    };
+  }
+  onToolCompleted(h: (e: ToolCompletedEvent) => void) {
+    this.emitToolCompleted = h;
+    return () => {
+      this.emitToolCompleted = undefined;
+    };
+  }
+  onProgressUpdated(h: (e: ProgressUpdatedEvent) => void) {
+    this.emitProgressUpdated = h;
+    return () => {
+      this.emitProgressUpdated = undefined;
+    };
+  }
   onConnectionStateChange(): () => void {
     return () => {};
   }
@@ -1025,6 +1065,9 @@ class FakeBridge implements UiProtocolBridge {
     return "connected";
   }
   onWarning(): () => void {
+    return () => {};
+  }
+  onSessionTitleUpdated(): () => void {
     return () => {};
   }
 }
@@ -1076,5 +1119,334 @@ describe("attachRouter", () => {
     });
     state = ThreadStore.getThreads(SESSION);
     expect(state[0].responses[0].status).toBe("error");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// PR fix/restore-progress-cost-meta-events — regressions A / B / C
+// ---------------------------------------------------------------------------
+
+describe("regression A: tool/* events fan out into crew:tool_progress", () => {
+  it("tool/started dispatches crew:tool_progress with the tool name", () => {
+    const dispatched: Event[] = [];
+    handleToolStarted(
+      { sessionId: SESSION, dispatchEvent: (e) => dispatched.push(e) },
+      {
+        session_id: SESSION,
+        turn_id: "cmid-A1",
+        tool_call_id: "tc-1",
+        tool_name: "shell",
+        arguments: { command: "cargo test" },
+      },
+    );
+    expect(dispatched).toHaveLength(1);
+    expect(dispatched[0].type).toBe("crew:tool_progress");
+    const detail = (dispatched[0] as CustomEvent).detail;
+    expect(detail.tool).toBe("shell");
+    expect(detail.sessionId).toBe(SESSION);
+    expect(detail.turnId).toBe("cmid-A1");
+    // The component reads `detail.message` (eventually rendered after the
+    // `[info]/.../` prefix strip), so a non-empty placeholder is required
+    // to flip the spinner ON.
+    expect(typeof detail.message).toBe("string");
+    expect(detail.message.length).toBeGreaterThan(0);
+  });
+
+  it("tool/progress dispatches crew:tool_progress with the status message", () => {
+    const dispatched: Event[] = [];
+    handleToolProgress(
+      { sessionId: SESSION, dispatchEvent: (e) => dispatched.push(e) },
+      {
+        session_id: SESSION,
+        turn_id: "cmid-A2",
+        tool_call_id: "tc-2",
+        message: "downloading 42%",
+        progress_pct: 42,
+      },
+    );
+    expect(dispatched).toHaveLength(1);
+    expect(dispatched[0].type).toBe("crew:tool_progress");
+    const detail = (dispatched[0] as CustomEvent).detail;
+    expect(detail.message).toBe("downloading 42%");
+  });
+
+  it("codex P3: tool/progress preserves the tool_name from the preceding tool/started", () => {
+    // Without the cache, the spinner row's tool label flipped from
+    // e.g. `shell` to `tc-xyz` on the first progress frame because
+    // `tool/progress` carries no `tool_name` on the wire. The cache
+    // populated by `handleToolStarted` keeps the friendly name
+    // sticky for the whole call.
+    const dispatched: Event[] = [];
+    const cfg = {
+      sessionId: SESSION,
+      dispatchEvent: (e: Event) => dispatched.push(e),
+    };
+    handleToolStarted(cfg, {
+      session_id: SESSION,
+      turn_id: "cmid-A4",
+      tool_call_id: "tc-keep",
+      tool_name: "shell",
+    });
+    handleToolProgress(cfg, {
+      session_id: SESSION,
+      turn_id: "cmid-A4",
+      tool_call_id: "tc-keep",
+      message: "running",
+    });
+    expect(dispatched).toHaveLength(2);
+    expect((dispatched[0] as CustomEvent).detail.tool).toBe("shell");
+    // The crucial regression: the SECOND event must still show "shell"
+    // instead of "tc-keep".
+    expect((dispatched[1] as CustomEvent).detail.tool).toBe("shell");
+  });
+
+  it("tool/progress falls back to tool_call_id when no tool/started was seen", () => {
+    // Defensive case: server-side bug or replay skips the
+    // `tool/started` frame. We still want to render *something*.
+    const dispatched: Event[] = [];
+    handleToolProgress(
+      { sessionId: SESSION, dispatchEvent: (e) => dispatched.push(e) },
+      {
+        session_id: SESSION,
+        turn_id: "cmid-A5",
+        tool_call_id: "tc-unknown",
+        message: "running",
+      },
+    );
+    expect(dispatched).toHaveLength(1);
+    expect((dispatched[0] as CustomEvent).detail.tool).toBe("tc-unknown");
+  });
+
+  it("tool/completed dispatches crew:tool_progress with success status", () => {
+    const dispatched: Event[] = [];
+    handleToolCompleted(
+      { sessionId: SESSION, dispatchEvent: (e) => dispatched.push(e) },
+      {
+        session_id: SESSION,
+        turn_id: "cmid-A3",
+        tool_call_id: "tc-3",
+        tool_name: "shell",
+        success: true,
+        duration_ms: 1250,
+      },
+    );
+    expect(dispatched).toHaveLength(1);
+    expect((dispatched[0] as CustomEvent).detail.tool).toBe("shell");
+  });
+});
+
+describe("regression B: progress/updated fans out into crew:cost (+ crew:message_meta)", () => {
+  it("token_cost_update dispatches crew:cost with input/output tokens + session cost", () => {
+    const dispatched: Event[] = [];
+    handleProgressUpdated(
+      { sessionId: SESSION, dispatchEvent: (e) => dispatched.push(e) },
+      {
+        session_id: SESSION,
+        turn_id: "cmid-B1",
+        metadata: {
+          kind: "token_cost_update",
+          token_cost: {
+            input_tokens: 1000,
+            output_tokens: 50,
+            session_cost: 0.0085,
+          },
+        },
+      },
+    );
+    const cost = dispatched.find((e) => e.type === "crew:cost") as
+      | CustomEvent
+      | undefined;
+    expect(cost).toBeDefined();
+    expect(cost!.detail.sessionId).toBe(SESSION);
+    expect(cost!.detail.input_tokens).toBe(1000);
+    expect(cost!.detail.output_tokens).toBe(50);
+    expect(cost!.detail.session_cost).toBe(0.0085);
+  });
+
+  it("token_cost_update with model label ALSO dispatches crew:message_meta", () => {
+    const dispatched: Event[] = [];
+    handleProgressUpdated(
+      { sessionId: SESSION, dispatchEvent: (e) => dispatched.push(e) },
+      {
+        session_id: SESSION,
+        turn_id: "cmid-B2",
+        metadata: {
+          kind: "token_cost_update",
+          label: "moonshot@autodl/kimi-k2.5",
+          token_cost: {
+            input_tokens: 30000,
+            output_tokens: 2000,
+            session_cost: 0.0228,
+          },
+        },
+      },
+    );
+    const meta = dispatched.find((e) => e.type === "crew:message_meta") as
+      | CustomEvent
+      | undefined;
+    expect(meta).toBeDefined();
+    expect(meta!.detail.model).toBe("moonshot@autodl/kimi-k2.5");
+    expect(meta!.detail.tokens_in).toBe(30000);
+    expect(meta!.detail.tokens_out).toBe(2000);
+    expect(meta!.detail.session_cost).toBe(0.0228);
+  });
+
+  it("ignores progress/updated with kind != token_cost_update", () => {
+    const dispatched: Event[] = [];
+    handleProgressUpdated(
+      { sessionId: SESSION, dispatchEvent: (e) => dispatched.push(e) },
+      {
+        session_id: SESSION,
+        turn_id: "cmid-B3",
+        metadata: { kind: "status", message: "thinking" },
+      },
+    );
+    expect(dispatched).toHaveLength(0);
+  });
+});
+
+describe("regression C: turn/completed stamps per-turn meta snapshot onto the finalised bubble", () => {
+  it("snapshot accumulated from progress/updated lands as message.meta on completion", () => {
+    seedThread("cmid-C1", "ask");
+    ThreadStore.appendAssistantToken("cmid-C1", "Hello.");
+    // Seed the turn-start anchor (sets firstSeenAtMs).
+    handleTurnStarted(
+      { sessionId: SESSION },
+      { session_id: SESSION, turn_id: "cmid-C1" },
+    );
+    // A cost frame mid-turn populates the snapshot.
+    handleProgressUpdated(
+      { sessionId: SESSION },
+      {
+        session_id: SESSION,
+        turn_id: "cmid-C1",
+        metadata: {
+          kind: "token_cost_update",
+          label: "moonshot@autodl/kimi-k2.5",
+          token_cost: { input_tokens: 100, output_tokens: 20 },
+        },
+      },
+    );
+    handleTurnCompleted(
+      { sessionId: SESSION },
+      { session_id: SESSION, turn_id: "cmid-C1", reason: "stop" },
+    );
+    const [thread] = ThreadStore.getThreads(SESSION);
+    expect(thread.responses).toHaveLength(1);
+    const meta = thread.responses[0].meta;
+    expect(meta).toBeDefined();
+    expect(meta!.model).toBe("moonshot@autodl/kimi-k2.5");
+    expect(meta!.tokens_in).toBe(100);
+    expect(meta!.tokens_out).toBe(20);
+    // duration_s is computed from `nowMs() - firstSeenAtMs`; under
+    // synchronous test execution it should be a tiny non-negative
+    // number. Asserting `>= 0` keeps the test stable across hosts.
+    expect(meta!.duration_s).toBeGreaterThanOrEqual(0);
+  });
+
+  it("turn/completed without any cost snapshot still finalises the bubble (no meta)", () => {
+    seedThread("cmid-C2", "ask");
+    ThreadStore.appendAssistantToken("cmid-C2", "Hello.");
+    handleTurnCompleted(
+      { sessionId: SESSION },
+      { session_id: SESSION, turn_id: "cmid-C2", reason: "stop" },
+    );
+    const [thread] = ThreadStore.getThreads(SESSION);
+    expect(thread.responses).toHaveLength(1);
+    expect(thread.responses[0].text).toBe("Hello.");
+  });
+
+  it("codex P2: meta lands on the response even when message/persisted finalised the bubble first", () => {
+    // Wire ordering: progress/updated → message/delta →
+    // message/persisted (with content, finalises) → turn/completed.
+    // Pre-fix the snapshot was deleted at turn/completed because
+    // `finalizeAssistant` bails when `pendingAssistant` is null. The
+    // `patchLastResponseMeta` fall-back lands the meta on the
+    // already-finalised response.
+    const cmid = "cmid-Cpersist";
+    seedThread(cmid, "ask");
+    handleTurnStarted(
+      { sessionId: SESSION },
+      { session_id: SESSION, turn_id: cmid },
+    );
+    handleProgressUpdated(
+      { sessionId: SESSION },
+      {
+        session_id: SESSION,
+        turn_id: cmid,
+        metadata: {
+          kind: "token_cost_update",
+          label: "moonshot@autodl/kimi-k2.5",
+          token_cost: { input_tokens: 9000, output_tokens: 300 },
+        },
+      },
+    );
+    handleMessageDelta(
+      { sessionId: SESSION },
+      { session_id: SESSION, turn_id: cmid, text: "Hello." },
+    );
+    // `message/persisted` arrives with a non-empty pending → promotion
+    // finalises the bubble before `turn/completed` ever lands.
+    handleMessagePersisted(
+      { sessionId: SESSION },
+      {
+        session_id: SESSION,
+        turn_id: cmid,
+        thread_id: cmid,
+        seq: 99,
+        role: "assistant",
+        message_id: "msg-Cpersist",
+        source: "assistant",
+        cursor: { stream: SESSION, seq: 99 },
+        persisted_at: "2026-05-04T00:00:00Z",
+      },
+    );
+    // At this point the bubble is already in `responses`, pending is
+    // null. The pre-fix `handleTurnCompleted` lost the snapshot here.
+    const beforeCompleted = ThreadStore.getThreads(SESSION)[0];
+    expect(beforeCompleted.pendingAssistant).toBeNull();
+    expect(beforeCompleted.responses).toHaveLength(1);
+    expect(beforeCompleted.responses[0].meta).toBeUndefined();
+
+    handleTurnCompleted(
+      { sessionId: SESSION },
+      { session_id: SESSION, turn_id: cmid, reason: "stop" },
+    );
+    const [thread] = ThreadStore.getThreads(SESSION);
+    expect(thread.responses[0].meta?.model).toBe("moonshot@autodl/kimi-k2.5");
+    expect(thread.responses[0].meta?.tokens_in).toBe(9000);
+    expect(thread.responses[0].meta?.tokens_out).toBe(300);
+  });
+
+  it("turn/error also stamps the snapshot so the bubble's meta survives errored turns", () => {
+    seedThread("cmid-C3", "ask");
+    ThreadStore.appendAssistantToken("cmid-C3", "partial");
+    handleTurnStarted(
+      { sessionId: SESSION },
+      { session_id: SESSION, turn_id: "cmid-C3" },
+    );
+    handleProgressUpdated(
+      { sessionId: SESSION },
+      {
+        session_id: SESSION,
+        turn_id: "cmid-C3",
+        metadata: {
+          kind: "token_cost_update",
+          label: "anthropic/claude",
+          token_cost: { input_tokens: 5, output_tokens: 1 },
+        },
+      },
+    );
+    handleTurnError(
+      { sessionId: SESSION },
+      {
+        session_id: SESSION,
+        turn_id: "cmid-C3",
+        error: { code: -1, message: "boom" },
+      },
+    );
+    const [thread] = ThreadStore.getThreads(SESSION);
+    expect(thread.responses[0].status).toBe("error");
+    expect(thread.responses[0].meta?.model).toBe("anthropic/claude");
   });
 });

--- a/src/runtime/ui-protocol-event-router.test.ts
+++ b/src/runtime/ui-protocol-event-router.test.ts
@@ -1217,6 +1217,84 @@ describe("regression A: tool/* events fan out into crew:tool_progress", () => {
     expect((dispatched[0] as CustomEvent).detail.tool).toBe("tc-unknown");
   });
 
+  it("codex round-2 P2: tool/* events also populate the bubble's ThreadStore tool card", () => {
+    // Pre-fix the synchronous tool lifecycle only fired the transient
+    // spinner; the finalised assistant bubble had no tool card. The
+    // fix mirrors `tool/started` → addToolCall, `tool/progress` →
+    // appendToolProgress, `tool/completed` → setToolCallStatus, the
+    // same pattern `handleTaskUpdated` uses for spawn_only tasks.
+    const cmid = "cmid-Atool-card";
+    seedThread(cmid, "ask");
+    handleToolStarted(
+      { sessionId: SESSION },
+      {
+        session_id: SESSION,
+        turn_id: cmid,
+        tool_call_id: "tc-card",
+        tool_name: "shell",
+      },
+    );
+    let [thread] = ThreadStore.getThreads(SESSION);
+    let tc = thread.pendingAssistant?.toolCalls.find((t) => t.id === "tc-card");
+    expect(tc).toBeDefined();
+    expect(tc!.name).toBe("shell");
+    expect(tc!.status).toBe("running");
+
+    handleToolProgress(
+      { sessionId: SESSION },
+      {
+        session_id: SESSION,
+        turn_id: cmid,
+        tool_call_id: "tc-card",
+        message: "executing cargo test",
+      },
+    );
+    [thread] = ThreadStore.getThreads(SESSION);
+    tc = thread.pendingAssistant?.toolCalls.find((t) => t.id === "tc-card");
+    expect(tc!.progress.map((p) => p.message)).toContain("executing cargo test");
+
+    handleToolCompleted(
+      { sessionId: SESSION },
+      {
+        session_id: SESSION,
+        turn_id: cmid,
+        tool_call_id: "tc-card",
+        tool_name: "shell",
+        success: true,
+      },
+    );
+    [thread] = ThreadStore.getThreads(SESSION);
+    tc = thread.pendingAssistant?.toolCalls.find((t) => t.id === "tc-card");
+    expect(tc!.status).toBe("complete");
+  });
+
+  it("codex round-2 P2: tool/completed with success=false flips the chip to error", () => {
+    const cmid = "cmid-Atool-err";
+    seedThread(cmid, "ask");
+    handleToolStarted(
+      { sessionId: SESSION },
+      {
+        session_id: SESSION,
+        turn_id: cmid,
+        tool_call_id: "tc-err",
+        tool_name: "shell",
+      },
+    );
+    handleToolCompleted(
+      { sessionId: SESSION },
+      {
+        session_id: SESSION,
+        turn_id: cmid,
+        tool_call_id: "tc-err",
+        tool_name: "shell",
+        success: false,
+      },
+    );
+    const [thread] = ThreadStore.getThreads(SESSION);
+    const tc = thread.pendingAssistant?.toolCalls.find((t) => t.id === "tc-err");
+    expect(tc!.status).toBe("error");
+  });
+
   it("tool/completed dispatches crew:tool_progress with success status", () => {
     const dispatched: Event[] = [];
     handleToolCompleted(
@@ -1342,6 +1420,68 @@ describe("regression C: turn/completed stamps per-turn meta snapshot onto the fi
     // synchronous test execution it should be a tiny non-negative
     // number. Asserting `>= 0` keeps the test stable across hosts.
     expect(meta!.duration_s).toBeGreaterThanOrEqual(0);
+  });
+
+  it("codex round-2 P2: per-turn meta tokens are the DELTA, not session cumulative totals", () => {
+    // Wire ordering: turn-1 emits one cost frame; turn-2 emits another
+    // whose `input_tokens` / `output_tokens` reflect the
+    // session-cumulative growth. The finalised bubble for turn-2 must
+    // show DELTA tokens (turn-2 alone), not session totals.
+    seedThread("cmid-T1", "first ask");
+    ThreadStore.appendAssistantToken("cmid-T1", "first reply");
+    handleTurnStarted(
+      { sessionId: SESSION },
+      { session_id: SESSION, turn_id: "cmid-T1" },
+    );
+    handleProgressUpdated(
+      { sessionId: SESSION },
+      {
+        session_id: SESSION,
+        turn_id: "cmid-T1",
+        metadata: {
+          kind: "token_cost_update",
+          label: "moonshot@autodl/kimi-k2.5",
+          token_cost: { input_tokens: 100, output_tokens: 20 },
+        },
+      },
+    );
+    handleTurnCompleted(
+      { sessionId: SESSION },
+      { session_id: SESSION, turn_id: "cmid-T1", reason: "stop" },
+    );
+    let [thread] = ThreadStore.getThreads(SESSION);
+    expect(thread.responses[0].meta?.tokens_in).toBe(100);
+    expect(thread.responses[0].meta?.tokens_out).toBe(20);
+
+    // Turn 2: cumulative is 250 / 60. Per-turn delta is 150 / 40.
+    seedThread("cmid-T2", "second ask");
+    ThreadStore.appendAssistantToken("cmid-T2", "second reply");
+    handleTurnStarted(
+      { sessionId: SESSION },
+      { session_id: SESSION, turn_id: "cmid-T2" },
+    );
+    handleProgressUpdated(
+      { sessionId: SESSION },
+      {
+        session_id: SESSION,
+        turn_id: "cmid-T2",
+        metadata: {
+          kind: "token_cost_update",
+          label: "moonshot@autodl/kimi-k2.5",
+          token_cost: { input_tokens: 250, output_tokens: 60 },
+        },
+      },
+    );
+    handleTurnCompleted(
+      { sessionId: SESSION },
+      { session_id: SESSION, turn_id: "cmid-T2", reason: "stop" },
+    );
+    const threadsAfter = ThreadStore.getThreads(SESSION);
+    const t2Thread = threadsAfter.find((t) => t.id === "cmid-T2");
+    expect(t2Thread).toBeDefined();
+    const turn2 = t2Thread!.responses[0];
+    expect(turn2.meta?.tokens_in).toBe(150); // 250 - 100 baseline
+    expect(turn2.meta?.tokens_out).toBe(40); // 60 - 20 baseline
   });
 
   it("turn/completed without any cost snapshot still finalises the bubble (no meta)", () => {

--- a/src/runtime/ui-protocol-event-router.ts
+++ b/src/runtime/ui-protocol-event-router.ts
@@ -26,8 +26,12 @@ import type {
   ApprovalRequestedEvent,
   MessageDeltaEvent,
   MessagePersistedEvent,
+  ProgressUpdatedEvent,
   TaskOutputDeltaEvent,
   TaskUpdatedEvent,
+  ToolCompletedEvent,
+  ToolProgressEvent,
+  ToolStartedEvent,
   TurnCompletedEvent,
   TurnErrorEvent,
   TurnSpawnCompleteEvent,
@@ -35,7 +39,87 @@ import type {
   UiProtocolBridge,
 } from "./ui-protocol-bridge";
 import * as ThreadStore from "@/store/thread-store";
+import type { MessageMeta } from "@/store/thread-store";
 import type { MessageInfo } from "@/api/types";
+
+// ---------------------------------------------------------------------------
+// Per-turn meta snapshot
+// ---------------------------------------------------------------------------
+//
+// Regression-#2 fix (chat-thread `ThreadMessageMeta` footer):
+//
+// PR #93 narrowed the wire shape of `MessagePersistedEvent` to
+// metadata-only (`{message_id, persisted_at, media}`); model + tokens +
+// duration migrated to `progress/updated` notifications carrying
+// `metadata.kind === "token_cost_update"`. The legacy
+// `ThreadMessageMeta` renderer reads `message.meta.{model, tokens_in,
+// tokens_out, duration_s}` and goes blank when meta is absent.
+//
+// We accumulate the latest cost snapshot per `turn_id` here and stamp it
+// onto the finalised assistant bubble via `finalizeAssistant({ meta })`
+// when `turn/completed` lands. The snapshot survives across multiple
+// `progress/updated` frames in a turn so a late cost frame between the
+// first delta and the completion doesn't drop fields. Clear on
+// `turn/completed` / `turn/error` so a stale snapshot can't leak into a
+// following turn.
+
+interface TurnMetaSnapshot {
+  /** Last model string we saw. Populated from `metadata.label` (the
+   *  server's display-name carrier; see
+   *  `crates/octos-cli/src/api/ui_protocol_progress.rs:363` and
+   *  follow-up). Optional — some turns don't carry a model. */
+  model?: string;
+  tokensIn?: number;
+  tokensOut?: number;
+  /** Turn duration in seconds, rounded to one decimal place. Computed
+   *  from the first `progress/updated{kind:"token_cost_update"}` arrival
+   *  time relative to either `turn/started` or, lacking that, the first
+   *  meta snapshot we ever recorded for the turn. */
+  durationS?: number;
+  /** Performance.now() (or Date.now()) at the first frame for this turn —
+   *  used to derive `durationS` on `turn/completed`. */
+  firstSeenAtMs?: number;
+}
+
+const turnMetaByTurnId = new Map<string, TurnMetaSnapshot>();
+
+/** `tool_call_id` → `tool_name` map, populated by `tool/started` so a
+ *  subsequent `tool/progress` (which carries no `tool_name` on the wire)
+ *  can still render the friendly tool label in the spinner row. Codex
+ *  P3 fix: the spinner used to flip from e.g. `shell` to `tc-abc...`
+ *  the moment the first `tool/progress` arrived. The map is bounded by
+ *  the number of in-flight tool calls per session (~tens, never
+ *  thousands); we clear an entry on `tool/completed` to keep it tight.
+ */
+const toolNameByCallId = new Map<string, string>();
+
+/** Reset the per-turn meta map + tool-name cache. Tests call this
+ *  between cases; production code does not need it because both maps
+ *  are bounded by the number of live turns + tool calls per session. */
+export function __resetTurnMetaForTest(): void {
+  turnMetaByTurnId.clear();
+  toolNameByCallId.clear();
+}
+
+function nowMs(): number {
+  if (typeof performance !== "undefined" && typeof performance.now === "function") {
+    return performance.now();
+  }
+  return Date.now();
+}
+
+function metaFromSnapshot(snap: TurnMetaSnapshot | undefined): MessageMeta | undefined {
+  if (!snap) return undefined;
+  if (!snap.model && !snap.tokensIn && !snap.tokensOut && !snap.durationS) {
+    return undefined;
+  }
+  return {
+    model: snap.model ?? "",
+    tokens_in: snap.tokensIn ?? 0,
+    tokens_out: snap.tokensOut ?? 0,
+    duration_s: snap.durationS ?? 0,
+  };
+}
 
 // ---------------------------------------------------------------------------
 // Per-task state-transition de-dupe
@@ -383,6 +467,13 @@ export function handleTurnStarted(
   // ThreadStore-side bookkeeping is handled by `addUserMessage` on send;
   // we do not synthesize a placeholder here because the user bubble is
   // already in place by the time the server confirms turn/started.
+  //
+  // Regression-#2 (bubble footer): seed a per-turn meta snapshot at
+  // turn-start so the duration timer has a starting point even if no
+  // intermediate `progress/updated` frame arrives.
+  const snap = turnMetaByTurnId.get(event.turn_id) ?? {};
+  snap.firstSeenAtMs = nowMs();
+  turnMetaByTurnId.set(event.turn_id, snap);
   dispatch(
     cfg,
     new CustomEvent("crew:thinking", {
@@ -401,7 +492,27 @@ export function handleTurnCompleted(
   cfg: RouterConfig,
   event: TurnCompletedEvent,
 ): void {
-  ThreadStore.finalizeAssistant(event.turn_id);
+  // Regression-#2 (bubble footer): stamp the accumulated per-turn meta
+  // snapshot onto the finalised bubble so `ThreadMessageMeta` can render
+  // model + tokens + duration. Compute the final duration from the
+  // `firstSeenAtMs` anchor we set on turn/started.
+  const snap = turnMetaByTurnId.get(event.turn_id);
+  if (snap && snap.firstSeenAtMs !== undefined) {
+    const elapsedMs = Math.max(0, nowMs() - snap.firstSeenAtMs);
+    snap.durationS = Math.round((elapsedMs / 1000) * 10) / 10;
+  }
+  const meta = metaFromSnapshot(snap);
+  // `finalizeAssistant` is the happy path — works when the pending slot
+  // is still live. Codex P2: an earlier `message/persisted` already may
+  // have promoted the pending bubble (`tryPromotePendingFromPersisted`),
+  // in which case `finalizeAssistant`'s pending-required guard returns
+  // without applying our meta. Fall back to `patchLastResponseMeta` so
+  // the meta still lands on the now-finalised response.
+  ThreadStore.finalizeAssistant(event.turn_id, meta ? { meta } : {});
+  if (meta) {
+    ThreadStore.patchLastResponseMeta(event.turn_id, { meta });
+  }
+  turnMetaByTurnId.delete(event.turn_id);
   dispatch(
     cfg,
     new CustomEvent("crew:thinking", {
@@ -424,7 +535,25 @@ export function handleTurnError(
   // `finalizeAssistant` accepts an explicit status override per its options
   // surface — we use it so the v1 path produces the same terminal state
   // shape (responses[].status === "error") as the v0 SSE `error` branch.
-  ThreadStore.finalizeAssistant(event.turn_id, { status: "error" });
+  const snap = turnMetaByTurnId.get(event.turn_id);
+  if (snap && snap.firstSeenAtMs !== undefined) {
+    const elapsedMs = Math.max(0, nowMs() - snap.firstSeenAtMs);
+    snap.durationS = Math.round((elapsedMs / 1000) * 10) / 10;
+  }
+  const meta = metaFromSnapshot(snap);
+  ThreadStore.finalizeAssistant(event.turn_id, {
+    status: "error",
+    ...(meta ? { meta } : {}),
+  });
+  // Codex P2: same fall-back as `handleTurnCompleted` for the
+  // persisted-promoted ordering. Also stamp `status:"error"` so the
+  // bubble's status changes even when persisted promoted it to
+  // "complete".
+  ThreadStore.patchLastResponseMeta(event.turn_id, {
+    status: "error",
+    ...(meta ? { meta } : {}),
+  });
+  turnMetaByTurnId.delete(event.turn_id);
   dispatch(
     cfg,
     new CustomEvent("crew:thinking", {
@@ -448,6 +577,183 @@ export function handleTurnError(
       },
     }),
   );
+}
+
+// ---------------------------------------------------------------------------
+// Synchronous tool-call lifecycle  (regression #1)
+// ---------------------------------------------------------------------------
+//
+// The legacy SSE bridge (`sse-bridge.ts`, deleted in PR #96) was the sole
+// dispatcher of `crew:tool_progress` DOM events — the
+// `ToolProgressIndicator` component listens to that event to render the
+// spinner under the streaming assistant bubble. Without a replacement,
+// the spinner never lit up for any in-flight tool call.
+//
+// Each handler below converts the typed UI Protocol v1 envelope into the
+// same `{ tool, message, sessionId, topic, turnId }` detail shape the
+// component reads (see `src/components/tool-progress-indicator.tsx`).
+// The component clears the spinner on `crew:thinking { thinking: false }`
+// (already dispatched by `handleTurnCompleted` / `handleTurnError`), so
+// no explicit clear event is needed on `tool/completed`.
+
+function dispatchToolProgressEvent(
+  cfg: RouterConfig,
+  turnId: string,
+  toolName: string,
+  message: string,
+): void {
+  dispatch(
+    cfg,
+    new CustomEvent("crew:tool_progress", {
+      detail: {
+        tool: toolName,
+        message,
+        sessionId: cfg.sessionId,
+        topic: cfg.topic,
+        turnId,
+      },
+    }),
+  );
+}
+
+export function handleToolStarted(
+  cfg: RouterConfig,
+  event: ToolStartedEvent,
+): void {
+  toolNameByCallId.set(event.tool_call_id, event.tool_name);
+  dispatchToolProgressEvent(cfg, event.turn_id, event.tool_name, "running");
+}
+
+export function handleToolProgress(
+  cfg: RouterConfig,
+  event: ToolProgressEvent,
+): void {
+  // The wire shape carries no `tool_name` on `tool/progress`. Codex P3:
+  // the legacy SSE bridge kept rendering the tool name from the
+  // preceding `tool/started`; we mirror that by consulting our
+  // `toolNameByCallId` cache. Falling back to the `tool_call_id` only
+  // when no cached name exists (race: progress arrives before started,
+  // or a server-side bug omits the started frame entirely) keeps the
+  // spinner row populated rather than blank.
+  const toolLabel =
+    toolNameByCallId.get(event.tool_call_id) ?? event.tool_call_id;
+  const message = event.message ?? "running";
+  dispatchToolProgressEvent(cfg, event.turn_id, toolLabel, message);
+}
+
+export function handleToolCompleted(
+  cfg: RouterConfig,
+  event: ToolCompletedEvent,
+): void {
+  const message =
+    event.success === false
+      ? "error"
+      : event.success === true
+        ? "done"
+        : "complete";
+  dispatchToolProgressEvent(cfg, event.turn_id, event.tool_name, message);
+  // Clear the cache entry so a long-lived session doesn't accumulate
+  // dead tool_call_id mappings.
+  toolNameByCallId.delete(event.tool_call_id);
+}
+
+// ---------------------------------------------------------------------------
+// progress/updated   (regressions #3 + #2 helper)
+// ---------------------------------------------------------------------------
+//
+// The server emits `progress/updated` for every cost telemetry frame
+// (`metadata.kind === "token_cost_update"`). The legacy SSE bridge was
+// the sole dispatcher of `crew:cost` (header cost badge) and
+// `crew:message_meta` (assistant-bubble footer). After PR #96 nobody
+// fired them — so the header model badge and bubble footer went blank.
+//
+// Wire shape (see `crates/octos-core/src/ui_protocol.rs`):
+//   metadata = {
+//     kind: "token_cost_update",
+//     label?: model display name,
+//     token_cost: { input_tokens?, output_tokens?, session_cost?, ... }
+//   }
+//
+// We dispatch two DOM events:
+//
+//   (a) `crew:cost` — every cost frame, with the wire field names the
+//       legacy listener in `session-context.tsx:702-744` expects
+//       (`input_tokens`, `output_tokens`, `session_cost`).
+//
+//   (b) `crew:message_meta` — only when the frame carries a model name
+//       AND we already have a turn anchor (so a duration can be
+//       computed). This is the cheap path for regression #2 the
+//       diagnostic flagged: rather than re-architecting the bubble
+//       renderer to read from `useSession()`, we keep stamping
+//       `message.meta` on `finalizeAssistant` (the `handleTurnCompleted`
+//       branch above) and let the legacy `crew:message_meta` listener
+//       also keep flowing for any subscribers that read off the global
+//       window event.
+
+export function handleProgressUpdated(
+  cfg: RouterConfig,
+  event: ProgressUpdatedEvent,
+): void {
+  if (event.metadata.kind !== "token_cost_update") return;
+  const cost = event.metadata.token_cost;
+  const inputTokens = cost?.input_tokens;
+  const outputTokens = cost?.output_tokens;
+  const sessionCost = cost?.session_cost;
+  // `metadata.label` is the server's display-name carrier (set by the
+  // agent when emitting cost frames; nullable for very early frames in
+  // the turn). We pass it through verbatim so the legacy listener can
+  // read `detail.model`.
+  const modelLabel =
+    typeof event.metadata.label === "string" && event.metadata.label.length > 0
+      ? event.metadata.label
+      : undefined;
+
+  // -- (a) crew:cost -------------------------------------------------------
+  dispatch(
+    cfg,
+    new CustomEvent("crew:cost", {
+      detail: {
+        sessionId: cfg.sessionId,
+        topic: cfg.topic,
+        turnId: event.turn_id,
+        input_tokens: inputTokens,
+        output_tokens: outputTokens,
+        session_cost: sessionCost,
+      },
+    }),
+  );
+
+  // -- Update per-turn meta snapshot for regression #2 ---------------------
+  if (event.turn_id) {
+    const snap = turnMetaByTurnId.get(event.turn_id) ?? {};
+    if (modelLabel) snap.model = modelLabel;
+    if (typeof inputTokens === "number") snap.tokensIn = inputTokens;
+    if (typeof outputTokens === "number") snap.tokensOut = outputTokens;
+    if (snap.firstSeenAtMs === undefined) snap.firstSeenAtMs = nowMs();
+    turnMetaByTurnId.set(event.turn_id, snap);
+  }
+
+  // -- (b) crew:message_meta ----------------------------------------------
+  // Only emit if we have a model name AND at least one token count.
+  // The legacy listener reads `model`, `tokens_in`, `tokens_out`,
+  // `session_cost` — verify field-name mapping in
+  // `session-context.tsx:720-735`.
+  if (modelLabel && (inputTokens !== undefined || outputTokens !== undefined)) {
+    dispatch(
+      cfg,
+      new CustomEvent("crew:message_meta", {
+        detail: {
+          sessionId: cfg.sessionId,
+          topic: cfg.topic,
+          turnId: event.turn_id,
+          model: modelLabel,
+          tokens_in: inputTokens,
+          tokens_out: outputTokens,
+          session_cost: sessionCost,
+        },
+      }),
+    );
+  }
 }
 
 export function handleApprovalRequested(
@@ -515,6 +821,16 @@ export function attachRouter(
   const offApprovalRequested = bridge.onApprovalRequested((e) =>
     handleApprovalRequested(cfg, e),
   );
+  const offToolStarted = bridge.onToolStarted((e) => handleToolStarted(cfg, e));
+  const offToolProgress = bridge.onToolProgress((e) =>
+    handleToolProgress(cfg, e),
+  );
+  const offToolCompleted = bridge.onToolCompleted((e) =>
+    handleToolCompleted(cfg, e),
+  );
+  const offProgressUpdated = bridge.onProgressUpdated((e) =>
+    handleProgressUpdated(cfg, e),
+  );
 
   let detached = false;
   return {
@@ -528,6 +844,10 @@ export function attachRouter(
       offTaskOutputDelta();
       offTurnLifecycle();
       offApprovalRequested();
+      offToolStarted();
+      offToolProgress();
+      offToolCompleted();
+      offProgressUpdated();
     },
   };
 }

--- a/src/runtime/ui-protocol-event-router.ts
+++ b/src/runtime/ui-protocol-event-router.ts
@@ -69,8 +69,28 @@ interface TurnMetaSnapshot {
    *  `crates/octos-cli/src/api/ui_protocol_progress.rs:363` and
    *  follow-up). Optional — some turns don't carry a model. */
   model?: string;
+  /** Per-turn delta of `input_tokens`. Codex round-2 P2 fix: the
+   *  `progress/updated{kind:"token_cost_update"}` frame carries SESSION
+   *  cumulative counters (server `emit_cost_update`'s
+   *  `total_usage.input_tokens` —
+   *  `crates/octos-agent/src/agent/streaming.rs:256`), so stamping the
+   *  raw counter onto `message.meta` would show session-total tokens on
+   *  every assistant bubble after the first turn. We derive the
+   *  per-turn delta by anchoring on `baselineInputTokens` (the
+   *  cumulative value at the first frame we see for this turn) and
+   *  subtracting it from every subsequent frame.
+   */
   tokensIn?: number;
   tokensOut?: number;
+  /** Baseline session-cumulative tokens at the start of the turn.
+   *  `tokensIn` / `tokensOut` are derived as `latest - baseline`. */
+  baselineInputTokens?: number;
+  baselineOutputTokens?: number;
+  /** Latest session-cumulative tokens seen on a `progress/updated`
+   *  frame for this turn. Used by `handleTurnCompleted` to roll the
+   *  session baseline forward for the next turn. */
+  latestCumulativeInputTokens?: number;
+  latestCumulativeOutputTokens?: number;
   /** Turn duration in seconds, rounded to one decimal place. Computed
    *  from the first `progress/updated{kind:"token_cost_update"}` arrival
    *  time relative to either `turn/started` or, lacking that, the first
@@ -83,6 +103,15 @@ interface TurnMetaSnapshot {
 
 const turnMetaByTurnId = new Map<string, TurnMetaSnapshot>();
 
+/** Session-cumulative token totals at the close of the most recent
+ *  turn. The next turn's baseline = this value, so its per-turn delta
+ *  comes out as `latest - lastTurnEndCumulative`. Keyed by `sessionId`
+ *  so cross-session leakage can't happen. Codex round-2 P2 fix. */
+const lastTurnEndCumulativeBySession = new Map<
+  string,
+  { inputTokens: number; outputTokens: number }
+>();
+
 /** `tool_call_id` → `tool_name` map, populated by `tool/started` so a
  *  subsequent `tool/progress` (which carries no `tool_name` on the wire)
  *  can still render the friendly tool label in the spinner row. Codex
@@ -93,12 +122,14 @@ const turnMetaByTurnId = new Map<string, TurnMetaSnapshot>();
  */
 const toolNameByCallId = new Map<string, string>();
 
-/** Reset the per-turn meta map + tool-name cache. Tests call this
- *  between cases; production code does not need it because both maps
- *  are bounded by the number of live turns + tool calls per session. */
+/** Reset the per-turn meta map + tool-name cache + cumulative
+ *  baseline. Tests call this between cases; production code does not
+ *  need it because all three maps are bounded by the number of live
+ *  turns + tool calls + sessions. */
 export function __resetTurnMetaForTest(): void {
   turnMetaByTurnId.clear();
   toolNameByCallId.clear();
+  lastTurnEndCumulativeBySession.clear();
 }
 
 function nowMs(): number {
@@ -501,6 +532,21 @@ export function handleTurnCompleted(
     const elapsedMs = Math.max(0, nowMs() - snap.firstSeenAtMs);
     snap.durationS = Math.round((elapsedMs / 1000) * 10) / 10;
   }
+  // Codex round-2 P2: roll the session-cumulative baseline forward so
+  // the next turn's per-turn delta is correct. We use the latest
+  // cumulative we saw on a cost frame this turn (which is the
+  // session-end total for this turn); if we never saw a cost frame,
+  // we preserve the existing baseline rather than zeroing it.
+  if (snap?.latestCumulativeInputTokens !== undefined || snap?.latestCumulativeOutputTokens !== undefined) {
+    const prior = lastTurnEndCumulativeBySession.get(cfg.sessionId) ?? {
+      inputTokens: 0,
+      outputTokens: 0,
+    };
+    lastTurnEndCumulativeBySession.set(cfg.sessionId, {
+      inputTokens: snap.latestCumulativeInputTokens ?? prior.inputTokens,
+      outputTokens: snap.latestCumulativeOutputTokens ?? prior.outputTokens,
+    });
+  }
   const meta = metaFromSnapshot(snap);
   // `finalizeAssistant` is the happy path — works when the pending slot
   // is still live. Codex P2: an earlier `message/persisted` already may
@@ -539,6 +585,16 @@ export function handleTurnError(
   if (snap && snap.firstSeenAtMs !== undefined) {
     const elapsedMs = Math.max(0, nowMs() - snap.firstSeenAtMs);
     snap.durationS = Math.round((elapsedMs / 1000) * 10) / 10;
+  }
+  if (snap?.latestCumulativeInputTokens !== undefined || snap?.latestCumulativeOutputTokens !== undefined) {
+    const prior = lastTurnEndCumulativeBySession.get(cfg.sessionId) ?? {
+      inputTokens: 0,
+      outputTokens: 0,
+    };
+    lastTurnEndCumulativeBySession.set(cfg.sessionId, {
+      inputTokens: snap.latestCumulativeInputTokens ?? prior.inputTokens,
+      outputTokens: snap.latestCumulativeOutputTokens ?? prior.outputTokens,
+    });
   }
   const meta = metaFromSnapshot(snap);
   ThreadStore.finalizeAssistant(event.turn_id, {
@@ -621,6 +677,13 @@ export function handleToolStarted(
   event: ToolStartedEvent,
 ): void {
   toolNameByCallId.set(event.tool_call_id, event.tool_name);
+  // Codex round-2 P2: mirror the synchronous tool-call lifecycle onto
+  // the ThreadStore so the finalised assistant bubble carries a tool
+  // card (`ToolCallBubble`), not just the transient spinner. Matches
+  // the pattern `handleTaskUpdated` uses for spawn_only / background
+  // tasks. `addToolCall` is idempotent on `(turn_id, tool_call_id)`,
+  // so a replayed `tool/started` is safe.
+  ThreadStore.addToolCall(event.turn_id, event.tool_call_id, event.tool_name);
   dispatchToolProgressEvent(cfg, event.turn_id, event.tool_name, "running");
 }
 
@@ -638,6 +701,16 @@ export function handleToolProgress(
   const toolLabel =
     toolNameByCallId.get(event.tool_call_id) ?? event.tool_call_id;
   const message = event.message ?? "running";
+  // Codex round-2 P2: feed progress chunks into the bubble's tool
+  // card timeline. `appendToolProgress` dedupes consecutive
+  // duplicates so resending the same chunk on reconnect is safe.
+  if (event.message) {
+    ThreadStore.appendToolProgress(
+      event.turn_id,
+      event.tool_call_id,
+      event.message,
+    );
+  }
   dispatchToolProgressEvent(cfg, event.turn_id, toolLabel, message);
 }
 
@@ -651,6 +724,15 @@ export function handleToolCompleted(
       : event.success === true
         ? "done"
         : "complete";
+  // Codex round-2 P2: persist the terminal tool-call status onto the
+  // bubble's tool card so the chip stops spinning. Failed calls
+  // surface as "error"; everything else as "complete" (matching the
+  // `handleTaskUpdated` `completed` / `failed` mapping).
+  ThreadStore.setToolCallStatus(
+    event.turn_id,
+    event.tool_call_id,
+    event.success === false ? "error" : "complete",
+  );
   dispatchToolProgressEvent(cfg, event.turn_id, event.tool_name, message);
   // Clear the cache entry so a long-lived session doesn't accumulate
   // dead tool_call_id mappings.
@@ -724,11 +806,46 @@ export function handleProgressUpdated(
   );
 
   // -- Update per-turn meta snapshot for regression #2 ---------------------
+  //
+  // Codex round-2 P2: `input_tokens` / `output_tokens` from the
+  // `progress/updated{kind:"token_cost_update"}` payload are SESSION
+  // cumulative counters (see `crates/octos-agent/src/agent/streaming.rs`
+  // `emit_cost_update` — they're sourced from `total_usage`). For the
+  // legacy `crew:cost` listener (header cost badge) that's exactly the
+  // right shape — it tracks session-wide totals. For
+  // `message.meta.{tokens_in, tokens_out}` (the per-bubble footer) we
+  // need PER-TURN deltas, otherwise after the 2nd turn the footer
+  // shows all tokens used in the session.
+  //
+  // The per-turn delta is `current_cumulative - baseline`, where
+  // `baseline` is the cumulative total at the end of the previous turn
+  // for THIS session. The first turn's baseline is 0 (no prior turns,
+  // so the cumulative IS the per-turn count). `handleTurnCompleted` /
+  // `handleTurnError` snapshot the session totals into
+  // `lastTurnEndCumulativeBySession` so the next turn's baseline is
+  // available.
+  //
+  // We also remember the latest cumulative counters on the snapshot
+  // itself (`latestCumulativeInputTokens` / `Output`) so
+  // `handleTurnCompleted` can roll the session baseline forward
+  // without depending on whether the last cost frame ran first.
   if (event.turn_id) {
     const snap = turnMetaByTurnId.get(event.turn_id) ?? {};
     if (modelLabel) snap.model = modelLabel;
-    if (typeof inputTokens === "number") snap.tokensIn = inputTokens;
-    if (typeof outputTokens === "number") snap.tokensOut = outputTokens;
+    const baseline = lastTurnEndCumulativeBySession.get(cfg.sessionId) ?? {
+      inputTokens: 0,
+      outputTokens: 0,
+    };
+    if (typeof inputTokens === "number") {
+      snap.baselineInputTokens = baseline.inputTokens;
+      snap.latestCumulativeInputTokens = inputTokens;
+      snap.tokensIn = Math.max(0, inputTokens - baseline.inputTokens);
+    }
+    if (typeof outputTokens === "number") {
+      snap.baselineOutputTokens = baseline.outputTokens;
+      snap.latestCumulativeOutputTokens = outputTokens;
+      snap.tokensOut = Math.max(0, outputTokens - baseline.outputTokens);
+    }
     if (snap.firstSeenAtMs === undefined) snap.firstSeenAtMs = nowMs();
     turnMetaByTurnId.set(event.turn_id, snap);
   }

--- a/src/runtime/ui-protocol-event-router.ts
+++ b/src/runtime/ui-protocol-event-router.ts
@@ -832,10 +832,36 @@ export function handleProgressUpdated(
   if (event.turn_id) {
     const snap = turnMetaByTurnId.get(event.turn_id) ?? {};
     if (modelLabel) snap.model = modelLabel;
-    const baseline = lastTurnEndCumulativeBySession.get(cfg.sessionId) ?? {
-      inputTokens: 0,
-      outputTokens: 0,
-    };
+    // Codex round-3 P2: when no per-session baseline exists yet (first
+    // turn after page reload / fresh session restore), the
+    // `progress/updated` payload's cumulative counters include
+    // pre-reload history we never saw. Falling back to a zero
+    // baseline would attribute ALL of those historical tokens to
+    // this turn's footer. Instead, seed the baseline from the FIRST
+    // cumulative we observe — that gives us a conservative delta = 0
+    // on the seeding frame and the delta grows monotonically for
+    // subsequent frames within the same turn. Trade-off: a restored
+    // session loses precise per-turn breakdown for the FIRST turn
+    // post-reload (footer shows "0 in / 0 out" if only one cost
+    // frame ever arrives that turn), but never shows misleading
+    // session totals. A subsequent server-side surface that
+    // exposes per-turn rather than cumulative counters would let
+    // us drop this seeding heuristic entirely.
+    const existing = lastTurnEndCumulativeBySession.get(cfg.sessionId);
+    const baseline =
+      existing ??
+      (() => {
+        // Self-seeding: snapshot the first observed cumulative as
+        // the baseline. This means turn N (first after reload) gets
+        // delta == 0; turn N+1 gets a real delta against THIS
+        // turn's last observed cumulative.
+        const seeded = {
+          inputTokens: typeof inputTokens === "number" ? inputTokens : 0,
+          outputTokens: typeof outputTokens === "number" ? outputTokens : 0,
+        };
+        lastTurnEndCumulativeBySession.set(cfg.sessionId, seeded);
+        return seeded;
+      })();
     if (typeof inputTokens === "number") {
       snap.baselineInputTokens = baseline.inputTokens;
       snap.latestCumulativeInputTokens = inputTokens;

--- a/src/runtime/ui-protocol-event-router.ts
+++ b/src/runtime/ui-protocol-event-router.ts
@@ -106,10 +106,19 @@ const turnMetaByTurnId = new Map<string, TurnMetaSnapshot>();
 /** Session-cumulative token totals at the close of the most recent
  *  turn. The next turn's baseline = this value, so its per-turn delta
  *  comes out as `latest - lastTurnEndCumulative`. Keyed by `sessionId`
- *  so cross-session leakage can't happen. Codex round-2 P2 fix. */
+ *  so cross-session leakage can't happen. Codex round-2 P2 fix.
+ *
+ *  Codex round-4: each counter is independently optional — a server
+ *  frame may carry only `output_tokens` (or only `session_cost` and
+ *  no token counters at all). We seed each counter's baseline ONLY
+ *  when that specific counter is observed. Otherwise a later frame's
+ *  first `input_tokens` value would get attributed in full to the
+ *  current turn (as if baseline=0), which is exactly the
+ *  session-cumulative-leak the round-3 self-seeding heuristic tried
+ *  to prevent. */
 const lastTurnEndCumulativeBySession = new Map<
   string,
-  { inputTokens: number; outputTokens: number }
+  { inputTokens?: number; outputTokens?: number }
 >();
 
 /** `tool_call_id` → `tool_name` map, populated by `tool/started` so a
@@ -532,16 +541,13 @@ export function handleTurnCompleted(
     const elapsedMs = Math.max(0, nowMs() - snap.firstSeenAtMs);
     snap.durationS = Math.round((elapsedMs / 1000) * 10) / 10;
   }
-  // Codex round-2 P2: roll the session-cumulative baseline forward so
-  // the next turn's per-turn delta is correct. We use the latest
-  // cumulative we saw on a cost frame this turn (which is the
-  // session-end total for this turn); if we never saw a cost frame,
-  // we preserve the existing baseline rather than zeroing it.
+  // Codex round-2/4 P2: roll the session-cumulative baseline forward
+  // so the next turn's per-turn delta is correct. Use the latest
+  // cumulative we saw on a cost frame this turn (per-counter); if a
+  // counter never appeared this turn, preserve the existing baseline
+  // for that counter rather than zeroing it.
   if (snap?.latestCumulativeInputTokens !== undefined || snap?.latestCumulativeOutputTokens !== undefined) {
-    const prior = lastTurnEndCumulativeBySession.get(cfg.sessionId) ?? {
-      inputTokens: 0,
-      outputTokens: 0,
-    };
+    const prior = lastTurnEndCumulativeBySession.get(cfg.sessionId) ?? {};
     lastTurnEndCumulativeBySession.set(cfg.sessionId, {
       inputTokens: snap.latestCumulativeInputTokens ?? prior.inputTokens,
       outputTokens: snap.latestCumulativeOutputTokens ?? prior.outputTokens,
@@ -587,10 +593,7 @@ export function handleTurnError(
     snap.durationS = Math.round((elapsedMs / 1000) * 10) / 10;
   }
   if (snap?.latestCumulativeInputTokens !== undefined || snap?.latestCumulativeOutputTokens !== undefined) {
-    const prior = lastTurnEndCumulativeBySession.get(cfg.sessionId) ?? {
-      inputTokens: 0,
-      outputTokens: 0,
-    };
+    const prior = lastTurnEndCumulativeBySession.get(cfg.sessionId) ?? {};
     lastTurnEndCumulativeBySession.set(cfg.sessionId, {
       inputTokens: snap.latestCumulativeInputTokens ?? prior.inputTokens,
       outputTokens: snap.latestCumulativeOutputTokens ?? prior.outputTokens,
@@ -832,45 +835,42 @@ export function handleProgressUpdated(
   if (event.turn_id) {
     const snap = turnMetaByTurnId.get(event.turn_id) ?? {};
     if (modelLabel) snap.model = modelLabel;
-    // Codex round-3 P2: when no per-session baseline exists yet (first
-    // turn after page reload / fresh session restore), the
+    // Codex round-3/4 P2: when no per-counter baseline exists yet
+    // (first turn after page reload / fresh session restore), the
     // `progress/updated` payload's cumulative counters include
-    // pre-reload history we never saw. Falling back to a zero
-    // baseline would attribute ALL of those historical tokens to
-    // this turn's footer. Instead, seed the baseline from the FIRST
-    // cumulative we observe — that gives us a conservative delta = 0
-    // on the seeding frame and the delta grows monotonically for
-    // subsequent frames within the same turn. Trade-off: a restored
-    // session loses precise per-turn breakdown for the FIRST turn
-    // post-reload (footer shows "0 in / 0 out" if only one cost
-    // frame ever arrives that turn), but never shows misleading
-    // session totals. A subsequent server-side surface that
-    // exposes per-turn rather than cumulative counters would let
-    // us drop this seeding heuristic entirely.
-    const existing = lastTurnEndCumulativeBySession.get(cfg.sessionId);
-    const baseline =
-      existing ??
-      (() => {
-        // Self-seeding: snapshot the first observed cumulative as
-        // the baseline. This means turn N (first after reload) gets
-        // delta == 0; turn N+1 gets a real delta against THIS
-        // turn's last observed cumulative.
-        const seeded = {
-          inputTokens: typeof inputTokens === "number" ? inputTokens : 0,
-          outputTokens: typeof outputTokens === "number" ? outputTokens : 0,
-        };
-        lastTurnEndCumulativeBySession.set(cfg.sessionId, seeded);
-        return seeded;
-      })();
+    // pre-reload history we never saw. Self-seed from the FIRST
+    // observed value of EACH counter independently — a frame that
+    // carries only `output_tokens` should NOT pin
+    // `inputTokens.baseline = 0` (round-4 fix), because the next
+    // frame's first `input_tokens` would then be attributed in full
+    // to this turn (defeating the round-3 anti-leak).
+    const existing = lastTurnEndCumulativeBySession.get(cfg.sessionId) ?? {};
+    let baselineIn = existing.inputTokens;
+    let baselineOut = existing.outputTokens;
+    if (typeof inputTokens === "number" && baselineIn === undefined) {
+      baselineIn = inputTokens;
+    }
+    if (typeof outputTokens === "number" && baselineOut === undefined) {
+      baselineOut = outputTokens;
+    }
+    // Persist the self-seeded baselines back to the session map so a
+    // later frame in the same turn doesn't re-seed against a fresh
+    // initial value.
+    lastTurnEndCumulativeBySession.set(cfg.sessionId, {
+      inputTokens: baselineIn,
+      outputTokens: baselineOut,
+    });
     if (typeof inputTokens === "number") {
-      snap.baselineInputTokens = baseline.inputTokens;
+      snap.baselineInputTokens = baselineIn;
       snap.latestCumulativeInputTokens = inputTokens;
-      snap.tokensIn = Math.max(0, inputTokens - baseline.inputTokens);
+      // `baselineIn` is guaranteed defined when `inputTokens` is a
+      // number because we seed it on the same frame.
+      snap.tokensIn = Math.max(0, inputTokens - (baselineIn ?? 0));
     }
     if (typeof outputTokens === "number") {
-      snap.baselineOutputTokens = baseline.outputTokens;
+      snap.baselineOutputTokens = baselineOut;
       snap.latestCumulativeOutputTokens = outputTokens;
-      snap.tokensOut = Math.max(0, outputTokens - baseline.outputTokens);
+      snap.tokensOut = Math.max(0, outputTokens - (baselineOut ?? 0));
     }
     if (snap.firstSeenAtMs === undefined) snap.firstSeenAtMs = nowMs();
     turnMetaByTurnId.set(event.turn_id, snap);

--- a/src/runtime/ui-protocol-runtime.test.ts
+++ b/src/runtime/ui-protocol-runtime.test.ts
@@ -93,6 +93,10 @@ function makeDeferredBridge(): DeferredBridge {
     onTaskOutputDelta: vi.fn(() => () => {}),
     onTurnLifecycle: vi.fn(() => () => {}),
     onApprovalRequested: vi.fn(() => () => {}),
+    onToolStarted: vi.fn(() => () => {}),
+    onToolProgress: vi.fn(() => () => {}),
+    onToolCompleted: vi.fn(() => () => {}),
+    onProgressUpdated: vi.fn(() => () => {}),
     onConnectionStateChange: vi.fn((h: (s: ConnectionState) => void) => {
       stateHandler = h;
       return () => {
@@ -101,6 +105,9 @@ function makeDeferredBridge(): DeferredBridge {
     }),
     getConnectionState: vi.fn(() => "connected" as ConnectionState),
     onWarning: vi.fn(() => () => {}),
+    onSessionTitleUpdated: vi.fn(() => () => {}),
+    hydrateSession: vi.fn(async () => null),
+    callMethod: vi.fn(async () => null),
   };
   return {
     bridge,

--- a/src/runtime/ui-protocol-types.ts
+++ b/src/runtime/ui-protocol-types.ts
@@ -287,6 +287,146 @@ export interface TurnErrorEvent {
   error: { code: number; message: string; data?: unknown };
 }
 
+/**
+ * `tool/started` notification per UI Protocol v1 spec. Server emits this when
+ * the agent begins executing a synchronous (non-spawn) tool call. Wire shape
+ * mirrors `octos_core::ui_protocol::ToolStartedEvent` —
+ * `session_id`, `turn_id`, `tool_call_id`, `tool_name` are required;
+ * `arguments` is optional.
+ *
+ * The web client lifts this onto the legacy `crew:tool_progress` DOM event
+ * (the spinner under the streaming assistant bubble) so the
+ * `ToolProgressIndicator` component lights up the moment a tool starts —
+ * the SSE bridge predecessor of this surface was the sole dispatcher prior
+ * to PR #96, and the new event-router restores parity.
+ */
+export interface ToolStartedEvent {
+  session_id: string;
+  turn_id: string;
+  tool_call_id: string;
+  tool_name: string;
+  arguments?: unknown;
+}
+
+/**
+ * `tool/progress` notification — mid-execution status frames a tool emits
+ * while it runs. Mirrors `octos_core::ui_protocol::ToolProgressEvent`.
+ * `message` and `progress_pct` are both optional on the wire (server emits
+ * whichever is meaningful for the tool surface).
+ */
+export interface ToolProgressEvent {
+  session_id: string;
+  turn_id: string;
+  tool_call_id: string;
+  message?: string;
+  progress_pct?: number;
+}
+
+/**
+ * `tool/completed` notification — terminal status frame for a synchronous
+ * tool call. Mirrors `octos_core::ui_protocol::ToolCompletedEvent`.
+ * `success`, `output_preview`, and `duration_ms` are all optional on the
+ * wire (server emits whichever is meaningful for the tool surface).
+ */
+export interface ToolCompletedEvent {
+  session_id: string;
+  turn_id: string;
+  tool_call_id: string;
+  tool_name: string;
+  success?: boolean;
+  output_preview?: string;
+  duration_ms?: number;
+}
+
+/**
+ * Token / cost counters carried on `progress/updated` notifications whose
+ * `metadata.kind === "token_cost_update"`. Mirrors
+ * `octos_core::ui_protocol::UiTokenCostUpdate`. All fields are optional on
+ * the wire — the server populates whichever counters changed for the
+ * frame.
+ */
+export interface UiTokenCostUpdate {
+  input_tokens?: number;
+  output_tokens?: number;
+  reasoning_tokens?: number;
+  cache_read_tokens?: number;
+  cache_write_tokens?: number;
+  total_tokens?: number;
+  response_cost?: number;
+  session_cost?: number;
+  currency?: string;
+}
+
+/**
+ * Retry / backoff counters carried on `progress/updated` notifications
+ * whose `metadata.kind === "retry_backoff"`. Mirrors
+ * `octos_core::ui_protocol::UiRetryBackoff`. All fields are optional on
+ * the wire.
+ */
+export interface UiRetryBackoff {
+  attempt?: number;
+  max_attempts?: number;
+  backoff_ms?: number;
+  reason?: string;
+  provider?: string;
+  next_provider?: string;
+}
+
+/**
+ * File-mutation notice carried on `progress/updated` notifications whose
+ * `metadata.kind === "file_mutation"`. Mirrors
+ * `octos_core::ui_protocol::UiFileMutationNotice`. `path` and `operation`
+ * are required; the rest are optional.
+ */
+export interface UiFileMutationNotice {
+  path: string;
+  operation: string;
+  tool_call_id?: string;
+  bytes_written?: number;
+}
+
+/**
+ * Metadata envelope on `progress/updated` notifications. Mirrors
+ * `octos_core::ui_protocol::UiProgressMetadata`. The wire shape carries an
+ * open `kind` discriminator plus per-kind structured payloads; legacy
+ * `extra` fields are passed through via the `[key: string]: unknown`
+ * index signature so future server-side extensions don't trip the
+ * fail-closed reject path.
+ */
+export interface UiProgressMetadata {
+  kind: string;
+  label?: string;
+  message?: string;
+  detail?: string;
+  iteration?: number;
+  progress_pct?: number;
+  retry?: UiRetryBackoff;
+  file_mutation?: UiFileMutationNotice;
+  token_cost?: UiTokenCostUpdate;
+  [extra: string]: unknown;
+}
+
+/**
+ * `progress/updated` notification — the canonical UI Protocol v1 channel
+ * for non-message-stream progress signals (cost telemetry, status pings,
+ * retry/backoff frames, file-mutation notices, ...). Mirrors
+ * `octos_core::ui_protocol::UiProgressEvent` /
+ * `ProgressUpdatedEvent`. `session_id` is required; `turn_id` is optional
+ * because some progress kinds (e.g. session-scoped status) emit outside a
+ * turn context.
+ *
+ * The web client lifts this onto two legacy DOM events: `crew:cost`
+ * (header model + token / cost badge) and, when model + duration are
+ * available, `crew:message_meta` (assistant bubble footer model + tokens
+ * + duration). The SSE bridge predecessor of this surface was the sole
+ * dispatcher prior to PR #96.
+ */
+export interface ProgressUpdatedEvent {
+  session_id: string;
+  turn_id?: string;
+  metadata: UiProgressMetadata;
+}
+
 export interface ApprovalRenderHints {
   default_decision?: ApprovalDecision;
   primary_label?: string;

--- a/src/store/thread-store.ts
+++ b/src/store/thread-store.ts
@@ -1320,17 +1320,27 @@ export interface FinalizeAssistantOptions {
  * meta, and clears `pendingAssistant`.
  */
 /**
- * Stamp `meta` (and optionally `status`) onto the most recently
- * finalised response for `threadId`. Used by the UI Protocol event
+ * Stamp `meta` (and optionally `status`) onto the most recent
+ * *assistant* response for `threadId`. Used by the UI Protocol event
  * router (`handleTurnCompleted` / `handleTurnError`) when an earlier
  * `message/persisted` already promoted the pending bubble — by the
  * time `turn/completed` lands, `pendingAssistant` is null and
  * `finalizeAssistant`'s pending-required guard would otherwise drop the
  * accumulated per-turn cost snapshot on the floor. Codex P2 fix.
  *
+ * Codex round-3 P2: we search BACKWARDS for the most recent `assistant`
+ * row rather than blindly patching the tail. A media-only companion
+ * row or a tool result appended AFTER the assistant promotion would
+ * otherwise capture the meta+status, leaving the visible answer
+ * blank. Tool rows (`role === "tool"`) aren't visible bubbles, and
+ * media-only companions render as part of the assistant they're
+ * attached to — but their `status` / `meta` are read by other parts
+ * of the renderer; we want the stamp to land on the actual text
+ * answer.
+ *
  * No-ops when:
  *   - no thread matches `threadId` in any session,
- *   - the thread has no finalised responses yet (the snapshot is just
+ *   - the thread has no assistant responses yet (the snapshot is just
  *     lost, same as before this helper existed; `handleTurnCompleted`
  *     fall back to `finalizeAssistant` for the pending-present case).
  */
@@ -1341,7 +1351,18 @@ export function patchLastResponseMeta(
   for (const state of sessionsByKey.values()) {
     const thread = state.byId.get(threadId);
     if (!thread || thread.responses.length === 0) continue;
-    const idx = thread.responses.length - 1;
+    // Walk responses tail-to-head looking for the most recent assistant
+    // row. Tool rows + media-only companions are skipped — they're
+    // either folded into the preceding assistant bubble at render time
+    // or filtered out entirely (`isVisibleResponse` drops tool rows).
+    let idx = -1;
+    for (let i = thread.responses.length - 1; i >= 0; i--) {
+      if (thread.responses[i].role === "assistant") {
+        idx = i;
+        break;
+      }
+    }
+    if (idx === -1) continue;
     const last = thread.responses[idx];
     const next: ThreadMessage = {
       ...last,

--- a/src/store/thread-store.ts
+++ b/src/store/thread-store.ts
@@ -1319,6 +1319,41 @@ export interface FinalizeAssistantOptions {
  * thread. Stamps `intra_thread_seq` from `committedSeq`, attaches optional
  * meta, and clears `pendingAssistant`.
  */
+/**
+ * Stamp `meta` (and optionally `status`) onto the most recently
+ * finalised response for `threadId`. Used by the UI Protocol event
+ * router (`handleTurnCompleted` / `handleTurnError`) when an earlier
+ * `message/persisted` already promoted the pending bubble — by the
+ * time `turn/completed` lands, `pendingAssistant` is null and
+ * `finalizeAssistant`'s pending-required guard would otherwise drop the
+ * accumulated per-turn cost snapshot on the floor. Codex P2 fix.
+ *
+ * No-ops when:
+ *   - no thread matches `threadId` in any session,
+ *   - the thread has no finalised responses yet (the snapshot is just
+ *     lost, same as before this helper existed; `handleTurnCompleted`
+ *     fall back to `finalizeAssistant` for the pending-present case).
+ */
+export function patchLastResponseMeta(
+  threadId: string,
+  opts: { meta?: MessageMeta; status?: ThreadMessage["status"] },
+): void {
+  for (const state of sessionsByKey.values()) {
+    const thread = state.byId.get(threadId);
+    if (!thread || thread.responses.length === 0) continue;
+    const idx = thread.responses.length - 1;
+    const last = thread.responses[idx];
+    const next: ThreadMessage = {
+      ...last,
+      meta: opts.meta ?? last.meta,
+      status: opts.status ?? last.status,
+    };
+    thread.responses[idx] = next;
+    notify();
+    return;
+  }
+}
+
 export function finalizeAssistant(
   threadId: string,
   opts: FinalizeAssistantOptions = {},

--- a/tests/restore-progress-cost-meta.spec.ts
+++ b/tests/restore-progress-cost-meta.spec.ts
@@ -1,0 +1,146 @@
+/**
+ * Live smoke test for PR fix/restore-progress-cost-meta-events.
+ *
+ * Exercises the three regressions in one happy path:
+ *
+ *   A. Spinner under the streaming assistant bubble lights up during
+ *      a tool call (`crew:tool_progress` fan-out from `tool/*` UI
+ *      Protocol v1 notifications).
+ *   B. Header cost-bar populates with model + token + cost from the
+ *      first `progress/updated{kind:"token_cost_update"}` frame.
+ *   C. The finalised assistant bubble's footer (model + tokens +
+ *      duration) renders via `message.meta` stamped on
+ *      `finalizeAssistant` from the per-turn snapshot.
+ *
+ * Sets up auth like `mini5-history-timing-probe.spec.ts` in the sibling
+ * octos repo — `OCTOS_USER_TOKEN` env var, OCTOS_TEST_URL for the
+ * target. Skips when no token is provided so CI can run the full
+ * suite without infra dependencies.
+ */
+
+import { test, expect, type Page } from "@playwright/test";
+
+const BASE_URL = process.env.OCTOS_TEST_URL || "";
+const TOKEN = process.env.OCTOS_USER_TOKEN || "";
+const PROFILE = process.env.OCTOS_PROFILE || "dspfac";
+
+test.describe("restore progress / cost / meta events", () => {
+  test.skip(!BASE_URL || !TOKEN, "OCTOS_TEST_URL + OCTOS_USER_TOKEN required");
+
+  async function seed(page: Page) {
+    await page.addInitScript(
+      ([t, p]) => {
+        try {
+          localStorage.setItem("octos_session_token", t as string);
+          localStorage.setItem("selected_profile", p as string);
+          localStorage.removeItem("octos_auth_token");
+        } catch {
+          // some sandbox modes block storage; nothing to do.
+        }
+      },
+      [TOKEN, PROFILE],
+    );
+  }
+
+  test("send a message, see spinner / cost-bar / bubble footer", async ({
+    page,
+  }) => {
+    test.setTimeout(120_000);
+
+    let progressDispatchCount = 0;
+    let costDispatchCount = 0;
+    let messageMetaDispatchCount = 0;
+
+    await page.exposeFunction("__recordCrewEvent", (eventType: string) => {
+      if (eventType === "crew:tool_progress") progressDispatchCount++;
+      if (eventType === "crew:cost") costDispatchCount++;
+      if (eventType === "crew:message_meta") messageMetaDispatchCount++;
+    });
+
+    // Install a window event sniffer BEFORE the SPA boots so we catch
+    // every dispatch from `ui-protocol-event-router.ts`.
+    await page.addInitScript(() => {
+      const types = ["crew:tool_progress", "crew:cost", "crew:message_meta"];
+      for (const type of types) {
+        window.addEventListener(type, () => {
+          (
+            window as unknown as {
+              __recordCrewEvent: (t: string) => void;
+            }
+          ).__recordCrewEvent(type);
+        });
+      }
+    });
+
+    await seed(page);
+    await page.goto(`${BASE_URL}/chat`, { waitUntil: "domcontentloaded" });
+
+    // Wait for the chat input to be ready (the SPA has booted and the
+    // WS bridge has connected).
+    await page.waitForSelector("[data-testid='chat-input']", { timeout: 30_000 });
+
+    // Start a new session to keep the test isolated.
+    await page.click("[data-testid='new-chat-button']").catch(() => {
+      // Some surfaces auto-create on first send; if the button is
+      // absent that's fine.
+    });
+
+    // Send a prompt that should trigger a tool call (shell) so the
+    // spinner fires. "What time is it?" is cheap and reliable on the
+    // mini5 deployment.
+    const input = page.locator("[data-testid='chat-input']").first();
+    await input.fill("What is 7 times 8? Use the shell tool.");
+    await page.locator("[data-testid='send-button']").click();
+
+    // Wait for the spinner row to appear — this is the regression #1
+    // surface (`crew:tool_progress` dispatched by the router).
+    await expect(page.locator("[data-testid='tool-progress']").first()).toBeVisible(
+      { timeout: 30_000 },
+    );
+
+    // Wait for the assistant bubble to finalise (turn/completed lands).
+    // The thinking indicator clears and `finalizeAssistant({ meta })`
+    // runs — the bubble footer (`ThreadMessageMeta`) should now show
+    // the model.
+    await page.waitForFunction(
+      () => {
+        const indicators = document.querySelectorAll(
+          "[data-testid='thinking-indicator']",
+        );
+        return indicators.length === 0;
+      },
+      { timeout: 90_000 },
+    );
+
+    // Regression #3 (header model + cost): the cost-bar at the top
+    // should now show at least one populated badge.
+    const costBar = page.locator("[data-testid='cost-bar']");
+    await expect(costBar).toBeVisible({ timeout: 30_000 });
+    const costBarText = await costBar.textContent();
+    expect(costBarText, "cost-bar must contain at least one populated badge")
+      .toBeTruthy();
+    expect(costBarText!.length).toBeGreaterThan(0);
+
+    // Regression #2 (bubble footer): a finalised assistant bubble
+    // should now have meta — assert the data-testid surface contains
+    // something looking like a token count or model marker.
+    const lastAssistant = page
+      .locator("[data-testid='assistant-message']")
+      .last();
+    await expect(lastAssistant).toBeVisible({ timeout: 30_000 });
+
+    // Counter assertions — at least one fan-out must have fired for
+    // each regression. We don't pin specific counts since timing varies
+    // across hosts; we only care that NONE is zero (the pre-fix bug
+    // had all three at zero forever).
+    expect(progressDispatchCount, "regression #1: crew:tool_progress fired")
+      .toBeGreaterThan(0);
+    expect(costDispatchCount, "regression #3: crew:cost fired")
+      .toBeGreaterThan(0);
+    // `crew:message_meta` fires only when the cost frame carries a
+    // model label; many backends omit it for early frames, so we
+    // accept zero here and rely on the `meta` being applied via
+    // `finalizeAssistant` instead.
+    void messageMetaDispatchCount;
+  });
+});


### PR DESCRIPTION
## Summary

- PR #96 (atomic SSE delete) removed `src/runtime/sse-bridge.ts`, the sole dispatcher of three DOM events that surviving listeners still bind: `crew:tool_progress` (`ToolProgressIndicator`), `crew:cost` (`CostBar`), `crew:message_meta` (`session-context.tsx` stats handler). The replacement UI Protocol v1 bridge + router re-emitted only `crew:thinking`, leaving the streaming-bubble spinner, the header cost badge, and the assistant-bubble footer (model + tokens + duration) all blank.
- Fix lifts the matching UI Protocol v1 notifications onto the same legacy DOM events: `tool/started` / `tool/progress` / `tool/completed` → `crew:tool_progress`; `progress/updated{kind:"token_cost_update"}` → `crew:cost` (+ `crew:message_meta` when the frame carries a model label).
- Adds a per-turn meta snapshot (`turnMetaByTurnId`) so `finalizeAssistant({ meta })` stamps model / tokens / duration onto the finalised bubble on `turn/completed` / `turn/error`. Codex caught two follow-up issues addressed in the same PR: P2 — when `message/persisted` already promoted the pending bubble, the snapshot was lost; `ThreadStore.patchLastResponseMeta` is the new fall-back. P3 — `tool/progress` carries no `tool_name` on the wire; `toolNameByCallId` caches the name from the preceding `tool/started` so the spinner label stays sticky.

## Test plan

- [x] `npm run test:unit` — 22 new unit tests in `ui-protocol-event-router.test.ts`, 6 new tests in `ui-protocol-bridge.test.ts`, 3 new tests in `tool-progress-indicator.test.tsx` (373 / 374 pass — the one failure pre-existed on `main`)
- [x] `npm run build` — clean
- [ ] Live smoke against mini1 (`dspfac.crew.ominix.io`) — deferred pending OTP token; `tests/restore-progress-cost-meta.spec.ts` is wired and gated on `OCTOS_USER_TOKEN` + `OCTOS_TEST_URL`
- [ ] Visually verify on a live mini after deploy: spinner during a tool call; header cost / model badge populated; finalised bubble shows model + tokens + duration

🤖 Generated with [Claude Code](https://claude.com/claude-code)