### PR TITLE
fix(chat): close spinner stuck-state — task_id vs tool_call_id mismatch + 3 codex gaps

### DIFF
--- a/src/runtime/task-status-applier.test.ts
+++ b/src/runtime/task-status-applier.test.ts
@@ -149,4 +149,186 @@ describe("applyTaskStatusToThreadStore", () => {
     applyTaskStatusToThreadStore(SESSION, undefined, task);
     expect(ThreadStore.getThreads(SESSION)).toHaveLength(0);
   });
+
+  // -------------------------------------------------------------------------
+  // Codex final-3 gap 3: dedupe entry must be recorded AFTER the lookup +
+  // status flip actually applied — never before.
+  // -------------------------------------------------------------------------
+  //
+  // Pre-fix sequence:
+  //   1. task-watcher polls /tasks, gets `completed`. Dispatches
+  //      `crew:task_status` → applyTaskStatusToThreadStore.
+  //   2. `synthesizeTaskProgressLine` writes
+  //      `lastTaskStatusById.set(task.id, "completed")` BEFORE the
+  //      `findThreadIdForToolCall` lookup.
+  //   3. lookup MISSES (tool/started hasn't landed yet). Function
+  //      returns without flipping status.
+  //   4. tool/started arrives a tick later. Chip is in `running`.
+  //   5. task-watcher polls AGAIN, sees same `completed` row. Dispatches
+  //      `crew:task_status` again → `previous === task.status === "completed"`,
+  //      synthesizeTaskProgressLine returns null → ENTIRE applier
+  //      no-ops. Chip stays running forever.
+  //
+  // Post-fix: dedupe entry is only recorded after `setToolCallStatus`
+  // confirms it applied. The retry at step 5 gets to try again, finds
+  // the chip, and flips status to "complete".
+  it(
+    "completed task BEFORE tool/started is retried AFTER tool/started arrives (codex final-3 gap 3)",
+    () => {
+      const cmid = "cmid-retry-after-arrival";
+      const taskId = "task_retry_after_arrival";
+
+      // Step 1: user prompt seeded, but tool/started has NOT landed.
+      ThreadStore.addUserMessage(SESSION, {
+        text: "ask",
+        clientMessageId: cmid,
+      });
+      ThreadStore.appendAssistantToken(cmid, "Started.");
+      ThreadStore.finalizeAssistant(cmid, { committedSeq: 1 });
+
+      // Step 2: task-watcher poll #1 arrives BEFORE tool/started.
+      const completedTask: BackgroundTaskInfo = {
+        id: taskId,
+        tool_name: "podcast_generate",
+        tool_call_id: taskId,
+        status: "completed",
+        started_at: "2026-05-15T00:00:00Z",
+        completed_at: "2026-05-15T00:00:05Z",
+        error: null,
+      };
+      applyTaskStatusToThreadStore(SESSION, undefined, completedTask);
+
+      // Step 3: tool/started lands. Chip is in "running".
+      handleToolStarted(
+        { sessionId: SESSION },
+        {
+          session_id: SESSION,
+          turn_id: cmid,
+          tool_call_id: taskId,
+          tool_name: "podcast_generate",
+        },
+      );
+      expect(
+        ThreadStore.getThreads(SESSION)[0].responses[0].toolCalls.find(
+          (c) => c.id === taskId,
+        )?.status,
+      ).toBe("running");
+
+      // Step 4: task-watcher poll #2 fires (same row, same status).
+      // Pre-fix: dedupe map already says "completed", so synthesize
+      // returns null and applier no-ops → chip stuck on "running".
+      // Post-fix: dedupe was NOT recorded because the lookup missed
+      // last time → this retry actually flips the chip to "complete".
+      applyTaskStatusToThreadStore(SESSION, undefined, completedTask);
+
+      const [thread] = ThreadStore.getThreads(SESSION);
+      const tc = thread.responses[0].toolCalls.find((c) => c.id === taskId);
+      expect(tc?.status).toBe("complete");
+    },
+  );
+
+  it(
+    "failed task BEFORE tool/started is retried AFTER tool/started arrives (codex final-3 gap 3)",
+    () => {
+      // Symmetric: same gap for the `failed` terminal state.
+      const cmid = "cmid-retry-failed";
+      const taskId = "task_retry_failed";
+      ThreadStore.addUserMessage(SESSION, {
+        text: "ask",
+        clientMessageId: cmid,
+      });
+      ThreadStore.appendAssistantToken(cmid, "Started.");
+      ThreadStore.finalizeAssistant(cmid, { committedSeq: 1 });
+
+      const failedTask: BackgroundTaskInfo = {
+        id: taskId,
+        tool_name: "deep_search",
+        tool_call_id: taskId,
+        status: "failed",
+        started_at: "2026-05-15T00:00:00Z",
+        error: "upstream 500",
+      };
+      // Poll #1: tool not yet in store → lookup misses → no dedupe record.
+      applyTaskStatusToThreadStore(SESSION, undefined, failedTask);
+
+      handleToolStarted(
+        { sessionId: SESSION },
+        {
+          session_id: SESSION,
+          turn_id: cmid,
+          tool_call_id: taskId,
+          tool_name: "deep_search",
+        },
+      );
+
+      // Poll #2: tool exists now → flip status to "error".
+      applyTaskStatusToThreadStore(SESSION, undefined, failedTask);
+
+      const [thread] = ThreadStore.getThreads(SESSION);
+      const tc = thread.responses[0].toolCalls.find((c) => c.id === taskId);
+      expect(tc?.status).toBe("error");
+    },
+  );
+
+  it(
+    "completed task AFTER successful flip suppresses identical replays (dedupe still works)",
+    () => {
+      // Defensive: confirm the dedupe still suppresses pathological
+      // bursts of identical `completed` rows on the same row after the
+      // first flip applied. The fix only delays the dedupe — it must
+      // still kick in once the status has been written.
+      const cmid = "cmid-dedupe-after-flip";
+      const taskId = "task_dedupe_after_flip";
+      ThreadStore.addUserMessage(SESSION, {
+        text: "ask",
+        clientMessageId: cmid,
+      });
+      ThreadStore.appendAssistantToken(cmid, "Started.");
+      ThreadStore.finalizeAssistant(cmid, { committedSeq: 1 });
+      handleToolStarted(
+        { sessionId: SESSION },
+        {
+          session_id: SESSION,
+          turn_id: cmid,
+          tool_call_id: taskId,
+          tool_name: "fm_tts",
+        },
+      );
+
+      const completedTask: BackgroundTaskInfo = {
+        id: taskId,
+        tool_name: "fm_tts",
+        tool_call_id: taskId,
+        status: "completed",
+        started_at: "2026-05-15T00:00:00Z",
+        completed_at: "2026-05-15T00:00:05Z",
+        error: null,
+      };
+      applyTaskStatusToThreadStore(SESSION, undefined, completedTask);
+      // First flip applied.
+      expect(
+        ThreadStore.getThreads(SESSION)[0].responses[0].toolCalls.find(
+          (c) => c.id === taskId,
+        )?.status,
+      ).toBe("complete");
+
+      // Count progress entries before the replay.
+      const beforeProgressCount =
+        ThreadStore.getThreads(SESSION)[0].responses[0].toolCalls.find(
+          (c) => c.id === taskId,
+        )?.progress?.length ?? 0;
+
+      // Replay 1: should be deduped (no extra progress line, no extra
+      // status churn).
+      applyTaskStatusToThreadStore(SESSION, undefined, completedTask);
+      // Replay 2: still deduped.
+      applyTaskStatusToThreadStore(SESSION, undefined, completedTask);
+
+      const afterProgressCount =
+        ThreadStore.getThreads(SESSION)[0].responses[0].toolCalls.find(
+          (c) => c.id === taskId,
+        )?.progress?.length ?? 0;
+      expect(afterProgressCount).toBe(beforeProgressCount);
+    },
+  );
 });

