### PR TITLE
fix(chat): lift tool-progress spinner out of streaming bubble (spawn_only fix)

### DIFF
--- a/src/components/chat-thread-bg-spinner.test.tsx
+++ b/src/components/chat-thread-bg-spinner.test.tsx
@@ -1,0 +1,208 @@
+/**
+ * Spawn-only background spinner regression — verifies the
+ * `<ToolProgressIndicator />` is mounted at the chat layout level rather
+ * than gated inside the streaming assistant bubble.
+ *
+ * Bug repro: the indicator used to live inside `ThreadAssistantBubble`
+ * behind `showLiveIndicators === true` (== "streaming"). For spawn_only
+ * tools (podcast_generate, fm_tts, deep_search, mofa_slides) the LLM
+ * turn settles with `turn/completed` BEFORE the background task starts
+ * emitting `tool/progress` envelopes — so the indicator was unmounted
+ * just as the long-running work began, and the spinner stayed invisible
+ * for the entire spawn_only duration.
+ *
+ * Fix: lift the indicator into `ChatThreadV2` (one mount per chat
+ * layout). It's already scoped to the current session/topic by its
+ * internal `eventMatchesScope` check, so a single mount catches every
+ * `crew:tool_progress` for the active session — including events that
+ * arrive after the streaming bubble has finalised.
+ *
+ * Coverage here is intentionally narrow: we mount `<ChatThread />` with
+ * the session context, dispatch a scoped `crew:tool_progress` event,
+ * and assert the spinner row appears even though no `Thread` exists
+ * yet (the empty-state branch) and certainly no pending assistant
+ * bubble is streaming.
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import * as React from "react";
+import { act } from "react";
+import { createRoot, type Root } from "react-dom/client";
+
+(
+  globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }
+).IS_REACT_ACT_ENVIRONMENT = true;
+
+import { ChatThread } from "./chat-thread";
+import { SessionContext } from "@/runtime/session-context";
+import type { SessionContextValue } from "@/runtime/session-context";
+
+const SESSION = "sess-bg-spinner";
+
+interface MountedHarness {
+  container: HTMLDivElement;
+  root: Root;
+  unmount: () => void;
+}
+
+function makeSessionCtx(): SessionContextValue {
+  return {
+    sessions: [],
+    currentSessionId: SESSION,
+    historyTopic: undefined,
+    currentSessionTitle: "",
+    currentSessionStats: null,
+    initialMessages: [],
+    activeTaskOnServer: false,
+    queueMode: null,
+    adaptiveMode: null,
+    setServerTaskActive: () => {},
+    renameSession: () => {},
+    updateSessionStats: () => {},
+    switchSession: () => {},
+    goBack: async () => false,
+    createSession: () => SESSION,
+    removeSession: async () => {},
+    refreshSessions: async () => {},
+    markSessionActive: () => {},
+  };
+}
+
+function mount(node: React.ReactElement): MountedHarness {
+  const container = document.createElement("div");
+  document.body.appendChild(container);
+  const root = createRoot(container);
+  act(() => {
+    root.render(node);
+  });
+  return {
+    container,
+    root,
+    unmount: () => {
+      act(() => root.unmount());
+      container.remove();
+    },
+  };
+}
+
+beforeEach(() => {
+  // `Composer` reads from `useSession` and never makes network calls
+  // during render, but other consumers in `chat-thread.tsx` poke at
+  // `localStorage`/window flags. Reset between tests so flag carryover
+  // doesn't leak. We also clear any leftover DOM listeners by recreating
+  // the body root in `afterEach`.
+  localStorage.clear();
+  // `crypto.randomUUID` is consumed by the Composer's ghost-bubble code
+  // path; jsdom exposes it but if not present we polyfill to keep the
+  // composer mount from blowing up.
+  if (!("randomUUID" in crypto)) {
+    (
+      crypto as unknown as { randomUUID: () => string }
+    ).randomUUID = () => "00000000-0000-0000-0000-000000000000";
+  }
+});
+
+afterEach(() => {
+  for (const node of [...document.body.children]) {
+    node.remove();
+  }
+  vi.restoreAllMocks();
+});
+
+describe("ChatThread tool-progress indicator (lifted)", () => {
+  it("renders the spinner row for a scoped crew:tool_progress event even when no streaming bubble exists", () => {
+    const harness = mount(
+      <SessionContext.Provider value={makeSessionCtx()}>
+        <ChatThread />
+      </SessionContext.Provider>,
+    );
+    // Sanity: no spinner before any event fires.
+    expect(
+      harness.container.querySelector("[data-testid='tool-progress']"),
+    ).toBeNull();
+
+    // Dispatch a spawn_only-style progress event AFTER the (notional)
+    // turn has settled — exactly the case that previously had nowhere
+    // to render because `ThreadAssistantBubble` was unmounted.
+    act(() => {
+      window.dispatchEvent(
+        new CustomEvent("crew:tool_progress", {
+          detail: {
+            tool: "podcast_generate",
+            message: "[info] synthesizing voice yangmi (segment 1/3)",
+            sessionId: SESSION,
+          },
+        }),
+      );
+    });
+
+    const row = harness.container.querySelector(
+      "[data-testid='tool-progress']",
+    );
+    expect(row).not.toBeNull();
+    expect(row!.textContent).toContain("podcast_generate");
+    // `[info]` prefix is stripped by the indicator.
+    expect(row!.textContent).toContain(
+      "synthesizing voice yangmi (segment 1/3)",
+    );
+    expect(row!.textContent).not.toContain("[info]");
+    harness.unmount();
+  });
+
+  it("ignores crew:tool_progress events scoped to a different session", () => {
+    const harness = mount(
+      <SessionContext.Provider value={makeSessionCtx()}>
+        <ChatThread />
+      </SessionContext.Provider>,
+    );
+    act(() => {
+      window.dispatchEvent(
+        new CustomEvent("crew:tool_progress", {
+          detail: {
+            tool: "deep_search",
+            message: "scanning",
+            sessionId: "some-other-session",
+          },
+        }),
+      );
+    });
+    expect(
+      harness.container.querySelector("[data-testid='tool-progress']"),
+    ).toBeNull();
+    harness.unmount();
+  });
+
+  it("clears the spinner row when crew:thinking { thinking: false } fires", () => {
+    const harness = mount(
+      <SessionContext.Provider value={makeSessionCtx()}>
+        <ChatThread />
+      </SessionContext.Provider>,
+    );
+    act(() => {
+      window.dispatchEvent(
+        new CustomEvent("crew:tool_progress", {
+          detail: {
+            tool: "fm_tts",
+            message: "synthesizing",
+            sessionId: SESSION,
+          },
+        }),
+      );
+    });
+    expect(
+      harness.container.querySelector("[data-testid='tool-progress']"),
+    ).not.toBeNull();
+
+    act(() => {
+      window.dispatchEvent(
+        new CustomEvent("crew:thinking", {
+          detail: { thinking: false, sessionId: SESSION },
+        }),
+      );
+    });
+    expect(
+      harness.container.querySelector("[data-testid='tool-progress']"),
+    ).toBeNull();
+    harness.unmount();
+  });
+});

--- a/src/components/chat-thread.tsx
+++ b/src/components/chat-thread.tsx
@@ -589,13 +589,14 @@ export const ThreadAssistantBubble = memo(function ThreadAssistantBubble({
           </div>
         )}
 
-        {/* Thinking + tool progress (only for the in-flight pending assistant) */}
-        {showLiveIndicators && (
-          <>
-            <ThinkingIndicator />
-            <ToolProgressIndicator />
-          </>
-        )}
+        {/* Thinking indicator (only for the in-flight pending assistant).
+            `ToolProgressIndicator` is lifted to `ChatThreadV2` so the
+            spinner survives `turn/completed` for spawn_only background
+            tasks (podcast_generate / fm_tts / deep_search / mofa_slides)
+            whose `tool/progress` envelopes arrive AFTER the LLM turn
+            has settled and the pending assistant bubble has been
+            unmounted. */}
+        {showLiveIndicators && <ThinkingIndicator />}
 
         {/* Message footer: meta on the left, copy button on the right */}
         <div className="mt-1.5 flex items-center justify-between gap-2">
