### PR TITLE
fix(chat): use wire-borne tool_call_id for spawn_only chip status

### DIFF
--- a/src/runtime/ui-protocol-bridge.test.ts
+++ b/src/runtime/ui-protocol-bridge.test.ts
@@ -551,6 +551,52 @@ describe("type guards (fail-closed)", () => {
     ).toBeNull();
   });
 
+  // Codex round 2 bug 2026-05-15: pre-fix this guard required
+  // `isString(p.turn_id)`. The server's `TaskUpdatedEvent` struct does
+  // NOT carry `turn_id` (supervisor publishes by `task_id` directly),
+  // so EVERY production envelope was silently dropped at the guard
+  // layer → TaskStore never populated → `resolveToolCallIdForTask`
+  // always fell back to the raw supervisor UUID → spinner stuck.
+  // Post-fix: guard accepts the envelope WITHOUT `turn_id`, picks up
+  // the new `tool_call_id` directly from the wire so the handler can
+  // flip the chip without the TaskStore race.
+  it(
+    "accepts task/updated WITHOUT turn_id BUT WITH tool_call_id (codex round 2 regression test)",
+    () => {
+      const ev = guards.guardTaskUpdated({
+        session_id: "s",
+        // turn_id intentionally OMITTED — matches server wire shape.
+        task_id: "task_supervisor_uuid",
+        tool_call_id: "call_llm_emitted_id",
+        state: "failed",
+      });
+      // Pre-fix: `expected envelope to be accepted, was null` — guard
+      // dropped the envelope on the `turn_id` requirement.
+      expect(ev).not.toBeNull();
+      expect(ev?.turn_id).toBeUndefined();
+      expect(ev?.tool_call_id).toBe("call_llm_emitted_id");
+      expect(ev?.task_id).toBe("task_supervisor_uuid");
+      expect(ev?.state).toBe("failed");
+    },
+  );
+
+  it(
+    "accepts task/output/delta WITHOUT turn_id BUT WITH tool_call_id (codex round 2 regression test)",
+    () => {
+      const ev = guards.guardTaskOutputDelta({
+        session_id: "s",
+        // turn_id intentionally OMITTED — matches server wire shape.
+        task_id: "task_supervisor_uuid",
+        tool_call_id: "call_llm_emitted_id",
+        chunk: "stdout line",
+      });
+      expect(ev).not.toBeNull();
+      expect(ev?.turn_id).toBeUndefined();
+      expect(ev?.tool_call_id).toBe("call_llm_emitted_id");
+      expect(ev?.chunk).toBe("stdout line");
+    },
+  );
+
   it("rejects task/output/delta without chunk", () => {
     expect(
       guards.guardTaskOutputDelta({

--- a/src/runtime/ui-protocol-bridge.ts
+++ b/src/runtime/ui-protocol-bridge.ts
@@ -674,6 +674,13 @@ function guardSpawnComplete(p: unknown): TurnSpawnCompleteEvent | null {
         ? p.thread_id
         : undefined,
     task_id: p.task_id,
+    // Parallel server PR adds `tool_call_id` so the originating LLM
+    // tool call can be flipped to "complete" without the TaskStore
+    // race. Optional for forward compatibility with legacy daemons.
+    tool_call_id:
+      typeof p.tool_call_id === "string" && p.tool_call_id.length > 0
+        ? p.tool_call_id
+        : undefined,
     response_to_client_message_id:
       typeof p.response_to_client_message_id === "string" &&
       p.response_to_client_message_id.length > 0
@@ -806,14 +813,25 @@ export function guardSessionHydrate(p: unknown): SessionHydrateResult | null {
 
 function guardTaskUpdated(p: unknown): TaskUpdatedEvent | null {
   if (!isPlainObject(p)) return null;
-  if (!isString(p.session_id) || !isString(p.turn_id) || !isString(p.task_id)) {
+  // The server's `TaskUpdatedEvent` struct does NOT include `turn_id`
+  // (supervisor publishes by `task_id` directly). Pre-fix this guard
+  // required `turn_id`, which silently dropped EVERY production
+  // `task/updated` envelope — TaskStore stayed empty, the
+  // task_id→tool_call_id mapping never landed, and `resolveToolCallIdForTask`
+  // always fell back to the raw supervisor UUID. The chip then never
+  // flipped. Drop the `turn_id` requirement; pick it up if present for
+  // forward compatibility. Pick up the new `tool_call_id` field which
+  // the parallel server PR adds so the chip status can flip directly
+  // from the wire.
+  if (!isString(p.session_id) || !isString(p.task_id)) {
     return null;
   }
   if (typeof p.state !== "string") return null;
   return {
     session_id: p.session_id,
-    turn_id: p.turn_id,
+    turn_id: isString(p.turn_id) ? p.turn_id : undefined,
     task_id: p.task_id,
+    tool_call_id: isString(p.tool_call_id) ? p.tool_call_id : undefined,
     state: p.state,
     title: typeof p.title === "string" ? p.title : undefined,
     runtime_detail:
@@ -825,7 +843,11 @@ function guardTaskUpdated(p: unknown): TaskUpdatedEvent | null {
 
 function guardTaskOutputDelta(p: unknown): TaskOutputDeltaEvent | null {
   if (!isPlainObject(p)) return null;
-  if (!isString(p.session_id) || !isString(p.turn_id) || !isString(p.task_id)) {
+  // Same relaxation as `guardTaskUpdated`: server-side struct has no
+  // `turn_id` field for output deltas either, so this guard previously
+  // dropped every production envelope. Keep the field optional and pick
+  // up the new wire-borne `tool_call_id`.
+  if (!isString(p.session_id) || !isString(p.task_id)) {
     return null;
   }
   if (typeof p.chunk !== "string") return null;
@@ -835,8 +857,9 @@ function guardTaskOutputDelta(p: unknown): TaskOutputDeltaEvent | null {
   }
   return {
     session_id: p.session_id,
-    turn_id: p.turn_id,
+    turn_id: isString(p.turn_id) ? p.turn_id : undefined,
     task_id: p.task_id,
+    tool_call_id: isString(p.tool_call_id) ? p.tool_call_id : undefined,
     chunk: p.chunk,
     cursor,
   };

--- a/src/runtime/ui-protocol-event-router.test.ts
+++ b/src/runtime/ui-protocol-event-router.test.ts
@@ -1142,6 +1142,132 @@ describe("router event mapping", () => {
     },
   );
 
+  // -------------------------------------------------------------------------
+  // Codex round 2 bug 2026-05-15: wire-borne `tool_call_id` is the
+  // authoritative source.
+  // -------------------------------------------------------------------------
+  //
+  // Pre-fix flow with PR #132 only:
+  //   1. server emits `task/updated` with NO `turn_id`
+  //   2. bridge guard rejects every such envelope → TaskStore stays empty
+  //   3. `handleSpawnComplete` calls `resolveToolCallIdForTask` → empty
+  //      lookup → returns raw supervisor `task_id`
+  //   4. `findThreadIdForToolCall(supervisor_task_id)` misses (ThreadStore
+  //      registered the LLM tool_call_id) → status flip no-ops
+  //   5. spinner spins forever
+  //
+  // Post-fix: server adds `tool_call_id` directly on the wire (parallel
+  // server PR). Bridge passes it through; handler uses it as the
+  // authoritative source, bypassing the TaskStore race entirely. This
+  // test asserts the happy path WITH the new field AND an empty TaskStore
+  // (production scenario after both PRs land).
+  it(
+    "handleSpawnComplete uses wire-borne tool_call_id when TaskStore is empty (production scenario, codex round 2)",
+    () => {
+      const cmid = "cmid-wire-tcid-spawn";
+      // Realistic shapes: supervisor UUID vs LLM tool call id (distinct).
+      const supervisorTaskId = "task_01J_SUPERVISOR_PODCAST";
+      const llmToolCallId = "call_llm_podcast_wire";
+      seedThread(cmid, "Generate a podcast about Rust async");
+      ThreadStore.appendAssistantToken(cmid, "Background work started.");
+      ThreadStore.finalizeAssistant(cmid, { committedSeq: 4 });
+
+      // tool/started registers the LLM tool_call_id (the chip's id).
+      handleToolStarted(
+        { sessionId: SESSION },
+        {
+          session_id: SESSION,
+          turn_id: cmid,
+          tool_call_id: llmToolCallId,
+          tool_name: "podcast_generate",
+        },
+      );
+
+      // CRITICAL: do NOT seed TaskStore. This is what the bridge guard
+      // bug created in production — the watcher never polled because
+      // `crew:bg_tasks` was never dispatched (every `task/updated` was
+      // dropped at the guard). The fallback `resolveToolCallIdForTask`
+      // lookup misses → returns the supervisor UUID → ThreadStore
+      // lookup misses → spinner stuck. The wire-borne `tool_call_id`
+      // is the only escape hatch in this scenario.
+
+      handleSpawnComplete(
+        { sessionId: SESSION },
+        {
+          session_id: SESSION,
+          turn_id: cmid,
+          thread_id: cmid,
+          task_id: supervisorTaskId,
+          // The parallel server PR adds this field — the LLM tool_call_id.
+          tool_call_id: llmToolCallId,
+          response_to_client_message_id: cmid,
+          seq: 12,
+          message_id: "msg-wire-tcid",
+          source: "background",
+          cursor: { stream: SESSION, seq: 12 },
+          persisted_at: "2026-05-15T00:00:05Z",
+          content: "Podcast generated.",
+        },
+      );
+
+      // Post-fix: chip flips to complete via the wire-borne id, even
+      // though TaskStore is empty (which is the production reality).
+      const [thread] = ThreadStore.getThreads(SESSION);
+      const tc = thread.responses[0].toolCalls.find(
+        (c) => c.id === llmToolCallId,
+      );
+      expect(tc?.status).toBe("complete");
+    },
+  );
+
+  it(
+    "handleTaskUpdated state=failed uses wire-borne tool_call_id with no prior turn_id (codex round 2)",
+    () => {
+      // Server-side `TaskUpdatedEvent` carries NO `turn_id`. With the
+      // bridge guard relaxed, the envelope is now ACCEPTED but
+      // `event.turn_id` is `undefined`. Routing must go via
+      // `findThreadIdForToolCall(wire.tool_call_id)` instead of trusting
+      // `event.turn_id`. Pre-fix the chip stayed running because the
+      // ThreadStore call hit a raw supervisor UUID that didn't match
+      // any registered tool call.
+      const cmid = "cmid-wire-tcid-failed";
+      const supervisorTaskId = "task_01J_SUPERVISOR_FAIL";
+      const llmToolCallId = "call_llm_failed_wire";
+      seedThread(cmid, "deep_search");
+      ThreadStore.appendAssistantToken(cmid, "Started.");
+      ThreadStore.finalizeAssistant(cmid, { committedSeq: 2 });
+
+      handleToolStarted(
+        { sessionId: SESSION },
+        {
+          session_id: SESSION,
+          turn_id: cmid,
+          tool_call_id: llmToolCallId,
+          tool_name: "deep_search",
+        },
+      );
+
+      // No TaskStore seeding (production reality, codex round 2 root
+      // cause). No turn_id on the wire envelope.
+      handleTaskUpdated(
+        { sessionId: SESSION },
+        {
+          session_id: SESSION,
+          // turn_id intentionally OMITTED (server doesn't emit it).
+          task_id: supervisorTaskId,
+          tool_call_id: llmToolCallId,
+          state: "failed",
+        },
+      );
+
+      const [thread] = ThreadStore.getThreads(SESSION);
+      const tc = thread.responses[0].toolCalls.find(
+        (c) => c.id === llmToolCallId,
+      );
+      expect(tc?.status).toBe("error");
+    },
+  );
+
   // ---- M10 Phase 2 regression-pin: lock the architecture ------------------
   //
   // This test fixes the failure mode that motivated M10. The legacy splice

--- a/src/runtime/ui-protocol-event-router.ts
+++ b/src/runtime/ui-protocol-event-router.ts
@@ -500,11 +500,19 @@ export function handleSpawnComplete(
   // `setToolCallStatus` would mint an empty-user orphan thread via
   // `ensureOrphanThread` and steal attribution from the user's real
   // prompt.
-  const resolvedToolCallId = resolveToolCallIdForTask(
-    cfg.sessionId,
-    cfg.topic,
-    event.task_id,
-  );
+  //
+  // Bug 2026-05-15 (codex round 2): the TaskStore lookup that
+  // `resolveToolCallIdForTask` relies on races against the task watcher's
+  // poll loop. In production the watcher only runs when the bridge's
+  // `task/updated` envelope first dispatches `crew:bg_tasks` — but the
+  // pre-fix bridge guard dropped EVERY `task/updated` (server emits no
+  // `turn_id`), so the store stayed empty and the resolver fell back to
+  // the raw supervisor UUID. The chip then never flipped. Prefer the
+  // wire-borne `tool_call_id` (parallel server PR adds it) and use the
+  // TaskStore lookup only as a fallback for legacy daemons.
+  const resolvedToolCallId =
+    event.tool_call_id ??
+    resolveToolCallIdForTask(cfg.sessionId, cfg.topic, event.task_id);
   const statusHostThreadId = ThreadStore.findThreadIdForToolCall(
     cfg.sessionId,
     cfg.topic,
@@ -574,18 +582,36 @@ export function handleTaskUpdated(
   // therefore needs the spinner-progress fan-out here as well, with
   // the terminal flag set on the completion legs so the row clears.
   //
-  // Bug 2026-05-15 (codex final-3 bonus check): the wire's
-  // `event.task_id` is the supervisor's `TaskId::new()` UUID, NOT
-  // the LLM `tool_call_id` that `tool/started` registered on the
-  // ThreadStore. Translate via `TaskStore` so the
-  // `appendToolProgress` / `setToolCallStatus` calls land on the
-  // correct chip. Falls back to `event.task_id` (legacy daemons that
-  // emit them equal, or pre-watcher boot).
-  const resolvedToolCallId = resolveToolCallIdForTask(
-    cfg.sessionId,
-    cfg.topic,
-    event.task_id,
-  );
+  // Bug 2026-05-15 (codex round 2): prefer the wire-borne
+  // `event.tool_call_id` (parallel server PR adds it). Falls back to
+  // the TaskStore `task_id → tool_call_id` lookup for legacy daemons,
+  // which itself falls back to the raw `task_id` when the watcher
+  // hasn't populated the store yet. The fallback chain handles all
+  // three wire generations (modern carries tool_call_id, mid-tier has
+  // separate task_id+tool_call_id with a watcher poll bridging them,
+  // legacy emits them equal).
+  const resolvedToolCallId =
+    event.tool_call_id ??
+    resolveToolCallIdForTask(cfg.sessionId, cfg.topic, event.task_id);
+
+  // Bug 2026-05-15 (codex round 2): server-side `TaskUpdatedEvent`
+  // carries NO `turn_id` — pre-fix bridge guard dropped every such
+  // envelope. With the guard relaxed, `event.turn_id` is now
+  // `undefined` in production. Route via `findThreadIdForToolCall`
+  // (which scans every thread's pending + finalized assistant slots
+  // for a tool call matching `resolvedToolCallId`) instead of trusting
+  // `event.turn_id`. Falls back to a (likely-undefined) `event.turn_id`
+  // only if no thread is found — `setToolCallStatus`/`appendToolProgress`
+  // then no-op cleanly via the `ensureOrphanThread(undefined)` path
+  // (`findThreadById(undefined)` returns null, and pickHostSessionForOrphan
+  // would mint a placeholder thread but with no matching tool call it
+  // exits without mutation).
+  const hostThreadId =
+    ThreadStore.findThreadIdForToolCall(
+      cfg.sessionId,
+      cfg.topic,
+      resolvedToolCallId,
+    ) ?? event.turn_id;
 
   // The `tool_name` lookup falls back to the task_id when no preceding
   // `tool/started` cached a name (e.g. a server-side flow that skips
@@ -602,7 +628,9 @@ export function handleTaskUpdated(
     case "spawned":
     case "running": {
       const label = event.title ?? event.runtime_detail ?? event.state;
-      ThreadStore.appendToolProgress(event.turn_id, resolvedToolCallId, label);
+      if (hostThreadId) {
+        ThreadStore.appendToolProgress(hostThreadId, resolvedToolCallId, label);
+      }
       // Mirror the legacy SSE bridge's `crew:bg_tasks` dispatch so any
       // listener that gates a session-level "background work" indicator
       // off the same event keeps firing.
@@ -613,18 +641,20 @@ export function handleTaskUpdated(
         }),
       );
       // Light / refresh the spinner with the latest task state label.
-      dispatchToolProgressEvent(cfg, event.turn_id, toolLabel, label);
+      dispatchToolProgressEvent(cfg, hostThreadId, toolLabel, label);
       break;
     }
     case "completed": {
-      ThreadStore.setToolCallStatus(
-        event.turn_id,
-        resolvedToolCallId,
-        "complete",
-      );
+      if (hostThreadId) {
+        ThreadStore.setToolCallStatus(
+          hostThreadId,
+          resolvedToolCallId,
+          "complete",
+        );
+      }
       dispatchToolProgressEvent(
         cfg,
-        event.turn_id,
+        hostThreadId,
         toolLabel,
         "done",
         /* terminal */ true,
@@ -640,10 +670,16 @@ export function handleTaskUpdated(
     }
     case "failed":
     case "errored": {
-      ThreadStore.setToolCallStatus(event.turn_id, resolvedToolCallId, "error");
+      if (hostThreadId) {
+        ThreadStore.setToolCallStatus(
+          hostThreadId,
+          resolvedToolCallId,
+          "error",
+        );
+      }
       dispatchToolProgressEvent(
         cfg,
-        event.turn_id,
+        hostThreadId,
         toolLabel,
         "error",
         /* terminal */ true,
@@ -697,17 +733,39 @@ export function handleTaskOutputDelta(
   event: TaskOutputDeltaEvent,
 ): void {
   if (!event.chunk) return;
+  // Codex round 2 wire alignment: prefer wire-borne `tool_call_id`,
+  // fall back to TaskStore mapping for legacy daemons. Route via
+  // `findThreadIdForToolCall` since `event.turn_id` is now optional
+  // (server-side struct doesn't carry it).
+  const resolvedToolCallId =
+    event.tool_call_id ??
+    resolveToolCallIdForTask(cfg.sessionId, cfg.topic, event.task_id);
+  const hostThreadId =
+    ThreadStore.findThreadIdForToolCall(
+      cfg.sessionId,
+      cfg.topic,
+      resolvedToolCallId,
+    ) ?? event.turn_id;
   // Surface live tool stdout into the bubble's progress timeline. Dedupe
   // logic lives in ThreadStore.appendToolProgress (consecutive duplicates
   // are dropped) so resending the same chunk on reconnect is safe.
-  ThreadStore.appendToolProgress(event.turn_id, event.task_id, event.chunk);
+  if (hostThreadId) {
+    ThreadStore.appendToolProgress(
+      hostThreadId,
+      resolvedToolCallId,
+      event.chunk,
+    );
+  }
   // Codex round-3: also fan out to the lifted spinner. Some spawn_only
   // flows emit their real progress as output chunks, not `task/updated`
   // running labels; without this dispatch the spinner text goes stale
   // mid-task. Non-terminal — completion is signalled by `task/updated`
   // completed/failed/errored.
-  const toolLabel = toolNameByCallId.get(event.task_id) ?? event.task_id;
-  dispatchToolProgressEvent(cfg, event.turn_id, toolLabel, event.chunk);
+  const toolLabel =
+    toolNameByCallId.get(resolvedToolCallId) ??
+    toolNameByCallId.get(event.task_id) ??
+    event.task_id;
+  dispatchToolProgressEvent(cfg, hostThreadId, toolLabel, event.chunk);
 }
 
 export function handleTurnStarted(
@@ -867,7 +925,7 @@ export function handleTurnError(
 
 function dispatchToolProgressEvent(
   cfg: RouterConfig,
-  turnId: string,
+  turnId: string | undefined,
   toolName: string,
   message: string,
   /** When true, the `ToolProgressIndicator` clears the spinner row.

--- a/src/runtime/ui-protocol-types.ts
+++ b/src/runtime/ui-protocol-types.ts
@@ -224,6 +224,14 @@ export interface TurnSpawnCompleteEvent {
   /** Always populated. Identifies the originating `spawn_only` task —
    *  used by Phase 4's `read_task_output` flow. */
   task_id: string;
+  /** Optional. The LLM-emitted `tool_call_id` of the originating
+   *  `spawn_only` tool call. Added in the parallel server PR so the
+   *  client can flip the right chip without the supervisor-UUID-to-LLM-id
+   *  TaskStore round-trip (which races against the task watcher's poll
+   *  and silently mis-resolves when the store is empty). Falls back to
+   *  the existing `resolveToolCallIdForTask(task_id)` helper on legacy
+   *  daemons that don't carry the field yet. */
+  tool_call_id?: string;
   /** Optional in Phase 1 (server emits a thread-id-flavoured value); used
    *  as advisory placement only. Phase 4 will populate this with the real
    *  user-prompt cmid. */
@@ -254,8 +262,19 @@ export interface TurnSpawnCompleteEvent {
 
 export interface TaskUpdatedEvent {
   session_id: string;
-  turn_id: string;
+  /** Optional. Server's `TaskUpdatedEvent` struct does NOT carry
+   *  `turn_id` (the supervisor publishes by `task_id` directly), so the
+   *  field is `undefined` on the wire today. Kept optional rather than
+   *  removed for forward compatibility with a future server PR that
+   *  threads it through. */
+  turn_id?: string;
   task_id: string;
+  /** Optional. The LLM-emitted `tool_call_id` of the originating
+   *  `spawn_only` tool call. Added in the parallel server PR so the
+   *  client can flip the right chip directly from the wire instead of
+   *  via the TaskStore poll lookup. Falls back to
+   *  `resolveToolCallIdForTask(task_id)` for legacy daemons. */
+  tool_call_id?: string;
   state: string;
   title?: string;
   runtime_detail?: string;
@@ -264,8 +283,13 @@ export interface TaskUpdatedEvent {
 
 export interface TaskOutputDeltaEvent {
   session_id: string;
-  turn_id: string;
+  /** Optional. Same rationale as `TaskUpdatedEvent.turn_id` — server's
+   *  output-delta envelope has no `turn_id`; the field is preserved for
+   *  forward compatibility. */
+  turn_id?: string;
   task_id: string;
+  /** Optional. Same rationale as `TaskUpdatedEvent.tool_call_id`. */
+  tool_call_id?: string;
   chunk: string;
   cursor?: { offset: number };
 }


### PR DESCRIPTION
## Root cause (codex round 2)

The bridge's `guardTaskUpdated` required `turn_id` to be a non-empty string, but the server's `TaskUpdatedEvent` struct (`crates/octos-core/src/ui_protocol.rs`) carries **no** `turn_id` — the supervisor publishes by `task_id` directly. **Every** production `task/updated` envelope was therefore silently dropped at the guard layer.

Downstream effects:
1. `handleTaskUpdated` never ran → `crew:bg_tasks` never dispatched
2. Task watcher never polled → `TaskStore` stayed empty
3. PR #132's `resolveToolCallIdForTask(task_id)` always fell back to the raw supervisor UUID
4. `findThreadIdForToolCall(supervisor_uuid)` missed (ThreadStore registered the LLM `tool_call_id`)
5. `setToolCallStatus` no-op → spinner spins forever

The ack bubble was purely client-side and disappeared on refresh, masking the bug from anyone who only tested via reload.

## Fix (client half — a parallel server PR adds `tool_call_id` to the wire)

1. **Bridge guards**: drop the `turn_id` requirement on `task/updated` and `task/output/delta`; pick up the new `tool_call_id` field. Same pickup on `turn/spawn_complete`.
2. **Event-router handlers**: prefer wire `event.tool_call_id`, fall back to `resolveToolCallIdForTask` (PR #132 helper) for legacy daemons. Route `task/updated` / `task/output/delta` via `ThreadStore.findThreadIdForToolCall(resolvedToolCallId)` instead of trusting `event.turn_id`.
3. **Types**: `turn_id` is now optional on `TaskUpdatedEvent` / `TaskOutputDeltaEvent`; `tool_call_id?: string` added to all three event interfaces.

## Forward compatibility

| Server | Behaviour |
|---|---|
| Legacy (no `tool_call_id` on wire) | Fallback chain works identically to PR #132 — `resolveToolCallIdForTask` via TaskStore once watcher populates it, raw `task_id` otherwise. Same risk surface as today. |
| Parallel server PR landed | Chip flips directly from the wire-borne `tool_call_id` — TaskStore race bypassed entirely, spinner clears even on a fresh tab where the watcher hasn't polled yet. |

## PR #132 defences are preserved

All four PR #132 fixes stay as defence-in-depth:
- terminal-status preservation in `addToolCall`
- full-thread fallback in `setToolCallStatus`
- dedupe-after-confirmation
- `resolveToolCallIdForTask` helper (now the fallback when wire `tool_call_id` is absent)

## Tests

3 new vitest cases (4 new test methods total):
- `bridge`: `task/updated` envelope WITHOUT `turn_id` BUT WITH `tool_call_id` is now **accepted** (regression on the drop-everything guard)
- `bridge`: same for `task/output/delta`
- `router`: `turn/spawn_complete` with wire-borne `tool_call_id` AND an empty TaskStore flips chip to `complete` (production scenario after both PRs land)
- `router`: `task/updated state=failed` with wire `tool_call_id` AND no `turn_id` flips chip to `error`

Pre-fix failure messages on the new tests:
- `expected null not to be null` (guard drops the envelope)
- `expected 'running' to be 'complete'` (chip stuck on success)
- `expected 'running' to be 'error'` (chip stuck on failure)

## Test plan

- [x] `npx tsc --noEmit` clean
- [x] `npm run build` clean → new bundle `dist/assets/index-VReY7Br3.js`
- [x] All 6 chip/spinner test files green (35/35 tests)
- [x] Bridge + router test files green: 136/136 (excluding pre-existing unrelated `router seq preservation > persisted message stamps seq onto the late-artifact response` failure on main)
- [x] Full vitest: 480/481 passing (only the pre-existing `router seq preservation` failure remains, unchanged)
- [ ] Manual verification on a mini once the parallel server PR lands: spawn_only tool (e.g. `podcast_generate`) chip clears spinner without page refresh