### PR TITLE
fix(runtime): turn/spawn_complete + crew:task_status flip tool status to complete

### DIFF
--- a/src/runtime/runtime-provider.tsx
+++ b/src/runtime/runtime-provider.tsx
@@ -19,80 +19,13 @@ import { getSessionStatus } from "@/api/sessions";
 import type { BackgroundTaskInfo } from "@/api/types";
 import { restoreWatchedSessions, unwatchSession, watchSession } from "./task-watcher";
 import { eventSessionId, eventTopic } from "./event-scope";
+import { applyTaskStatusToThreadStore } from "./task-status-applier";
 import {
   startBridgeForSession,
   stopActiveBridgeIfScope,
 } from "./ui-protocol-runtime";
 /** Max sessions kept in memory simultaneously. */
 const MAX_CACHED = 5;
-
-/** Last task_status seen per `task.id`. Used to suppress synthesizing a
- *  duplicate progress line on replays/oscillations — only emit a line
- *  when the status actually changes for that task. Per-task scoping
- *  also means two unrelated tasks sharing one `tool_call_id` (rare but
- *  possible across reconnects) each contribute exactly one entry per
- *  transition rather than collapsing into the previous task's line.
- */
-const lastTaskStatusById = new Map<string, BackgroundTaskInfo["status"]>();
-
-/** Cap individual task labels and error suffixes so a pathological
- *  payload cannot bloat the in-bubble timeline. The bubble renders
- *  monospace at small text sizes — long single-line failures are
- *  unreadable. */
-const MAX_TASK_LABEL_CHARS = 64;
-const MAX_PROGRESS_LINE_CHARS = 320;
-
-function clip(text: string, max: number): string {
-  if (text.length <= max) return text;
-  return `${text.slice(0, Math.max(0, max - 1))}…`;
-}
-
-/** Display-form a snake_case tool name. Mirrors the simplification in
- *  `session-task-dock.tsx`'s `taskDisplayName` so the same task surfaces
- *  with the same label everywhere ("deep_research" → "deep research").
- *  Capped to a reasonable width. */
-function displayTaskName(tool: string): string {
-  const stripped = (tool || "task").replace(/_/g, " ").trim();
-  return clip(stripped || "task", MAX_TASK_LABEL_CHARS);
-}
-
-/** Build a human-readable progress line for a task_status transition.
- *  Returns null when the status carries no useful narration (e.g. the
- *  daemon emitted an unknown status string), or when this exact status
- *  was already seen for this task and a duplicate line should be
- *  suppressed at the source. */
-function synthesizeTaskProgressLine(
-  task: BackgroundTaskInfo,
-): string | null {
-  const previous = lastTaskStatusById.get(task.id);
-  if (previous === task.status) return null;
-  // Record the new status BEFORE returning the line so re-entrant
-  // dispatches (within the same tick) can short-circuit on the second
-  // call. Failures still record so a `failed -> failed` replay is
-  // suppressed too.
-  lastTaskStatusById.set(task.id, task.status);
-
-  const label = displayTaskName(task.tool_name);
-  switch (task.status) {
-    case "spawned":
-      return clip(`${label} started`, MAX_PROGRESS_LINE_CHARS);
-    case "running":
-      return clip(`${label} running`, MAX_PROGRESS_LINE_CHARS);
-    case "completed":
-      return clip(`${label} completed`, MAX_PROGRESS_LINE_CHARS);
-    case "failed": {
-      // Single-line normalize the error: collapse newlines/whitespace
-      // so the bubble doesn't line-break inside a tiny mono pill.
-      const detail = task.error
-        ? task.error.replace(/\s+/g, " ").trim()
-        : "";
-      const line = detail ? `${label} failed: ${detail}` : `${label} failed`;
-      return clip(line, MAX_PROGRESS_LINE_CHARS);
-    }
-    default:
-      return null;
-  }
-}
 
 /** Tracks which sessions have been mounted so we can evict old ones.
  *  Exported as `ScopedRuntimeBridge` so embedded chat surfaces
@@ -275,37 +208,17 @@ function RuntimeWithSession({ children }: { children: ReactNode }) {
         TaskStore.mergeTask(sessionId, task, topic);
         // M9-γ-6: bg-task↔message binding lived only in MessageStore.
         // Mirror the status as a synthetic progress line into the
-        // ThreadStore's tool-call timeline. Background subagents
-        // (e.g. deep_research / run_pipeline) emit their per-step
-        // `tool_progress` SSE events on the spawned task's own stream,
-        // not the parent chat stream — without this mirror the
-        // tool-call bubble in the parent thread renders empty even
-        // when the task is actively running. Only synthesize a line
-        // when the bubble has a stable id to anchor against; the
-        // helper de-duplicates consecutive identical entries so we
-        // tolerate task_status replays without doubling the timeline.
-        const progressLine = synthesizeTaskProgressLine(task);
-        if (progressLine && task.tool_call_id) {
-          // Mirror into the thread store when it already knows about
-          // this tool_call_id (i.e. tool_start arrived before
-          // task_status). When the lookup misses we deliberately drop
-          // the synthetic progress rather than synthesize an orphan
-          // thread — creating phantom threads for every backgrounded
-          // task on first paint would race with the real tool_start
-          // that arrives moments later.
-          const threadId = ThreadStore.findThreadIdForToolCall(
-            sessionId,
-            topic,
-            task.tool_call_id,
-          );
-          if (threadId) {
-            ThreadStore.appendToolProgress(
-              threadId,
-              task.tool_call_id,
-              progressLine,
-            );
-          }
-        }
+        // ThreadStore's tool-call timeline AND flip the originating
+        // tool call's terminal status (codex 2026-05-15 live-event
+        // variant). Background subagents (e.g. deep_research /
+        // run_pipeline) emit their per-step `tool_progress` SSE events
+        // on the spawned task's own stream, not the parent chat
+        // stream — without this mirror the tool-call bubble in the
+        // parent thread renders empty even when the task is actively
+        // running. `applyTaskStatusToThreadStore` is the testable
+        // extract; it dedupes consecutive identical entries so a
+        // task_status replay does not double the timeline.
+        applyTaskStatusToThreadStore(sessionId, topic, task);
         const hasActiveTasks = TaskStore.getTasks(sessionId, topic).some(
           (candidate) =>
             candidate.status === "spawned" || candidate.status === "running",

--- a/src/runtime/task-status-applier.test.ts
+++ b/src/runtime/task-status-applier.test.ts
@@ -1,0 +1,152 @@
+/**
+ * task-status-applier unit tests.
+ *
+ * Coverage:
+ *   - `applyTaskStatusToThreadStore` mirrors a `crew:task_status` payload
+ *     into ThreadStore: synthetic progress line + terminal status flip.
+ *
+ * This is the live-event counterpart to the `handleSpawnComplete` fix in
+ * `ui-protocol-event-router.test.ts`. Both paths converge on the same
+ * `ThreadStore.setToolCallStatus(...)` call; this file exercises the
+ * `crew:task_status` route that `runtime-provider.tsx` dispatches into
+ * via the extracted helper.
+ */
+
+import { afterEach, describe, expect, it } from "vitest";
+import * as ThreadStore from "@/store/thread-store";
+import {
+  __resetTaskStatusDedupForTest,
+  applyTaskStatusToThreadStore,
+} from "./task-status-applier";
+import { handleToolStarted, __resetTurnMetaForTest } from "./ui-protocol-event-router";
+import type { BackgroundTaskInfo } from "@/api/types";
+
+const SESSION = "sess-runtime-provider";
+
+afterEach(() => {
+  ThreadStore.__resetForTests();
+  __resetTaskStatusDedupForTest();
+  __resetTurnMetaForTest();
+});
+
+function seedToolCall(cmid: string, toolCallId: string, toolName: string) {
+  // Realistic spawn_only setup: ack bubble finalized, then tool/started
+  // for the long-running background tool lands on the finalized response.
+  ThreadStore.addUserMessage(SESSION, {
+    text: "ask",
+    clientMessageId: cmid,
+  });
+  ThreadStore.appendAssistantToken(cmid, "Started.");
+  ThreadStore.finalizeAssistant(cmid, { committedSeq: 1 });
+  handleToolStarted(
+    { sessionId: SESSION },
+    {
+      session_id: SESSION,
+      turn_id: cmid,
+      tool_call_id: toolCallId,
+      tool_name: toolName,
+    },
+  );
+}
+
+describe("applyTaskStatusToThreadStore", () => {
+  it(
+    "task.status=completed flips the originating tool call status to complete",
+    () => {
+      // This is the live-event counterpart to the
+      // `turn/spawn_complete` stuck-spinner bug (codex 2026-05-15). The
+      // synthetic progress line at runtime-provider.tsx:~81 says
+      // "completed" — pre-fix the chip TEXT said completed but
+      // `toolCall.status` stayed on "running", so every spinner gated
+      // on `status === "running"` kept spinning.
+      const cmid = "cmid-live-1";
+      const taskId = "task_pipeline_1";
+      seedToolCall(cmid, taskId, "run_pipeline");
+
+      const task: BackgroundTaskInfo = {
+        id: taskId,
+        tool_name: "run_pipeline",
+        tool_call_id: taskId,
+        status: "completed",
+        started_at: "2026-05-15T00:00:00Z",
+        completed_at: "2026-05-15T00:00:05Z",
+        error: null,
+      };
+      applyTaskStatusToThreadStore(SESSION, undefined, task);
+
+      const [thread] = ThreadStore.getThreads(SESSION);
+      const tc = thread.responses[0].toolCalls.find((c) => c.id === taskId);
+      expect(tc?.status).toBe("complete");
+    },
+  );
+
+  it("task.status=failed flips the originating tool call status to error", () => {
+    const cmid = "cmid-live-2";
+    const taskId = "task_pipeline_2";
+    seedToolCall(cmid, taskId, "deep_research");
+
+    const task: BackgroundTaskInfo = {
+      id: taskId,
+      tool_name: "deep_research",
+      tool_call_id: taskId,
+      status: "failed",
+      started_at: "2026-05-15T00:00:00Z",
+      error: "upstream returned 500",
+    };
+    applyTaskStatusToThreadStore(SESSION, undefined, task);
+
+    const [thread] = ThreadStore.getThreads(SESSION);
+    const tc = thread.responses[0].toolCalls.find((c) => c.id === taskId);
+    expect(tc?.status).toBe("error");
+  });
+
+  it("task.status=running does NOT flip status (the chip is correctly running)", () => {
+    const cmid = "cmid-live-3";
+    const taskId = "task_pipeline_3";
+    seedToolCall(cmid, taskId, "podcast_generate");
+
+    const task: BackgroundTaskInfo = {
+      id: taskId,
+      tool_name: "podcast_generate",
+      tool_call_id: taskId,
+      status: "running",
+      started_at: "2026-05-15T00:00:00Z",
+      error: null,
+    };
+    applyTaskStatusToThreadStore(SESSION, undefined, task);
+
+    const [thread] = ThreadStore.getThreads(SESSION);
+    const tc = thread.responses[0].toolCalls.find((c) => c.id === taskId);
+    expect(tc?.status).toBe("running");
+  });
+
+  it("task with no tool_call_id is a no-op (no orphan thread mint)", () => {
+    const task: BackgroundTaskInfo = {
+      id: "task-orphan",
+      tool_name: "deep_search",
+      tool_call_id: undefined,
+      status: "completed",
+      started_at: "2026-05-15T00:00:00Z",
+      error: null,
+    };
+    // Should not throw and should not produce any thread.
+    applyTaskStatusToThreadStore(SESSION, undefined, task);
+    expect(ThreadStore.getThreads(SESSION)).toHaveLength(0);
+  });
+
+  it("task whose tool_call_id is unknown to ThreadStore is dropped, not orphaned", () => {
+    // Pre-fix the synthetic line was dropped silently when the lookup
+    // missed; we deliberately do not synthesize orphan threads here
+    // because the real `tool/started` arrives moments later.
+    const task: BackgroundTaskInfo = {
+      id: "task-stranger",
+      tool_name: "fm_tts",
+      tool_call_id: "tc-unknown-to-store",
+      status: "completed",
+      started_at: "2026-05-15T00:00:00Z",
+      error: null,
+    };
+    applyTaskStatusToThreadStore(SESSION, undefined, task);
+    expect(ThreadStore.getThreads(SESSION)).toHaveLength(0);
+  });
+});