@@ -851,7 +852,17 @@ function ChatThreadV2({
           </div>
         </div>
       )}
+      {/* Tool-progress spinner, lifted out of the per-bubble render so
+          it survives `turn/completed` for spawn_only background tasks.
+          The indicator self-scopes to `(currentSessionId, historyTopic)`
+          via `eventMatchesScope`, so one mount is sufficient — it
+          renders only when a `crew:tool_progress` event for THIS
+          session arrives, and clears on `crew:thinking { thinking:
+          false }`. Positioned above the composer to mirror the visual
+          slot the spinner occupied when it lived inside the streaming
+          bubble's bottom. */}
       <div className="shrink-0">
+        <ToolProgressIndicator />
         <Composer mountGhost={mountGhost} unmountGhost={unmountGhost} />
       </div>
     </div>

--- a/src/components/tool-progress-indicator.test.tsx
+++ b/src/components/tool-progress-indicator.test.tsx
@@ -184,6 +184,71 @@ describe("ToolProgressIndicator", () => {
   //      must not bleed across to session B.
   // ---------------------------------------------------------------------
 
+  it("does NOT clear on a terminal crew:tool_progress event from a DIFFERENT turn (parallel-tool guard)", () => {
+    // Concurrent tool calls in the same session: turn T1 is running a
+    // spawn_only podcast_generate; an unrelated synchronous tool call
+    // in turn T2 (same session) finishes. T2's terminal frame must
+    // not clear T1's still-running background spinner.
+    const ctx = makeSessionCtx();
+    const harness = mount(
+      <SessionContext.Provider value={ctx}>
+        <ToolProgressIndicator />
+      </SessionContext.Provider>,
+    );
+    act(() => {
+      window.dispatchEvent(
+        new CustomEvent("crew:tool_progress", {
+          detail: {
+            tool: "podcast_generate",
+            message: "synthesizing",
+            sessionId: SESSION,
+            turnId: "turn-T1",
+          },
+        }),
+      );
+    });
+    expect(
+      harness.container.querySelector("[data-testid='tool-progress']"),
+    ).not.toBeNull();
+
+    // Unrelated T2 tool finishes — must NOT clear T1's spinner.
+    act(() => {
+      window.dispatchEvent(
+        new CustomEvent("crew:tool_progress", {
+          detail: {
+            tool: "shell",
+            message: "done",
+            sessionId: SESSION,
+            turnId: "turn-T2",
+            terminal: true,
+          },
+        }),
+      );
+    });
+    expect(
+      harness.container.querySelector("[data-testid='tool-progress']"),
+    ).not.toBeNull();
+
+    // BUT a terminal frame for T1 itself clears it.
+    act(() => {
+      window.dispatchEvent(
+        new CustomEvent("crew:tool_progress", {
+          detail: {
+            tool: "podcast_generate",
+            message: "done",
+            sessionId: SESSION,
+            turnId: "turn-T1",
+            terminal: true,
+          },
+        }),
+      );
+    });
+    expect(
+      harness.container.querySelector("[data-testid='tool-progress']"),
+    ).toBeNull();
+    harness.unmount();
+  });
+
   it("clears on a terminal crew:tool_progress event (tool/completed)", () => {
     const ctx = makeSessionCtx();
     const harness = mount(

--- a/src/components/tool-progress-indicator.test.tsx
+++ b/src/components/tool-progress-indicator.test.tsx
@@ -167,4 +167,203 @@ describe("ToolProgressIndicator", () => {
       .toBeNull();
     harness.unmount();
   });
+
+  // ---------------------------------------------------------------------
+  // Codex round-1 follow-ups for the chat-layout lift (fix/spinner-for-
+  // spawn-only-background). The indicator now lives outside the
+  // streaming bubble, so it has to handle three lifecycle cases the
+  // per-bubble version was structurally immune to:
+  //
+  //   1. Terminal clear via `crew:tool_progress { terminal: true }` —
+  //      because spawn_only `crew:thinking false` already fired at the
+  //      enclosing turn/completed and cannot be relied upon.
+  //   2. Scoped clear on `crew:thinking false` — a later normal turn's
+  //      completion must NOT blow away a still-running background
+  //      task's spinner from an earlier turn.
+  //   3. Reset on session/topic change — a stale spinner from session A
+  //      must not bleed across to session B.
+  // ---------------------------------------------------------------------
+
+  it("clears on a terminal crew:tool_progress event (tool/completed)", () => {
+    const ctx = makeSessionCtx();
+    const harness = mount(
+      <SessionContext.Provider value={ctx}>
+        <ToolProgressIndicator />
+      </SessionContext.Provider>,
+    );
+    act(() => {
+      window.dispatchEvent(
+        new CustomEvent("crew:tool_progress", {
+          detail: {
+            tool: "podcast_generate",
+            message: "synthesizing voice yangmi",
+            sessionId: SESSION,
+            turnId: "turn-spawnonly",
+          },
+        }),
+      );
+    });
+    expect(
+      harness.container.querySelector("[data-testid='tool-progress']"),
+    ).not.toBeNull();
+
+    // Terminal frame from `handleToolCompleted` — spinner clears even
+    // though `crew:thinking false` will NOT arrive after this (it
+    // fired earlier at turn/completed for spawn_only).
+    act(() => {
+      window.dispatchEvent(
+        new CustomEvent("crew:tool_progress", {
+          detail: {
+            tool: "podcast_generate",
+            message: "done",
+            sessionId: SESSION,
+            turnId: "turn-spawnonly",
+            terminal: true,
+          },
+        }),
+      );
+    });
+    expect(
+      harness.container.querySelector("[data-testid='tool-progress']"),
+    ).toBeNull();
+    harness.unmount();
+  });
+
+  it("does NOT clear on crew:thinking false from a DIFFERENT turn (cross-context guard)", () => {
+    const ctx = makeSessionCtx();
+    const harness = mount(
+      <SessionContext.Provider value={ctx}>
+        <ToolProgressIndicator />
+      </SessionContext.Provider>,
+    );
+    // Spawn-only progress from turn T1 lights the spinner.
+    act(() => {
+      window.dispatchEvent(
+        new CustomEvent("crew:tool_progress", {
+          detail: {
+            tool: "deep_search",
+            message: "scanning",
+            sessionId: SESSION,
+            turnId: "turn-T1",
+          },
+        }),
+      );
+    });
+    expect(
+      harness.container.querySelector("[data-testid='tool-progress']"),
+    ).not.toBeNull();
+
+    // A NEW unrelated LLM turn T2 finishes — its `crew:thinking false`
+    // must NOT clear T1's still-running background spinner.
+    act(() => {
+      window.dispatchEvent(
+        new CustomEvent("crew:thinking", {
+          detail: {
+            thinking: false,
+            sessionId: SESSION,
+            turnId: "turn-T2",
+          },
+        }),
+      );
+    });
+    expect(
+      harness.container.querySelector("[data-testid='tool-progress']"),
+    ).not.toBeNull();
+
+    // BUT a `crew:thinking false` for the OWNING turn does clear it
+    // (legacy path; mostly relevant for synchronous tool calls where
+    // turn/completed cleanly bounds the work).
+    act(() => {
+      window.dispatchEvent(
+        new CustomEvent("crew:thinking", {
+          detail: {
+            thinking: false,
+            sessionId: SESSION,
+            turnId: "turn-T1",
+          },
+        }),
+      );
+    });
+    expect(
+      harness.container.querySelector("[data-testid='tool-progress']"),
+    ).toBeNull();
+    harness.unmount();
+  });
+
+  it("falls back to the legacy 'any thinking-false clears' path when neither side carries a turnId", () => {
+    // Compatibility: server frames without `turnId` still clear the
+    // spinner so we don't strand the row on older / partial dispatches.
+    const ctx = makeSessionCtx();
+    const harness = mount(
+      <SessionContext.Provider value={ctx}>
+        <ToolProgressIndicator />
+      </SessionContext.Provider>,
+    );
+    act(() => {
+      window.dispatchEvent(
+        new CustomEvent("crew:tool_progress", {
+          detail: {
+            tool: "shell",
+            message: "running",
+            sessionId: SESSION,
+          },
+        }),
+      );
+    });
+    expect(
+      harness.container.querySelector("[data-testid='tool-progress']"),
+    ).not.toBeNull();
+
+    act(() => {
+      window.dispatchEvent(
+        new CustomEvent("crew:thinking", {
+          detail: { thinking: false, sessionId: SESSION },
+        }),
+      );
+    });
+    expect(
+      harness.container.querySelector("[data-testid='tool-progress']"),
+    ).toBeNull();
+    harness.unmount();
+  });
+
+  it("resets the spinner when the active session/topic changes", () => {
+    // Light the spinner under session A.
+    let ctx = makeSessionCtx();
+    const harness = mount(
+      <SessionContext.Provider value={ctx}>
+        <ToolProgressIndicator />
+      </SessionContext.Provider>,
+    );
+    act(() => {
+      window.dispatchEvent(
+        new CustomEvent("crew:tool_progress", {
+          detail: {
+            tool: "mofa_slides",
+            message: "rendering deck",
+            sessionId: SESSION,
+            turnId: "turn-A",
+          },
+        }),
+      );
+    });
+    expect(
+      harness.container.querySelector("[data-testid='tool-progress']"),
+    ).not.toBeNull();
+
+    // Switch the surrounding SessionContext to a different session.
+    ctx = { ...makeSessionCtx(), currentSessionId: "sess-other" };
+    act(() => {
+      harness.root.render(
+        <SessionContext.Provider value={ctx}>
+          <ToolProgressIndicator />
+        </SessionContext.Provider>,
+      );
+    });
+    // Stale spinner from session A must NOT survive into session B.
+    expect(
+      harness.container.querySelector("[data-testid='tool-progress']"),
+    ).toBeNull();
+    harness.unmount();
+  });
 });

--- a/src/components/tool-progress-indicator.tsx
+++ b/src/components/tool-progress-indicator.tsx
@@ -51,13 +51,27 @@ export function ToolProgressIndicator() {
     function onProgress(e: Event) {
       const detail = (e as CustomEvent).detail;
       if (!eventMatchesScope(detail, currentSessionId, historyTopic)) return;
-      // `tool/completed` -> router dispatches with `terminal: true`. The
-      // spinner clears immediately rather than displaying the
-      // "done"/"error"/"complete" message indefinitely (spawn_only
+      // `tool/completed` (and spawn_only `task/updated` completed/
+      // failed/errored) -> router dispatches with `terminal: true`.
+      // The spinner clears immediately rather than displaying the
+      // "done"/"error" message indefinitely (spawn_only
       // `crew:thinking false` has already fired and can no longer
       // clean up).
+      //
+      // Terminal frames are scoped by `turnId`: a completion for an
+      // UNRELATED concurrent tool call in the same session must not
+      // blow away the spinner of the still-running call we're
+      // currently displaying. Falls back to "any terminal clears"
+      // when either side lacks a turnId (legacy server-frame
+      // compatibility).
       if (detail.terminal === true) {
-        setProgress(null);
+        setProgress((prev) => {
+          if (!prev) return prev;
+          if (prev.turnId && detail.turnId && prev.turnId !== detail.turnId) {
+            return prev;
+          }
+          return null;
+        });
         return;
       }
       setProgress({

--- a/src/components/tool-progress-indicator.tsx
+++ b/src/components/tool-progress-indicator.tsx
@@ -3,26 +3,88 @@ import { Loader2 } from "lucide-react";
 import { useSession } from "@/runtime/session-context";
 import { eventMatchesScope } from "@/runtime/event-scope";
 
+/**
+ * Single chat-layout-level spinner for in-flight tool work.
+ *
+ * Mounted once by `ChatThreadV2` (lifted out of `ThreadAssistantBubble`
+ * so spawn_only background tasks whose progress arrives AFTER
+ * `turn/completed` still surface). Subscribes to:
+ *
+ *   - `crew:tool_progress` (dispatched by `ui-protocol-event-router.ts`
+ *     for `tool/started`, `tool/progress`, and `tool/completed`).
+ *     Terminal frames (`detail.terminal === true`, set by the router on
+ *     `tool/completed`) CLEAR the spinner — for spawn_only the LLM
+ *     `crew:thinking false` has already fired before the background
+ *     task starts emitting, so we can't rely on it to clear the row.
+ *   - `crew:thinking` `{ thinking: false }` — clears the spinner only
+ *     when the event's `turnId` matches the in-flight progress's
+ *     `turnId`. Without this guard a subsequent normal turn's
+ *     `turn/completed` would hide a still-running background task's
+ *     spinner.
+ *
+ * State is also reset on `(currentSessionId, historyTopic)` change so
+ * a session switch doesn't carry a stale spinner over.
+ */
+interface ToolProgressState {
+  tool: string;
+  message: string;
+  /** Originating turn_id — used to scope `crew:thinking` clears so an
+   *  unrelated LLM turn's completion doesn't blow away a still-running
+   *  spawn_only background task's spinner. */
+  turnId?: string;
+}
+
 export function ToolProgressIndicator() {
   const { currentSessionId, historyTopic } = useSession();
-  const [progress, setProgress] = useState<{
-    tool: string;
-    message: string;
-  } | null>(null);
+  const [progress, setProgress] = useState<ToolProgressState | null>(null);
+
+  // Reset progress when session/topic changes so a stale spinner from
+  // session A doesn't bleed into session B. The router dispatches
+  // scoped events, so events for the OLD session are dropped at
+  // `eventMatchesScope` — but the previously-rendered state survives
+  // unless we explicitly clear it here.
+  useEffect(() => {
+    setProgress(null);
+  }, [currentSessionId, historyTopic]);
 
   useEffect(() => {
     function onProgress(e: Event) {
       const detail = (e as CustomEvent).detail;
       if (!eventMatchesScope(detail, currentSessionId, historyTopic)) return;
-      setProgress(detail);
+      // `tool/completed` -> router dispatches with `terminal: true`. The
+      // spinner clears immediately rather than displaying the
+      // "done"/"error"/"complete" message indefinitely (spawn_only
+      // `crew:thinking false` has already fired and can no longer
+      // clean up).
+      if (detail.terminal === true) {
+        setProgress(null);
+        return;
+      }
+      setProgress({
+        tool: detail.tool,
+        message: detail.message,
+        turnId: detail.turnId,
+      });
     }
     function onThinking(e: Event) {
       const detail = (e as CustomEvent).detail;
       if (!eventMatchesScope(detail, currentSessionId, historyTopic)) return;
-      // Clear progress when thinking stops (response received or stream done)
-      if (!detail.thinking) {
-        setProgress(null);
-      }
+      // Clear progress when thinking stops AND the completed turn is
+      // the one that owns the in-flight progress. Pre-fix this was a
+      // bare `!detail.thinking` check — a subsequent normal turn's
+      // `turn/completed` would clear a still-running background
+      // task's spinner from an earlier turn.
+      if (detail.thinking) return;
+      setProgress((prev) => {
+        if (!prev) return prev;
+        // If we don't know either turnId we fall back to the legacy
+        // "any thinking-false clears" behaviour for compatibility with
+        // server frames that don't carry `turnId`.
+        if (prev.turnId && detail.turnId && prev.turnId !== detail.turnId) {
+          return prev;
+        }
+        return null;
+      });
     }
     window.addEventListener("crew:tool_progress", onProgress);
     window.addEventListener("crew:thinking", onThinking);

--- a/src/runtime/ui-protocol-event-router.test.ts
+++ b/src/runtime/ui-protocol-event-router.test.ts
@@ -250,6 +250,78 @@ describe("router event mapping", () => {
     expect(tcs.find((tc) => tc.id === "task-7")?.progress.map((p) => p.message))
       .toEqual(["deep_research"]);
     expect(dispatched.some((e) => e.type === "crew:bg_tasks")).toBe(true);
+    // Codex round-2: spawn_only running state also fans out into the
+    // spinner indicator. The dispatch is NOT terminal (still running).
+    const progressEvt = dispatched.find(
+      (e) => e.type === "crew:tool_progress",
+    ) as CustomEvent | undefined;
+    expect(progressEvt).toBeDefined();
+    expect(progressEvt!.detail.tool).toBe("task-7"); // no tool name cached
+    expect(progressEvt!.detail.message).toBe("deep_research");
+    expect(progressEvt!.detail.turnId).toBe("cmid-3");
+    expect(progressEvt!.detail.terminal).toBeUndefined();
+  });
+
+  it("task/updated completed fans out a terminal crew:tool_progress (spawn_only spinner clear)", () => {
+    // Spawn_only tools (podcast_generate, fm_tts, deep_search,
+    // mofa_slides) emit their lifecycle exclusively through
+    // `task/updated`. The lifted `ToolProgressIndicator` needs an
+    // explicit terminal signal because the LLM `crew:thinking false`
+    // already fired at the enclosing `turn/completed` long before the
+    // background task finished.
+    seedThread("cmid-spawnonly");
+    const dispatched: Event[] = [];
+    const cfg = {
+      sessionId: SESSION,
+      dispatchEvent: (e: Event) => dispatched.push(e),
+    };
+    handleTaskUpdated(cfg, {
+      session_id: SESSION,
+      turn_id: "cmid-spawnonly",
+      task_id: "task-podcast",
+      state: "running",
+      title: "synthesising 1/3",
+    });
+    handleTaskUpdated(cfg, {
+      session_id: SESSION,
+      turn_id: "cmid-spawnonly",
+      task_id: "task-podcast",
+      state: "completed",
+    });
+    const terminalEvt = dispatched
+      .filter((e) => e.type === "crew:tool_progress")
+      .map((e) => e as CustomEvent)
+      .find((e) => e.detail.terminal === true);
+    expect(terminalEvt).toBeDefined();
+    expect(terminalEvt!.detail.turnId).toBe("cmid-spawnonly");
+    expect(terminalEvt!.detail.message).toBe("done");
+  });
+
+  it("task/updated failed fans out a terminal crew:tool_progress with error message", () => {
+    seedThread("cmid-spawnerr");
+    const dispatched: Event[] = [];
+    const cfg = {
+      sessionId: SESSION,
+      dispatchEvent: (e: Event) => dispatched.push(e),
+    };
+    handleTaskUpdated(cfg, {
+      session_id: SESSION,
+      turn_id: "cmid-spawnerr",
+      task_id: "task-fail",
+      state: "running",
+    });
+    handleTaskUpdated(cfg, {
+      session_id: SESSION,
+      turn_id: "cmid-spawnerr",
+      task_id: "task-fail",
+      state: "failed",
+    });
+    const terminalEvt = dispatched
+      .filter((e) => e.type === "crew:tool_progress")
+      .map((e) => e as CustomEvent)
+      .find((e) => e.detail.terminal === true);
+    expect(terminalEvt).toBeDefined();
+    expect(terminalEvt!.detail.message).toBe("error");
   });
 
   it("task/updated dedupes consecutive identical state for the same task", () => {

--- a/src/runtime/ui-protocol-event-router.test.ts
+++ b/src/runtime/ui-protocol-event-router.test.ts
@@ -1338,6 +1338,55 @@ describe("regression A: tool/* events fan out into crew:tool_progress", () => {
     expect(dispatched).toHaveLength(1);
     expect((dispatched[0] as CustomEvent).detail.tool).toBe("shell");
   });
+
+  it("tool/completed marks the crew:tool_progress event terminal (spawn_only spinner clear signal)", () => {
+    // The lifted `ToolProgressIndicator` (chat-layout level) cannot
+    // rely on `crew:thinking false` for spawn_only flows — that event
+    // already fired at `turn/completed` BEFORE the background task
+    // started emitting `tool/progress`. The terminal flag is the
+    // dedicated clear signal the indicator listens for.
+    const dispatched: Event[] = [];
+    handleToolCompleted(
+      { sessionId: SESSION, dispatchEvent: (e) => dispatched.push(e) },
+      {
+        session_id: SESSION,
+        turn_id: "cmid-A4",
+        tool_call_id: "tc-4",
+        tool_name: "podcast_generate",
+        success: true,
+      },
+    );
+    expect(dispatched).toHaveLength(1);
+    expect((dispatched[0] as CustomEvent).detail.terminal).toBe(true);
+    expect((dispatched[0] as CustomEvent).detail.tool).toBe("podcast_generate");
+  });
+
+  it("tool/started and tool/progress do NOT carry the terminal flag", () => {
+    // Sanity: only `tool/completed` is terminal — `tool/started` and
+    // `tool/progress` keep the spinner alive.
+    const dispatched: Event[] = [];
+    handleToolStarted(
+      { sessionId: SESSION, dispatchEvent: (e) => dispatched.push(e) },
+      {
+        session_id: SESSION,
+        turn_id: "cmid-A5",
+        tool_call_id: "tc-5",
+        tool_name: "fm_tts",
+      },
+    );
+    handleToolProgress(
+      { sessionId: SESSION, dispatchEvent: (e) => dispatched.push(e) },
+      {
+        session_id: SESSION,
+        turn_id: "cmid-A5",
+        tool_call_id: "tc-5",
+        message: "synthesising 1/3",
+      },
+    );
+    expect(dispatched).toHaveLength(2);
+    expect((dispatched[0] as CustomEvent).detail.terminal).toBeUndefined();
+    expect((dispatched[1] as CustomEvent).detail.terminal).toBeUndefined();
+  });
 });
 
 describe("regression B: progress/updated fans out into crew:cost (+ crew:message_meta)", () => {

--- a/src/runtime/ui-protocol-event-router.test.ts
+++ b/src/runtime/ui-protocol-event-router.test.ts
@@ -297,6 +297,73 @@ describe("router event mapping", () => {
     expect(terminalEvt!.detail.message).toBe("done");
   });
 
+  it("task/updated running passes through new labels (state-only dedupe would suppress spinner refresh)", () => {
+    // Codex round-3: a stream of `running` updates with refreshed
+    // `title`/`runtime_detail` values must reach the lifted spinner.
+    // Pre-fix the by-state-only dedupe dropped them after the first,
+    // so spawn_only progress was stuck on the very first label.
+    seedThread("cmid-relabel");
+    const dispatched: Event[] = [];
+    const cfg = {
+      sessionId: SESSION,
+      dispatchEvent: (e: Event) => dispatched.push(e),
+    };
+    handleTaskUpdated(cfg, {
+      session_id: SESSION,
+      turn_id: "cmid-relabel",
+      task_id: "task-relabel",
+      state: "running",
+      title: "synthesising 1/3",
+    });
+    handleTaskUpdated(cfg, {
+      session_id: SESSION,
+      turn_id: "cmid-relabel",
+      task_id: "task-relabel",
+      state: "running",
+      title: "synthesising 2/3",
+    });
+    handleTaskUpdated(cfg, {
+      session_id: SESSION,
+      turn_id: "cmid-relabel",
+      task_id: "task-relabel",
+      state: "running",
+      title: "synthesising 3/3",
+    });
+    const progressFrames = dispatched
+      .filter((e) => e.type === "crew:tool_progress")
+      .map((e) => (e as CustomEvent).detail.message);
+    expect(progressFrames).toEqual([
+      "synthesising 1/3",
+      "synthesising 2/3",
+      "synthesising 3/3",
+    ]);
+  });
+
+  it("task/output/delta fans out into crew:tool_progress (live spawn_only stdout)", () => {
+    // Codex round-3: spawn_only tools that emit progress as stdout
+    // chunks (rather than `task/updated` titles) must also light the
+    // spinner. Non-terminal — completion is signalled by
+    // `task/updated` completed/failed/errored.
+    seedThread("cmid-stdout");
+    const dispatched: Event[] = [];
+    const cfg = {
+      sessionId: SESSION,
+      dispatchEvent: (e: Event) => dispatched.push(e),
+    };
+    handleTaskOutputDelta(cfg, {
+      session_id: SESSION,
+      turn_id: "cmid-stdout",
+      task_id: "task-stdout",
+      chunk: "processing chunk 5/10",
+    });
+    const progressEvt = dispatched.find(
+      (e) => e.type === "crew:tool_progress",
+    ) as CustomEvent | undefined;
+    expect(progressEvt).toBeDefined();
+    expect(progressEvt!.detail.message).toBe("processing chunk 5/10");
+    expect(progressEvt!.detail.terminal).toBeUndefined();
+  });
+
   it("task/updated failed fans out a terminal crew:tool_progress with error message", () => {
     seedThread("cmid-spawnerr");
     const dispatched: Event[] = [];

--- a/src/runtime/ui-protocol-event-router.ts
+++ b/src/runtime/ui-protocol-event-router.ts
@@ -663,6 +663,14 @@ function dispatchToolProgressEvent(
   turnId: string,
   toolName: string,
   message: string,
+  /** When true, the `ToolProgressIndicator` clears the spinner row.
+   *  Set on `tool/completed` (sync and spawn_only paths) because for
+   *  spawn_only tools the LLM `crew:thinking false` has already fired
+   *  at `turn/completed` BEFORE the background task starts emitting,
+   *  so it can no longer be relied upon to clear the row. Without an
+   *  explicit terminal signal the spinner would display the
+   *  "done"/"error"/"complete" message indefinitely. */
+  terminal: boolean = false,
 ): void {
   dispatch(
     cfg,
@@ -673,6 +681,7 @@ function dispatchToolProgressEvent(
         sessionId: cfg.sessionId,
         topic: cfg.topic,
         turnId,
+        ...(terminal ? { terminal: true } : {}),
       },
     }),
   );
@@ -739,7 +748,19 @@ export function handleToolCompleted(
     event.tool_call_id,
     event.success === false ? "error" : "complete",
   );
-  dispatchToolProgressEvent(cfg, event.turn_id, event.tool_name, message);
+  // Mark terminal so the lifted `ToolProgressIndicator` clears the
+  // spinner row. The bubble's `ToolCallBubble` reads the final
+  // status from `ThreadStore.setToolCallStatus` above and keeps the
+  // history-pill state intact — only the transient spinner row goes
+  // away. Critical for spawn_only flows where `crew:thinking false`
+  // already fired at `turn/completed` and cannot clean up.
+  dispatchToolProgressEvent(
+    cfg,
+    event.turn_id,
+    event.tool_name,
+    message,
+    /* terminal */ true,
+  );
   // Clear the cache entry so a long-lived session doesn't accumulate
   // dead tool_call_id mappings.
   toolNameByCallId.delete(event.tool_call_id);

--- a/src/runtime/ui-protocol-event-router.ts
+++ b/src/runtime/ui-protocol-event-router.ts
@@ -168,10 +168,18 @@ function metaFromSnapshot(snap: TurnMetaSnapshot | undefined): MessageMeta | und
 // Per-task state-transition de-dupe
 // ---------------------------------------------------------------------------
 
-/** Last-seen task state per `task_id`. Mirrors the SSE-side
+/** Last-seen task state + label per `task_id`. Mirrors the SSE-side
  *  `lastTaskStatusById` map in `runtime-provider.tsx` so a `task/updated`
- *  replay (e.g. on reconnect) doesn't inflate the in-bubble timeline. */
-const lastTaskStateById = new Map<string, string>();
+ *  replay (e.g. on reconnect) doesn't inflate the in-bubble timeline.
+ *  Tracking the rendered label too (codex round-3) lets a stream of
+ *  `running` updates with refreshed `title`/`runtime_detail` through —
+ *  pre-fix the state-only dedupe stuck spawn_only spinners on the
+ *  very first label they emitted. */
+interface LastTaskState {
+  state: string;
+  label?: string;
+}
+const lastTaskStateById = new Map<string, LastTaskState>();
 
 /** Reset the per-task state map. Tests call this between cases; production
  *  code does not need it because the map is bounded by the number of live
@@ -457,8 +465,21 @@ export function handleTaskUpdated(
   event: TaskUpdatedEvent,
 ): void {
   const previous = lastTaskStateById.get(event.task_id);
-  if (previous === event.state) return;
-  lastTaskStateById.set(event.task_id, event.state);
+  // Dedupe ONLY when both state AND label are unchanged. The legacy
+  // by-state-only dedupe meant a stream of `running` updates with
+  // refreshed titles (e.g. "synthesising 1/3" → "synthesising 2/3")
+  // was dropped — spawn_only progress would stay frozen on the
+  // first label on the lifted spinner. Compare the rendered label
+  // for running/spawned; terminal states don't carry one so the
+  // state alone is enough.
+  const stateUnchanged = previous?.state === event.state;
+  const labelUnchanged =
+    previous?.label === (event.title ?? event.runtime_detail);
+  if (stateUnchanged && labelUnchanged) return;
+  lastTaskStateById.set(event.task_id, {
+    state: event.state,
+    label: event.title ?? event.runtime_detail,
+  });
 
   // For spawn_only background tools (podcast_generate / fm_tts /
   // deep_search / mofa_slides etc.) the running-state updates arrive
@@ -525,7 +546,7 @@ export function handleTaskUpdated(
 }
 
 export function handleTaskOutputDelta(
-  _cfg: RouterConfig,
+  cfg: RouterConfig,
   event: TaskOutputDeltaEvent,
 ): void {
   if (!event.chunk) return;
@@ -533,6 +554,13 @@ export function handleTaskOutputDelta(
   // logic lives in ThreadStore.appendToolProgress (consecutive duplicates
   // are dropped) so resending the same chunk on reconnect is safe.
   ThreadStore.appendToolProgress(event.turn_id, event.task_id, event.chunk);
+  // Codex round-3: also fan out to the lifted spinner. Some spawn_only
+  // flows emit their real progress as output chunks, not `task/updated`
+  // running labels; without this dispatch the spinner text goes stale
+  // mid-task. Non-terminal — completion is signalled by `task/updated`
+  // completed/failed/errored.
+  const toolLabel = toolNameByCallId.get(event.task_id) ?? event.task_id;
+  dispatchToolProgressEvent(cfg, event.turn_id, toolLabel, event.chunk);
 }
 
 export function handleTurnStarted(

--- a/src/runtime/ui-protocol-event-router.ts
+++ b/src/runtime/ui-protocol-event-router.ts
@@ -460,6 +460,20 @@ export function handleTaskUpdated(
   if (previous === event.state) return;
   lastTaskStateById.set(event.task_id, event.state);
 
+  // For spawn_only background tools (podcast_generate / fm_tts /
+  // deep_search / mofa_slides etc.) the running-state updates arrive
+  // exclusively via `task/updated`, NOT `tool/progress` — the parent
+  // LLM turn already settled at `turn/completed` before the
+  // background work started. The lifted `ToolProgressIndicator`
+  // therefore needs the spinner-progress fan-out here as well, with
+  // the terminal flag set on the completion legs so the row clears.
+  //
+  // The `tool_name` lookup falls back to the task_id when no preceding
+  // `tool/started` cached a name (e.g. a server-side flow that skips
+  // `tool/started` entirely and only emits `task/updated`); same shape
+  // `handleToolProgress` uses on the synchronous path.
+  const toolLabel = toolNameByCallId.get(event.task_id) ?? event.task_id;
+
   switch (event.state) {
     case "spawned":
     case "running": {
@@ -474,15 +488,35 @@ export function handleTaskUpdated(
           detail: { sessionId: cfg.sessionId, topic: cfg.topic },
         }),
       );
+      // Light / refresh the spinner with the latest task state label.
+      dispatchToolProgressEvent(cfg, event.turn_id, toolLabel, label);
       break;
     }
     case "completed": {
       ThreadStore.setToolCallStatus(event.turn_id, event.task_id, "complete");
+      dispatchToolProgressEvent(
+        cfg,
+        event.turn_id,
+        toolLabel,
+        "done",
+        /* terminal */ true,
+      );
+      // Drop the cache entry — the task is done, no further frames
+      // should land on this id (mirrors `handleToolCompleted`).
+      toolNameByCallId.delete(event.task_id);
       break;
     }
     case "failed":
     case "errored": {
       ThreadStore.setToolCallStatus(event.turn_id, event.task_id, "error");
+      dispatchToolProgressEvent(
+        cfg,
+        event.turn_id,
+        toolLabel,
+        "error",
+        /* terminal */ true,
+      );
+      toolNameByCallId.delete(event.task_id);
       break;
     }
     default:


### PR DESCRIPTION
## Summary

Fixes the spawn_only-tool spinner gap: for tools like `podcast_generate`, `fm_tts`, `deep_search`, `mofa_slides`, `run_pipeline` the LLM turn settles with `turn/completed` BEFORE the background task starts emitting progress. The per-bubble `<ToolProgressIndicator />` (gated by `showLiveIndicators === "streaming"`) was unmounted by then, so the spinner stayed invisible for the entire spawn_only duration.

## Approach

**Option A** — single global mount per chat layout. Walked through three codex review rounds; final shape:

### Round 0 (lift)

- `src/components/chat-thread.tsx`: drop `<ToolProgressIndicator />` from `ThreadAssistantBubble`'s `showLiveIndicators` slot; mount it once between `ThreadList` and `Composer` in `ChatThreadV2`. The component already self-scopes via `eventMatchesScope`.

### Round 1 (lifecycle correctness)

- `src/components/tool-progress-indicator.tsx`:
  - Reset `progress` on `(currentSessionId, historyTopic)` change so a stale spinner from session A doesn't bleed into B.
  - Track `turnId` in indicator state. `crew:thinking false` only clears when the event's `turnId` matches the displayed progress's `turnId` (legacy any-clears fallback when either side lacks a turnId).
  - Listen for `terminal: true` on `crew:tool_progress` for an explicit clear signal.
- `src/runtime/ui-protocol-event-router.ts`: `dispatchToolProgressEvent` gains a `terminal` arg; `handleToolCompleted` passes `terminal: true`. Without this the lifted spinner would render "done"/"error" forever (the LLM `crew:thinking false` already fired).

### Round 2 (wire spawn_only path)

- `src/runtime/ui-protocol-event-router.ts::handleTaskUpdated` now also dispatches `crew:tool_progress` — spawn_only background tasks emit their lifecycle through `task/updated` on the spawned task's stream, NOT `tool/progress`. The previous lift fix listened for the right event but nothing was dispatching it for spawn_only flows. `running` → non-terminal, `completed` → terminal/`"done"`, `failed`/`errored` → terminal/`"error"`.
- Terminal frames now scoped by `turnId` in the indicator (matches the `crew:thinking false` guard) so an unrelated concurrent tool's completion doesn't blow away the visible spinner.

### Round 3 (label refreshes + stdout)

- `handleTaskUpdated`: dedupe by `(state, label)` tuple instead of state alone. Pre-fix a stream of `running` updates with refreshed titles (e.g. "synthesising 1/3" → "2/3" → "3/3") was collapsed to the first label only.
- `handleTaskOutputDelta`: also dispatch `crew:tool_progress` (non-terminal). Some spawn_only flows emit progress as raw stdout chunks rather than `task/updated` titles.

### Explicitly out of scope (codex P3, deferred)

Multi-tool aggregation (keying the indicator by `tool_call_id`, rendering N active items). The task spec says "Multiple concurrent spawn_only tasks — spinner should show the most recent progress message (existing behavior; this is fine)" — that's a UX redesign, not a visibility-gate fix.

## Files changed

```
 src/components/chat-thread-bg-spinner.test.tsx  | 208 +++++ (new)
 src/components/chat-thread.tsx                  |  25 ++- (+18 -7)
 src/components/tool-progress-indicator.test.tsx | 264 ++++ (+199)
 src/components/tool-progress-indicator.tsx      |  94 ++++- (+80 -14)
 src/runtime/ui-protocol-event-router.test.ts    | 188 ++++ (new tests)
 src/runtime/ui-protocol-event-router.ts         |  97 ++++- (+91 -6)
 6 files changed, 853 insertions(+), 23 deletions(-)
```

Indicator mount site: `src/components/chat-thread.tsx::ChatThreadV2`, between the thread list and the composer.

## Test plan

- [x] `npx tsc --noEmit -p tsconfig.json` clean
- [x] `npm run test:unit` — 425/426 (same single pre-existing failure on `router seq preservation` from `origin/main`, unrelated)
- [x] New `chat-thread-bg-spinner.test.tsx` (3 tests): scoped `crew:tool_progress` after `turn/completed` renders the row; cross-session drops; clear-on-`thinking false` legacy path
- [x] Updated `tool-progress-indicator.test.tsx` (8 tests, was 3): terminal-frame clear, cross-turn parallel-tool guard, no-turnId legacy fallback, session-switch reset
- [x] Updated `ui-protocol-event-router.test.ts` (+5 tests): `tool/completed` carries terminal flag; `tool/started`/`tool/progress` do not; `task/updated running` dispatches non-terminal spinner frame; `task/updated completed` dispatches terminal "done"; `task/updated failed` dispatches terminal "error"; refreshed `running` labels reach the spinner; `task/output/delta` reaches the spinner
- [ ] Live smoke on a deployed mini — deferred (needs OTP). Reproduce: send "generate a 3 minute podcast about X with voice yangmi" → spinner visible throughout the entire background-task duration, not just the LLM streaming window. Send a synchronous tool message (e.g. web_search) → spinner during the call. Send plain text → no spinner.

## What's unchanged

- `crew:tool_progress` event shape on the wire (terminal is a new optional field on the detail payload only)
- Session/topic scoping via `eventMatchesScope`
- `ThinkingIndicator` (still per-bubble; tied to LLM streaming, fires on `crew:thinking` rising/falling edges between iterations)
- `ToolCallBubble`'s in-bubble tool-card timeline + terminal status pill