### PR TITLE
fix(runtime): thread metadata.token_cost.model into chat bubble footer

### DIFF
--- a/src/runtime/ui-protocol-bridge.test.ts
+++ b/src/runtime/ui-protocol-bridge.test.ts
@@ -664,6 +664,55 @@ describe("type guards (fail-closed)", () => {
     expect(ok?.metadata.token_cost?.session_cost).toBe(0.01);
   });
 
+  // Server PR `feat/cost-update-carry-model` adds an authoritative
+  // `metadata.token_cost.model` field, populated from
+  // `LlmProvider::provider_metadata_for_index(...).model`. Codex caught
+  // that the fail-closed guard was silently dropping the new field
+  // before it reached the router — so the chat bubble footer would
+  // continue to fall back to the legacy `metadata.label` carrier in
+  // production even though the wire carried the right value. This test
+  // pins the guard's handling of the new field.
+  it("preserves token_cost.model through the guard", () => {
+    const ok = guards.guardProgressUpdated({
+      session_id: "s",
+      turn_id: "t",
+      metadata: {
+        kind: "token_cost_update",
+        token_cost: {
+          input_tokens: 120,
+          output_tokens: 45,
+          model: "deepseek-v4-pro",
+        },
+      },
+    });
+    expect(ok?.metadata.token_cost?.model).toBe("deepseek-v4-pro");
+  });
+
+  // Defensive: a malformed `model` field (non-string / empty string)
+  // must not synthesise a `model` value on the snapshot — empty would
+  // confuse the bubble footer renderer downstream.
+  it("drops empty / non-string token_cost.model", () => {
+    const emptyString = guards.guardProgressUpdated({
+      session_id: "s",
+      turn_id: "t",
+      metadata: {
+        kind: "token_cost_update",
+        token_cost: { input_tokens: 1, output_tokens: 2, model: "" },
+      },
+    });
+    expect(emptyString?.metadata.token_cost?.model).toBeUndefined();
+
+    const wrongType = guards.guardProgressUpdated({
+      session_id: "s",
+      turn_id: "t",
+      metadata: {
+        kind: "token_cost_update",
+        token_cost: { input_tokens: 1, output_tokens: 2, model: 42 },
+      },
+    });
+    expect(wrongType?.metadata.token_cost?.model).toBeUndefined();
+  });
+
   it("rejects progress/updated missing metadata.kind", () => {
     expect(
       guards.guardProgressUpdated({

--- a/src/runtime/ui-protocol-bridge.ts
+++ b/src/runtime/ui-protocol-bridge.ts
@@ -996,6 +996,16 @@ function guardUiTokenCost(p: unknown): UiTokenCostUpdate | undefined {
   if (typeof p.response_cost === "number") out.response_cost = p.response_cost;
   if (typeof p.session_cost === "number") out.session_cost = p.session_cost;
   if (typeof p.currency === "string") out.currency = p.currency;
+  // Server PR `feat/cost-update-carry-model` adds `model: Option<String>`
+  // to `UiTokenCostUpdate`, populated from
+  // `LlmProvider::provider_metadata_for_index(...).model` so the chat
+  // bubble footer (`model · tokens_in / tokens_out · duration`) can
+  // render even for failover / routed responses. Codex flagged the
+  // omission here — without this branch the field is silently dropped
+  // by the fail-closed guard before reaching
+  // `handleProgressUpdated`, so the router's `cost.model` lookup
+  // always resolves `undefined`.
+  if (typeof p.model === "string" && p.model.length > 0) out.model = p.model;
   return out;
 }
 

--- a/src/runtime/ui-protocol-event-router.test.ts
+++ b/src/runtime/ui-protocol-event-router.test.ts
@@ -1408,6 +1408,65 @@ describe("regression B: progress/updated fans out into crew:cost (+ crew:message
     );
     expect(dispatched).toHaveLength(0);
   });
+
+  it("token_cost_update prefers metadata.token_cost.model over metadata.label", () => {
+    // Server PR `feat/cost-update-carry-model` adds an authoritative
+    // `metadata.token_cost.model` field, populated from
+    // `LlmProvider::provider_metadata_for_index(...).model` so failover
+    // / routed responses surface the model that actually answered. The
+    // router must prefer the new field and fall back to the legacy
+    // `metadata.label` carrier only when the new field is absent.
+    const dispatched: Event[] = [];
+    handleProgressUpdated(
+      { sessionId: SESSION, dispatchEvent: (e) => dispatched.push(e) },
+      {
+        session_id: SESSION,
+        turn_id: "cmid-B4-prefers-token-cost-model",
+        metadata: {
+          kind: "token_cost_update",
+          label: "stale-label-from-older-bridge",
+          token_cost: {
+            input_tokens: 120,
+            output_tokens: 45,
+            model: "deepseek-v4-pro",
+          },
+        },
+      },
+    );
+    const meta = dispatched.find((e) => e.type === "crew:message_meta") as
+      | CustomEvent
+      | undefined;
+    expect(meta).toBeDefined();
+    expect(meta!.detail.model).toBe("deepseek-v4-pro");
+  });
+
+  it("token_cost_update falls back to metadata.label when token_cost.model is absent", () => {
+    // Back-compat: older daemons that don't populate
+    // `token_cost.model` yet still flow through the legacy
+    // `metadata.label` carrier. The router must not regress those
+    // flows before the fleet is upgraded.
+    const dispatched: Event[] = [];
+    handleProgressUpdated(
+      { sessionId: SESSION, dispatchEvent: (e) => dispatched.push(e) },
+      {
+        session_id: SESSION,
+        turn_id: "cmid-B5-falls-back-to-label",
+        metadata: {
+          kind: "token_cost_update",
+          label: "moonshot@autodl/kimi-k2.5",
+          token_cost: {
+            input_tokens: 12,
+            output_tokens: 7,
+          },
+        },
+      },
+    );
+    const meta = dispatched.find((e) => e.type === "crew:message_meta") as
+      | CustomEvent
+      | undefined;
+    expect(meta).toBeDefined();
+    expect(meta!.detail.model).toBe("moonshot@autodl/kimi-k2.5");
+  });
 });
 
 describe("regression C: turn/completed stamps per-turn meta snapshot onto the finalised bubble", () => {

--- a/src/runtime/ui-protocol-event-router.ts
+++ b/src/runtime/ui-protocol-event-router.ts
@@ -67,10 +67,14 @@ import type { MessageInfo } from "@/api/types";
 // following turn.
 
 interface TurnMetaSnapshot {
-  /** Last model string we saw. Populated from `metadata.label` (the
-   *  server's display-name carrier; see
-   *  `crates/octos-cli/src/api/ui_protocol_progress.rs:363` and
-   *  follow-up). Optional — some turns don't carry a model. */
+  /** Last model string we saw. Primary source is
+   *  `metadata.token_cost.model` (added server-side in PR
+   *  `feat/cost-update-carry-model` —
+   *  `crates/octos-cli/src/api/ui_protocol_progress.rs::map_cost_update`
+   *  threads the field from `LlmProvider::provider_metadata_for_index`).
+   *  Falls back to the legacy `metadata.label` carrier for daemons that
+   *  haven't been upgraded yet. Optional — some turns don't carry a
+   *  model. */
   model?: string;
   /** Per-turn delta of `input_tokens`. Codex round-2 P2 fix: the
    *  `progress/updated{kind:"token_cost_update"}` frame carries SESSION
@@ -787,14 +791,21 @@ export function handleProgressUpdated(
   const inputTokens = cost?.input_tokens;
   const outputTokens = cost?.output_tokens;
   const sessionCost = cost?.session_cost;
-  // `metadata.label` is the server's display-name carrier (set by the
-  // agent when emitting cost frames; nullable for very early frames in
-  // the turn). We pass it through verbatim so the legacy listener can
-  // read `detail.model`.
-  const modelLabel =
+  // Server PR `feat/cost-update-carry-model` adds an authoritative
+  // `metadata.token_cost.model` field, populated from
+  // `LlmProvider::provider_metadata_for_index(...).model` so failover /
+  // routed responses surface the model that actually answered. Prefer
+  // that field; fall back to the legacy `metadata.label` carrier so
+  // older daemons (the field is opt-in additive) continue to work.
+  const costModel =
+    typeof cost?.model === "string" && cost.model.length > 0
+      ? cost.model
+      : undefined;
+  const labelModel =
     typeof event.metadata.label === "string" && event.metadata.label.length > 0
       ? event.metadata.label
       : undefined;
+  const modelLabel = costModel ?? labelModel;
 
   // -- (a) crew:cost -------------------------------------------------------
   dispatch(

--- a/src/runtime/ui-protocol-types.ts
+++ b/src/runtime/ui-protocol-types.ts
@@ -355,6 +355,15 @@ export interface UiTokenCostUpdate {
   response_cost?: number;
   session_cost?: number;
   currency?: string;
+  /**
+   * Model identifier that produced this response. Populated by the server's
+   * agent emit layer from `LlmProvider::model_id()` so chat clients can
+   * render the assistant bubble footer
+   * (`model · tokens_in / tokens_out · duration`) without scraping the
+   * legacy `metadata.label` field. Older servers omit this field; the
+   * router falls back to `metadata.label` for back-compat.
+   */
+  model?: string;
 }
 
 /**


### PR DESCRIPTION
## Summary

The assistant bubble footer (`model · tokens_in / tokens_out · duration`) went blank for the post-PR-#93 cost wire shape: `progress/updated{kind:"token_cost_update"}` carried token counts in `metadata.token_cost`, but the router scraped `metadata.label` for the model display name, which `cost_update` frames don't populate.

Companion server PR [octos-org/octos#957](https://github.com/octos-org/octos/pull/957) adds an authoritative `metadata.token_cost.model` field, populated from `LlmProvider::provider_metadata_for_index(...).model` so failover / routed responses surface the model that actually answered.

This PR threads the new field through the web runtime:

- `ui-protocol-types.ts`: extend `UiTokenCostUpdate` with `model?: string`, mirroring the Rust struct
- `ui-protocol-bridge.ts`: `guardUiTokenCost` was silently dropping any field it didn't explicitly copy — `model` would never reach the router from a real WebSocket frame. Codex caught this. Add the branch with empty / non-string rejection
- `ui-protocol-event-router.ts`: `handleProgressUpdated` prefers `metadata.token_cost.model` over `metadata.label`; the legacy carrier remains a fallback for daemons that haven't been redeployed

## Test plan

- [x] `npx tsc --noEmit` clean
- [x] `npm run test:unit` — 415/416 passing (1 pre-existing failure in `router seq preservation > persisted message stamps seq onto the late-artifact response` that exists on `origin/main`; unrelated to this PR)
- [x] 4 new tests pinning the model-threading path:
  - `preserves token_cost.model through the guard`
  - `drops empty / non-string token_cost.model`
  - `token_cost_update prefers metadata.token_cost.model over metadata.label`
  - `token_cost_update falls back to metadata.label when token_cost.model is absent`
- [x] Codex review round 1 caught the `guardUiTokenCost` omission (P2); round 2 clean

## Wire-format compatibility

Strictly back-compat. Frames without the new field flow through the legacy `metadata.label` path unchanged. This PR can land before the server-side companion PR — the new fallback chain resolves via `metadata.label` exactly as today.

## Deployment ordering

1. This PR can land any time — back-compat is the design.
2. Server PR octos-org/octos#957 must merge AND the fleet must redeploy for the new field to appear on the wire.
3. Once both are deployed, failover / routed responses surface the correct per-response model in the footer (today, when the daemon falls back from primary to secondary, the footer can show the wrong model — the new server PR fixes that, but only after the daemon is up-to-date).