--- a/src/runtime/task-status-applier.ts
+++ b/src/runtime/task-status-applier.ts
@@ -1,0 +1,132 @@
+/**
+ * Apply `crew:task_status` payloads to ThreadStore.
+ *
+ * Extracted from `runtime-provider.tsx` so unit tests can exercise the
+ * same code path the live effect uses without mounting the provider,
+ * and so the `.tsx` host file stays component-only (react-refresh
+ * `only-export-components` boundary).
+ *
+ * Background subagents (e.g. `deep_research` / `run_pipeline`) emit
+ * their per-step `tool_progress` SSE events on the spawned task's own
+ * stream, not the parent chat stream. Without this mirror the
+ * tool-call bubble in the parent thread renders empty even when the
+ * task is actively running, and never clears its spinner when the
+ * task settles (codex 2026-05-15 live-event variant).
+ */
+
+import * as ThreadStore from "@/store/thread-store";
+import type { BackgroundTaskInfo } from "@/api/types";
+
+/** Last task_status seen per `task.id`. Used to suppress synthesizing a
+ *  duplicate progress line on replays/oscillations — only emit a line
+ *  when the status actually changes for that task. Per-task scoping
+ *  also means two unrelated tasks sharing one `tool_call_id` (rare but
+ *  possible across reconnects) each contribute exactly one entry per
+ *  transition rather than collapsing into the previous task's line.
+ */
+const lastTaskStatusById = new Map<string, BackgroundTaskInfo["status"]>();
+
+/** Cap individual task labels and error suffixes so a pathological
+ *  payload cannot bloat the in-bubble timeline. The bubble renders
+ *  monospace at small text sizes — long single-line failures are
+ *  unreadable. */
+const MAX_TASK_LABEL_CHARS = 64;
+const MAX_PROGRESS_LINE_CHARS = 320;
+
+function clip(text: string, max: number): string {
+  if (text.length <= max) return text;
+  return `${text.slice(0, Math.max(0, max - 1))}…`;
+}
+
+/** Display-form a snake_case tool name. Mirrors the simplification in
+ *  `session-task-dock.tsx`'s `taskDisplayName` so the same task surfaces
+ *  with the same label everywhere ("deep_research" → "deep research").
+ *  Capped to a reasonable width. */
+function displayTaskName(tool: string): string {
+  const stripped = (tool || "task").replace(/_/g, " ").trim();
+  return clip(stripped || "task", MAX_TASK_LABEL_CHARS);
+}
+
+/** Build a human-readable progress line for a task_status transition.
+ *  Returns null when the status carries no useful narration (e.g. the
+ *  daemon emitted an unknown status string), or when this exact status
+ *  was already seen for this task and a duplicate line should be
+ *  suppressed at the source. */
+function synthesizeTaskProgressLine(
+  task: BackgroundTaskInfo,
+): string | null {
+  const previous = lastTaskStatusById.get(task.id);
+  if (previous === task.status) return null;
+  // Record the new status BEFORE returning the line so re-entrant
+  // dispatches (within the same tick) can short-circuit on the second
+  // call. Failures still record so a `failed -> failed` replay is
+  // suppressed too.
+  lastTaskStatusById.set(task.id, task.status);
+
+  const label = displayTaskName(task.tool_name);
+  switch (task.status) {
+    case "spawned":
+      return clip(`${label} started`, MAX_PROGRESS_LINE_CHARS);
+    case "running":
+      return clip(`${label} running`, MAX_PROGRESS_LINE_CHARS);
+    case "completed":
+      return clip(`${label} completed`, MAX_PROGRESS_LINE_CHARS);
+    case "failed": {
+      // Single-line normalize the error: collapse newlines/whitespace
+      // so the bubble doesn't line-break inside a tiny mono pill.
+      const detail = task.error
+        ? task.error.replace(/\s+/g, " ").trim()
+        : "";
+      const line = detail ? `${label} failed: ${detail}` : `${label} failed`;
+      return clip(line, MAX_PROGRESS_LINE_CHARS);
+    }
+    default:
+      return null;
+  }
+}
+
+/** Reset the per-task status-dedupe map. Tests call this between
+ *  cases so a transition seen in one case can re-fire in the next. */
+export function __resetTaskStatusDedupForTest(): void {
+  lastTaskStatusById.clear();
+}
+
+/** Apply a `crew:task_status` payload to ThreadStore: synthesize a
+ *  progress line into the tool call's timeline, and flip the
+ *  originating tool call's terminal status (`complete` / `error`).
+ *  Bug 2026-05-15 (codex live-event variant): the synthetic progress
+ *  line at this site says "completed" / "failed" — but pre-fix nobody
+ *  updated `toolCall.status`, so every spinner gated on
+ *  `status === "running"` kept spinning. This is the live counterpart
+ *  to the `handleSpawnComplete` gap in
+ *  `ui-protocol-event-router.ts`. */
+export function applyTaskStatusToThreadStore(
+  sessionId: string,
+  topic: string | undefined,
+  task: BackgroundTaskInfo,
+): void {
+  const progressLine = synthesizeTaskProgressLine(task);
+  if (!progressLine || !task.tool_call_id) return;
+  // Mirror into the thread store when it already knows about this
+  // tool_call_id (i.e. tool_start arrived before task_status). When
+  // the lookup misses we deliberately drop the synthetic progress
+  // rather than synthesize an orphan thread — creating phantom
+  // threads for every backgrounded task on first paint would race
+  // with the real tool_start that arrives moments later.
+  const threadId = ThreadStore.findThreadIdForToolCall(
+    sessionId,
+    topic,
+    task.tool_call_id,
+  );
+  if (!threadId) return;
+  ThreadStore.appendToolProgress(threadId, task.tool_call_id, progressLine);
+  // Mirror the terminal status into ThreadStore so the spinner clears
+  // on the same tick the progress line says "done". Non-terminal
+  // `spawned`/`running` lines do NOT flip status (the chip is
+  // correctly running during those frames).
+  if (task.status === "completed") {
+    ThreadStore.setToolCallStatus(threadId, task.tool_call_id, "complete");
+  } else if (task.status === "failed") {
+    ThreadStore.setToolCallStatus(threadId, task.tool_call_id, "error");
+  }
+}

