### PR TITLE
feat(chat): copy-as-markdown button on assistant bubbles

### DIFF
--- a/src/components/chat-thread-copy.test.tsx
+++ b/src/components/chat-thread-copy.test.tsx
@@ -1,0 +1,181 @@
+/**
+ * Integration test for the copy-as-markdown button slot in
+ * `ThreadAssistantBubble`. Exercises the render-time gating contract:
+ *
+ *   - A FINALIZED assistant message (`status: "complete"` and no live
+ *     indicators) shows the copy button next to `ThreadMessageMeta`.
+ *   - A STREAMING assistant message (or one in `showLiveIndicators`
+ *     mode) suppresses the button so partial content can't leak to the
+ *     clipboard.
+ *
+ * We mount `ThreadAssistantBubble` directly with hand-built
+ * `ThreadMessage` records — no SessionContext or Composer plumbing
+ * required.
+ */
+
+import { afterEach, describe, expect, it } from "vitest";
+import * as React from "react";
+import { act } from "react";
+import { createRoot, type Root } from "react-dom/client";
+
+(
+  globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }
+).IS_REACT_ACT_ENVIRONMENT = true;
+
+import { ThreadAssistantBubble } from "./chat-thread";
+import type { ThreadMessage } from "@/store/thread-store";
+import { SessionContext } from "@/runtime/session-context";
+import type { SessionContextValue } from "@/runtime/session-context";
+
+function makeSessionCtx(): SessionContextValue {
+  return {
+    sessions: [],
+    currentSessionId: "sess-copy-md",
+    historyTopic: undefined,
+    currentSessionTitle: "",
+    currentSessionStats: null,
+    initialMessages: [],
+    activeTaskOnServer: false,
+    queueMode: null,
+    adaptiveMode: null,
+    setServerTaskActive: () => {},
+    renameSession: () => {},
+    updateSessionStats: () => {},
+    switchSession: () => {},
+    goBack: async () => false,
+    createSession: () => "sess-copy-md",
+    removeSession: async () => {},
+    refreshSessions: async () => {},
+    markSessionActive: () => {},
+  };
+}
+
+interface MountedHarness {
+  container: HTMLDivElement;
+  root: Root;
+  unmount: () => void;
+}
+
+function mount(node: React.ReactElement): MountedHarness {
+  const container = document.createElement("div");
+  document.body.appendChild(container);
+  const root = createRoot(container);
+  act(() => {
+    root.render(node);
+  });
+  return {
+    container,
+    root,
+    unmount: () => {
+      act(() => root.unmount());
+      container.remove();
+    },
+  };
+}
+
+function makeAssistant(overrides: Partial<ThreadMessage> = {}): ThreadMessage {
+  return {
+    id: overrides.id ?? "msg-1",
+    role: "assistant",
+    text: overrides.text ?? "# Hello\n\nworld",
+    files: [],
+    toolCalls: [],
+    status: overrides.status ?? "complete",
+    timestamp: 1700000000000,
+    ...overrides,
+  };
+}
+
+afterEach(() => {
+  for (const node of [...document.body.children]) {
+    node.remove();
+  }
+});
+
+describe("ThreadAssistantBubble copy-markdown button", () => {
+  it("renders the copy button on finalized assistant messages", () => {
+    const msg = makeAssistant({
+      text: "## Done\n\nFinal answer.",
+      status: "complete",
+    });
+    const { container, unmount } = mount(
+      <SessionContext.Provider value={makeSessionCtx()}>
+        <ThreadAssistantBubble
+          message={msg}
+          isStreaming={false}
+          showLiveIndicators={false}
+          threadId="thr-1"
+        />
+      </SessionContext.Provider>,
+    );
+    const btn = container.querySelector(
+      "[data-testid='copy-markdown-button']",
+    );
+    expect(btn).not.toBeNull();
+    expect(btn!.getAttribute("aria-label")).toBe("Copy as markdown");
+    unmount();
+  });
+
+  it("does NOT render the copy button while the assistant is streaming", () => {
+    const msg = makeAssistant({
+      text: "partial...",
+      status: "streaming",
+    });
+    const { container, unmount } = mount(
+      <SessionContext.Provider value={makeSessionCtx()}>
+        <ThreadAssistantBubble
+          message={msg}
+          isStreaming={true}
+          showLiveIndicators={true}
+          threadId="thr-2"
+        />
+      </SessionContext.Provider>,
+    );
+    expect(
+      container.querySelector("[data-testid='copy-markdown-button']"),
+    ).toBeNull();
+    unmount();
+  });
+
+  it("does NOT render the copy button while live indicators are still pinned (turn not settled)", () => {
+    // A pending assistant briefly flips `status: "complete"` ahead of the
+    // turn fully settling. The render gate also checks
+    // `!showLiveIndicators` so we don't flash an icon during that window.
+    const msg = makeAssistant({
+      text: "interim",
+      status: "complete",
+    });
+    const { container, unmount } = mount(
+      <SessionContext.Provider value={makeSessionCtx()}>
+        <ThreadAssistantBubble
+          message={msg}
+          isStreaming={false}
+          showLiveIndicators={true}
+          threadId="thr-3"
+        />
+      </SessionContext.Provider>,
+    );
+    expect(
+      container.querySelector("[data-testid='copy-markdown-button']"),
+    ).toBeNull();
+    unmount();
+  });
+
+  it("does NOT render the copy button on a finalized assistant with empty text (file-only)", () => {
+    const msg = makeAssistant({ text: "", status: "complete" });
+    const { container, unmount } = mount(
+      <SessionContext.Provider value={makeSessionCtx()}>
+        <ThreadAssistantBubble
+          message={msg}
+          isStreaming={false}
+          showLiveIndicators={false}
+          threadId="thr-4"
+        />
+      </SessionContext.Provider>,
+    );
+    expect(
+      container.querySelector("[data-testid='copy-markdown-button']"),
+    ).toBeNull();
+    unmount();
+  });
+});

