### PR TITLE
fix(runtime): finish Wave4-A scope helper migration in router-mode-switcher

### DIFF
--- a/src/components/router-mode-switcher.tsx
+++ b/src/components/router-mode-switcher.tsx
@@ -240,7 +240,7 @@ export function RouterModeSwitcher({
         // the reconcile effect will replace it when adaptiveMode
         // transitions away from the pre-click value.
       } catch (err) {
-        if (issuedFor !== activeSessionIdRef.current) return;
+        if (!scopeStillCurrent()) return;
         // Roll the optimistic state back. If the failure is
         // `runtime_unavailable`, flip the disabled flag so the user
         // doesn't keep retrying.
@@ -250,7 +250,7 @@ export function RouterModeSwitcher({
           setAvailable(false);
         }
       } finally {
-        if (issuedFor === activeSessionIdRef.current) setBusy(false);
+        if (scopeStillCurrent()) setBusy(false);
       }
     },
     [activeSessionId, adaptiveMode, busy, resolveBridge],


### PR DESCRIPTION
## Summary

PR #124's codex round-2 fix introduced a `scopeStillCurrent()` helper but two callers in the catch+finally blocks still referenced the old removed `issuedFor` name. TypeScript build on origin/main fails.

## Fix

Replace both dangling references with the same helper used on the success path.

## Verification

`npm run build` clean. Failing main currently can't build the web bundle.
