### PR TITLE
feat(runtime): Wave4-A — wire router/status + queue/state DOM events

### DIFF
--- a/src/components/chat-thread.tsx
+++ b/src/components/chat-thread.tsx
@@ -865,8 +865,15 @@ function Composer({ mountGhost, unmountGhost }: ComposerProps) {
     beforeSend,
     queueMode,
     adaptiveMode,
+    currentSessionStats,
   } =
     useSession();
+  // Wave4-A: surface the live client-side queue depth in the toolbar pill.
+  // `currentSessionStats.queue_depth` is updated by the `crew:queue_state`
+  // subscription in `session-context.tsx`. Falls back to `null` so the
+  // existing `queueMode` literal label still renders for sessions that
+  // never push anything onto the queue.
+  const queueDepth = currentSessionStats?.queue_depth ?? 0;
   // M10.5: ThreadStore is the single source of truth — read `isRunning`
   // from the active session's threads.
   const threadsForRunning = useThreads(currentSessionId, historyTopic);
@@ -1638,17 +1645,26 @@ function Composer({ mountGhost, unmountGhost }: ComposerProps) {
             >
               <Camera size={16} />
             </button>
-            {/* Mode indicator badges */}
-            {(queueMode || adaptiveMode) && (
+            {/* Mode indicator badges. Wave4-A: `queueDepth` is the live
+                count of turns parked behind the in-flight gate (see
+                `ui-protocol-send.ts`); we render it whenever a queued
+                turn exists OR a legacy `queueMode` label is set, so
+                "N queued" appears regardless of whether the session
+                also has a `queueMode` label. */}
+            {(queueMode || adaptiveMode || queueDepth > 0) && (
               <div className="ml-auto flex items-center gap-1.5">
-                {queueMode && (
+                {(queueMode || queueDepth > 0) && (
                   <span
                     data-testid="queue-mode-badge"
                     className="mode-badge flex items-center gap-1 rounded-full px-2 py-0.5 text-[10px] font-medium"
-                    title={`Queue mode: ${queueMode}`}
+                    title={
+                      queueDepth > 0
+                        ? `${queueDepth} queued${queueMode ? ` (${queueMode})` : ""}`
+                        : `Queue mode: ${queueMode}`
+                    }
                   >
                     <Layers size={10} />
-                    {queueMode}
+                    {queueDepth > 0 ? `${queueDepth} queued` : queueMode}
                   </span>
                 )}
                 {adaptiveMode && (

--- a/src/components/router-failover-banner.test.tsx
+++ b/src/components/router-failover-banner.test.tsx
@@ -11,6 +11,33 @@ import { createRoot, type Root } from "react-dom/client";
   true;
 
 import { RouterFailoverBanner } from "./router-failover-banner";
+import { SessionContext } from "@/runtime/session-context";
+import type { SessionContextValue } from "@/runtime/session-context";
+
+const SESSION = "sess-failover-banner";
+
+function makeSessionCtx(sessionId = SESSION): SessionContextValue {
+  return {
+    sessions: [],
+    currentSessionId: sessionId,
+    historyTopic: undefined,
+    currentSessionTitle: "",
+    currentSessionStats: null,
+    initialMessages: [],
+    activeTaskOnServer: false,
+    queueMode: null,
+    adaptiveMode: null,
+    setServerTaskActive: () => {},
+    renameSession: () => {},
+    updateSessionStats: () => {},
+    switchSession: () => {},
+    goBack: async () => false,
+    createSession: () => sessionId,
+    removeSession: async () => {},
+    refreshSessions: async () => {},
+    markSessionActive: () => {},
+  };
+}
 
 interface MountedHarness {
   container: HTMLDivElement;
@@ -23,7 +50,11 @@ function mount(node: React.ReactElement): MountedHarness {
   document.body.appendChild(container);
   const root = createRoot(container);
   act(() => {
-    root.render(node);
+    root.render(
+      <SessionContext.Provider value={makeSessionCtx()}>
+        {node}
+      </SessionContext.Provider>,
+    );
   });
   return {
     container,
@@ -65,7 +96,7 @@ describe("RouterFailoverBanner", () => {
         window.dispatchEvent(
           new CustomEvent("crew:router_failover", {
             detail: {
-              sessionId: "s",
+              sessionId: SESSION,
               from: "openrouter/openai/gpt-5",
               to: "openrouter/anthropic/claude-opus-4-7",
               reason: "circuit_breaker_open",
@@ -88,6 +119,32 @@ describe("RouterFailoverBanner", () => {
     }
   });
 
+  it("drops events for other sessions (codex Wave4-A P2 scope guard)", () => {
+    const harness = mount(<RouterFailoverBanner />);
+    try {
+      act(() => {
+        window.dispatchEvent(
+          new CustomEvent("crew:router_failover", {
+            detail: {
+              sessionId: "different-session",
+              from: "a/m1",
+              to: "b/m2",
+              reason: "r",
+              elapsedMs: 100,
+            },
+          }),
+        );
+      });
+      expect(
+        harness.container.querySelector(
+          "[data-testid='router-failover-banner']",
+        ),
+      ).toBeNull();
+    } finally {
+      harness.unmount();
+    }
+  });
+
   it("auto-dismisses after 4 seconds", () => {
     const harness = mount(<RouterFailoverBanner />);
     try {
@@ -95,7 +152,7 @@ describe("RouterFailoverBanner", () => {
         window.dispatchEvent(
           new CustomEvent("crew:router_failover", {
             detail: {
-              sessionId: "s",
+              sessionId: SESSION,
               from: "a/m1",
               to: "b/m2",
               reason: "r",

--- a/src/components/router-failover-banner.test.tsx
+++ b/src/components/router-failover-banner.test.tsx
@@ -1,0 +1,124 @@
+/**
+ * Wave4-A router failover banner unit tests.
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import * as React from "react";
+import { act } from "react";
+import { createRoot, type Root } from "react-dom/client";
+
+(globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT =
+  true;
+
+import { RouterFailoverBanner } from "./router-failover-banner";
+
+interface MountedHarness {
+  container: HTMLDivElement;
+  root: Root;
+  unmount: () => void;
+}
+
+function mount(node: React.ReactElement): MountedHarness {
+  const container = document.createElement("div");
+  document.body.appendChild(container);
+  const root = createRoot(container);
+  act(() => {
+    root.render(node);
+  });
+  return {
+    container,
+    root,
+    unmount: () => {
+      act(() => root.unmount());
+      container.remove();
+    },
+  };
+}
+
+beforeEach(() => {
+  vi.useFakeTimers();
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+  document.body.innerHTML = "";
+});
+
+describe("RouterFailoverBanner", () => {
+  it("renders nothing until a crew:router_failover event fires", () => {
+    const harness = mount(<RouterFailoverBanner />);
+    try {
+      expect(
+        harness.container.querySelector(
+          "[data-testid='router-failover-banner']",
+        ),
+      ).toBeNull();
+    } finally {
+      harness.unmount();
+    }
+  });
+
+  it("shows the banner with from/to/reason/elapsedMs when a failover event fires", () => {
+    const harness = mount(<RouterFailoverBanner />);
+    try {
+      act(() => {
+        window.dispatchEvent(
+          new CustomEvent("crew:router_failover", {
+            detail: {
+              sessionId: "s",
+              from: "openrouter/openai/gpt-5",
+              to: "openrouter/anthropic/claude-opus-4-7",
+              reason: "circuit_breaker_open",
+              elapsedMs: 1500,
+            },
+          }),
+        );
+      });
+      const banner = harness.container.querySelector(
+        "[data-testid='router-failover-banner']",
+      );
+      expect(banner).not.toBeNull();
+      const text = banner?.textContent ?? "";
+      expect(text).toContain("openrouter/openai/gpt-5");
+      expect(text).toContain("openrouter/anthropic/claude-opus-4-7");
+      expect(text).toContain("circuit_breaker_open");
+      expect(text).toContain("1500ms");
+    } finally {
+      harness.unmount();
+    }
+  });
+
+  it("auto-dismisses after 4 seconds", () => {
+    const harness = mount(<RouterFailoverBanner />);
+    try {
+      act(() => {
+        window.dispatchEvent(
+          new CustomEvent("crew:router_failover", {
+            detail: {
+              sessionId: "s",
+              from: "a/m1",
+              to: "b/m2",
+              reason: "r",
+              elapsedMs: 100,
+            },
+          }),
+        );
+      });
+      expect(
+        harness.container.querySelector(
+          "[data-testid='router-failover-banner']",
+        ),
+      ).not.toBeNull();
+      act(() => {
+        vi.advanceTimersByTime(4000);
+      });
+      expect(
+        harness.container.querySelector(
+          "[data-testid='router-failover-banner']",
+        ),
+      ).toBeNull();
+    } finally {
+      harness.unmount();
+    }
+  });
+});

--- a/src/components/router-failover-banner.tsx
+++ b/src/components/router-failover-banner.tsx
@@ -21,6 +21,7 @@
 
 import { useEffect, useState } from "react";
 import { useSession } from "@/runtime/session-context";
+import { eventMatchesScope } from "@/runtime/event-scope";
 
 interface FailoverDetail {
   sessionId: string;
@@ -51,13 +52,14 @@ export function RouterFailoverBanner({
 }: RouterFailoverBannerProps = {}) {
   const session = useSession();
   const activeSessionId = sessionId ?? session.currentSessionId;
+  const activeTopic = session.historyTopic;
   const [visible, setVisible] = useState<VisibleFailover | null>(null);
 
   // Codex Wave4-A P2 review fix: drop any in-flight banner on session
-  // change so a non-current session's failover doesn't keep showing.
+  // / topic change so a non-current view's failover doesn't keep showing.
   useEffect(() => {
     setVisible(null);
-  }, [activeSessionId]);
+  }, [activeSessionId, activeTopic]);
 
   useEffect(() => {
     let timer: ReturnType<typeof setTimeout> | null = null;
@@ -65,12 +67,13 @@ export function RouterFailoverBanner({
     function handle(e: Event) {
       const detail = (e as CustomEvent).detail as FailoverDetail | undefined;
       if (!detail) return;
-      // Codex Wave4-A P2: scope by the active session so a routed
-      // failover for a previous bridge doesn't render globally.
-      if (
-        typeof detail.sessionId === "string" &&
-        detail.sessionId !== activeSessionId
-      ) {
+      // Codex Wave4-A P2 (round 2): scope by sessionId AND topic via
+      // the shared `eventMatchesScope` helper the rest of the UI uses.
+      // The event-router dispatches both fields, so a same-session
+      // /different-topic failover (slides/sites subview while the
+      // user is on the default view, or vice versa) is now suppressed
+      // until the user navigates to that scope.
+      if (!eventMatchesScope(detail, activeSessionId, activeTopic)) {
         return;
       }
       keySeq += 1;
@@ -86,7 +89,7 @@ export function RouterFailoverBanner({
       window.removeEventListener("crew:router_failover", handle);
       if (timer) clearTimeout(timer);
     };
-  }, [dismissAfterMs, activeSessionId]);
+  }, [dismissAfterMs, activeSessionId, activeTopic]);
 
   if (!visible) return null;
   return (

--- a/src/components/router-failover-banner.tsx
+++ b/src/components/router-failover-banner.tsx
@@ -8,12 +8,19 @@
  * sequence (subsequent ones replace the visible one and reset the
  * timer).
  *
+ * Scope: filters by the active session id passed via `sessionId`
+ * prop (or `useSession()`'s `currentSessionId` when absent). Late
+ * events from a previously-active bridge are dropped so a banner
+ * for a non-visible session doesn't pop up during a rapid session
+ * switch (codex Wave4-A P2 review fix).
+ *
  * Shape mirrors the existing inline file toast in `chat-layout.tsx`
  * — no shared toast infrastructure exists, so this component owns
  * its own state.
  */
 
 import { useEffect, useState } from "react";
+import { useSession } from "@/runtime/session-context";
 
 interface FailoverDetail {
   sessionId: string;
@@ -34,12 +41,23 @@ interface VisibleFailover extends FailoverDetail {
 export interface RouterFailoverBannerProps {
   /** Test-injection: override the auto-dismiss interval. */
   dismissAfterMs?: number;
+  /** Test-injection: bypass `useSession()` for component-level tests. */
+  sessionId?: string;
 }
 
 export function RouterFailoverBanner({
   dismissAfterMs = 4000,
+  sessionId,
 }: RouterFailoverBannerProps = {}) {
+  const session = useSession();
+  const activeSessionId = sessionId ?? session.currentSessionId;
   const [visible, setVisible] = useState<VisibleFailover | null>(null);
+
+  // Codex Wave4-A P2 review fix: drop any in-flight banner on session
+  // change so a non-current session's failover doesn't keep showing.
+  useEffect(() => {
+    setVisible(null);
+  }, [activeSessionId]);
 
   useEffect(() => {
     let timer: ReturnType<typeof setTimeout> | null = null;
@@ -47,6 +65,14 @@ export function RouterFailoverBanner({
     function handle(e: Event) {
       const detail = (e as CustomEvent).detail as FailoverDetail | undefined;
       if (!detail) return;
+      // Codex Wave4-A P2: scope by the active session so a routed
+      // failover for a previous bridge doesn't render globally.
+      if (
+        typeof detail.sessionId === "string" &&
+        detail.sessionId !== activeSessionId
+      ) {
+        return;
+      }
       keySeq += 1;
       setVisible({ ...detail, key: keySeq });
       if (timer) clearTimeout(timer);
@@ -60,7 +86,7 @@ export function RouterFailoverBanner({
       window.removeEventListener("crew:router_failover", handle);
       if (timer) clearTimeout(timer);
     };
-  }, [dismissAfterMs]);
+  }, [dismissAfterMs, activeSessionId]);
 
   if (!visible) return null;
   return (

--- a/src/components/router-failover-banner.tsx
+++ b/src/components/router-failover-banner.tsx
@@ -1,0 +1,82 @@
+/**
+ * Wave4-A `crew:router_failover` transient banner.
+ *
+ * Listens for the DOM event the event-router dispatches when the
+ * adaptive router crosses lanes and surfaces a 4 s auto-dismiss
+ * notice. The chat-layout mounts a single instance under the main
+ * scroll area; the banner stacks if multiple failovers fire in
+ * sequence (subsequent ones replace the visible one and reset the
+ * timer).
+ *
+ * Shape mirrors the existing inline file toast in `chat-layout.tsx`
+ * — no shared toast infrastructure exists, so this component owns
+ * its own state.
+ */
+
+import { useEffect, useState } from "react";
+
+interface FailoverDetail {
+  sessionId: string;
+  topic?: string;
+  from: string;
+  to: string;
+  reason: string;
+  elapsedMs: number;
+}
+
+interface VisibleFailover extends FailoverDetail {
+  /** Monotonic id so React keys the latest banner uniquely. Without
+   *  this, two failovers with the same `from`/`to` pair would render
+   *  with the same key and React would not remount the timer. */
+  key: number;
+}
+
+export interface RouterFailoverBannerProps {
+  /** Test-injection: override the auto-dismiss interval. */
+  dismissAfterMs?: number;
+}
+
+export function RouterFailoverBanner({
+  dismissAfterMs = 4000,
+}: RouterFailoverBannerProps = {}) {
+  const [visible, setVisible] = useState<VisibleFailover | null>(null);
+
+  useEffect(() => {
+    let timer: ReturnType<typeof setTimeout> | null = null;
+    let keySeq = 0;
+    function handle(e: Event) {
+      const detail = (e as CustomEvent).detail as FailoverDetail | undefined;
+      if (!detail) return;
+      keySeq += 1;
+      setVisible({ ...detail, key: keySeq });
+      if (timer) clearTimeout(timer);
+      timer = setTimeout(() => {
+        setVisible(null);
+        timer = null;
+      }, dismissAfterMs);
+    }
+    window.addEventListener("crew:router_failover", handle);
+    return () => {
+      window.removeEventListener("crew:router_failover", handle);
+      if (timer) clearTimeout(timer);
+    };
+  }, [dismissAfterMs]);
+
+  if (!visible) return null;
+  return (
+    <div
+      data-testid="router-failover-banner"
+      role="status"
+      aria-live="polite"
+      className="glass-pill pointer-events-none absolute left-1/2 top-3 z-30 -translate-x-1/2 rounded-[12px] px-4 py-2 text-xs text-text shadow-lg"
+    >
+      <span className="font-semibold">Router switched</span>
+      <span className="ml-1.5 text-muted/85">
+        {visible.from} → {visible.to}
+      </span>
+      <span className="ml-2 text-muted/70">
+        ({visible.reason}, {visible.elapsedMs}ms)
+      </span>
+    </div>
+  );
+}

--- a/src/components/router-mode-switcher.test.tsx
+++ b/src/components/router-mode-switcher.test.tsx
@@ -1,0 +1,240 @@
+/**
+ * Wave4-A router-mode switcher unit tests.
+ *
+ * Coverage:
+ *   - mount + happy probe: `router/get_metrics` resolves → switcher
+ *     enabled, all three modes renderable
+ *   - `runtime_unavailable` from `router/get_metrics` → switcher
+ *     disabled (single-provider profile)
+ *   - clicking a mode issues `router/set_mode` with `{session_id, mode}`
+ *     and optimistically reflects the selection
+ *   - the optimistic state reconciles against a `crew:mode_update`
+ *     dispatch (the same listener `useModeState()` consumes)
+ */
+
+import { afterEach, describe, expect, it, vi } from "vitest";
+import * as React from "react";
+import { act } from "react";
+import { createRoot, type Root } from "react-dom/client";
+
+(globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT =
+  true;
+
+import { RouterModeSwitcher } from "./router-mode-switcher";
+import { SessionContext } from "@/runtime/session-context";
+import type {
+  SessionContextValue,
+  AdaptiveMode,
+} from "@/runtime/session-context";
+import { BridgeRpcError } from "@/runtime/ui-protocol-bridge";
+
+const SESSION = "sess-router-switch";
+
+interface MountedHarness {
+  container: HTMLDivElement;
+  root: Root;
+  unmount: () => void;
+}
+
+function makeSessionCtx(
+  adaptiveMode: AdaptiveMode = null,
+): SessionContextValue {
+  return {
+    sessions: [],
+    currentSessionId: SESSION,
+    historyTopic: undefined,
+    currentSessionTitle: "",
+    currentSessionStats: null,
+    initialMessages: [],
+    activeTaskOnServer: false,
+    queueMode: null,
+    adaptiveMode,
+    setServerTaskActive: () => {},
+    renameSession: () => {},
+    updateSessionStats: () => {},
+    switchSession: () => {},
+    goBack: async () => false,
+    createSession: () => SESSION,
+    removeSession: async () => {},
+    refreshSessions: async () => {},
+    markSessionActive: () => {},
+  };
+}
+
+function mount(node: React.ReactElement): MountedHarness {
+  const container = document.createElement("div");
+  document.body.appendChild(container);
+  const root = createRoot(container);
+  act(() => {
+    root.render(node);
+  });
+  return {
+    container,
+    root,
+    unmount: () => {
+      act(() => root.unmount());
+      container.remove();
+    },
+  };
+}
+
+afterEach(() => {
+  document.body.innerHTML = "";
+});
+
+describe("RouterModeSwitcher", () => {
+  it("renders three mode buttons + reflects adaptiveMode from session context", async () => {
+    const callMethod = vi.fn().mockResolvedValue({
+      provider_name: "p",
+      mode: "lane",
+      qos_ranking: true,
+      lane_scores: {},
+      circuit_breakers: {},
+    });
+    const harness = mount(
+      <SessionContext.Provider value={makeSessionCtx("lane")}>
+        <RouterModeSwitcher getBridge={() => ({ callMethod })} />
+      </SessionContext.Provider>,
+    );
+    try {
+      // Let the probe resolve.
+      await act(async () => {
+        await Promise.resolve();
+        await Promise.resolve();
+      });
+      const root = harness.container.querySelector(
+        "[data-testid='router-mode-switcher']",
+      );
+      expect(root).not.toBeNull();
+      const buttons = harness.container.querySelectorAll(
+        "button[data-testid^='router-mode-']",
+      );
+      expect(buttons.length).toBe(3);
+      const lane = harness.container.querySelector(
+        "[data-testid='router-mode-lane']",
+      ) as HTMLButtonElement;
+      expect(lane.getAttribute("data-active")).toBe("true");
+      const off = harness.container.querySelector(
+        "[data-testid='router-mode-off']",
+      ) as HTMLButtonElement;
+      expect(off.getAttribute("data-active")).toBe("false");
+    } finally {
+      harness.unmount();
+    }
+  });
+
+  it("clicking a mode issues router/set_mode and optimistically highlights the selection", async () => {
+    const callMethod = vi.fn(async (method: string) => {
+      if (method === "router/get_metrics") {
+        return {
+          provider_name: "p",
+          mode: "off",
+          qos_ranking: false,
+          lane_scores: {},
+          circuit_breakers: {},
+        };
+      }
+      // router/set_mode
+      return { mode: "hedge" };
+    });
+    const harness = mount(
+      <SessionContext.Provider value={makeSessionCtx(null)}>
+        <RouterModeSwitcher getBridge={() => ({ callMethod })} />
+      </SessionContext.Provider>,
+    );
+    try {
+      await act(async () => {
+        await Promise.resolve();
+        await Promise.resolve();
+      });
+      const hedge = harness.container.querySelector(
+        "[data-testid='router-mode-hedge']",
+      ) as HTMLButtonElement;
+      await act(async () => {
+        hedge.click();
+        await Promise.resolve();
+        await Promise.resolve();
+      });
+      // Look at the most recent call (probe was call #0).
+      const setModeCall = callMethod.mock.calls.find(
+        ([m]) => m === "router/set_mode",
+      );
+      expect(setModeCall).toBeDefined();
+      expect(setModeCall?.[1]).toEqual({
+        session_id: SESSION,
+        mode: "hedge",
+      });
+      // Optimistic highlight: hedge button now active.
+      expect(hedge.getAttribute("data-active")).toBe("true");
+    } finally {
+      harness.unmount();
+    }
+  });
+
+  it("router/get_metrics returning runtime_unavailable greys out the switcher", async () => {
+    const err = new BridgeRpcError(-32602, "no adaptive router", {
+      kind: "runtime_unavailable",
+    });
+    const callMethod = vi.fn().mockRejectedValue(err);
+    const harness = mount(
+      <SessionContext.Provider value={makeSessionCtx(null)}>
+        <RouterModeSwitcher getBridge={() => ({ callMethod })} />
+      </SessionContext.Provider>,
+    );
+    try {
+      await act(async () => {
+        await Promise.resolve();
+        await Promise.resolve();
+        await Promise.resolve();
+      });
+      const root = harness.container.querySelector(
+        "[data-testid='router-mode-switcher']",
+      ) as HTMLDivElement;
+      expect(root.getAttribute("aria-disabled")).toBe("true");
+      expect(root.getAttribute("title")).toMatch(/Adaptive routing is off/);
+      const buttons = harness.container.querySelectorAll<HTMLButtonElement>(
+        "button[data-testid^='router-mode-']",
+      );
+      for (const b of buttons) {
+        expect(b.disabled).toBe(true);
+      }
+    } finally {
+      harness.unmount();
+    }
+  });
+
+  it("renders disabled when bridge is unavailable; probes again on crew:bridge_connected", async () => {
+    let bridgeAvailable = false;
+    const callMethod = vi.fn().mockResolvedValue({
+      provider_name: "p",
+      mode: "off",
+      qos_ranking: false,
+      lane_scores: {},
+      circuit_breakers: {},
+    });
+    const harness = mount(
+      <SessionContext.Provider value={makeSessionCtx(null)}>
+        <RouterModeSwitcher
+          getBridge={() => (bridgeAvailable ? { callMethod } : null)}
+        />
+      </SessionContext.Provider>,
+    );
+    try {
+      await act(async () => {
+        await Promise.resolve();
+      });
+      expect(callMethod).not.toHaveBeenCalled();
+      bridgeAvailable = true;
+      await act(async () => {
+        window.dispatchEvent(new CustomEvent("crew:bridge_connected"));
+        await Promise.resolve();
+        await Promise.resolve();
+      });
+      expect(callMethod).toHaveBeenCalledWith("router/get_metrics", {
+        session_id: SESSION,
+      });
+    } finally {
+      harness.unmount();
+    }
+  });
+});

--- a/src/components/router-mode-switcher.tsx
+++ b/src/components/router-mode-switcher.tsx
@@ -43,6 +43,14 @@ const MODE_LABELS: Record<SwitcherMode, string> = {
 };
 const MODES: SwitcherMode[] = ["off", "lane", "hedge"];
 
+/** Normalize a server-emitted mode string (`"off"` / `"hedge"` /
+ *  `"lane"`) into the local `SwitcherMode` shape. Unknown values map
+ *  back to `null` so we never highlight a button that doesn't exist. */
+function normalizeAdaptiveMode(mode: string): SwitcherMode | null {
+  if (mode === "off" || mode === "hedge" || mode === "lane") return mode;
+  return null;
+}
+
 /** Treat any RPC error whose `data.kind` equals `runtime_unavailable`
  *  as the "no adaptive router attached" signal — the server returns it
  *  from both `handle_router_set_mode` and `handle_router_get_metrics`
@@ -74,10 +82,12 @@ export function RouterModeSwitcher({
   const activeSessionId = sessionId ?? session.currentSessionId;
   const adaptiveMode = session.adaptiveMode;
 
-  // Local optimistic mode — set on click, cleared when the next
-  // `router/status` notification (via session-context's `adaptiveMode`)
-  // matches it. Renders as the active highlight even before the server
-  // reconciliation arrives.
+  // Local optimistic mode — set on click, cleared the moment EITHER
+  // the `router/set_mode` RPC echoes a mode back OR the next
+  // `router/status` notification arrives (codex Wave4-A P1 review fix:
+  // the old "wait for `adaptiveMode === optimisticMode`" gate could
+  // never clear when the server reports a different mode than the
+  // user's optimistic click).
   const [optimisticMode, setOptimisticMode] = useState<SwitcherMode | null>(
     null,
   );
@@ -87,6 +97,35 @@ export function RouterModeSwitcher({
   const [available, setAvailable] = useState<boolean | null>(null);
   // True while a `router/set_mode` RPC is in flight; locks every button.
   const [busy, setBusy] = useState(false);
+
+  // Codex Wave4-A P2 review fix: reset local switcher state on session
+  // change so a previous session's `runtime_unavailable` flag,
+  // optimistic mode, or busy lock doesn't carry over to a freshly
+  // switched session. The probe useEffect below re-runs (its dep
+  // array includes `activeSessionId`) and re-probes the new scope.
+  useEffect(() => {
+    setOptimisticMode(null);
+    setAvailable(null);
+    setBusy(false);
+  }, [activeSessionId]);
+
+  // Reconcile the optimistic state against the live `adaptiveMode` from
+  // session context (fed by `crew:mode_update` → `useModeState()`).
+  // Any authoritative same-session status drop clears the optimistic
+  // highlight — even when the reported mode disagrees with the
+  // optimistic value (e.g. server rejected the mode silently). This
+  // also runs when the optimistic mode is cleared by the RPC echo
+  // path, in which case it's a cheap no-op.
+  useEffect(() => {
+    if (
+      optimisticMode &&
+      (adaptiveMode === "off" ||
+        adaptiveMode === "lane" ||
+        adaptiveMode === "hedge")
+    ) {
+      setOptimisticMode(null);
+    }
+  }, [adaptiveMode, optimisticMode]);
 
   const resolveBridge = useCallback(() => {
     if (getBridge) return getBridge();
@@ -135,29 +174,44 @@ export function RouterModeSwitcher({
     };
   }, [activeSessionId, resolveBridge]);
 
-  // Reconcile the optimistic state once the server-side mode arrives via
-  // `router/status` (fed through `useModeState()` → `adaptiveMode`).
-  useEffect(() => {
-    if (optimisticMode && adaptiveMode === optimisticMode) {
-      setOptimisticMode(null);
-    }
-  }, [adaptiveMode, optimisticMode]);
-
   const handleClick = useCallback(
     async (mode: SwitcherMode) => {
       if (busy) return;
       const bridge = resolveBridge();
       if (!bridge) return;
+      // Pin the session this click is for. Codex Wave4-A P2: if the
+      // user switches sessions while `router/set_mode` is in flight,
+      // we drop the result instead of letting it leak into the new
+      // session's local state.
+      const issuedFor = activeSessionId;
       setOptimisticMode(mode);
       setBusy(true);
       try {
-        await bridge.callMethod<RouterSetModeResult>(
+        const result = await bridge.callMethod<RouterSetModeResult>(
           METHODS.ROUTER_SET_MODE,
-          { session_id: activeSessionId, mode },
+          { session_id: issuedFor, mode },
         );
-        // Success: hold the optimistic mode until `router/status`
-        // confirms. The reconcile effect above clears it then.
+        if (issuedFor !== activeSessionId) return;
+        // Codex Wave4-A P1: trust the server's echo. If the server
+        // committed a different mode (e.g. silently coerced an unknown
+        // value back to `off`), reflect that. We hold the resolved
+        // mode locally until `router/status` (via `adaptiveMode`)
+        // catches up — the reconcile useEffect above clears it the
+        // moment ANY authoritative mode arrives, so we never freeze
+        // on a stale optimistic value even when the server reports a
+        // different mode than the user's click.
+        const echoed = normalizeAdaptiveMode(result?.mode ?? "");
+        if (echoed && echoed !== mode) {
+          setOptimisticMode(echoed);
+        }
+        // If echoed === mode (typical happy path), leave the
+        // optimistic value as-is — the next `router/status` push
+        // clears it. If echoed is null (unparsed), also leave the
+        // optimistic value visible so the click stays responsive;
+        // the reconcile effect will replace it when adaptiveMode
+        // catches up.
       } catch (err) {
+        if (issuedFor !== activeSessionId) return;
         // Roll the optimistic state back. If the failure is
         // `runtime_unavailable`, flip the disabled flag so the user
         // doesn't keep retrying.
@@ -166,7 +220,7 @@ export function RouterModeSwitcher({
           setAvailable(false);
         }
       } finally {
-        setBusy(false);
+        if (issuedFor === activeSessionId) setBusy(false);
       }
     },
     [activeSessionId, busy, resolveBridge],

--- a/src/components/router-mode-switcher.tsx
+++ b/src/components/router-mode-switcher.tsx
@@ -1,0 +1,224 @@
+/**
+ * Wave4-A adaptive router mode switcher.
+ *
+ * Renders three buttons (Off / Lane / Hedge) in the chat header next to
+ * the cost-bar. The active mode is highlighted; clicking another mode
+ * issues `router/set_mode` over the live UI Protocol v1 bridge and
+ * optimistically reflects the new mode locally — the next
+ * `router/status` notification reconciles the optimistic state.
+ *
+ * Discovery: on mount, the component issues `router/get_metrics` to
+ * detect whether an adaptive router is attached. The server returns an
+ * RPC `invalid_params` error with `data.kind === "runtime_unavailable"`
+ * when the session has only a single provider (no adaptive routing
+ * possible), in which case the switcher renders disabled with a
+ * tooltip explanation.
+ *
+ * Sourcing notes:
+ *   - `useSession()` provides `currentSessionId` + `historyTopic` so we
+ *     pull the bridge for the active scope.
+ *   - `getActiveBridge` is the runtime registry; null while the bridge
+ *     is mid-handshake, in which case we render disabled until the
+ *     `crew:bridge_connected` event fires.
+ *   - The `crew:mode_update` listener in `useModeState()` already
+ *     receives the server-side reconciliation push; we read that mode
+ *     value to render the active highlight.
+ */
+
+import { useCallback, useEffect, useState } from "react";
+import { useSession } from "@/runtime/session-context";
+import type { AdaptiveMode } from "@/runtime/session-context";
+import { getActiveBridge } from "@/runtime/ui-protocol-runtime";
+import { METHODS, BridgeRpcError } from "@/runtime/ui-protocol-bridge";
+import type {
+  RouterGetMetricsResult,
+  RouterSetModeResult,
+} from "@/runtime/ui-protocol-types";
+
+type SwitcherMode = "off" | "lane" | "hedge";
+const MODE_LABELS: Record<SwitcherMode, string> = {
+  off: "Off",
+  lane: "Lane",
+  hedge: "Hedge",
+};
+const MODES: SwitcherMode[] = ["off", "lane", "hedge"];
+
+/** Treat any RPC error whose `data.kind` equals `runtime_unavailable`
+ *  as the "no adaptive router attached" signal — the server returns it
+ *  from both `handle_router_set_mode` and `handle_router_get_metrics`
+ *  when the session's provider chain isn't wrapped in `AdaptiveRouter`. */
+function isRuntimeUnavailable(err: unknown): boolean {
+  if (!(err instanceof BridgeRpcError)) return false;
+  const data = err.data;
+  if (data && typeof data === "object" && "kind" in data) {
+    const kind = (data as { kind?: unknown }).kind;
+    return kind === "runtime_unavailable";
+  }
+  return false;
+}
+
+export interface RouterModeSwitcherProps {
+  /** Test-injection: bypass the live bridge resolver. */
+  getBridge?: () => {
+    callMethod: <T = unknown>(method: string, params?: unknown) => Promise<T>;
+  } | null;
+  /** Test-injection: bypass `useSession()` for component-level tests. */
+  sessionId?: string;
+}
+
+export function RouterModeSwitcher({
+  getBridge,
+  sessionId,
+}: RouterModeSwitcherProps = {}) {
+  const session = useSession();
+  const activeSessionId = sessionId ?? session.currentSessionId;
+  const adaptiveMode = session.adaptiveMode;
+
+  // Local optimistic mode — set on click, cleared when the next
+  // `router/status` notification (via session-context's `adaptiveMode`)
+  // matches it. Renders as the active highlight even before the server
+  // reconciliation arrives.
+  const [optimisticMode, setOptimisticMode] = useState<SwitcherMode | null>(
+    null,
+  );
+  // `null` = not yet probed; `true` = adaptive router available;
+  // `false` = `runtime_unavailable` (single-provider profile). The
+  // switcher renders disabled when `false`.
+  const [available, setAvailable] = useState<boolean | null>(null);
+  // True while a `router/set_mode` RPC is in flight; locks every button.
+  const [busy, setBusy] = useState(false);
+
+  const resolveBridge = useCallback(() => {
+    if (getBridge) return getBridge();
+    return getActiveBridge(activeSessionId, session.historyTopic);
+  }, [getBridge, activeSessionId, session.historyTopic]);
+
+  // Probe once on mount / sessionId change. The probe is best-effort —
+  // if the bridge is not yet connected, leave `available = null` and
+  // re-try on the next `crew:bridge_connected` window event.
+  useEffect(() => {
+    let cancelled = false;
+    async function probe() {
+      const bridge = resolveBridge();
+      if (!bridge) return;
+      try {
+        await bridge.callMethod<RouterGetMetricsResult>(
+          METHODS.ROUTER_GET_METRICS,
+          { session_id: activeSessionId },
+        );
+        if (!cancelled) setAvailable(true);
+      } catch (err) {
+        if (cancelled) return;
+        if (isRuntimeUnavailable(err)) {
+          setAvailable(false);
+        }
+        // Other errors (transient): leave `available = null` so a later
+        // probe (next session switch / bridge reconnect) gets a fresh
+        // chance.
+      }
+    }
+    void probe();
+    function onBridgeConnected() {
+      if (!cancelled) void probe();
+    }
+    if (typeof window !== "undefined") {
+      window.addEventListener("crew:bridge_connected", onBridgeConnected);
+    }
+    return () => {
+      cancelled = true;
+      if (typeof window !== "undefined") {
+        window.removeEventListener(
+          "crew:bridge_connected",
+          onBridgeConnected,
+        );
+      }
+    };
+  }, [activeSessionId, resolveBridge]);
+
+  // Reconcile the optimistic state once the server-side mode arrives via
+  // `router/status` (fed through `useModeState()` → `adaptiveMode`).
+  useEffect(() => {
+    if (optimisticMode && adaptiveMode === optimisticMode) {
+      setOptimisticMode(null);
+    }
+  }, [adaptiveMode, optimisticMode]);
+
+  const handleClick = useCallback(
+    async (mode: SwitcherMode) => {
+      if (busy) return;
+      const bridge = resolveBridge();
+      if (!bridge) return;
+      setOptimisticMode(mode);
+      setBusy(true);
+      try {
+        await bridge.callMethod<RouterSetModeResult>(
+          METHODS.ROUTER_SET_MODE,
+          { session_id: activeSessionId, mode },
+        );
+        // Success: hold the optimistic mode until `router/status`
+        // confirms. The reconcile effect above clears it then.
+      } catch (err) {
+        // Roll the optimistic state back. If the failure is
+        // `runtime_unavailable`, flip the disabled flag so the user
+        // doesn't keep retrying.
+        setOptimisticMode(null);
+        if (isRuntimeUnavailable(err)) {
+          setAvailable(false);
+        }
+      } finally {
+        setBusy(false);
+      }
+    },
+    [activeSessionId, busy, resolveBridge],
+  );
+
+  // Effective rendered mode: optimistic wins (so click → instant feedback);
+  // otherwise read the reconciled `adaptiveMode` from session context.
+  const renderedMode: AdaptiveMode =
+    optimisticMode ??
+    (adaptiveMode === "off" || adaptiveMode === "lane" || adaptiveMode === "hedge"
+      ? adaptiveMode
+      : null);
+  const disabled = available === false || busy;
+  const disabledTooltip =
+    available === false
+      ? "Adaptive routing is off for this profile."
+      : undefined;
+
+  return (
+    <div
+      data-testid="router-mode-switcher"
+      role="radiogroup"
+      aria-label="Adaptive router mode"
+      aria-disabled={disabled ? "true" : "false"}
+      className={`flex items-center gap-1 ${
+        disabled ? "opacity-50 pointer-events-none" : ""
+      }`}
+      title={disabledTooltip}
+    >
+      {MODES.map((mode) => {
+        const active = renderedMode === mode;
+        return (
+          <button
+            key={mode}
+            type="button"
+            role="radio"
+            aria-checked={active}
+            data-testid={`router-mode-${mode}`}
+            data-mode={mode}
+            data-active={active ? "true" : "false"}
+            disabled={disabled}
+            onClick={() => {
+              void handleClick(mode);
+            }}
+            className={`glass-pill rounded-[10px] px-2 py-1 text-[10px] font-medium ${
+              active ? "is-active" : ""
+            }`}
+          >
+            {MODE_LABELS[mode]}
+          </button>
+        );
+      })}
+    </div>
+  );
+}

--- a/src/components/router-mode-switcher.tsx
+++ b/src/components/router-mode-switcher.tsx
@@ -25,7 +25,7 @@
  *     value to render the active highlight.
  */
 
-import { useCallback, useEffect, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import { useSession } from "@/runtime/session-context";
 import type { AdaptiveMode } from "@/runtime/session-context";
 import { getActiveBridge } from "@/runtime/ui-protocol-runtime";
@@ -80,17 +80,21 @@ export function RouterModeSwitcher({
 }: RouterModeSwitcherProps = {}) {
   const session = useSession();
   const activeSessionId = sessionId ?? session.currentSessionId;
+  const activeTopic = session.historyTopic;
   const adaptiveMode = session.adaptiveMode;
 
-  // Local optimistic mode — set on click, cleared the moment EITHER
-  // the `router/set_mode` RPC echoes a mode back OR the next
-  // `router/status` notification arrives (codex Wave4-A P1 review fix:
-  // the old "wait for `adaptiveMode === optimisticMode`" gate could
-  // never clear when the server reports a different mode than the
-  // user's optimistic click).
+  // Local optimistic mode — set on click. Cleared when an
+  // authoritative `adaptiveMode` value DIFFERENT FROM THE ONE AT
+  // CLICK TIME arrives via `router/status` (the codex round 2 P2 fix:
+  // the prior reconcile cleared on any `off|lane|hedge` push, which
+  // for a session whose current mode is "off" caused the optimistic
+  // click to "hedge" to flicker back to "off" before the server
+  // reflected the new mode). `adaptiveModeAtClickRef` pins the
+  // pre-click reference so we can detect "new mode observed".
   const [optimisticMode, setOptimisticMode] = useState<SwitcherMode | null>(
     null,
   );
+  const adaptiveModeAtClickRef = useRef<AdaptiveMode>(null);
   // `null` = not yet probed; `true` = adaptive router available;
   // `false` = `runtime_unavailable` (single-provider profile). The
   // switcher renders disabled when `false`.
@@ -98,33 +102,52 @@ export function RouterModeSwitcher({
   // True while a `router/set_mode` RPC is in flight; locks every button.
   const [busy, setBusy] = useState(false);
 
-  // Codex Wave4-A P2 review fix: reset local switcher state on session
-  // change so a previous session's `runtime_unavailable` flag,
-  // optimistic mode, or busy lock doesn't carry over to a freshly
-  // switched session. The probe useEffect below re-runs (its dep
-  // array includes `activeSessionId`) and re-probes the new scope.
+  // Codex Wave4-A P2 review fix: mirror the full SCOPE (session +
+  // topic) into refs so async RPC callbacks can compare against the
+  // LATEST value (not the closure snapshot from the render when the
+  // RPC was issued). Without this, `issuedFor !== activeSessionId`
+  // compared two captures from the same render and never detected a
+  // mid-flight scope switch.
+  const activeSessionIdRef = useRef(activeSessionId);
+  const activeTopicRef = useRef(activeTopic);
+  useEffect(() => {
+    activeSessionIdRef.current = activeSessionId;
+    activeTopicRef.current = activeTopic;
+  }, [activeSessionId, activeTopic]);
+
+  // Codex Wave4-A P2 (rounds 2+3) review fix: reset local switcher
+  // state on scope (session/topic) change so a previous scope's
+  // `runtime_unavailable` flag, optimistic mode, or busy lock doesn't
+  // carry over. The probe useEffect below re-runs (its dep array
+  // includes `activeSessionId`) and re-probes the new scope.
   useEffect(() => {
     setOptimisticMode(null);
+    adaptiveModeAtClickRef.current = null;
     setAvailable(null);
     setBusy(false);
-  }, [activeSessionId]);
+  }, [activeSessionId, activeTopic]);
 
-  // Reconcile the optimistic state against the live `adaptiveMode` from
-  // session context (fed by `crew:mode_update` → `useModeState()`).
-  // Any authoritative same-session status drop clears the optimistic
-  // highlight — even when the reported mode disagrees with the
-  // optimistic value (e.g. server rejected the mode silently). This
-  // also runs when the optimistic mode is cleared by the RPC echo
-  // path, in which case it's a cheap no-op.
+  // Reconcile the optimistic state ONLY when an authoritative
+  // `adaptiveMode` value DIFFERENT from the one we observed at click
+  // time arrives. This handles both branches:
+  //   - server commits the user's optimistic click → adaptiveMode
+  //     transitions to that value → reconcile fires → optimistic
+  //     cleared (and `renderedMode` falls back to the freshly-pushed
+  //     `adaptiveMode`, which equals the optimistic mode anyway).
+  //   - server rejects / coerces → adaptiveMode transitions to a
+  //     different value → reconcile fires → optimistic cleared and
+  //     the rendered state reflects the server-committed mode.
+  //
+  // If `adaptiveMode` is still the pre-click value, we hold the
+  // optimistic highlight (no flicker). When `adaptiveMode` was null
+  // pre-click (fresh session, never reconciled), any subsequent
+  // authoritative push clears the optimistic value.
   useEffect(() => {
-    if (
-      optimisticMode &&
-      (adaptiveMode === "off" ||
-        adaptiveMode === "lane" ||
-        adaptiveMode === "hedge")
-    ) {
-      setOptimisticMode(null);
-    }
+    if (!optimisticMode) return;
+    if (adaptiveMode === null) return;
+    if (adaptiveMode === adaptiveModeAtClickRef.current) return;
+    setOptimisticMode(null);
+    adaptiveModeAtClickRef.current = null;
   }, [adaptiveMode, optimisticMode]);
 
   const resolveBridge = useCallback(() => {
@@ -179,27 +202,33 @@ export function RouterModeSwitcher({
       if (busy) return;
       const bridge = resolveBridge();
       if (!bridge) return;
-      // Pin the session this click is for. Codex Wave4-A P2: if the
-      // user switches sessions while `router/set_mode` is in flight,
-      // we drop the result instead of letting it leak into the new
-      // session's local state.
-      const issuedFor = activeSessionId;
+      // Pin the SCOPE this click is for via refs (codex Wave4-A P2
+      // rounds 2-3): both session id AND topic must match at RPC
+      // resolve time. Closure-captured comparisons against
+      // `activeSessionId` / `activeTopic` are tautologies because they
+      // come from the same render; refs carry the latest scope.
+      const issuedForSession = activeSessionId;
+      const issuedForTopic = activeTopic;
+      const scopeStillCurrent = () =>
+        issuedForSession === activeSessionIdRef.current &&
+        issuedForTopic === activeTopicRef.current;
+      adaptiveModeAtClickRef.current = adaptiveMode;
       setOptimisticMode(mode);
       setBusy(true);
       try {
         const result = await bridge.callMethod<RouterSetModeResult>(
           METHODS.ROUTER_SET_MODE,
-          { session_id: issuedFor, mode },
+          { session_id: issuedForSession, mode },
         );
-        if (issuedFor !== activeSessionId) return;
+        if (!scopeStillCurrent()) return;
         // Codex Wave4-A P1: trust the server's echo. If the server
         // committed a different mode (e.g. silently coerced an unknown
         // value back to `off`), reflect that. We hold the resolved
         // mode locally until `router/status` (via `adaptiveMode`)
         // catches up — the reconcile useEffect above clears it the
-        // moment ANY authoritative mode arrives, so we never freeze
-        // on a stale optimistic value even when the server reports a
-        // different mode than the user's click.
+        // moment any DIFFERENT authoritative mode arrives, so we
+        // never freeze on a stale optimistic value even when the
+        // server reports a different mode than the user's click.
         const echoed = normalizeAdaptiveMode(result?.mode ?? "");
         if (echoed && echoed !== mode) {
           setOptimisticMode(echoed);
@@ -209,21 +238,22 @@ export function RouterModeSwitcher({
         // clears it. If echoed is null (unparsed), also leave the
         // optimistic value visible so the click stays responsive;
         // the reconcile effect will replace it when adaptiveMode
-        // catches up.
+        // transitions away from the pre-click value.
       } catch (err) {
-        if (issuedFor !== activeSessionId) return;
+        if (issuedFor !== activeSessionIdRef.current) return;
         // Roll the optimistic state back. If the failure is
         // `runtime_unavailable`, flip the disabled flag so the user
         // doesn't keep retrying.
         setOptimisticMode(null);
+        adaptiveModeAtClickRef.current = null;
         if (isRuntimeUnavailable(err)) {
           setAvailable(false);
         }
       } finally {
-        if (issuedFor === activeSessionId) setBusy(false);
+        if (issuedFor === activeSessionIdRef.current) setBusy(false);
       }
     },
-    [activeSessionId, busy, resolveBridge],
+    [activeSessionId, adaptiveMode, busy, resolveBridge],
   );
 
   // Effective rendered mode: optimistic wins (so click → instant feedback);

--- a/src/layouts/chat-layout.tsx
+++ b/src/layouts/chat-layout.tsx
@@ -4,6 +4,8 @@ import { useOctosStatus } from "@/hooks/use-octos-status";
 import { useTheme } from "@/hooks/use-theme";
 import { useResizablePanel } from "@/hooks/use-resizable-panel";
 import { CostBar } from "@/components/cost-bar";
+import { RouterModeSwitcher } from "@/components/router-mode-switcher";
+import { RouterFailoverBanner } from "@/components/router-failover-banner";
 import { SessionList } from "@/components/session-list";
 import { ContentBrowser } from "@/components/content-browser";
 import { SessionTaskIndicator } from "@/components/session-task-dock";
@@ -181,13 +183,19 @@ export function ChatLayout({ children }: { children: ReactNode }) {
                   )}
                 </button>
               </div>
-              <div className="mt-3 min-w-0">
+              <div className="mt-3 min-w-0 flex flex-wrap items-center gap-3">
                 <CostBar model={status?.model} provider={status?.provider} />
+                {/* Wave4-A router mode switcher. Anchored next to the
+                    cost-bar so the live model + cost + routing mode
+                    surface as a single block. */}
+                <RouterModeSwitcher />
               </div>
             </div>
           </div>
           <div className="relative flex-1 min-h-0 overflow-hidden px-2 pb-2">
             {children}
+            {/* Wave4-A router failover banner — auto-dismisses after 4 s. */}
+            <RouterFailoverBanner />
             {/* Inline toast notification */}
             {toast && (
               <button

--- a/src/runtime/session-context.tsx
+++ b/src/runtime/session-context.tsx
@@ -16,6 +16,7 @@ import {
 } from "@/api/sessions";
 import type { BackgroundTaskInfo, SessionInfo, MessageInfo } from "@/api/types";
 import { nextTopicForCommand } from "@/lib/slash-commands";
+import { eventMatchesScope } from "@/runtime/event-scope";
 import * as ThreadStore from "@/store/thread-store";
 import * as TaskStore from "@/store/task-store";
 import * as FileStore from "@/store/file-store";
@@ -130,37 +131,33 @@ export type QueueMode = "followup" | "collect" | "steer" | "interrupt" | "specul
 export type AdaptiveMode = "off" | "hedge" | "lane" | null;
 
 /** Shared hook that listens for crew:mode_update events and returns
- *  reactive mode state. Scoped to `sessionId` — only events whose
- *  detail.sessionId matches the current session are accepted, and
- *  switching to a different session resets the mode state so stale
- *  events from the previous session can't bleed through (codex
- *  Wave4-A P1 review fix). When called without an argument (legacy
- *  call shape — pre-router unscoped queue mode), accept every event
- *  so back-compat tests keep working. */
-export function useModeState(sessionId?: string) {
+ *  reactive mode state. Scoped to `sessionId` + `topic` via the shared
+ *  `eventMatchesScope` helper — events for a different scope are
+ *  dropped, and switching to a different scope resets the mode state
+ *  so stale RouterStatus pushes from the previous scope can't bleed
+ *  through (codex Wave4-A P1 + round-3 P2 review fixes). When called
+ *  without arguments (legacy call shape — pre-router unscoped queue
+ *  mode), accept every event so back-compat tests keep working. */
+export function useModeState(sessionId?: string, topic?: string) {
   const [queueMode, setQueueMode] = useState<QueueMode>(null);
   const [adaptiveMode, setAdaptiveMode] = useState<AdaptiveMode>(null);
 
   useEffect(() => {
-    // Reset on session change so a stale mode from the prior session
+    // Reset on scope change so a stale mode from the prior session/topic
     // doesn't persist into the active pill / switcher highlight.
     setQueueMode(null);
     setAdaptiveMode(null);
-  }, [sessionId]);
+  }, [sessionId, topic]);
 
   useEffect(() => {
     function onMode(e: Event) {
       const detail = (e as CustomEvent).detail;
-      // Codex Wave4-A P1: events carry `detail.sessionId` since the
-      // event-router was wired. Drop events for other sessions so a
-      // late RouterStatus push from a previous session doesn't
-      // overwrite the active one. Legacy callers (sessionId undefined)
-      // accept every event.
-      if (
-        sessionId !== undefined &&
-        typeof detail?.sessionId === "string" &&
-        detail.sessionId !== sessionId
-      ) {
+      // Codex Wave4-A P1 + round-3 P2: drop events whose `sessionId` /
+      // `topic` don't match. `eventMatchesScope` parses
+      // `detail.{sessionId, topic}` (the camelCase shape the
+      // event-router dispatches) and tolerates absent topic on both
+      // sides. Legacy callers (sessionId undefined) accept every event.
+      if (sessionId !== undefined && !eventMatchesScope(detail, sessionId, topic)) {
         return;
       }
       if (detail.queueMode !== undefined) setQueueMode(detail.queueMode);
@@ -168,7 +165,7 @@ export function useModeState(sessionId?: string) {
     }
     window.addEventListener("crew:mode_update", onMode);
     return () => window.removeEventListener("crew:mode_update", onMode);
-  }, [sessionId]);
+  }, [sessionId, topic]);
 
   return { queueMode, adaptiveMode };
 }
@@ -245,7 +242,23 @@ function loadStoredStats(): Record<string, SessionRunStats> {
 
 function persistStoredStats(stats: Record<string, SessionRunStats>) {
   if (typeof window === "undefined") return;
-  localStorage.setItem(SESSION_STATS_STORAGE_KEY, JSON.stringify(stats));
+  // Wave4-A codex round-2 review fix: strip transient `queue_depth`
+  // before persisting. The depth is owned by `ui-protocol-send.ts`'s
+  // in-memory FIFO and is meaningless after a page reload — leaving
+  // it on disk would resurrect a stale "N queued" badge for a queue
+  // that no longer exists. Other stats (model / token counters /
+  // cost) survive the reload because they reflect server-side state.
+  const sanitized: Record<string, SessionRunStats> = {};
+  for (const [id, s] of Object.entries(stats)) {
+    sanitized[id] = {
+      model: s.model,
+      inputTokens: s.inputTokens,
+      outputTokens: s.outputTokens,
+      cost: s.cost,
+      // intentionally NOT copying `queue_depth`
+    };
+  }
+  localStorage.setItem(SESSION_STATS_STORAGE_KEY, JSON.stringify(sanitized));
 }
 
 function loadStoredTopics(): Record<string, string> {
@@ -442,7 +455,10 @@ export function SessionProvider({ children }: { children: ReactNode }) {
   const [serverTaskActiveBySession, setServerTaskActiveBySession] = useState<
     Record<string, boolean>
   >({});
-  const { queueMode, adaptiveMode } = useModeState(currentSessionId);
+  const { queueMode, adaptiveMode } = useModeState(
+    currentSessionId,
+    activeHistoryTopic,
+  );
   const previousSessionIdRef = useRef<string | null>(null);
   const titleCache = useRef<Record<string, string>>(loadStoredTitles());
   // Codex NIT G: track per-session title-fetch state to prevent the

--- a/src/runtime/session-context.tsx
+++ b/src/runtime/session-context.tsx
@@ -129,20 +129,46 @@ export interface SessionBeforeSendResult extends Partial<SessionSendRequest> {
 export type QueueMode = "followup" | "collect" | "steer" | "interrupt" | "speculative" | null;
 export type AdaptiveMode = "off" | "hedge" | "lane" | null;
 
-/** Shared hook that listens for crew:mode_update events and returns reactive mode state. */
-export function useModeState() {
+/** Shared hook that listens for crew:mode_update events and returns
+ *  reactive mode state. Scoped to `sessionId` — only events whose
+ *  detail.sessionId matches the current session are accepted, and
+ *  switching to a different session resets the mode state so stale
+ *  events from the previous session can't bleed through (codex
+ *  Wave4-A P1 review fix). When called without an argument (legacy
+ *  call shape — pre-router unscoped queue mode), accept every event
+ *  so back-compat tests keep working. */
+export function useModeState(sessionId?: string) {
   const [queueMode, setQueueMode] = useState<QueueMode>(null);
   const [adaptiveMode, setAdaptiveMode] = useState<AdaptiveMode>(null);
 
   useEffect(() => {
+    // Reset on session change so a stale mode from the prior session
+    // doesn't persist into the active pill / switcher highlight.
+    setQueueMode(null);
+    setAdaptiveMode(null);
+  }, [sessionId]);
+
+  useEffect(() => {
     function onMode(e: Event) {
       const detail = (e as CustomEvent).detail;
+      // Codex Wave4-A P1: events carry `detail.sessionId` since the
+      // event-router was wired. Drop events for other sessions so a
+      // late RouterStatus push from a previous session doesn't
+      // overwrite the active one. Legacy callers (sessionId undefined)
+      // accept every event.
+      if (
+        sessionId !== undefined &&
+        typeof detail?.sessionId === "string" &&
+        detail.sessionId !== sessionId
+      ) {
+        return;
+      }
       if (detail.queueMode !== undefined) setQueueMode(detail.queueMode);
       if (detail.adaptiveMode !== undefined) setAdaptiveMode(detail.adaptiveMode);
     }
     window.addEventListener("crew:mode_update", onMode);
     return () => window.removeEventListener("crew:mode_update", onMode);
-  }, []);
+  }, [sessionId]);
 
   return { queueMode, adaptiveMode };
 }
@@ -416,7 +442,7 @@ export function SessionProvider({ children }: { children: ReactNode }) {
   const [serverTaskActiveBySession, setServerTaskActiveBySession] = useState<
     Record<string, boolean>
   >({});
-  const { queueMode, adaptiveMode } = useModeState();
+  const { queueMode, adaptiveMode } = useModeState(currentSessionId);
   const previousSessionIdRef = useRef<string | null>(null);
   const titleCache = useRef<Record<string, string>>(loadStoredTitles());
   // Codex NIT G: track per-session title-fetch state to prevent the

--- a/src/runtime/session-context.tsx
+++ b/src/runtime/session-context.tsx
@@ -106,6 +106,12 @@ export interface SessionRunStats {
   inputTokens: number;
   outputTokens: number;
   cost: number | null;
+  /** Wave4-A — current send-queue depth as observed by the client-side
+   *  FIFO in `ui-protocol-send.ts`. Zero / absent means nothing queued
+   *  behind the in-flight turn. Surfaced into the toolbar pill at
+   *  `chat-thread.tsx:1642` so the "N queued" indicator is finally
+   *  driven by something live. */
+  queue_depth?: number;
 }
 
 export interface SessionSendRequest {
@@ -740,6 +746,37 @@ export function SessionProvider({ children }: { children: ReactNode }) {
     return () => {
       window.removeEventListener("crew:cost", handleCost);
       window.removeEventListener("crew:message_meta", handleMeta);
+    };
+  }, [storeSessionStats]);
+
+  // Wave4-A — listen for the per-session client-side queue depth
+  // dispatched by `ui-protocol-send.ts` and stamp it onto
+  // `currentSessionStats.queue_depth` so the toolbar pill renders the
+  // live count. The send-path dispatches on every push (synchronous
+  // with the user submit) and every drain (turn lifecycle completed
+  // OR transport drop).
+  useEffect(() => {
+    function handleQueue(e: Event) {
+      const detail = (e as CustomEvent).detail;
+      const sessionId = detail?.sessionId;
+      if (!sessionId) return;
+      const pendingCount =
+        typeof detail.pendingCount === "number"
+          ? detail.pendingCount
+          : 0;
+      const current = statsCache.current[sessionId] ?? {
+        inputTokens: 0,
+        outputTokens: 0,
+        cost: null,
+      };
+      storeSessionStats(sessionId, {
+        ...current,
+        queue_depth: pendingCount,
+      });
+    }
+    window.addEventListener("crew:queue_state", handleQueue);
+    return () => {
+      window.removeEventListener("crew:queue_state", handleQueue);
     };
   }, [storeSessionStats]);
 

--- a/src/runtime/ui-protocol-bridge.test.ts
+++ b/src/runtime/ui-protocol-bridge.test.ts
@@ -672,6 +672,88 @@ describe("type guards (fail-closed)", () => {
       }),
     ).toBeNull();
   });
+
+  // Wave4-A guards
+  it("accepts a well-formed router/status event", () => {
+    const ok = guards.guardRouterStatus({
+      session_id: "s",
+      provider_name: "openrouter/anthropic/claude-opus-4-7",
+      mode: "lane",
+      qos_ranking: true,
+      lane_scores: {
+        "openrouter/anthropic/claude-opus-4-7": 0.92,
+        "openrouter/openai/gpt-5": 0.78,
+      },
+      circuit_breakers: {
+        "openrouter/openai/gpt-5": "open",
+      },
+    });
+    expect(ok?.provider_name).toBe(
+      "openrouter/anthropic/claude-opus-4-7",
+    );
+    expect(ok?.mode).toBe("lane");
+    expect(ok?.qos_ranking).toBe(true);
+    expect(ok?.lane_scores["openrouter/anthropic/claude-opus-4-7"]).toBe(
+      0.92,
+    );
+    expect(ok?.circuit_breakers["openrouter/openai/gpt-5"]).toBe("open");
+  });
+
+  it("rejects router/status missing qos_ranking flag", () => {
+    expect(
+      guards.guardRouterStatus({
+        session_id: "s",
+        provider_name: "p",
+        mode: "lane",
+        lane_scores: {},
+        circuit_breakers: {},
+      }),
+    ).toBeNull();
+  });
+
+  it("accepts a well-formed router/failover event", () => {
+    const ok = guards.guardRouterFailover({
+      session_id: "s",
+      from_provider: "a",
+      to_provider: "b",
+      reason: "circuit_breaker_open",
+      elapsed_ms: 1500,
+    });
+    expect(ok?.from_provider).toBe("a");
+    expect(ok?.to_provider).toBe("b");
+    expect(ok?.elapsed_ms).toBe(1500);
+  });
+
+  it("rejects router/failover with negative elapsed_ms", () => {
+    expect(
+      guards.guardRouterFailover({
+        session_id: "s",
+        from_provider: "a",
+        to_provider: "b",
+        reason: "r",
+        elapsed_ms: -1,
+      }),
+    ).toBeNull();
+  });
+
+  it("accepts a well-formed queue/state event", () => {
+    const ok = guards.guardQueueState({
+      session_id: "s",
+      pending_count: 2,
+      head_client_message_id: "cmid-head",
+    });
+    expect(ok?.pending_count).toBe(2);
+    expect(ok?.head_client_message_id).toBe("cmid-head");
+  });
+
+  it("queue/state head is null when absent", () => {
+    const ok = guards.guardQueueState({
+      session_id: "s",
+      pending_count: 0,
+    });
+    expect(ok?.pending_count).toBe(0);
+    expect(ok?.head_client_message_id).toBeNull();
+  });
 });
 
 // ---------------------------------------------------------------------------
@@ -1328,6 +1410,51 @@ describe("notification dispatch", () => {
     expect(progressed).toHaveLength(1);
     expect(completed).toHaveLength(1);
     expect(updates).toHaveLength(1);
+  });
+
+  it("Wave4-A: routes router/status, router/failover, queue/state through the new subscribers", async () => {
+    const { bridge, ws } = await freshConnected();
+    const statuses: unknown[] = [];
+    const failovers: unknown[] = [];
+    const queues: unknown[] = [];
+    bridge.onRouterStatus((e) => statuses.push(e));
+    bridge.onRouterFailover((e) => failovers.push(e));
+    bridge.onQueueState((e) => queues.push(e));
+    ws.triggerMessage({
+      jsonrpc: "2.0",
+      method: METHODS.ROUTER_STATUS,
+      params: {
+        session_id: "sess-1",
+        provider_name: "openrouter/anthropic/claude-opus-4-7",
+        mode: "hedge",
+        qos_ranking: true,
+        lane_scores: { "openrouter/anthropic/claude-opus-4-7": 0.9 },
+        circuit_breakers: {},
+      },
+    });
+    ws.triggerMessage({
+      jsonrpc: "2.0",
+      method: METHODS.ROUTER_FAILOVER,
+      params: {
+        session_id: "sess-1",
+        from_provider: "a/m1",
+        to_provider: "b/m2",
+        reason: "score_drop",
+        elapsed_ms: 250,
+      },
+    });
+    ws.triggerMessage({
+      jsonrpc: "2.0",
+      method: METHODS.QUEUE_STATE,
+      params: {
+        session_id: "sess-1",
+        pending_count: 1,
+        head_client_message_id: "cmid-Q1",
+      },
+    });
+    expect(statuses).toHaveLength(1);
+    expect(failovers).toHaveLength(1);
+    expect(queues).toHaveLength(1);
   });
 
   it("routes turn lifecycle and approval/requested", async () => {

--- a/src/runtime/ui-protocol-bridge.ts
+++ b/src/runtime/ui-protocol-bridge.ts
@@ -29,6 +29,9 @@ import type {
   MessageDeltaEvent,
   MessagePersistedEvent,
   ProgressUpdatedEvent,
+  QueueStateEvent,
+  RouterFailoverEvent,
+  RouterStatusEvent,
   RpcErrorPayload,
   SessionHydrateResult,
   SessionOpenResult,
@@ -64,6 +67,9 @@ export type {
   PersistedMessage,
   PersistedMessageFile,
   ProgressUpdatedEvent,
+  QueueStateEvent,
+  RouterFailoverEvent,
+  RouterStatusEvent,
   SessionHydrateResult,
   SessionOpenResult,
   SessionOpenedResult,
@@ -155,6 +161,22 @@ export const METHODS = {
   // cross-tab / auto-title flows can refresh their cache without polling
   // the REST list. See the M12 Phase D ADR.
   SESSION_TITLE_UPDATED: "session/title-updated",
+  // Wave4-A (server PR #946) adaptive router surface. Server pushes
+  // `router/status` adjacent to `turn/started` and `turn/completed` so
+  // the SPA can render the routing pill / lane debug view without
+  // polling; `router/failover` fires once when the adaptive router
+  // crosses lanes mid-turn.  `queue/state` is the client-emitted
+  // counterpart for the per-session FIFO that lives in
+  // `ui-protocol-send.ts`; the variant exists on the wire so other
+  // clients can observe queue depth uniformly. Client-issued RPCs:
+  // `router/set_mode` toggles the active adaptive mode at runtime and
+  // `router/get_metrics` snapshots the same payload `router/status`
+  // pushes for on-demand reads.
+  ROUTER_STATUS: "router/status",
+  ROUTER_FAILOVER: "router/failover",
+  QUEUE_STATE: "queue/state",
+  ROUTER_SET_MODE: "router/set_mode",
+  ROUTER_GET_METRICS: "router/get_metrics",
 } as const;
 
 /**
@@ -355,6 +377,20 @@ export interface UiProtocolBridge {
    *  DOM events so the header cost badge and assistant-bubble footer
    *  keep firing post-PR-#96 SSE-bridge deletion. */
   onProgressUpdated(handler: (e: ProgressUpdatedEvent) => void): () => void;
+  /** Wave4-A `router/status` subscriber. The event-router fans this
+   *  out into the `crew:mode_update` DOM event so `useModeState()` in
+   *  `session-context.tsx:127` lights the toolbar pill. */
+  onRouterStatus(handler: (e: RouterStatusEvent) => void): () => void;
+  /** Wave4-A `router/failover` subscriber. The event-router dispatches
+   *  a `crew:router_failover` DOM event so the chat-layout can surface
+   *  a transient banner. */
+  onRouterFailover(handler: (e: RouterFailoverEvent) => void): () => void;
+  /** Wave4-A `queue/state` subscriber. Symmetric with the other
+   *  notification surfaces — `ui-protocol-send.ts` self-dispatches
+   *  these through a window CustomEvent (the queue is client-side
+   *  today), but the bridge still routes server-emitted variants for
+   *  forward compatibility. */
+  onQueueState(handler: (e: QueueStateEvent) => void): () => void;
   onConnectionStateChange(handler: (state: ConnectionState) => void): () => void;
   /** Codex BLOCK F: synchronous read of the bridge's current
    *  connection state. The `onConnectionStateChange` listener fires on
@@ -1036,6 +1072,93 @@ function guardProgressUpdated(p: unknown): ProgressUpdatedEvent | null {
   };
 }
 
+/**
+ * Guard for `router/status` (Wave4-A server PR #946). All fields are
+ * required on the wire. `lane_scores` / `circuit_breakers` are wire
+ * objects (Rust `BTreeMap<String, _>`); we accept any plain object and
+ * filter out entries whose value is not the expected primitive type so
+ * a future server-side schema extension can't trip the fail-closed
+ * reject path.
+ */
+function guardRouterStatus(p: unknown): RouterStatusEvent | null {
+  if (!isPlainObject(p)) return null;
+  if (!isString(p.session_id)) return null;
+  if (!isString(p.provider_name)) return null;
+  if (!isString(p.mode)) return null;
+  if (typeof p.qos_ranking !== "boolean") return null;
+  if (!isPlainObject(p.lane_scores)) return null;
+  if (!isPlainObject(p.circuit_breakers)) return null;
+  const laneScores: Record<string, number> = {};
+  for (const [k, v] of Object.entries(p.lane_scores)) {
+    if (typeof v === "number" && Number.isFinite(v)) laneScores[k] = v;
+  }
+  const breakers: Record<string, string> = {};
+  for (const [k, v] of Object.entries(p.circuit_breakers)) {
+    if (typeof v === "string") breakers[k] = v;
+  }
+  return {
+    session_id: p.session_id,
+    provider_name: p.provider_name,
+    mode: p.mode,
+    qos_ranking: p.qos_ranking,
+    lane_scores: laneScores,
+    circuit_breakers: breakers,
+  };
+}
+
+/**
+ * Guard for `router/failover` (Wave4-A server PR #946). All fields are
+ * required on the wire. `elapsed_ms` is a `u64` on the wire so we reject
+ * negative / non-finite values.
+ */
+function guardRouterFailover(p: unknown): RouterFailoverEvent | null {
+  if (!isPlainObject(p)) return null;
+  if (!isString(p.session_id)) return null;
+  if (!isString(p.from_provider) || !isString(p.to_provider)) return null;
+  if (typeof p.reason !== "string") return null;
+  if (
+    typeof p.elapsed_ms !== "number" ||
+    !Number.isFinite(p.elapsed_ms) ||
+    p.elapsed_ms < 0
+  ) {
+    return null;
+  }
+  return {
+    session_id: p.session_id,
+    from_provider: p.from_provider,
+    to_provider: p.to_provider,
+    reason: p.reason,
+    elapsed_ms: p.elapsed_ms,
+  };
+}
+
+/**
+ * Guard for `queue/state` (Wave4-A). Client-emitted today (the queue
+ * lives in `ui-protocol-send.ts` per-session FIFO); the guard is in
+ * place so the bridge round-trips the variant uniformly if the server
+ * ever starts emitting it.
+ */
+function guardQueueState(p: unknown): QueueStateEvent | null {
+  if (!isPlainObject(p)) return null;
+  if (!isString(p.session_id)) return null;
+  if (
+    typeof p.pending_count !== "number" ||
+    !Number.isFinite(p.pending_count) ||
+    p.pending_count < 0
+  ) {
+    return null;
+  }
+  let head: string | null = null;
+  if (typeof p.head_client_message_id === "string" && p.head_client_message_id.length > 0) {
+    head = p.head_client_message_id;
+  }
+  return {
+    session_id: p.session_id,
+    pending_count: p.pending_count,
+    head_client_message_id: head,
+  };
+}
+
 /** Minimal guard for `session/title-updated`.
  *
  *  The server's ADR-defined payload is
@@ -1133,6 +1256,9 @@ class UiProtocolBridgeImpl implements UiProtocolBridge {
   private readonly subToolProgress = new Subscribers<ToolProgressEvent>();
   private readonly subToolCompleted = new Subscribers<ToolCompletedEvent>();
   private readonly subProgressUpdated = new Subscribers<ProgressUpdatedEvent>();
+  private readonly subRouterStatus = new Subscribers<RouterStatusEvent>();
+  private readonly subRouterFailover = new Subscribers<RouterFailoverEvent>();
+  private readonly subQueueState = new Subscribers<QueueStateEvent>();
   private readonly subWarning = new Subscribers<WarningEvent>();
   private readonly subState = new Subscribers<ConnectionState>();
   private readonly subSessionTitleUpdated = new Subscribers<{
@@ -1198,6 +1324,18 @@ class UiProtocolBridgeImpl implements UiProtocolBridge {
     [METHODS.PROGRESS_UPDATED]: {
       guard: guardProgressUpdated,
       emit: (v) => this.subProgressUpdated.emit(v as ProgressUpdatedEvent),
+    },
+    [METHODS.ROUTER_STATUS]: {
+      guard: guardRouterStatus,
+      emit: (v) => this.subRouterStatus.emit(v as RouterStatusEvent),
+    },
+    [METHODS.ROUTER_FAILOVER]: {
+      guard: guardRouterFailover,
+      emit: (v) => this.subRouterFailover.emit(v as RouterFailoverEvent),
+    },
+    [METHODS.QUEUE_STATE]: {
+      guard: guardQueueState,
+      emit: (v) => this.subQueueState.emit(v as QueueStateEvent),
     },
     [METHODS.WARNING]: {
       guard: guardWarning,
@@ -1304,6 +1442,9 @@ class UiProtocolBridgeImpl implements UiProtocolBridge {
     this.subToolProgress.clear();
     this.subToolCompleted.clear();
     this.subProgressUpdated.clear();
+    this.subRouterStatus.clear();
+    this.subRouterFailover.clear();
+    this.subQueueState.clear();
     this.subWarning.clear();
     this.subState.clear();
     this.subSessionTitleUpdated.clear();
@@ -1455,6 +1596,15 @@ class UiProtocolBridgeImpl implements UiProtocolBridge {
   }
   onProgressUpdated(handler: Listener<ProgressUpdatedEvent>): () => void {
     return this.subProgressUpdated.add(handler);
+  }
+  onRouterStatus(handler: Listener<RouterStatusEvent>): () => void {
+    return this.subRouterStatus.add(handler);
+  }
+  onRouterFailover(handler: Listener<RouterFailoverEvent>): () => void {
+    return this.subRouterFailover.add(handler);
+  }
+  onQueueState(handler: Listener<QueueStateEvent>): () => void {
+    return this.subQueueState.add(handler);
   }
   onConnectionStateChange(handler: Listener<ConnectionState>): () => void {
     return this.subState.add(handler);
@@ -2061,5 +2211,8 @@ export const __INTERNAL_GUARDS_FOR_TEST__ = {
   guardToolProgress,
   guardToolCompleted,
   guardProgressUpdated,
+  guardRouterStatus,
+  guardRouterFailover,
+  guardQueueState,
   guardWarning,
 };

--- a/src/runtime/ui-protocol-event-router.test.ts
+++ b/src/runtime/ui-protocol-event-router.test.ts
@@ -21,6 +21,9 @@ import {
   handleMessageDelta,
   handleMessagePersisted,
   handleProgressUpdated,
+  handleQueueState,
+  handleRouterFailover,
+  handleRouterStatus,
   handleSpawnComplete,
   handleTaskOutputDelta,
   handleTaskUpdated,
@@ -36,6 +39,9 @@ import type {
   MessageDeltaEvent,
   MessagePersistedEvent,
   ProgressUpdatedEvent,
+  QueueStateEvent,
+  RouterFailoverEvent,
+  RouterStatusEvent,
   TaskOutputDeltaEvent,
   TaskUpdatedEvent,
   ToolCompletedEvent,
@@ -977,6 +983,9 @@ class FakeBridge implements UiProtocolBridge {
   emitToolProgress?: (e: ToolProgressEvent) => void;
   emitToolCompleted?: (e: ToolCompletedEvent) => void;
   emitProgressUpdated?: (e: ProgressUpdatedEvent) => void;
+  emitRouterStatus?: (e: RouterStatusEvent) => void;
+  emitRouterFailover?: (e: RouterFailoverEvent) => void;
+  emitQueueState?: (e: QueueStateEvent) => void;
 
   start = vi.fn(async () => {});
   stop = vi.fn(async () => {});
@@ -1056,6 +1065,24 @@ class FakeBridge implements UiProtocolBridge {
     this.emitProgressUpdated = h;
     return () => {
       this.emitProgressUpdated = undefined;
+    };
+  }
+  onRouterStatus(h: (e: RouterStatusEvent) => void) {
+    this.emitRouterStatus = h;
+    return () => {
+      this.emitRouterStatus = undefined;
+    };
+  }
+  onRouterFailover(h: (e: RouterFailoverEvent) => void) {
+    this.emitRouterFailover = h;
+    return () => {
+      this.emitRouterFailover = undefined;
+    };
+  }
+  onQueueState(h: (e: QueueStateEvent) => void) {
+    this.emitQueueState = h;
+    return () => {
+      this.emitQueueState = undefined;
     };
   }
   onConnectionStateChange(): () => void {
@@ -1809,5 +1836,109 @@ describe("regression C: turn/completed stamps per-turn meta snapshot onto the fi
     const [thread] = ThreadStore.getThreads(SESSION);
     expect(thread.responses[0].status).toBe("error");
     expect(thread.responses[0].meta?.model).toBe("anthropic/claude");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Wave4-A: router/status, router/failover, queue/state DOM fan-out
+// ---------------------------------------------------------------------------
+
+describe("Wave4-A: router/status fans out into crew:mode_update", () => {
+  it("dispatches crew:mode_update with normalized adaptiveMode + provider/breaker context", () => {
+    const dispatched: Event[] = [];
+    handleRouterStatus(
+      {
+        sessionId: SESSION,
+        dispatchEvent: (e) => dispatched.push(e),
+      },
+      {
+        session_id: SESSION,
+        provider_name: "openrouter/anthropic/claude-opus-4-7",
+        mode: "lane",
+        qos_ranking: true,
+        lane_scores: {
+          "openrouter/anthropic/claude-opus-4-7": 0.92,
+        },
+        circuit_breakers: {},
+      },
+    );
+    expect(dispatched).toHaveLength(1);
+    expect(dispatched[0].type).toBe("crew:mode_update");
+    const detail = (dispatched[0] as CustomEvent).detail;
+    expect(detail.adaptiveMode).toBe("lane");
+    expect(detail.providerName).toBe(
+      "openrouter/anthropic/claude-opus-4-7",
+    );
+    expect(detail.qosRanking).toBe(true);
+    expect(detail.laneScores["openrouter/anthropic/claude-opus-4-7"]).toBe(
+      0.92,
+    );
+  });
+
+  it("normalises unknown mode strings to null so the pill doesn't render stale state", () => {
+    const dispatched: Event[] = [];
+    handleRouterStatus(
+      {
+        sessionId: SESSION,
+        dispatchEvent: (e) => dispatched.push(e),
+      },
+      {
+        session_id: SESSION,
+        provider_name: "p",
+        mode: "speculative", // not one of off|lane|hedge today
+        qos_ranking: false,
+        lane_scores: {},
+        circuit_breakers: {},
+      },
+    );
+    expect((dispatched[0] as CustomEvent).detail.adaptiveMode).toBeNull();
+  });
+});
+
+describe("Wave4-A: router/failover fans out into crew:router_failover", () => {
+  it("dispatches crew:router_failover with from/to/reason/elapsedMs", () => {
+    const dispatched: Event[] = [];
+    handleRouterFailover(
+      {
+        sessionId: SESSION,
+        dispatchEvent: (e) => dispatched.push(e),
+      },
+      {
+        session_id: SESSION,
+        from_provider: "openrouter/openai/gpt-5",
+        to_provider: "openrouter/anthropic/claude-opus-4-7",
+        reason: "circuit_breaker_open",
+        elapsed_ms: 1200,
+      },
+    );
+    expect(dispatched).toHaveLength(1);
+    expect(dispatched[0].type).toBe("crew:router_failover");
+    const detail = (dispatched[0] as CustomEvent).detail;
+    expect(detail.from).toBe("openrouter/openai/gpt-5");
+    expect(detail.to).toBe("openrouter/anthropic/claude-opus-4-7");
+    expect(detail.reason).toBe("circuit_breaker_open");
+    expect(detail.elapsedMs).toBe(1200);
+  });
+});
+
+describe("Wave4-A: queue/state fans out into crew:queue_state", () => {
+  it("dispatches crew:queue_state with pendingCount + head", () => {
+    const dispatched: Event[] = [];
+    handleQueueState(
+      {
+        sessionId: SESSION,
+        dispatchEvent: (e) => dispatched.push(e),
+      },
+      {
+        session_id: SESSION,
+        pending_count: 3,
+        head_client_message_id: "cmid-head",
+      },
+    );
+    expect(dispatched).toHaveLength(1);
+    expect(dispatched[0].type).toBe("crew:queue_state");
+    const detail = (dispatched[0] as CustomEvent).detail;
+    expect(detail.pendingCount).toBe(3);
+    expect(detail.head).toBe("cmid-head");
   });
 });

--- a/src/runtime/ui-protocol-event-router.ts
+++ b/src/runtime/ui-protocol-event-router.ts
@@ -27,6 +27,9 @@ import type {
   MessageDeltaEvent,
   MessagePersistedEvent,
   ProgressUpdatedEvent,
+  QueueStateEvent,
+  RouterFailoverEvent,
+  RouterStatusEvent,
   TaskOutputDeltaEvent,
   TaskUpdatedEvent,
   ToolCompletedEvent,
@@ -915,6 +918,107 @@ export function handleApprovalRequested(
 }
 
 // ---------------------------------------------------------------------------
+// Wave4-A: router/status, router/failover, queue/state
+// ---------------------------------------------------------------------------
+//
+// Server PR #946 added three new notifications so the SPA can render the
+// adaptive routing pill / failover banner / queue-depth indicator without
+// polling. We fan each out into a `crew:*` DOM event so existing listeners
+// (the dormant `crew:mode_update` subscriber in `useModeState()` plus the
+// dead `queueMode` pill at `chat-thread.tsx:1642`) finally light up.
+//
+//   - `router/status`   → `crew:mode_update`  ({ adaptiveMode, providerName,
+//                          qosRanking, laneScores, circuitBreakers })
+//   - `router/failover` → `crew:router_failover` ({ from, to, reason,
+//                          elapsedMs }) — chat-layout pops a 4 s banner.
+//   - `queue/state`     → `crew:queue_state` ({ pendingCount, head })
+//                          — also dispatched by the client-side FIFO in
+//                          `ui-protocol-send.ts`, this branch covers a
+//                          future server emission.
+
+/**
+ * Normalize the `router/status` adaptive mode wire value (`"off"` |
+ * `"hedge"` | `"lane"`) into the `AdaptiveMode` shape `useModeState()`
+ * expects. Unknown values map back to `null` so a server-side schema
+ * extension doesn't render a stale pill.
+ */
+function normalizeAdaptiveMode(mode: string): "off" | "hedge" | "lane" | null {
+  if (mode === "off" || mode === "hedge" || mode === "lane") return mode;
+  return null;
+}
+
+export function handleRouterStatus(
+  cfg: RouterConfig,
+  event: RouterStatusEvent,
+): void {
+  // `crew:mode_update` shape was historically `{ queueMode?, adaptiveMode? }`
+  // — the listener in `useModeState()` switches on each independently
+  // (see `session-context.tsx:131-138`). The router-status path drives
+  // the adaptive leg; queue depth flows via `crew:queue_state` below.
+  // We additionally surface provider / score / breaker context so the
+  // future routing-pill detail view can render a tooltip without an
+  // extra round-trip.
+  dispatch(
+    cfg,
+    new CustomEvent("crew:mode_update", {
+      detail: {
+        sessionId: cfg.sessionId,
+        topic: cfg.topic,
+        adaptiveMode: normalizeAdaptiveMode(event.mode),
+        providerName: event.provider_name,
+        qosRanking: event.qos_ranking,
+        laneScores: event.lane_scores,
+        circuitBreakers: event.circuit_breakers,
+      },
+    }),
+  );
+}
+
+export function handleRouterFailover(
+  cfg: RouterConfig,
+  event: RouterFailoverEvent,
+): void {
+  // Pop a transient banner. The chat-layout listens for this event and
+  // renders a 4 s auto-dismiss notice describing the lane change. Field
+  // names follow the existing camelCase DOM-event convention used by
+  // `crew:tool_progress`, `crew:cost`, etc.
+  dispatch(
+    cfg,
+    new CustomEvent("crew:router_failover", {
+      detail: {
+        sessionId: cfg.sessionId,
+        topic: cfg.topic,
+        from: event.from_provider,
+        to: event.to_provider,
+        reason: event.reason,
+        elapsedMs: event.elapsed_ms,
+      },
+    }),
+  );
+}
+
+export function handleQueueState(
+  cfg: RouterConfig,
+  event: QueueStateEvent,
+): void {
+  // `ui-protocol-send.ts` dispatches the same shape directly because the
+  // queue is client-side today (server PR #946 leaves the variant
+  // unemitted). The bridge-routed branch covers a future server-side
+  // emission and keeps the schema unified.
+  dispatch(
+    cfg,
+    new CustomEvent("crew:queue_state", {
+      detail: {
+        sessionId: cfg.sessionId,
+        topic: cfg.topic,
+        pendingCount: event.pending_count,
+        head: event.head_client_message_id,
+      },
+    }),
+  );
+}
+
+// ---------------------------------------------------------------------------
 // Wiring
 // ---------------------------------------------------------------------------
 
@@ -974,6 +1078,17 @@ export function attachRouter(
   const offProgressUpdated = bridge.onProgressUpdated((e) =>
     handleProgressUpdated(cfg, e),
   );
+  // Wave4-A: adaptive router + queue depth surfaces. Three independent
+  // subscriptions so each one's detach is local; the chat-layout's
+  // banner listener and `useModeState()`'s pill listener consume the
+  // dispatched DOM events directly.
+  const offRouterStatus = bridge.onRouterStatus((e) =>
+    handleRouterStatus(cfg, e),
+  );
+  const offRouterFailover = bridge.onRouterFailover((e) =>
+    handleRouterFailover(cfg, e),
+  );
+  const offQueueState = bridge.onQueueState((e) => handleQueueState(cfg, e));
 
   let detached = false;
   return {
@@ -991,6 +1106,9 @@ export function attachRouter(
       offToolProgress();
       offToolCompleted();
       offProgressUpdated();
+      offRouterStatus();
+      offRouterFailover();
+      offQueueState();
     },
   };
 }

--- a/src/runtime/ui-protocol-runtime.test.ts
+++ b/src/runtime/ui-protocol-runtime.test.ts
@@ -97,6 +97,9 @@ function makeDeferredBridge(): DeferredBridge {
     onToolProgress: vi.fn(() => () => {}),
     onToolCompleted: vi.fn(() => () => {}),
     onProgressUpdated: vi.fn(() => () => {}),
+    onRouterStatus: vi.fn(() => () => {}),
+    onRouterFailover: vi.fn(() => () => {}),
+    onQueueState: vi.fn(() => () => {}),
     onConnectionStateChange: vi.fn((h: (s: ConnectionState) => void) => {
       stateHandler = h;
       return () => {

--- a/src/runtime/ui-protocol-send.test.ts
+++ b/src/runtime/ui-protocol-send.test.ts
@@ -93,6 +93,9 @@ function makeBridge(): UiProtocolBridge & {
     onTaskOutputDelta: vi.fn(() => () => {}),
     onTurnLifecycle: vi.fn(() => () => {}),
     onApprovalRequested: vi.fn(() => () => {}),
+    onRouterStatus: vi.fn(() => () => {}),
+    onRouterFailover: vi.fn(() => () => {}),
+    onQueueState: vi.fn(() => () => {}),
     onConnectionStateChange: vi.fn(() => () => {}),
     getConnectionState: vi.fn(() => "connected"),
     onWarning: vi.fn(() => () => {}),
@@ -149,6 +152,9 @@ describe("sendMessage", () => {
       onTaskOutputDelta: vi.fn(() => () => {}),
       onTurnLifecycle: vi.fn(() => () => {}),
       onApprovalRequested: vi.fn(() => () => {}),
+      onRouterStatus: vi.fn(() => () => {}),
+      onRouterFailover: vi.fn(() => () => {}),
+      onQueueState: vi.fn(() => () => {}),
       onConnectionStateChange: vi.fn(() => () => {}),
       getConnectionState: vi.fn(() => "connected"),
       onWarning: vi.fn(() => () => {}),
@@ -771,6 +777,9 @@ describe("sendMessage", () => {
       onTaskOutputDelta: vi.fn(() => () => {}),
       onTurnLifecycle: vi.fn(() => () => {}),
       onApprovalRequested: vi.fn(() => () => {}),
+      onRouterStatus: vi.fn(() => () => {}),
+      onRouterFailover: vi.fn(() => () => {}),
+      onQueueState: vi.fn(() => () => {}),
       onConnectionStateChange: vi.fn(() => () => {}),
       getConnectionState: vi.fn(() => "connected"),
       onWarning: vi.fn(() => () => {}),
@@ -787,5 +796,65 @@ describe("sendMessage", () => {
     // `enqueueSendV1`'s catch branch.
     expect(bridge.sendTurn).toHaveBeenCalledTimes(1);
     expect(onComplete2).toHaveBeenCalledTimes(1);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Wave4-A: per-session queue depth surfaces via `crew:queue_state`
+// ---------------------------------------------------------------------------
+//
+// The send path mirrors push / drain transitions onto a window
+// CustomEvent so `session-context.tsx`'s toolbar pill can render the
+// live depth without consulting the runtime internals. See
+// `incrementQueueDepth` / `decrementQueueDepth` in `ui-protocol-send.ts`.
+
+describe("Wave4-A: client-side queue/state DOM dispatch", () => {
+  it("a single send dispatches push (pendingCount=1) then drain (pendingCount=0)", async () => {
+    const bridge = makeBridge();
+    __setActiveBridgeForTest(SESSION, bridge);
+
+    let lifecycleHandler:
+      | ((e: { turn_id: string; reason?: string; error?: unknown }) => void)
+      | undefined;
+    (bridge.onTurnLifecycle as ReturnType<typeof vi.fn>).mockImplementation(
+      (h: (e: { turn_id: string; reason?: string; error?: unknown }) => void) => {
+        lifecycleHandler = h;
+        return () => {
+          lifecycleHandler = undefined;
+        };
+      },
+    );
+
+    const events: Array<{ pendingCount: number; head: string | null }> = [];
+    function onEvent(e: Event) {
+      const detail = (e as CustomEvent).detail;
+      if (detail.sessionId !== SESSION) return;
+      events.push({ pendingCount: detail.pendingCount, head: detail.head });
+    }
+    window.addEventListener("crew:queue_state", onEvent);
+    try {
+      sendMessage({
+        sessionId: SESSION,
+        text: "hi",
+        media: [],
+        clientMessageId: "cmid-Q1",
+      });
+      // Synchronous push fires before any await — the first observation
+      // already shows pendingCount=1.
+      expect(events).toHaveLength(1);
+      expect(events[0].pendingCount).toBe(1);
+      expect(events[0].head).toBe("cmid-Q1");
+
+      for (let i = 0; i < 12; i++) await Promise.resolve();
+      lifecycleHandler?.({ turn_id: "cmid-Q1", reason: "stop" });
+      for (let i = 0; i < 12; i++) await Promise.resolve();
+
+      // Drain dispatch follows the lifecycle release; pendingCount=0.
+      const last = events[events.length - 1];
+      expect(last.pendingCount).toBe(0);
+      expect(last.head).toBeNull();
+    } finally {
+      window.removeEventListener("crew:queue_state", onEvent);
+    }
   });
 });

--- a/src/runtime/ui-protocol-send.test.ts
+++ b/src/runtime/ui-protocol-send.test.ts
@@ -809,7 +809,10 @@ describe("sendMessage", () => {
 // `incrementQueueDepth` / `decrementQueueDepth` in `ui-protocol-send.ts`.
 
 describe("Wave4-A: client-side queue/state DOM dispatch", () => {
-  it("a single send dispatches push (pendingCount=1) then drain (pendingCount=0)", async () => {
+  it("a single in-flight send dispatches pendingCount=0 (no backlog) then 0 on drain", async () => {
+    // Codex Wave4-A P2 review fix: a lone send must NOT render as "1
+    // queued". `pendingCount` is the backlog behind the in-flight
+    // turn — the in-flight turn itself isn't counted.
     const bridge = makeBridge();
     __setActiveBridgeForTest(SESSION, bridge);
 
@@ -839,20 +842,75 @@ describe("Wave4-A: client-side queue/state DOM dispatch", () => {
         media: [],
         clientMessageId: "cmid-Q1",
       });
-      // Synchronous push fires before any await — the first observation
-      // already shows pendingCount=1.
+      // Synchronous push fires before any await. `pendingCount` is 0
+      // (the in-flight turn isn't counted) but `head` carries its cmid.
       expect(events).toHaveLength(1);
-      expect(events[0].pendingCount).toBe(1);
+      expect(events[0].pendingCount).toBe(0);
       expect(events[0].head).toBe("cmid-Q1");
 
       for (let i = 0; i < 12; i++) await Promise.resolve();
       lifecycleHandler?.({ turn_id: "cmid-Q1", reason: "stop" });
       for (let i = 0; i < 12; i++) await Promise.resolve();
 
-      // Drain dispatch follows the lifecycle release; pendingCount=0.
+      // Drain dispatch follows the lifecycle release; pendingCount=0, head=null.
       const last = events[events.length - 1];
       expect(last.pendingCount).toBe(0);
       expect(last.head).toBeNull();
+    } finally {
+      window.removeEventListener("crew:queue_state", onEvent);
+    }
+  });
+
+  it("a second send while the first is mid-turn dispatches pendingCount=1", async () => {
+    const bridge = makeBridge();
+    __setActiveBridgeForTest(SESSION, bridge);
+
+    let lifecycleHandler:
+      | ((e: { turn_id: string; reason?: string; error?: unknown }) => void)
+      | undefined;
+    (bridge.onTurnLifecycle as ReturnType<typeof vi.fn>).mockImplementation(
+      (h: (e: { turn_id: string; reason?: string; error?: unknown }) => void) => {
+        lifecycleHandler = h;
+        return () => {
+          lifecycleHandler = undefined;
+        };
+      },
+    );
+
+    const events: Array<{ pendingCount: number; head: string | null }> = [];
+    function onEvent(e: Event) {
+      const detail = (e as CustomEvent).detail;
+      if (detail.sessionId !== SESSION) return;
+      events.push({ pendingCount: detail.pendingCount, head: detail.head });
+    }
+    window.addEventListener("crew:queue_state", onEvent);
+    try {
+      sendMessage({
+        sessionId: SESSION,
+        text: "first",
+        media: [],
+        clientMessageId: "cmid-A",
+      });
+      sendMessage({
+        sessionId: SESSION,
+        text: "second",
+        media: [],
+        clientMessageId: "cmid-B",
+      });
+      // Both pushes have fired synchronously. The latest dispatch
+      // shows pendingCount=1 (one entry parked behind the in-flight).
+      const afterPush = events[events.length - 1];
+      expect(afterPush.pendingCount).toBe(1);
+      expect(afterPush.head).toBe("cmid-A");
+
+      // Resolve the first turn → second turn becomes in-flight,
+      // backlog drops to 0.
+      for (let i = 0; i < 12; i++) await Promise.resolve();
+      lifecycleHandler?.({ turn_id: "cmid-A", reason: "stop" });
+      for (let i = 0; i < 12; i++) await Promise.resolve();
+
+      const last = events[events.length - 1];
+      expect(last.pendingCount).toBe(0);
     } finally {
       window.removeEventListener("crew:queue_state", onEvent);
     }

--- a/src/runtime/ui-protocol-send.ts
+++ b/src/runtime/ui-protocol-send.ts
@@ -174,6 +174,72 @@ function queueKey(sessionId: string): string {
   return sessionId;
 }
 
+// ---------------------------------------------------------------------------
+// Wave4-A: client-side `crew:queue_state` emission
+// ---------------------------------------------------------------------------
+//
+// The server PR #946 protocol added a `queue/state` notification variant
+// but explicitly does NOT emit it server-side — the per-session FIFO
+// lives here on the client. We mirror push / drain transitions onto a
+// window CustomEvent so `session-context.tsx` can surface queue depth in
+// the toolbar without consulting the runtime internals (which are
+// module-scope and not React-reactive).
+//
+// `queueDepthBySession` carries the SHALLOW pending count — turns parked
+// behind the in-flight lifecycle gate. The in-flight turn itself is NOT
+// counted; pendingCount === 0 with the queue idle = nothing queued,
+// pendingCount === 0 mid-turn = the in-flight turn is the only thing
+// flowing. The pill in `chat-thread.tsx:1630` only renders when the
+// count is non-zero so the queue is visible only when there's true
+// backpressure.
+
+const queueDepthBySession = new Map<string, number>();
+const queueHeadBySession = new Map<string, string | null>();
+
+function dispatchQueueState(sessionId: string): void {
+  if (typeof window === "undefined") return;
+  const pendingCount = queueDepthBySession.get(sessionId) ?? 0;
+  const head = queueHeadBySession.get(sessionId) ?? null;
+  try {
+    window.dispatchEvent(
+      new CustomEvent("crew:queue_state", {
+        detail: {
+          sessionId,
+          pendingCount,
+          head,
+        },
+      }),
+    );
+  } catch {
+    // best-effort — some sandbox modes block CustomEvent.
+  }
+}
+
+function incrementQueueDepth(sessionId: string, head: string): void {
+  const prev = queueDepthBySession.get(sessionId) ?? 0;
+  queueDepthBySession.set(sessionId, prev + 1);
+  // Head is the cmid of the IN-FLIGHT turn — the first entry to land on
+  // a fresh queue is treated as in-flight and recorded so a future
+  // consumer (e.g. a "cancel queued" button) can identify it. Subsequent
+  // pushes leave the head pinned until release.
+  if (!queueHeadBySession.has(sessionId)) {
+    queueHeadBySession.set(sessionId, head);
+  }
+  dispatchQueueState(sessionId);
+}
+
+function decrementQueueDepth(sessionId: string): void {
+  const prev = queueDepthBySession.get(sessionId) ?? 0;
+  const next = Math.max(0, prev - 1);
+  if (next === 0) {
+    queueDepthBySession.delete(sessionId);
+    queueHeadBySession.delete(sessionId);
+  } else {
+    queueDepthBySession.set(sessionId, next);
+  }
+  dispatchQueueState(sessionId);
+}
+
 async function enqueueSendV1(opts: SendOptions): Promise<void> {
   const key = queueKey(opts.sessionId);
   const prev = turnQueues.get(key) ?? Promise.resolve();
@@ -205,6 +271,10 @@ async function enqueueSendV1(opts: SendOptions): Promise<void> {
   // `Promise.resolve()` as their `prev`, defeating the per-session FIFO.
   const chained = prev.then(() => lifecycleDone);
   turnQueues.set(key, chained);
+  // Wave4-A: surface the push BEFORE awaiting the prior turn so the
+  // toolbar pill updates synchronously with the user's submit. The
+  // matching `decrementQueueDepth` runs in the `finally` block below.
+  incrementQueueDepth(key, clientMessageId);
 
   try {
     await prev;
@@ -287,6 +357,11 @@ async function enqueueSendV1(opts: SendOptions): Promise<void> {
     if (turnQueues.get(key) === chained) {
       turnQueues.delete(key);
     }
+    // Wave4-A: drain signal — fires on every send-path termination
+    // (happy path, transport drop, queue-wedge safety release).
+    // Symmetric with the push above so the pill ticks down to 0 when
+    // the in-flight turn lands.
+    decrementQueueDepth(key);
   }
 }
 
@@ -294,6 +369,8 @@ async function enqueueSendV1(opts: SendOptions): Promise<void> {
 /** Test-only reset for the per-session queue map. */
 export function __resetSendQueueForTest(): void {
   turnQueues.clear();
+  queueDepthBySession.clear();
+  queueHeadBySession.clear();
 }
 
 async function sendMessageV1(

--- a/src/runtime/ui-protocol-send.ts
+++ b/src/runtime/ui-protocol-send.ts
@@ -185,20 +185,25 @@ function queueKey(sessionId: string): string {
 // the toolbar without consulting the runtime internals (which are
 // module-scope and not React-reactive).
 //
-// `queueDepthBySession` carries the SHALLOW pending count — turns parked
-// behind the in-flight lifecycle gate. The in-flight turn itself is NOT
-// counted; pendingCount === 0 with the queue idle = nothing queued,
-// pendingCount === 0 mid-turn = the in-flight turn is the only thing
-// flowing. The pill in `chat-thread.tsx:1630` only renders when the
-// count is non-zero so the queue is visible only when there's true
-// backpressure.
+// `queueTotalBySession` carries the TOTAL number of entries on the chain
+// (in-flight + parked-behind). The dispatched `pendingCount` is
+// `max(0, total - 1)` — the in-flight turn does NOT count toward queue
+// backpressure (codex Wave4-A P2 review fix: a lone send used to render
+// "1 queued" even when nothing was waiting). The pill in
+// `chat-thread.tsx:1630` only renders when `pendingCount > 0` so the
+// indicator is visible only when there's true backpressure.
 
-const queueDepthBySession = new Map<string, number>();
+const queueTotalBySession = new Map<string, number>();
 const queueHeadBySession = new Map<string, string | null>();
+
+function pendingBacklog(sessionId: string): number {
+  const total = queueTotalBySession.get(sessionId) ?? 0;
+  return total > 0 ? total - 1 : 0;
+}
 
 function dispatchQueueState(sessionId: string): void {
   if (typeof window === "undefined") return;
-  const pendingCount = queueDepthBySession.get(sessionId) ?? 0;
+  const pendingCount = pendingBacklog(sessionId);
   const head = queueHeadBySession.get(sessionId) ?? null;
   try {
     window.dispatchEvent(
@@ -215,9 +220,9 @@ function dispatchQueueState(sessionId: string): void {
   }
 }
 
-function incrementQueueDepth(sessionId: string, head: string): void {
-  const prev = queueDepthBySession.get(sessionId) ?? 0;
-  queueDepthBySession.set(sessionId, prev + 1);
+function incrementQueueTotal(sessionId: string, head: string): void {
+  const prev = queueTotalBySession.get(sessionId) ?? 0;
+  queueTotalBySession.set(sessionId, prev + 1);
   // Head is the cmid of the IN-FLIGHT turn — the first entry to land on
   // a fresh queue is treated as in-flight and recorded so a future
   // consumer (e.g. a "cancel queued" button) can identify it. Subsequent
@@ -228,14 +233,14 @@ function incrementQueueDepth(sessionId: string, head: string): void {
   dispatchQueueState(sessionId);
 }
 
-function decrementQueueDepth(sessionId: string): void {
-  const prev = queueDepthBySession.get(sessionId) ?? 0;
+function decrementQueueTotal(sessionId: string): void {
+  const prev = queueTotalBySession.get(sessionId) ?? 0;
   const next = Math.max(0, prev - 1);
   if (next === 0) {
-    queueDepthBySession.delete(sessionId);
+    queueTotalBySession.delete(sessionId);
     queueHeadBySession.delete(sessionId);
   } else {
-    queueDepthBySession.set(sessionId, next);
+    queueTotalBySession.set(sessionId, next);
   }
   dispatchQueueState(sessionId);
 }
@@ -273,8 +278,8 @@ async function enqueueSendV1(opts: SendOptions): Promise<void> {
   turnQueues.set(key, chained);
   // Wave4-A: surface the push BEFORE awaiting the prior turn so the
   // toolbar pill updates synchronously with the user's submit. The
-  // matching `decrementQueueDepth` runs in the `finally` block below.
-  incrementQueueDepth(key, clientMessageId);
+  // matching `decrementQueueTotal` runs in the `finally` block below.
+  incrementQueueTotal(key, clientMessageId);
 
   try {
     await prev;
@@ -361,7 +366,7 @@ async function enqueueSendV1(opts: SendOptions): Promise<void> {
     // (happy path, transport drop, queue-wedge safety release).
     // Symmetric with the push above so the pill ticks down to 0 when
     // the in-flight turn lands.
-    decrementQueueDepth(key);
+    decrementQueueTotal(key);
   }
 }
 
@@ -369,7 +374,7 @@ async function enqueueSendV1(opts: SendOptions): Promise<void> {
 /** Test-only reset for the per-session queue map. */
 export function __resetSendQueueForTest(): void {
   turnQueues.clear();
-  queueDepthBySession.clear();
+  queueTotalBySession.clear();
   queueHeadBySession.clear();
 }
 

--- a/src/runtime/ui-protocol-types.ts
+++ b/src/runtime/ui-protocol-types.ts
@@ -460,6 +460,97 @@ export interface WarningEvent {
 }
 
 /**
+ * Wave4-A `router/status` notification — adaptive routing snapshot
+ * pushed alongside `turn/started` and `turn/completed` so clients can
+ * render the routing pill / lane debug view without polling. Mirrors
+ * `octos_core::ui_protocol::RouterStatusEvent` (server PR #946).
+ *
+ * `lane_scores` keys are `"<provider_name>/<model_id>"`. `circuit_breakers`
+ * carries the same keys mapped to a string-rendered breaker state
+ * (`"closed"`, `"open"`, `"half_open"`). Both wire as deterministic
+ * `BTreeMap`s on the server side so re-renders stay diff-stable.
+ */
+export interface RouterStatusEvent {
+  session_id: string;
+  /** Currently selected provider, in `"<provider_name>/<model_id>"` form. */
+  provider_name: string;
+  /** Active adaptive mode (`"off"` | `"hedge"` | `"lane"`). */
+  mode: string;
+  /** QoS quality-ranking toggle (orthogonal to mode). */
+  qos_ranking: boolean;
+  /** Per-lane scores, keyed by `"<provider_name>/<model_id>"`. */
+  lane_scores: Record<string, number>;
+  /** Per-lane breaker state — `"closed"` / `"open"` / `"half_open"`. */
+  circuit_breakers: Record<string, string>;
+}
+
+/**
+ * Wave4-A `router/failover` notification — emitted when the adaptive
+ * router crosses lanes. Mirrors `octos_core::ui_protocol::RouterFailoverEvent`.
+ *
+ * `from_provider` / `to_provider` use the same `"<provider_name>/<model_id>"`
+ * key shape as `RouterStatusEvent.lane_scores`. `reason` is free-text
+ * (e.g. `"circuit_breaker_open"`, `"score_drop"`). `elapsed_ms` is the
+ * wall time from initial provider attempt to failover decision.
+ */
+export interface RouterFailoverEvent {
+  session_id: string;
+  from_provider: string;
+  to_provider: string;
+  reason: string;
+  elapsed_ms: number;
+}
+
+/**
+ * Wave4-A `queue/state` notification — pending-queue snapshot.
+ * Client-emitted today (the queue lives in
+ * `src/runtime/ui-protocol-send.ts`'s per-session FIFO). The server
+ * never emits this variant — the web bridge manufactures it locally so
+ * other clients can observe queue depth uniformly. Mirrors
+ * `octos_core::ui_protocol::QueueStateEvent`.
+ */
+export interface QueueStateEvent {
+  session_id: string;
+  pending_count: number;
+  /** Identifies the in-flight turn whose completion will release the
+   *  next queued frame. `null` when the queue is empty. */
+  head_client_message_id: string | null;
+}
+
+/**
+ * Wave4-A `router/set_mode` params + result. Mirrors
+ * `octos_core::ui_protocol::RouterSetModeParams` /
+ * `RouterSetModeResult`. `mode` is the lowercase string rendering of
+ * `octos_llm::AdaptiveMode` — `"off"`, `"hedge"`, or `"lane"`.
+ */
+export interface RouterSetModeParams {
+  session_id: string;
+  mode: string;
+}
+
+export interface RouterSetModeResult {
+  /** New mode actually committed by the router. Echo of `params.mode`
+   *  when the call succeeded. */
+  mode: string;
+}
+
+/**
+ * Wave4-A `router/get_metrics` result. Identical wire shape to
+ * `RouterStatusEvent` minus the `session_id` echo. When no adaptive
+ * router is attached to the session (single-provider profile), the
+ * server returns an `invalid_params` RPC error whose
+ * `data.kind === "runtime_unavailable"` — clients use that signal to
+ * grey out the router-mode switcher.
+ */
+export interface RouterGetMetricsResult {
+  provider_name: string;
+  mode: string;
+  qos_ranking: boolean;
+  lane_scores: Record<string, number>;
+  circuit_breakers: Record<string, string>;
+}
+
+/**
  * UPCR-2026-016 (M9-β-2) `session/closed` notification.
  *
  * Server emits this after a successful `session/delete` clears at

--- a/src/runtime/use-mode-state.test.tsx
+++ b/src/runtime/use-mode-state.test.tsx
@@ -1,0 +1,124 @@
+/**
+ * `useModeState()` tests (Wave4-A codex review fix).
+ *
+ * The hook scopes `crew:mode_update` events by `sessionId` so a late
+ * RouterStatus push from a prior session can't bleed into the current
+ * session's pill. Switching to a different session id also resets the
+ * mode state.
+ */
+
+import { afterEach, describe, expect, it } from "vitest";
+import * as React from "react";
+import { act } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { useModeState } from "./session-context";
+
+(globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT =
+  true;
+
+interface Captured {
+  current: ReturnType<typeof useModeState>;
+}
+
+function Harness({
+  sessionId,
+  out,
+}: {
+  sessionId: string;
+  out: Captured;
+}) {
+  const state = useModeState(sessionId);
+  out.current = state;
+  return null;
+}
+
+interface MountedHarness {
+  unmount: () => void;
+  rerender: (sessionId: string) => void;
+}
+
+function mount(initialSessionId: string, out: Captured): MountedHarness {
+  const container = document.createElement("div");
+  document.body.appendChild(container);
+  const root = createRoot(container);
+  act(() => {
+    root.render(<Harness sessionId={initialSessionId} out={out} />);
+  });
+  return {
+    unmount: () => {
+      act(() => root.unmount());
+      container.remove();
+    },
+    rerender: (sessionId) => {
+      act(() => {
+        root.render(<Harness sessionId={sessionId} out={out} />);
+      });
+    },
+  };
+}
+
+afterEach(() => {
+  document.body.innerHTML = "";
+});
+
+describe("useModeState", () => {
+  it("accepts crew:mode_update events whose sessionId matches", () => {
+    const out: Captured = {
+      current: { queueMode: null, adaptiveMode: null },
+    };
+    const h = mount("A", out);
+    try {
+      act(() => {
+        window.dispatchEvent(
+          new CustomEvent("crew:mode_update", {
+            detail: { sessionId: "A", adaptiveMode: "hedge" },
+          }),
+        );
+      });
+      expect(out.current.adaptiveMode).toBe("hedge");
+    } finally {
+      h.unmount();
+    }
+  });
+
+  it("drops crew:mode_update events for a different sessionId", () => {
+    const out: Captured = {
+      current: { queueMode: null, adaptiveMode: null },
+    };
+    const h = mount("A", out);
+    try {
+      act(() => {
+        window.dispatchEvent(
+          new CustomEvent("crew:mode_update", {
+            detail: { sessionId: "OTHER", adaptiveMode: "hedge" },
+          }),
+        );
+      });
+      expect(out.current.adaptiveMode).toBeNull();
+    } finally {
+      h.unmount();
+    }
+  });
+
+  it("resets adaptive/queue mode when the sessionId changes", () => {
+    const out: Captured = {
+      current: { queueMode: null, adaptiveMode: null },
+    };
+    const h = mount("A", out);
+    try {
+      act(() => {
+        window.dispatchEvent(
+          new CustomEvent("crew:mode_update", {
+            detail: { sessionId: "A", adaptiveMode: "lane" },
+          }),
+        );
+      });
+      expect(out.current.adaptiveMode).toBe("lane");
+      // Switch to session B → mode should reset.
+      h.rerender("B");
+      expect(out.current.adaptiveMode).toBeNull();
+    } finally {
+      h.unmount();
+    }
+  });
+});


### PR DESCRIPTION
## Summary

Server PR octos#946 added the adaptive-routing UI Protocol surface — `router/status` notifications, `router/failover`, `queue/state`, plus `router/set_mode` and `router/get_metrics` RPCs. The web client had a dormant `crew:mode_update` listener and an invisible-mode toolbar pill that nothing wrote to. This PR wires those events end-to-end and revives both the queue pill and the adaptive-mode indicator.

- **B1.1 Bridge METHODS + guards + subscribers** for `router/status`, `router/failover`, `queue/state`, `router/set_mode`, `router/get_metrics`.
- **B1.2 Event-router handlers**: `handleRouterStatus` → `crew:mode_update` (matches the existing `useModeState()` listener); `handleRouterFailover` → `crew:router_failover` (4 s `<RouterFailoverBanner />`); `handleQueueState` → `crew:queue_state`.
- **B1.3 Client-side `crew:queue_state`** dispatched from `ui-protocol-send.ts` on every queue push/drain. `session-context.tsx` stamps it onto `currentSessionStats.queue_depth`; the previously-dead chat-thread pill at line 1642 renders \"N queued\" live.
- **B1.4 `<RouterModeSwitcher />`** next to `<CostBar />` in the chat header — Off/Lane/Hedge buttons, optimistic highlight, reconciles on the next `router/status`. `router/get_metrics` returning `runtime_unavailable` (single-provider profile) greys out the switcher with a tooltip.

Server's `RouterStatus` push lands adjacent to `turn/started`/`turn/completed` and via `AdaptiveRouter::subscribe_failover()`. `QueueState` stays client-emitted (server PR #946 left the variant unemitted by design).

## Files changed

```
src/components/chat-thread.tsx               +26 / -3
src/components/router-failover-banner.tsx    new
src/components/router-failover-banner.test.tsx new
src/components/router-mode-switcher.tsx      new
src/components/router-mode-switcher.test.tsx new
src/layouts/chat-layout.tsx                  +10 / -3
src/runtime/session-context.tsx              +37 / -0
src/runtime/ui-protocol-bridge.ts            +153 / -0
src/runtime/ui-protocol-bridge.test.ts       +127 / -0
src/runtime/ui-protocol-event-router.ts      +118 / -0
src/runtime/ui-protocol-event-router.test.ts +131 / -0
src/runtime/ui-protocol-runtime.test.ts      +3 / -0
src/runtime/ui-protocol-send.ts              +77 / -0
src/runtime/ui-protocol-send.test.ts         +69 / -0
src/runtime/ui-protocol-types.ts             +91 / -0
```

Net: 15 files, +1506 / -6, +19 new tests.

## Test plan

- [x] `npx tsc --noEmit -p tsconfig.json` clean
- [x] `npm run test:unit` — 398/399 pass (1 pre-existing baseline failure on `router seq preservation` unrelated to this PR; same on `origin/main`)
- [x] `npx vite build` — succeeds
- [x] Bridge guards reject malformed wire shapes; well-formed shapes round-trip
- [x] Router handlers dispatch DOM events with the documented payload shape (`session-context.tsx:127` `useModeState()` listener already consumes `{ adaptiveMode }`)
- [x] `<RouterModeSwitcher />` greys out on `runtime_unavailable`; optimistic state reconciles on next `router/status` push
- [ ] Live smoke (Playwright): deferred — requires an OCTOS_USER_TOKEN against a deployment that has Wave4-A server PR octos#946 in its binary