--- a/src/runtime/task-status-applier.ts
+++ b/src/runtime/task-status-applier.ts
@@ -51,17 +51,19 @@ function displayTaskName(tool: string): string {
  *  Returns null when the status carries no useful narration (e.g. the
  *  daemon emitted an unknown status string), or when this exact status
  *  was already seen for this task and a duplicate line should be
- *  suppressed at the source. */
+ *  suppressed at the source.
+ *
+ *  Bug 2026-05-15 (codex final-3 gap 3): does NOT record the dedupe
+ *  entry here — the caller MUST record only AFTER the lookup +
+ *  `setToolCallStatus` actually applied. Pre-fix this function wrote
+ *  the dedupe before the lookup at the call site succeeded, so a
+ *  later retry of the same terminal task was silently suppressed and
+ *  the status flip never got another chance. */
 function synthesizeTaskProgressLine(
   task: BackgroundTaskInfo,
 ): string | null {
   const previous = lastTaskStatusById.get(task.id);
   if (previous === task.status) return null;
-  // Record the new status BEFORE returning the line so re-entrant
-  // dispatches (within the same tick) can short-circuit on the second
-  // call. Failures still record so a `failed -> failed` replay is
-  // suppressed too.
-  lastTaskStatusById.set(task.id, task.status);
 
   const label = displayTaskName(task.tool_name);
   switch (task.status) {
@@ -118,15 +120,44 @@ export function applyTaskStatusToThreadStore(
     topic,
     task.tool_call_id,
   );
-  if (!threadId) return;
+  if (!threadId) {
+    // Bug 2026-05-15 (codex final-3 gap 3): DO NOT record the dedupe
+    // entry — the lookup missed, so a later retry of the same
+    // `completed`/`failed` task MUST be allowed to try again. The
+    // task watcher's poll loop re-fires the same row on every tick,
+    // and the originating `tool/started` may not have landed yet when
+    // the first attempt arrived.
+    return;
+  }
   ThreadStore.appendToolProgress(threadId, task.tool_call_id, progressLine);
   // Mirror the terminal status into ThreadStore so the spinner clears
   // on the same tick the progress line says "done". Non-terminal
   // `spawned`/`running` lines do NOT flip status (the chip is
   // correctly running during those frames).
+  //
+  // Bug 2026-05-15 (codex final-3 gap 3): record the dedupe entry
+  // ONLY AFTER `setToolCallStatus` confirms it actually applied.
+  // `setToolCallStatus` returns `true` when it found the target tool
+  // call and flipped its status, `false` when the lookup no-oped. If
+  // the status flip no-ops (tool call not in store yet, picker
+  // missed, etc.) the next retry should be allowed to try again.
+  let applied = true;
   if (task.status === "completed") {
-    ThreadStore.setToolCallStatus(threadId, task.tool_call_id, "complete");
+    applied = ThreadStore.setToolCallStatus(
+      threadId,
+      task.tool_call_id,
+      "complete",
+    );
   } else if (task.status === "failed") {
-    ThreadStore.setToolCallStatus(threadId, task.tool_call_id, "error");
+    applied = ThreadStore.setToolCallStatus(
+      threadId,
+      task.tool_call_id,
+      "error",
+    );
+  }
+  // Non-terminal `spawned`/`running` lines always count as applied
+  // (the progress line itself landed; no status flip required).
+  if (applied) {
+    lastTaskStatusById.set(task.id, task.status);
   }
 }

--- a/src/runtime/ui-protocol-event-router.test.ts
+++ b/src/runtime/ui-protocol-event-router.test.ts
@@ -855,6 +855,293 @@ describe("router event mapping", () => {
     },
   );
 
+  // -------------------------------------------------------------------------
+  // Codex final-3 gap 1: addToolCall must NOT revert terminal status to
+  // "running" when a `tool/started` event replays for a settled tool call.
+  // -------------------------------------------------------------------------
+  //
+  // Pre-fix sequence (mini5 with bundle index-CnOGu3kL.js, PR #131 only):
+  //   1. tool/started → addToolCall(..., status: "running")
+  //   2. background completes
+  //   3. turn/spawn_complete → setToolCallStatus(..., "complete") ✓
+  //   4. **replayed tool/started for same tool_call_id** → addToolCall
+  //      force-set status BACK to "running"
+  //   5. all in-bubble spinner gates re-activate → "tool bubble still has
+  //      spinning even task is done"
+  //
+  // Post-fix: addToolCall preserves terminal status. Idempotent re-registration
+  // is fine; reopening a settled tool call is the bug.
+  it(
+    "handleToolStarted replayed after handleSpawnComplete does NOT revert complete → running (codex final-3 gap 1)",
+    () => {
+      const cmid = "cmid-replay-revert";
+      const taskId = "task_replay_revert";
+      seedThread(cmid, "Generate a podcast");
+      ThreadStore.appendAssistantToken(cmid, "Background work started.");
+      ThreadStore.finalizeAssistant(cmid, { committedSeq: 3 });
+
+      // 1. tool/started → status="running"
+      handleToolStarted(
+        { sessionId: SESSION },
+        {
+          session_id: SESSION,
+          turn_id: cmid,
+          tool_call_id: taskId,
+          tool_name: "podcast_generate",
+        },
+      );
+      expect(
+        ThreadStore.getThreads(SESSION)[0].responses[0].toolCalls.find(
+          (c) => c.id === taskId,
+        )?.status,
+      ).toBe("running");
+
+      // 2./3. turn/spawn_complete → status="complete"
+      handleSpawnComplete(
+        { sessionId: SESSION },
+        {
+          session_id: SESSION,
+          turn_id: cmid,
+          thread_id: cmid,
+          task_id: taskId,
+          response_to_client_message_id: cmid,
+          seq: 9,
+          message_id: "msg-replay-revert",
+          source: "background",
+          cursor: { stream: SESSION, seq: 9 },
+          persisted_at: "2026-05-15T00:00:00Z",
+          content: "Podcast generated.",
+        },
+      );
+      expect(
+        ThreadStore.getThreads(SESSION)[0].responses[0].toolCalls.find(
+          (c) => c.id === taskId,
+        )?.status,
+      ).toBe("complete");
+
+      // 4. **Replayed `tool/started` for same id.** Pre-fix this reset
+      //    status to "running"; post-fix it preserves "complete".
+      handleToolStarted(
+        { sessionId: SESSION },
+        {
+          session_id: SESSION,
+          turn_id: cmid,
+          tool_call_id: taskId,
+          tool_name: "podcast_generate",
+        },
+      );
+
+      // CRITICAL: the spinner gate must clear and stay cleared.
+      const [thread] = ThreadStore.getThreads(SESSION);
+      const tc = thread.responses[0].toolCalls.find((c) => c.id === taskId);
+      expect(tc?.status).toBe("complete");
+    },
+  );
+
+  it(
+    "handleToolStarted replayed after error status does NOT revert error → running (codex final-3 gap 1)",
+    () => {
+      // Symmetric: terminal `error` (from task/updated failed/errored) also
+      // must be preserved against a replayed tool/started.
+      const cmid = "cmid-replay-error";
+      const taskId = "task_replay_error";
+      seedThread(cmid, "Generate a podcast");
+      ThreadStore.appendAssistantToken(cmid, "Started.");
+      ThreadStore.finalizeAssistant(cmid, { committedSeq: 2 });
+
+      handleToolStarted(
+        { sessionId: SESSION },
+        {
+          session_id: SESSION,
+          turn_id: cmid,
+          tool_call_id: taskId,
+          tool_name: "deep_search",
+        },
+      );
+      // Drive an error terminal status via setToolCallStatus directly.
+      ThreadStore.setToolCallStatus(cmid, taskId, "error");
+      expect(
+        ThreadStore.getThreads(SESSION)[0].responses[0].toolCalls.find(
+          (c) => c.id === taskId,
+        )?.status,
+      ).toBe("error");
+
+      // Replay tool/started → must preserve "error".
+      handleToolStarted(
+        { sessionId: SESSION },
+        {
+          session_id: SESSION,
+          turn_id: cmid,
+          tool_call_id: taskId,
+          tool_name: "deep_search",
+        },
+      );
+      const [thread] = ThreadStore.getThreads(SESSION);
+      const tc = thread.responses[0].toolCalls.find((c) => c.id === taskId);
+      expect(tc?.status).toBe("error");
+    },
+  );
+
+  // -------------------------------------------------------------------------
+  // Codex final-3 gap 2: setToolCallStatus full-thread fallback when
+  // `pickAssistantSlot` misses.
+  // -------------------------------------------------------------------------
+  //
+  // Real-world sequence (mini5 reproduction): tool/started lands the tool
+  // card on responses[0] (the spawn-ack bubble). turn/spawn_complete
+  // appends a NEW bubble at responses[1]. Now responses[1] is the most
+  // recent assistant slot — `pickAssistantSlot` returns it, the tool-call
+  // lookup misses, and `setToolCallStatus` no-ops. Without the
+  // full-thread fallback, terminal status flips (from a replayed
+  // task/updated `completed`, or a redrive of turn/spawn_complete) all
+  // silently no-op, and the chip stays running forever.
+  it(
+    "setToolCallStatus falls back to a full-thread scan when pickAssistantSlot returns the wrong bubble (codex final-3 gap 2)",
+    () => {
+      const cmid = "cmid-slot-fallback";
+      const toolCallId = "tc_slot_fallback";
+      seedThread(cmid, "Generate a podcast");
+      ThreadStore.appendAssistantToken(cmid, "Background work started.");
+      ThreadStore.finalizeAssistant(cmid, { committedSeq: 3 });
+
+      // tool/started lands the chip on responses[0].
+      handleToolStarted(
+        { sessionId: SESSION },
+        {
+          session_id: SESSION,
+          turn_id: cmid,
+          tool_call_id: toolCallId,
+          tool_name: "podcast_generate",
+        },
+      );
+      // Append a NEW completion bubble at responses[1]. Now responses[1]
+      // is the most recent slot (the one pickAssistantSlot returns) but
+      // does NOT carry the tool card.
+      ThreadStore.appendCompletionBubble(cmid, {
+        text: "Another response.",
+        media: [],
+        spawnComplete: true,
+        sourceClientMessageId: cmid,
+        historySeq: 12,
+        messageId: "msg-extra",
+        persistedAt: "2026-05-15T00:00:01Z",
+        sessionId: SESSION,
+      });
+
+      // Sanity check: 2 bubbles exist, tool call is on responses[0],
+      // responses[1] has no tool cards.
+      const [before] = ThreadStore.getThreads(SESSION);
+      expect(before.responses).toHaveLength(2);
+      expect(
+        before.responses[0].toolCalls.find((c) => c.id === toolCallId)
+          ?.status,
+      ).toBe("running");
+      expect(before.responses[1].toolCalls).toHaveLength(0);
+
+      // Now flip the tool status. With the old `pickAssistantSlot`-only
+      // logic this would no-op because the picker returns responses[1]
+      // (no tool call there). The full-thread fallback walks every
+      // assistant slot and finds the tool card on responses[0].
+      const applied = ThreadStore.setToolCallStatus(
+        cmid,
+        toolCallId,
+        "complete",
+      );
+      expect(applied).toBe(true);
+
+      const [after] = ThreadStore.getThreads(SESSION);
+      const tc = after.responses[0].toolCalls.find((c) => c.id === toolCallId);
+      expect(tc?.status).toBe("complete");
+    },
+  );
+
+  // -------------------------------------------------------------------------
+  // Codex final-3 bonus check: server's `task_id` and `tool_call_id` are
+  // DIFFERENT identifiers on the wire.
+  // -------------------------------------------------------------------------
+  //
+  // `TaskId::new()` mints a fresh UUID in `register_full` (see
+  // `crates/octos-agent/src/task_supervisor.rs:1180`) — distinct from the
+  // LLM's `tool_call_id` which is stored as a separate field on the
+  // `BackgroundTask` struct. `TurnSpawnCompleteEvent.task_id` and
+  // `TaskUpdatedEvent.task_id` carry the supervisor UUID; only
+  // `ToolStartedEvent.tool_call_id` carries the LLM id. The PR #131 tests
+  // used identical values for both fields, hiding the divergence — in
+  // production they always differ.
+  //
+  // Fix: translate `event.task_id → task.tool_call_id` via
+  // `TaskStore.getTasks(...)` (populated by the task-watcher poll's
+  // `crew:task_status` event), then look up + flip status via the
+  // resolved id.
+  it(
+    "handleSpawnComplete resolves task_id → tool_call_id via TaskStore (codex final-3 bonus check)",
+    async () => {
+      const cmid = "cmid-task-bonus";
+      // Realistic shapes: supervisor UUID vs LLM tool call id.
+      const supervisorTaskId = "task_01J9PODCAST_SUPERVISOR";
+      const llmToolCallId = "call_abc_llm_emitted";
+      seedThread(cmid, "Generate a podcast");
+      ThreadStore.appendAssistantToken(cmid, "Started.");
+      ThreadStore.finalizeAssistant(cmid, { committedSeq: 3 });
+
+      // tool/started registers the LLM's tool_call_id (NOT the
+      // supervisor id) — this is how production wires arrive.
+      handleToolStarted(
+        { sessionId: SESSION },
+        {
+          session_id: SESSION,
+          turn_id: cmid,
+          tool_call_id: llmToolCallId,
+          tool_name: "podcast_generate",
+        },
+      );
+
+      // Seed the TaskStore mapping (production: the task watcher's
+      // poll loop dispatches `crew:task_status` with a
+      // `BackgroundTaskInfo` carrying both ids).
+      const TaskStore = await import("@/store/task-store");
+      TaskStore.mergeTask(SESSION, {
+        id: supervisorTaskId,
+        tool_name: "podcast_generate",
+        tool_call_id: llmToolCallId,
+        status: "running",
+        started_at: "2026-05-15T00:00:00Z",
+        error: null,
+      });
+
+      // turn/spawn_complete carries the SUPERVISOR task_id, not the
+      // LLM tool_call_id.
+      handleSpawnComplete(
+        { sessionId: SESSION },
+        {
+          session_id: SESSION,
+          turn_id: cmid,
+          thread_id: cmid,
+          task_id: supervisorTaskId,
+          response_to_client_message_id: cmid,
+          seq: 11,
+          message_id: "msg-bonus",
+          source: "background",
+          cursor: { stream: SESSION, seq: 11 },
+          persisted_at: "2026-05-15T00:00:05Z",
+          content: "Podcast generated.",
+        },
+      );
+
+      // Post-fix: handleSpawnComplete translated through TaskStore and
+      // flipped the right tool call. Pre-fix it would have looked up by
+      // `supervisorTaskId`, missed, and left the chip running.
+      const [thread] = ThreadStore.getThreads(SESSION);
+      const tc = thread.responses[0].toolCalls.find(
+        (c) => c.id === llmToolCallId,
+      );
+      expect(tc?.status).toBe("complete");
+      // Reset the TaskStore between tests (no afterEach helper exposed,
+      // but each test seeds its own).
+      TaskStore.clearTasks(SESSION);
+    },
+  );
+
   // ---- M10 Phase 2 regression-pin: lock the architecture ------------------
   //
   // This test fixes the failure mode that motivated M10. The legacy splice

--- a/src/runtime/ui-protocol-event-router.ts
+++ b/src/runtime/ui-protocol-event-router.ts
@@ -42,6 +42,7 @@ import type {
   UiProtocolBridge,
 } from "./ui-protocol-bridge";
 import * as ThreadStore from "@/store/thread-store";
+import * as TaskStore from "@/store/task-store";
 import type { MessageMeta } from "@/store/thread-store";
 import type { MessageInfo } from "@/api/types";
 
@@ -471,26 +472,48 @@ export function handleSpawnComplete(
   // would miss and the status flip would no-op. Run the status flip
   // first, while the ack bubble is still the topmost finalized slot.
   //
-  // Locator strategy: resolve by `task_id`. The envelope's `turn_id` /
-  // `thread_id` may be a foreign id (codex orphan-thread defence
-  // scenario in `chat-thread-tool-failure-preserves-user-prompt.test`)
-  // that does NOT contain the tool call — passing such an id to
+  // Locator strategy: resolve by the originating `tool_call_id` after
+  // translating from the envelope's `task_id`.
+  //
+  // Bug 2026-05-15 (codex final-3 bonus check): the envelope's
+  // `task_id` is the supervisor's `TaskId::new()` UUID (see
+  // `crates/octos-agent/src/task_supervisor.rs::register_full`), NOT
+  // the LLM's `tool_call_id`. The `BackgroundTask` struct keeps them
+  // as separate fields, and `tool/started` registered the LLM's
+  // `tool_call_id`. Passing `event.task_id` directly to ThreadStore's
+  // by-tool-call-id lookup misses (different identifier shapes), and
+  // the spinner stays stuck. We translate `task_id → tool_call_id`
+  // through `TaskStore` (which the task watcher's
+  // `crew:task_status` poll populates with `BackgroundTaskInfo`
+  // rows carrying both `id` and `tool_call_id`). When the mapping is
+  // not yet known (the task watcher hasn't polled, or the task is
+  // brand new) fall back to treating `event.task_id` as the
+  // tool_call_id — the older test fixtures used identical values
+  // there and a fraction of legacy daemons still emit them equal.
+  //
+  // The previous defence (use `findThreadIdForToolCall` not
+  // `setToolCallStatus(thread_id, ...)`) is still required: the
+  // envelope's `turn_id` / `thread_id` may be a foreign id (codex
+  // orphan-thread scenario in
+  // `chat-thread-tool-failure-preserves-user-prompt.test`) that
+  // does NOT contain the tool call — passing such an id to
   // `setToolCallStatus` would mint an empty-user orphan thread via
   // `ensureOrphanThread` and steal attribution from the user's real
-  // prompt. Use the side-effect-free `findThreadIdForToolCall` lookup
-  // instead — it searches all threads in the active session for a
-  // tool call with this id and returns the host thread_id (or null).
-  // No-op when the lookup misses (the originating `tool/started` may
-  // not have landed yet, or fired into a different session).
-  const statusHostThreadId = ThreadStore.findThreadIdForToolCall(
+  // prompt.
+  const resolvedToolCallId = resolveToolCallIdForTask(
     cfg.sessionId,
     cfg.topic,
     event.task_id,
   );
+  const statusHostThreadId = ThreadStore.findThreadIdForToolCall(
+    cfg.sessionId,
+    cfg.topic,
+    resolvedToolCallId,
+  );
   if (statusHostThreadId) {
     ThreadStore.setToolCallStatus(
       statusHostThreadId,
-      event.task_id,
+      resolvedToolCallId,
       "complete",
     );
   }
@@ -513,8 +536,13 @@ export function handleSpawnComplete(
   });
   // Drop the cache entry — the BG task is done. The per-bubble
   // `ToolProgressIndicator` reads from ThreadStore (not window
-  // events), so no terminal dispatch is needed here.
+  // events), so no terminal dispatch is needed here. Drop both
+  // identifier shapes so the cache cannot leak through the
+  // task_id-vs-tool_call_id divergence.
   toolNameByCallId.delete(event.task_id);
+  if (resolvedToolCallId !== event.task_id) {
+    toolNameByCallId.delete(resolvedToolCallId);
+  }
 }
 
 export function handleTaskUpdated(
@@ -546,17 +574,35 @@ export function handleTaskUpdated(
   // therefore needs the spinner-progress fan-out here as well, with
   // the terminal flag set on the completion legs so the row clears.
   //
+  // Bug 2026-05-15 (codex final-3 bonus check): the wire's
+  // `event.task_id` is the supervisor's `TaskId::new()` UUID, NOT
+  // the LLM `tool_call_id` that `tool/started` registered on the
+  // ThreadStore. Translate via `TaskStore` so the
+  // `appendToolProgress` / `setToolCallStatus` calls land on the
+  // correct chip. Falls back to `event.task_id` (legacy daemons that
+  // emit them equal, or pre-watcher boot).
+  const resolvedToolCallId = resolveToolCallIdForTask(
+    cfg.sessionId,
+    cfg.topic,
+    event.task_id,
+  );
+
   // The `tool_name` lookup falls back to the task_id when no preceding
   // `tool/started` cached a name (e.g. a server-side flow that skips
   // `tool/started` entirely and only emits `task/updated`); same shape
-  // `handleToolProgress` uses on the synchronous path.
-  const toolLabel = toolNameByCallId.get(event.task_id) ?? event.task_id;
+  // `handleToolProgress` uses on the synchronous path. Try both the
+  // resolved tool_call_id and the raw task_id so we hit the cache
+  // whichever shape `tool/started` populated.
+  const toolLabel =
+    toolNameByCallId.get(resolvedToolCallId) ??
+    toolNameByCallId.get(event.task_id) ??
+    event.task_id;
 
   switch (event.state) {
     case "spawned":
     case "running": {
       const label = event.title ?? event.runtime_detail ?? event.state;
-      ThreadStore.appendToolProgress(event.turn_id, event.task_id, label);
+      ThreadStore.appendToolProgress(event.turn_id, resolvedToolCallId, label);
       // Mirror the legacy SSE bridge's `crew:bg_tasks` dispatch so any
       // listener that gates a session-level "background work" indicator
       // off the same event keeps firing.
@@ -571,7 +617,11 @@ export function handleTaskUpdated(
       break;
     }
     case "completed": {
-      ThreadStore.setToolCallStatus(event.turn_id, event.task_id, "complete");
+      ThreadStore.setToolCallStatus(
+        event.turn_id,
+        resolvedToolCallId,
+        "complete",
+      );
       dispatchToolProgressEvent(
         cfg,
         event.turn_id,
@@ -580,13 +630,17 @@ export function handleTaskUpdated(
         /* terminal */ true,
       );
       // Drop the cache entry — the task is done, no further frames
-      // should land on this id (mirrors `handleToolCompleted`).
+      // should land on this id (mirrors `handleToolCompleted`). Drop
+      // both identifier shapes.
       toolNameByCallId.delete(event.task_id);
+      if (resolvedToolCallId !== event.task_id) {
+        toolNameByCallId.delete(resolvedToolCallId);
+      }
       break;
     }
     case "failed":
     case "errored": {
-      ThreadStore.setToolCallStatus(event.turn_id, event.task_id, "error");
+      ThreadStore.setToolCallStatus(event.turn_id, resolvedToolCallId, "error");
       dispatchToolProgressEvent(
         cfg,
         event.turn_id,
@@ -595,11 +649,47 @@ export function handleTaskUpdated(
         /* terminal */ true,
       );
       toolNameByCallId.delete(event.task_id);
+      if (resolvedToolCallId !== event.task_id) {
+        toolNameByCallId.delete(resolvedToolCallId);
+      }
       break;
     }
     default:
       break;
   }
+}
+
+/** Map a server-emitted `task_id` (supervisor UUID) to the LLM
+ *  `tool_call_id` the ThreadStore registered via `tool/started`.
+ *
+ *  Codex final-3 bonus check: the server's `TurnSpawnCompleteEvent.task_id`
+ *  and `TaskUpdatedEvent.task_id` carry the supervisor's
+ *  `TaskId::new()` UUID, while `ToolStartedEvent.tool_call_id` carries
+ *  the LLM-emitted tool call id. They are different on the wire. The
+ *  task watcher's `crew:task_status` poll populates `TaskStore` with
+ *  `BackgroundTaskInfo` rows that carry BOTH fields, so we can
+ *  translate by walking the session's tasks for a matching `id`.
+ *
+ *  Falls back to the raw `taskId` when:
+ *  - the watcher hasn't polled yet (task list empty),
+ *  - the task is brand new and not yet in the store,
+ *  - a legacy daemon emits them equal (older tests / fixtures).
+ *
+ *  Returning the raw id is safe — `findThreadIdForToolCall` /
+ *  `setToolCallStatus` no-op cleanly when the lookup misses. */
+function resolveToolCallIdForTask(
+  sessionId: string,
+  topic: string | undefined,
+  taskId: string,
+): string {
+  if (!taskId) return taskId;
+  const tasks = TaskStore.getTasks(sessionId, topic);
+  for (const task of tasks) {
+    if (task.id === taskId && task.tool_call_id) {
+      return task.tool_call_id;
+    }
+  }
+  return taskId;
 }
 
 export function handleTaskOutputDelta(

--- a/src/store/thread-store.ts
+++ b/src/store/thread-store.ts
@@ -791,6 +791,13 @@ export function addToolCall(
   //
   // Bug 2026-05-15: see `replaceAssistantSlot` for the React.memo
   // freeze that motivates the immutable updates below.
+  //
+  // Bug 2026-05-15 (codex final-3 gap 1): when an existing tool call is
+  // already in a terminal state (`"complete"` or `"error"`), preserve
+  // that status — DO NOT force it back to `"running"`. Pre-fix, a
+  // replayed `tool/started` for a settled task reverted the chip to
+  // running, re-activating every in-bubble spinner gate. Idempotent
+  // re-registration is fine; reopening a settled tool call is the bug.
   if (toolCallId) {
     for (const candidate of [
       found.thread.pendingAssistant,
@@ -799,8 +806,15 @@ export function addToolCall(
       if (!candidate) continue;
       const idx = candidate.toolCalls.findIndex((tc) => tc.id === toolCallId);
       if (idx !== -1) {
+        const existing = candidate.toolCalls[idx];
+        // Preserve terminal status — only flip to "running" when the
+        // tool call has not yet settled.
+        const preservedStatus =
+          existing.status === "complete" || existing.status === "error"
+            ? existing.status
+            : ("running" as const);
         const newTcs = candidate.toolCalls.map((tc, i) =>
-          i === idx ? { ...tc, status: "running" as const } : tc,
+          i === idx ? { ...tc, status: preservedStatus } : tc,
         );
         replaceAssistantSlot(found.thread, candidate, {
           ...candidate,
@@ -823,8 +837,15 @@ export function addToolCall(
   if (toolCallId) {
     const byId = tcs.findIndex((tc) => tc.id === toolCallId);
     if (byId !== -1) {
+      const existing = tcs[byId];
+      // Bug 2026-05-15 (codex final-3 gap 1): preserve terminal status —
+      // see the cross-slot branch above for the same logic.
+      const preservedStatus =
+        existing.status === "complete" || existing.status === "error"
+          ? existing.status
+          : ("running" as const);
       const newTcs = tcs.map((tc, i) =>
-        i === byId ? { ...tc, status: "running" as const } : tc,
+        i === byId ? { ...tc, status: preservedStatus } : tc,
       );
       replaceAssistantSlot(found.thread, slot, {
         ...slot,
@@ -1012,32 +1033,74 @@ export function setToolCallStatus(
   toolCallId: string,
   status: ThreadToolCall["status"],
   toolName?: string,
-): void {
+): boolean {
   const found = ensureOrphanThread(threadId);
-  if (!found) return;
+  if (!found) return false;
   const slot = pickAssistantSlot(found.thread);
-  if (!slot) return;
-  const tcs = slot.toolCalls;
+
+  // Resolve the slot that actually contains the tool call. The
+  // `pickAssistantSlot` heuristic returns the in-flight pending OR the
+  // MOST RECENT finalized response — that's correct for the live path
+  // but misses when an EARLIER ack bubble holds the tool card and a
+  // later completion bubble has since been appended. Without this
+  // fallback the lookup misses and `setToolCallStatus` silently
+  // no-ops, leaving the chip's spinner spinning forever (codex
+  // final-3 gap 2). When the slot picker misses, fall back to a
+  // full-thread scan: find the assistant message in this thread that
+  // actually contains a `toolCalls[i].id === toolCallId`.
+  let containingSlot: ThreadMessage | null = null;
   let idx = -1;
-  if (toolCallId) {
-    idx = tcs.findIndex((tc) => tc.id === toolCallId);
-  } else if (toolName) {
-    // Legacy daemon path — route by tool name to the most recent match.
-    for (let i = tcs.length - 1; i >= 0; i -= 1) {
-      if (tcs[i].name === toolName) {
-        idx = i;
+  if (slot) {
+    let tentativeIdx = -1;
+    if (toolCallId) {
+      tentativeIdx = slot.toolCalls.findIndex((tc) => tc.id === toolCallId);
+    } else if (toolName) {
+      // Legacy daemon path — route by tool name to the most recent match.
+      for (let i = slot.toolCalls.length - 1; i >= 0; i -= 1) {
+        if (slot.toolCalls[i].name === toolName) {
+          tentativeIdx = i;
+          break;
+        }
+      }
+    }
+    if (tentativeIdx !== -1) {
+      containingSlot = slot;
+      idx = tentativeIdx;
+    }
+  }
+  // Slot picker missed → scan every assistant slot in the thread.
+  // Cheap; only fires when the happy path missed. Walks
+  // pendingAssistant + responses (most-recent-first) so the chosen
+  // slot is the same one a future `pickAssistantSlot` would prefer.
+  if (idx === -1 && toolCallId) {
+    const candidates: ThreadMessage[] = [];
+    if (found.thread.pendingAssistant) {
+      candidates.push(found.thread.pendingAssistant);
+    }
+    for (let i = found.thread.responses.length - 1; i >= 0; i -= 1) {
+      const candidate = found.thread.responses[i];
+      if (candidate.role === "assistant") candidates.push(candidate);
+    }
+    for (const candidate of candidates) {
+      const tentativeIdx = candidate.toolCalls.findIndex(
+        (tc) => tc.id === toolCallId,
+      );
+      if (tentativeIdx !== -1) {
+        containingSlot = candidate;
+        idx = tentativeIdx;
         break;
       }
     }
   }
-  if (idx === -1) return;
+  if (!containingSlot || idx === -1) return false;
   // Bug 2026-05-15: see `replaceAssistantSlot` for the React.memo
   // freeze — assigning into `tcs[idx]` keeps the surrounding
   // `ThreadMessage` reference identical and the bubble's terminal
   // status chip never repainted.
+  const tcs = containingSlot.toolCalls;
   const newTcs = tcs.map((tc, i) => (i === idx ? { ...tc, status } : tc));
-  replaceAssistantSlot(found.thread, slot, {
-    ...slot,
+  replaceAssistantSlot(found.thread, containingSlot, {
+    ...containingSlot,
     toolCalls: newTcs,
   });
   notify();
@@ -1058,6 +1121,7 @@ export function setToolCallStatus(
       }
     }
   }
+  return true;
 }
 
 /**


### PR DESCRIPTION
## Summary

PR #131 fixed *part* of the stuck spinner, but the bug persists in production. Codex re-audit + server-side verification found:

**Real root cause (the bonus check):** `TurnSpawnComplete.task_id` carries the **supervisor's** UUID (`TaskId::new()` at `crates/octos-agent/src/task_supervisor.rs:1180`), while `tool/started` registers the **LLM's** `tool_call_id`. They DIFFER on the wire. PR #131's tests used identical values for both → hid the bug. `findThreadIdForToolCall(event.task_id)` always misses in prod.

**Plus 3 codex-diagnosed gaps:**
1. `addToolCall` reverted terminal `complete`/`error` back to `running` on replayed `tool/started`.
2. `setToolCallStatus` silently no-oped when `pickAssistantSlot` picked the wrong (later) bubble.
3. `task-status-applier.ts` wrote the dedupe entry BEFORE confirming the status flip applied, suppressing later retries.

## Fixes

- `runtime/ui-protocol-event-router.ts`: new `resolveToolCallIdForTask(sessionId, topic, taskId)` walks TaskStore to translate `task_id → tool_call_id`. Used in `handleSpawnComplete` + `handleTaskUpdated`.
- `store/thread-store.ts`: `addToolCall` preserves terminal status (2 branches). `setToolCallStatus` falls back to full-thread scan when the slot picker misses; returns `boolean` to confirm application.
- `runtime/task-status-applier.ts`: dedupe entry written only AFTER `setToolCallStatus` returns `true`.

## Tests

- 7 new vitest tests covering all 4 gaps (1 bonus + 2 for gap 1 + 1 for gap 2 + 3 for gap 3).
- Full suite: 476 passing. Pre-existing `router seq preservation > persisted message stamps seq` failure unrelated.

## Test plan
- [x] `npx tsc --noEmit` clean
- [x] `npm run build` clean → bundle `index-BUI7l3vJ.js`
- [x] All 6 chip/spinner/bubble test files green (31 tests)
- [x] 7 new tests green