--- a/src/runtime/ui-protocol-event-router.test.ts
+++ b/src/runtime/ui-protocol-event-router.test.ts
@@ -735,6 +735,126 @@ describe("router event mapping", () => {
     expect(completions).toHaveLength(1);
   });
 
+  // -------------------------------------------------------------------------
+  // Stuck-spinner-after-spawn_only-completion bug — codex independent diagnosis
+  // -------------------------------------------------------------------------
+  //
+  // Pre-fix gap: `handleSpawnComplete` (the terminal `turn/spawn_complete`
+  // signal for spawn_only background completion) appended the completion
+  // bubble and dropped the `toolNameByCallId` cache, but it NEVER called
+  // `ThreadStore.setToolCallStatus(toolCallId, "complete")`. So the
+  // originating `addToolCall(...)` left the tool card stuck at
+  // `status: "running"` after the work finished, and every spinner / icon
+  // gated on `toolCall.status === "running"` (`ToolProgressIndicator`,
+  // `ToolCallBubble` per-tool icon, streaming-dots placeholder) kept
+  // spinning. The four cosmetic commits (586ce04, f8717fc2, 27420f1) all
+  // correctly gate on `status` — this test fixes WHO updates status.
+  //
+  // The `turn/spawn_complete` envelope has NO `success` field (see the
+  // `TurnSpawnCompleteEvent` wire struct in
+  // `crates/octos-core/src/ui_protocol.rs`). The envelope is emitted ONLY
+  // on successful completion; failures arrive via `task/updated`
+  // `state="failed"|"errored"` which `handleTaskUpdated` already maps to
+  // `setToolCallStatus(..., "error")` (test on line 436).
+  it(
+    "turn/spawn_complete flips the originating tool call status to complete (stuck-spinner fix)",
+    () => {
+      const cmid = "cmid-spawn-status";
+      const taskId = "task_podcast_1";
+      seedThread(cmid, "Generate a podcast about Rust async");
+
+      // Real spawn_only flow: `turn/completed` lands FIRST (server-side
+      // ack), THEN `tool/started` arrives for the long-running tool that
+      // runs in the background. So we finalize before adding the tool.
+      ThreadStore.appendAssistantToken(cmid, "Background work started.");
+      ThreadStore.finalizeAssistant(cmid, { committedSeq: 5 });
+
+      // `tool/started` lands the tool card on the finalized response
+      // (via `pickAssistantSlot` fallback). Status: "running".
+      handleToolStarted(
+        { sessionId: SESSION },
+        {
+          session_id: SESSION,
+          turn_id: cmid,
+          tool_call_id: taskId,
+          tool_name: "podcast_generate",
+        },
+      );
+
+      // Sanity check: tool card was placed and is running.
+      const beforeEvt = ThreadStore.getThreads(SESSION)[0];
+      const beforeTc = beforeEvt.responses[0].toolCalls.find(
+        (c) => c.id === taskId,
+      );
+      expect(beforeTc?.status).toBe("running");
+
+      // Fire the terminal `turn/spawn_complete` envelope.
+      const evt: TurnSpawnCompleteEvent = {
+        session_id: SESSION,
+        turn_id: cmid,
+        thread_id: cmid,
+        task_id: taskId,
+        response_to_client_message_id: cmid,
+        seq: 17,
+        message_id: "msg-spawn-status",
+        source: "background",
+        cursor: { stream: SESSION, seq: 17 },
+        persisted_at: "2026-05-04T00:00:00Z",
+        content: "✓ podcast generated (output.mp3)",
+        media: ["output.mp3"],
+      };
+      handleSpawnComplete({ sessionId: SESSION }, evt);
+
+      // Post-fix: the originating tool call flips to `complete`, so every
+      // spinner / icon gated on `toolCall.status === "running"` clears.
+      const [thread] = ThreadStore.getThreads(SESSION);
+      const tc = thread.responses[0].toolCalls.find((c) => c.id === taskId);
+      expect(tc?.status).toBe("complete");
+    },
+  );
+
+  it(
+    "turn/spawn_complete flips status when only response_to_client_message_id resolves the thread",
+    () => {
+      // Same bug, narrower placement path: when `event.turn_id` is absent
+      // (older daemons) the placement key falls back to
+      // `response_to_client_message_id`. The status-update path must use
+      // the same fallback so the tool call still locates its host thread.
+      const cmid = "cmid-spawn-status-fallback";
+      const taskId = "task_deep_search_fallback";
+      seedThread(cmid, "ask");
+      ThreadStore.appendAssistantToken(cmid, "Started.");
+      ThreadStore.finalizeAssistant(cmid, { committedSeq: 2 });
+      handleToolStarted(
+        { sessionId: SESSION },
+        {
+          session_id: SESSION,
+          turn_id: cmid,
+          tool_call_id: taskId,
+          tool_name: "deep_search",
+        },
+      );
+
+      const evt: TurnSpawnCompleteEvent = {
+        session_id: SESSION,
+        // turn_id intentionally omitted
+        task_id: taskId,
+        response_to_client_message_id: cmid,
+        seq: 9,
+        message_id: "msg-spawn-fb",
+        source: "background",
+        cursor: { stream: SESSION, seq: 9 },
+        persisted_at: "2026-05-04T00:00:00Z",
+        content: "Done via fallback.",
+      };
+      handleSpawnComplete({ sessionId: SESSION }, evt);
+
+      const [thread] = ThreadStore.getThreads(SESSION);
+      const tc = thread.responses[0].toolCalls.find((c) => c.id === taskId);
+      expect(tc?.status).toBe("complete");
+    },
+  );
+
   // ---- M10 Phase 2 regression-pin: lock the architecture ------------------
   //
   // This test fixes the failure mode that motivated M10. The legacy splice