--- a/src/components/chat-thread.tsx
+++ b/src/components/chat-thread.tsx
@@ -47,6 +47,7 @@ import { ThinkingIndicator } from "./thinking-indicator";
 import { ToolProgressIndicator } from "./tool-progress-indicator";
 import { GhostBubble } from "./GhostBubble";
 import { UserBubbleShell } from "./user-bubble-shell";
+import { CopyMarkdownButton } from "./copy-markdown-button";
 import { buildAuthenticatedFileUrl, buildFileUrl } from "@/api/files";
 import { displayFilenameFromPath } from "@/lib/utils";
 import { nextTopicForCommand } from "@/lib/slash-commands";
@@ -524,7 +525,7 @@ function ToolCallBubble({
   );
 }
 
-const ThreadAssistantBubble = memo(function ThreadAssistantBubble({
+export const ThreadAssistantBubble = memo(function ThreadAssistantBubble({
   message,
   isStreaming,
   showLiveIndicators,
@@ -539,12 +540,20 @@ const ThreadAssistantBubble = memo(function ThreadAssistantBubble({
   // message's own backref so a finalized assistant whose origin tid
   // got rewritten still tags its DOM with the canonical thread bucket.
   const tid = threadId || message.responseToClientMessageId || "";
+  // Only finalized assistant messages get the "copy as markdown"
+  // affordance — streaming/error bubbles would copy partial content.
+  // `showLiveIndicators` covers the in-flight pending case where
+  // `status` may briefly be `"complete"` while a follow-on pending is
+  // about to spawn; gating on both keeps the icon off the in-flight
+  // bubble until the turn truly settles.
+  const showCopyButton =
+    message.status === "complete" && !showLiveIndicators && !!message.text;
   return (
     <div className="flex px-4 py-3">
       <div
         data-testid="assistant-message"
         data-thread-id={tid}
-        className="message-card message-card-assistant animate-shell-rise max-w-[88%] rounded-[14px] rounded-bl-[4px] px-4 py-3 text-sm leading-relaxed text-text"
+        className="group/assistant message-card message-card-assistant animate-shell-rise max-w-[88%] rounded-[14px] rounded-bl-[4px] px-4 py-3 text-sm leading-relaxed text-text"
       >
         {message.text ? (
           <MarkdownContent
@@ -588,8 +597,15 @@ const ThreadAssistantBubble = memo(function ThreadAssistantBubble({
           </>
         )}
 
-        {/* Message meta */}
-        <ThreadMessageMeta message={message} />
+        {/* Message footer: meta on the left, copy button on the right */}
+        <div className="mt-1.5 flex items-center justify-between gap-2">
+          <ThreadMessageMeta message={message} />
+          {showCopyButton ? (
+            <CopyMarkdownButton content={message.text} />
+          ) : (
+            <span aria-hidden="true" />
+          )}
+        </div>
       </div>
     </div>
   );
@@ -609,7 +625,7 @@ function ThreadMessageMeta({ message }: { message: ThreadMessage }) {
 
   if (meta && (meta.model || meta.tokens_in || meta.tokens_out)) {
     return (
-      <div className="mt-1.5 flex items-center gap-1.5 text-[10px] text-muted/60 select-none">
+      <div className="flex items-center gap-1.5 text-[10px] text-muted/60 select-none">
         <span className="inline-block h-1.5 w-1.5 rounded-full bg-accent/40" />
         {parts.join(" · ")}
       </div>
@@ -617,7 +633,7 @@ function ThreadMessageMeta({ message }: { message: ThreadMessage }) {
   }
 
   return (
-    <div className="mt-1.5 text-[10px] text-muted/60 select-none">
+    <div className="text-[10px] text-muted/60 select-none">
       {formatTimestamp(message.timestamp)}
     </div>
   );

--- a/src/components/copy-markdown-button.test.tsx
+++ b/src/components/copy-markdown-button.test.tsx
@@ -1,0 +1,222 @@
+/**
+ * Unit tests for `CopyMarkdownButton`.
+ *
+ * Coverage:
+ *   1. Renders a clickable button with the documented `aria-label` /
+ *      `data-testid`, plus the `Copy` icon while idle.
+ *   2. Click writes the supplied markdown to `navigator.clipboard` and
+ *      swaps the icon to a checkmark (`data-state="copied"`) for
+ *      1.5s, then reverts to idle.
+ *   3. Clipboard rejection falls back to the legacy `execCommand`
+ *      path; if THAT also fails the button surfaces the error state
+ *      (`data-state="error"`).
+ *   4. The aria-label updates with state so screen readers announce
+ *      success / failure.
+ *
+ * Test rig mirrors the rest of the repo — `react-dom/client` + `act`,
+ * no `@testing-library/react`.
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import * as React from "react";
+import { act } from "react";
+import { createRoot, type Root } from "react-dom/client";
+
+(
+  globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }
+).IS_REACT_ACT_ENVIRONMENT = true;
+
+import { CopyMarkdownButton } from "./copy-markdown-button";
+
+interface MountedHarness {
+  container: HTMLDivElement;
+  root: Root;
+  unmount: () => void;
+}
+
+function mount(node: React.ReactElement): MountedHarness {
+  const container = document.createElement("div");
+  document.body.appendChild(container);
+  const root = createRoot(container);
+  act(() => {
+    root.render(node);
+  });
+  return {
+    container,
+    root,
+    unmount: () => {
+      act(() => root.unmount());
+      container.remove();
+    },
+  };
+}
+
+afterEach(() => {
+  for (const node of [...document.body.children]) {
+    node.remove();
+  }
+});
+
+describe("CopyMarkdownButton", () => {
+  let originalClipboard: PropertyDescriptor | undefined;
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+    originalClipboard = Object.getOwnPropertyDescriptor(navigator, "clipboard");
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    if (originalClipboard) {
+      Object.defineProperty(navigator, "clipboard", originalClipboard);
+    } else {
+      // Test installed a stub on a clipboard-less navigator; remove it.
+      delete (navigator as unknown as { clipboard?: unknown }).clipboard;
+    }
+  });
+
+  function stubClipboard(writeText: (text: string) => Promise<void>) {
+    Object.defineProperty(navigator, "clipboard", {
+      configurable: true,
+      writable: true,
+      value: { writeText },
+    });
+  }
+
+  it("renders an idle copy button with the documented aria-label", () => {
+    const { container, unmount } = mount(
+      <CopyMarkdownButton content="# Hello" />,
+    );
+    const btn = container.querySelector(
+      "[data-testid='copy-markdown-button']",
+    ) as HTMLButtonElement | null;
+    expect(btn).not.toBeNull();
+    expect(btn!.getAttribute("aria-label")).toBe("Copy as markdown");
+    expect(btn!.getAttribute("data-state")).toBe("idle");
+    // Lucide renders an inline <svg>; just confirm SOME glyph is mounted.
+    expect(btn!.querySelector("svg")).not.toBeNull();
+    unmount();
+  });
+
+  it("writes the markdown to clipboard and shows the copied state for 1.5s", async () => {
+    const writeText = vi.fn().mockResolvedValue(undefined);
+    stubClipboard(writeText);
+
+    const markdown = "# Title\n\nSome **bold** body.";
+    const { container, unmount } = mount(
+      <CopyMarkdownButton content={markdown} />,
+    );
+
+    const btn = container.querySelector(
+      "[data-testid='copy-markdown-button']",
+    ) as HTMLButtonElement;
+    await act(async () => {
+      btn.click();
+      // Flush the resolved clipboard promise.
+      await Promise.resolve();
+    });
+
+    expect(writeText).toHaveBeenCalledTimes(1);
+    expect(writeText).toHaveBeenCalledWith(markdown);
+    expect(btn.getAttribute("data-state")).toBe("copied");
+    expect(btn.getAttribute("aria-label")).toBe("Copied");
+
+    // Just before the revert timer fires — still copied.
+    act(() => {
+      vi.advanceTimersByTime(1499);
+    });
+    expect(btn.getAttribute("data-state")).toBe("copied");
+
+    // Cross the 1.5s threshold — revert to idle.
+    act(() => {
+      vi.advanceTimersByTime(2);
+    });
+    expect(btn.getAttribute("data-state")).toBe("idle");
+    expect(btn.getAttribute("aria-label")).toBe("Copy as markdown");
+
+    unmount();
+  });
+
+  it("surfaces an error state when both async and legacy copy fail", async () => {
+    stubClipboard(() => Promise.reject(new Error("permission denied")));
+    // Force the legacy path to fail too. jsdom doesn't ship
+    // `document.execCommand`, so attach a stub first.
+    const originalExec = (document as unknown as { execCommand?: unknown })
+      .execCommand;
+    (document as unknown as { execCommand: () => boolean }).execCommand = () =>
+      false;
+    const execSpy = vi
+      .spyOn(document, "execCommand")
+      .mockReturnValue(false);
+
+    const { container, unmount } = mount(
+      <CopyMarkdownButton content="hello" />,
+    );
+    const btn = container.querySelector(
+      "[data-testid='copy-markdown-button']",
+    ) as HTMLButtonElement;
+
+    await act(async () => {
+      btn.click();
+      // Drain both the rejected promise + microtask queue.
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    expect(btn.getAttribute("data-state")).toBe("error");
+    expect(btn.getAttribute("aria-label")).toBe("Copy failed");
+
+    // Error state also reverts after 1.5s.
+    act(() => {
+      vi.advanceTimersByTime(1501);
+    });
+    expect(btn.getAttribute("data-state")).toBe("idle");
+
+    execSpy.mockRestore();
+    if (originalExec === undefined) {
+      delete (document as unknown as { execCommand?: unknown }).execCommand;
+    } else {
+      (document as unknown as { execCommand: unknown }).execCommand = originalExec;
+    }
+    unmount();
+  });
+
+  it("uses the legacy execCommand path when navigator.clipboard is unavailable", async () => {
+    // No clipboard on navigator (simulate an insecure-context page).
+    Object.defineProperty(navigator, "clipboard", {
+      configurable: true,
+      writable: true,
+      value: undefined,
+    });
+    const originalExec = (document as unknown as { execCommand?: unknown })
+      .execCommand;
+    (document as unknown as { execCommand: () => boolean }).execCommand = () =>
+      true;
+    const execSpy = vi
+      .spyOn(document, "execCommand")
+      .mockReturnValue(true);
+
+    const { container, unmount } = mount(
+      <CopyMarkdownButton content="legacy md" />,
+    );
+    const btn = container.querySelector(
+      "[data-testid='copy-markdown-button']",
+    ) as HTMLButtonElement;
+
+    await act(async () => {
+      btn.click();
+      await Promise.resolve();
+    });
+
+    expect(execSpy).toHaveBeenCalledWith("copy");
+    expect(btn.getAttribute("data-state")).toBe("copied");
+
+    execSpy.mockRestore();
+    if (originalExec === undefined) {
+      delete (document as unknown as { execCommand?: unknown }).execCommand;
+    } else {
+      (document as unknown as { execCommand: unknown }).execCommand = originalExec;
+    }
+    unmount();
+  });
+});

--- a/src/components/copy-markdown-button.tsx
+++ b/src/components/copy-markdown-button.tsx
@@ -1,0 +1,169 @@
+/**
+ * Small ghost icon button that copies the raw markdown of an assistant
+ * bubble to the clipboard.
+ *
+ * UX contract (matches ChatGPT / Claude.ai pattern):
+ *   - Subtle by default, fades in on bubble hover.
+ *   - Click writes `content` to `navigator.clipboard.writeText`.
+ *   - On success: swap the copy glyph for a checkmark for 1.5s, then
+ *     revert. Pure local React state — no portal, no toast plumbing.
+ *   - On failure: surface an inline "failed" state for 1.5s and update
+ *     `aria-label` so screen readers announce the error. We deliberately
+ *     don't ship a toast — the project has no toast system today.
+ *   - Insecure-context fallback: when `navigator.clipboard` is missing
+ *     (HTTP page, etc.) we fall back to a hidden `<textarea>` +
+ *     `document.execCommand("copy")` so the button still works in
+ *     non-HTTPS dev environments.
+ *
+ * Callers are responsible for gating render on "message finalized"
+ * (e.g. `message.status === "complete"`). This component does not know
+ * about thread-store types — it just takes a `content` string.
+ */
+
+import { useCallback, useEffect, useRef, useState } from "react";
+import { Check, Copy, X } from "lucide-react";
+
+type CopyState = "idle" | "copied" | "error";
+
+/** Window for the success/error icon swap before reverting to idle. */
+const FEEDBACK_DURATION_MS = 1500;
+
+interface CopyMarkdownButtonProps {
+  /** Raw markdown to write to the clipboard. Required and non-empty. */
+  content: string;
+  /** Optional `data-testid`. Defaults to `copy-markdown-button`. */
+  testId?: string;
+  /** Extra classes appended after the default Tailwind chain. */
+  className?: string;
+}
+
+/**
+ * Fallback path for insecure contexts (HTTP, file://) where
+ * `navigator.clipboard` is unavailable. Returns true on success.
+ *
+ * `execCommand("copy")` is deprecated but still the only universal
+ * fallback. We mount the hidden textarea on body, select it, fire the
+ * command, then remove it synchronously — no DOM leak even if the call
+ * throws.
+ */
+function legacyCopy(text: string): boolean {
+  if (typeof document === "undefined") return false;
+  const textarea = document.createElement("textarea");
+  textarea.value = text;
+  // Out-of-flow so it can't affect layout / scroll position.
+  textarea.setAttribute("readonly", "");
+  textarea.style.position = "fixed";
+  textarea.style.top = "0";
+  textarea.style.left = "0";
+  textarea.style.opacity = "0";
+  textarea.style.pointerEvents = "none";
+  document.body.appendChild(textarea);
+  try {
+    textarea.select();
+    textarea.setSelectionRange(0, text.length);
+    return document.execCommand("copy");
+  } catch {
+    return false;
+  } finally {
+    document.body.removeChild(textarea);
+  }
+}
+
+export function CopyMarkdownButton({
+  content,
+  testId = "copy-markdown-button",
+  className = "",
+}: CopyMarkdownButtonProps) {
+  const [state, setState] = useState<CopyState>("idle");
+  const timerRef = useRef<number | null>(null);
+
+  // Clean up any pending revert timer on unmount so a fast-clicking
+  // user can't trigger a setState on a disposed component.
+  useEffect(() => {
+    return () => {
+      if (timerRef.current !== null) {
+        window.clearTimeout(timerRef.current);
+        timerRef.current = null;
+      }
+    };
+  }, []);
+
+  const scheduleRevert = useCallback(() => {
+    if (timerRef.current !== null) {
+      window.clearTimeout(timerRef.current);
+    }
+    timerRef.current = window.setTimeout(() => {
+      timerRef.current = null;
+      setState("idle");
+    }, FEEDBACK_DURATION_MS);
+  }, []);
+
+  const handleClick = useCallback(() => {
+    if (!content) return;
+    const onOk = () => {
+      setState("copied");
+      scheduleRevert();
+    };
+    const onFail = () => {
+      setState("error");
+      scheduleRevert();
+    };
+
+    // Prefer the async clipboard API (only in secure contexts).
+    if (typeof navigator !== "undefined" && navigator.clipboard?.writeText) {
+      void navigator.clipboard
+        .writeText(content)
+        .then(onOk)
+        .catch(() => {
+          // Permission denied (or insecure context with a stub
+          // present) — try the legacy path before giving up.
+          if (legacyCopy(content)) onOk();
+          else onFail();
+        });
+      return;
+    }
+    if (legacyCopy(content)) onOk();
+    else onFail();
+  }, [content, scheduleRevert]);
+
+  const ariaLabel =
+    state === "copied"
+      ? "Copied"
+      : state === "error"
+        ? "Copy failed"
+        : "Copy as markdown";
+  const title =
+    state === "copied"
+      ? "Copied"
+      : state === "error"
+        ? "Copy failed"
+        : "Copy as markdown";
+
+  return (
+    <button
+      type="button"
+      data-testid={testId}
+      data-state={state}
+      onClick={handleClick}
+      aria-label={ariaLabel}
+      title={title}
+      className={
+        "inline-flex items-center justify-center rounded-md p-1 text-muted/60 " +
+        "opacity-0 transition-opacity duration-150 " +
+        "group-hover/assistant:opacity-100 focus:opacity-100 focus:outline-none " +
+        "hover:bg-white/10 hover:text-text " +
+        (state === "copied" ? "text-accent " : "") +
+        (state === "error" ? "text-red-400 " : "") +
+        className
+      }
+    >
+      {state === "copied" ? (
+        <Check size={14} aria-hidden="true" />
+      ) : state === "error" ? (
+        <X size={14} aria-hidden="true" />
+      ) : (
+        <Copy size={14} aria-hidden="true" />
+      )}
+    </button>
+  );
+}

--- a/src/components/copy-markdown-button.tsx
+++ b/src/components/copy-markdown-button.tsx
@@ -148,12 +148,18 @@ export function CopyMarkdownButton({
       aria-label={ariaLabel}
       title={title}
       className={
+        // Visible-by-default with low opacity so touch-only devices
+        // (where `group-hover/assistant:opacity-100` is gated under
+        // `@media (hover:hover)` in Tailwind v4 and never fires) can
+        // still discover + tap the affordance. On hover-capable devices
+        // the bubble's `group/assistant` hover and the button's own
+        // hover/focus state bump it to full opacity.
         "inline-flex items-center justify-center rounded-md p-1 text-muted/60 " +
-        "opacity-0 transition-opacity duration-150 " +
-        "group-hover/assistant:opacity-100 focus:opacity-100 focus:outline-none " +
+        "opacity-40 transition-opacity duration-150 " +
+        "group-hover/assistant:opacity-100 hover:opacity-100 focus:opacity-100 focus:outline-none " +
         "hover:bg-white/10 hover:text-text " +
-        (state === "copied" ? "text-accent " : "") +
-        (state === "error" ? "text-red-400 " : "") +
+        (state === "copied" ? "text-accent opacity-100 " : "") +
+        (state === "error" ? "text-red-400 opacity-100 " : "") +
         className
       }
     >


### PR DESCRIPTION
## Summary

- New `CopyMarkdownButton` icon ghost-button (clipboard → checkmark for 1.5s) lives bottom-right of every **finalized** assistant bubble, in line with `ThreadMessageMeta`. UX matches ChatGPT / Claude.ai and the existing `CodeBlock` copy button: subtle, fades in on bubble hover via Tailwind v4 `group/assistant`.
- Click writes `message.text` (raw markdown, the same string `MarkdownContent` renders from) to `navigator.clipboard.writeText`. On rejection or insecure-context pages we fall back to a hidden-textarea + `document.execCommand("copy")` path. If BOTH fail, the button surfaces an inline error state (X icon, `aria-label="Copy failed"`) for 1.5s.
- Render gate: `message.status === "complete" && !showLiveIndicators && !!message.text` — keeps partial / in-flight / file-only bubbles button-less so users can't ever copy a half-streamed answer.

## Bubble integration

`ThreadAssistantBubble` (in `src/components/chat-thread.tsx`) now wraps the meta footer in a single flex row: `<ThreadMessageMeta>` on the left, `<CopyMarkdownButton>` on the right. Margin moved from inside `ThreadMessageMeta` to the row container so nothing visually shifts.

## Test plan

- [x] `src/components/copy-markdown-button.test.tsx` (4 tests): idle render, success path (`clipboard.writeText` called + `data-state="copied"` + 1.5s revert), dual-failure error state, legacy `execCommand` fallback when `navigator.clipboard` is missing.
- [x] `src/components/chat-thread-copy.test.tsx` (4 tests): finalized assistant shows the button; streaming, live-indicators-pinned, and empty-text bubbles all suppress it.
- [x] `npx vitest run` — 387 / 388 unit tests pass (the one pre-existing failure in `ui-protocol-event-router.test.ts` reproduces on `origin/main` and is unrelated).
- [x] `npx tsc --noEmit -p tsconfig.json` clean.
- [x] `npx eslint` on changed files clean (the two warnings in `chat-thread.tsx` are pre-existing on `main` and untouched by this PR).

## Edge cases handled

- Streaming bubble → button hidden until turn settles.
- Long messages → `clipboard.writeText` handles any length, no chunking needed.
- Permission denied / insecure context → execCommand fallback, then inline error.
- Selection-only copy → intentionally skipped per task brief (rendered DOM does not round-trip to source markdown).