--- a/src/runtime/ui-protocol-event-router.ts
+++ b/src/runtime/ui-protocol-event-router.ts
@@ -446,6 +446,55 @@ export function handleSpawnComplete(
     return;
   }
 
+  // Bug 2026-05-15 (codex): flip the originating tool call's status to
+  // `complete` BEFORE appending the new completion bubble. Pre-fix
+  // `handleSpawnComplete` appended the bubble and dropped the
+  // toolNameByCallId cache but never updated ThreadStore's tool-call
+  // `status` field — so `addToolCall(..., status:"running")` left the
+  // chip stuck at "running" forever after the background work finished.
+  // Every spinner/icon gated on `toolCall.status === "running"`
+  // (`ToolProgressIndicator`, `ToolCallBubble` per-tool icon,
+  // streaming-dots placeholder) kept spinning.
+  //
+  // The `turn/spawn_complete` envelope is only emitted on SUCCESS (see
+  // `TurnSpawnCompleteEvent` in `crates/octos-core/src/ui_protocol.rs`
+  // — no `success` field); failures travel through `task/updated
+  // state="failed"|"errored"` which `handleTaskUpdated` already maps
+  // to `setToolCallStatus(..., "error")`. So this site is
+  // unconditionally `"complete"`.
+  //
+  // Ordering matters: `setToolCallStatus` walks the host thread's
+  // assistant slots via `pickAssistantSlot`, which returns the MOST
+  // RECENT assistant response. If we appended the new completion
+  // bubble first, that bubble would become the "most recent" slot —
+  // and the tool call lives on the EARLIER ack bubble, so the lookup
+  // would miss and the status flip would no-op. Run the status flip
+  // first, while the ack bubble is still the topmost finalized slot.
+  //
+  // Locator strategy: resolve by `task_id`. The envelope's `turn_id` /
+  // `thread_id` may be a foreign id (codex orphan-thread defence
+  // scenario in `chat-thread-tool-failure-preserves-user-prompt.test`)
+  // that does NOT contain the tool call — passing such an id to
+  // `setToolCallStatus` would mint an empty-user orphan thread via
+  // `ensureOrphanThread` and steal attribution from the user's real
+  // prompt. Use the side-effect-free `findThreadIdForToolCall` lookup
+  // instead — it searches all threads in the active session for a
+  // tool call with this id and returns the host thread_id (or null).
+  // No-op when the lookup misses (the originating `tool/started` may
+  // not have landed yet, or fired into a different session).
+  const statusHostThreadId = ThreadStore.findThreadIdForToolCall(
+    cfg.sessionId,
+    cfg.topic,
+    event.task_id,
+  );
+  if (statusHostThreadId) {
+    ThreadStore.setToolCallStatus(
+      statusHostThreadId,
+      event.task_id,
+      "complete",
+    );
+  }
+
   ThreadStore.appendCompletionBubble(placementKey, {
     text: event.content,
     media: event.media ?? [],


### PR DESCRIPTION
## Summary

After four cosmetic spinner fixes today, the stuck-spinner-after-spawn_only-completion bug persisted. Codex independently diagnosed it: `handleSpawnComplete` (the actual terminal handler for spawn_only) was the only major event path that **never called `setToolCallStatus(toolCallId, "complete")`**. Every spinner I'd gated on `toolCall.status === "running"` was correct — the status itself was never transitioning.

## Root cause

| Event | Sets `toolCall.status` to terminal? |
|---|---|
| `tool/completed` | ✅ at `ui-protocol-event-router.ts:~814` |
| `task/updated state="completed"` | ✅ at `:~525` |
| **`turn/spawn_complete`** | ❌ only appended bubble + cleared cache |
| **`crew:task_status` (live-event variant)** | ❌ synthesized "completed" progress LINE but didn't touch status |

For spawn_only flows (`podcast_generate`, `fm_tts`, `run_pipeline`), `turn/spawn_complete` IS the terminal event. The tool call's status stayed on `"running"` indefinitely, so the chip text could read "completed" while every status-gated spinner kept spinning.

## Fix

1. `handleSpawnComplete` (`ui-protocol-event-router.ts`): locate the tool call's host thread via the side-effect-free `findThreadIdForToolCall(sessionId, topic, task_id)`, then call `setToolCallStatus(threadId, task_id, "complete")`. Side-effect-free locator avoids the orphan-thread minting race that `424b8832` had to guard against.
2. `runtime-provider.tsx` (live-event variant): extracted into `task-status-applier.ts::applyTaskStatusToThreadStore` for testability. Now flips `status` to `"complete"`/`"error"` matching the synthesized progress line.

## Empirical verification (codex's exact prediction)

The new vitest case `turn/spawn_complete flips the originating tool call status to complete` FAILED pre-fix with:
```
AssertionError: expected 'running' to be 'complete'
- Expected: complete
+ Received: running
```

Passes post-fix. The stuck spinner gate (`toolCall.status === "running"`) is finally satisfied.

## Test plan

- [x] `npx tsc --noEmit` clean
- [x] `npm run build` clean → `dist/assets/index-CnOGu3kL.js`
- [x] 2 new tests in `ui-protocol-event-router.test.ts` (with + without `turn_id`)
- [x] 5 new tests in `task-status-applier.test.ts` (extracted live-event helper)
- [x] All 6 existing chip/spinner/bubble test files green
- [x] Full unit suite: 469 passing
- [ ] 1 pre-existing failure in `router seq preservation > persisted message stamps seq` — unrelated, confirmed on `origin/main` before this change

🤖 Generated with [Claude Code](https://claude.com/claude-code)