### PR TITLE
fix(chat): hydrate TaskStore from live task/updated for sidebar spinner

### DIFF
--- a/src/runtime/ui-protocol-event-router.test.ts
+++ b/src/runtime/ui-protocol-event-router.test.ts
@@ -461,6 +461,119 @@ describe("router event mapping", () => {
     expect(tc?.status).toBe("error");
   });
 
+  // -------------------------------------------------------------------------
+  // Sidebar spinner — live `task/updated` must hydrate TaskStore directly
+  // -------------------------------------------------------------------------
+  //
+  // The sidebar session-row spinner (`useAllTasksBySession()` in
+  // `chat-thread.tsx`) gates on TaskStore having at least one
+  // `spawned`/`running` row for the session. Pre-fix the router's
+  // `handleTaskUpdated` only mutated ThreadStore + dispatched
+  // `crew:bg_tasks` (which arms the 2.5 s task-watcher poll) — it never
+  // mutated TaskStore. The poll itself is currently broken upstream by a
+  // session_key filter mismatch on the server's `/api/sessions/.../tasks`
+  // path (see `task_supervisor.rs:1753-1758`: the WS-side `snapshot_excluding`
+  // path clears the supervisor's `session_key`, so the endpoint returns
+  // `[]` for the very tasks the running session has). So the sidebar
+  // spinner stayed cold for spawn_only tasks even though the wire path
+  // was working.
+  //
+  // Fix: hydrate TaskStore directly from the live `task/updated` envelope
+  // (and from the terminal `turn/spawn_complete` belt-and-braces) so the
+  // sidebar spinner fires regardless of poll state.
+  it("handleTaskUpdated state=\"running\" hydrates TaskStore for the sidebar spinner", async () => {
+    const TaskStore = await import("@/store/task-store");
+    TaskStore.clearTasks(SESSION);
+    seedThread("cmid-sidebar-run");
+    handleTaskUpdated(
+      { sessionId: SESSION },
+      {
+        session_id: SESSION,
+        turn_id: "cmid-sidebar-run",
+        task_id: "task-sidebar-running",
+        tool_call_id: "tc-sidebar-running",
+        state: "running",
+        title: "deep_search",
+      },
+    );
+    const tasks = TaskStore.getTasks(SESSION);
+    expect(tasks).toHaveLength(1);
+    expect(tasks[0].id).toBe("task-sidebar-running");
+    expect(tasks[0].status).toBe("running");
+    expect(tasks[0].tool_call_id).toBe("tc-sidebar-running");
+    expect(tasks[0].tool_name).toBe("deep_search");
+    TaskStore.clearTasks(SESSION);
+  });
+
+  it("handleTaskUpdated state=\"completed\" flips the TaskStore row to completed", async () => {
+    const TaskStore = await import("@/store/task-store");
+    TaskStore.clearTasks(SESSION);
+    seedThread("cmid-sidebar-done");
+    handleTaskUpdated(
+      { sessionId: SESSION },
+      {
+        session_id: SESSION,
+        turn_id: "cmid-sidebar-done",
+        task_id: "task-sidebar-done",
+        tool_call_id: "tc-sidebar-done",
+        state: "running",
+        title: "podcast_generate",
+      },
+    );
+    expect(TaskStore.getTasks(SESSION)[0]?.status).toBe("running");
+    handleTaskUpdated(
+      { sessionId: SESSION },
+      {
+        session_id: SESSION,
+        turn_id: "cmid-sidebar-done",
+        task_id: "task-sidebar-done",
+        tool_call_id: "tc-sidebar-done",
+        state: "completed",
+      },
+    );
+    const tasks = TaskStore.getTasks(SESSION);
+    expect(tasks).toHaveLength(1);
+    expect(tasks[0].status).toBe("completed");
+    expect(tasks[0].completed_at).toBeTruthy();
+    TaskStore.clearTasks(SESSION);
+  });
+
+  it("handleSpawnComplete merges a completed TaskStore row even when TaskStore is empty (defence-in-depth)", async () => {
+    // Regression check: the helper must run unconditionally — gating on
+    // a pre-existing row would leave the sidebar stuck if the
+    // `task/updated state="running"` envelope was missed or arrived
+    // after `turn/spawn_complete` due to reorder/replay.
+    const TaskStore = await import("@/store/task-store");
+    TaskStore.clearTasks(SESSION);
+    const cmid = "cmid-sidebar-spawn-only";
+    seedThread(cmid, "Generate a podcast");
+    ThreadStore.appendAssistantToken(cmid, "Background work started.");
+    ThreadStore.finalizeAssistant(cmid, { committedSeq: 5 });
+    handleSpawnComplete(
+      { sessionId: SESSION },
+      {
+        session_id: SESSION,
+        turn_id: cmid,
+        thread_id: cmid,
+        task_id: "task-sidebar-spawn-only",
+        tool_call_id: "tc-sidebar-spawn-only",
+        response_to_client_message_id: cmid,
+        seq: 17,
+        message_id: "msg-sidebar-spawn-only",
+        source: "background",
+        cursor: { stream: SESSION, seq: 17 },
+        persisted_at: "2026-05-15T00:00:00Z",
+        content: "Podcast generated.",
+      },
+    );
+    const tasks = TaskStore.getTasks(SESSION);
+    expect(tasks).toHaveLength(1);
+    expect(tasks[0].id).toBe("task-sidebar-spawn-only");
+    expect(tasks[0].status).toBe("completed");
+    expect(tasks[0].tool_call_id).toBe("tc-sidebar-spawn-only");
+    TaskStore.clearTasks(SESSION);
+  });
+
   it("task/output/delta appends a chunk into the matching tool call timeline", () => {
     seedThread("cmid-6");
     handleTaskUpdated(

--- a/src/runtime/ui-protocol-event-router.ts
+++ b/src/runtime/ui-protocol-event-router.ts
@@ -526,6 +526,20 @@ export function handleSpawnComplete(
     );
   }
 
+  // Belt-and-braces: clear the sidebar spinner at completion even if
+  // the terminal `task/updated state="completed"` envelope is missed
+  // (it already happens in practice — `turn/spawn_complete` is the
+  // durable completion signal). Run unconditionally so the helper
+  // works for tasks the running-state envelope was never delivered
+  // for (e.g. reorder / replay where completion lands first).
+  mergeLiveTask(
+    cfg.sessionId,
+    cfg.topic,
+    event.task_id,
+    resolvedToolCallId,
+    "completed",
+  );
+
   ThreadStore.appendCompletionBubble(placementKey, {
     text: event.content,
     media: event.media ?? [],
@@ -623,6 +637,25 @@ export function handleTaskUpdated(
     toolNameByCallId.get(resolvedToolCallId) ??
     toolNameByCallId.get(event.task_id) ??
     event.task_id;
+
+  // Hydrate TaskStore directly from the live envelope so the sidebar
+  // session-row spinner (`useAllTasksBySession()` in `chat-thread.tsx`)
+  // lights within ms instead of waiting on the 2.5 s task-watcher poll
+  // — which is currently broken upstream by a server-side session_key
+  // filter mismatch (see `task_supervisor.rs:1753-1758`: the WS-side
+  // `snapshot_excluding` path clears the supervisor's session_key, so
+  // `/api/sessions/.../tasks` returns `[]` for the very tasks the
+  // running session has). The poll path remains intact as redundant
+  // safety net once the server bug is fixed.
+  mergeLiveTask(
+    cfg.sessionId,
+    cfg.topic,
+    event.task_id,
+    resolvedToolCallId,
+    event.state,
+    event.title,
+    event.runtime_detail,
+  );
 
   switch (event.state) {
     case "spawned":
@@ -726,6 +759,67 @@ function resolveToolCallIdForTask(
     }
   }
   return taskId;
+}
+
+/** Hydrate TaskStore from a live `task/updated` (or terminal
+ *  `turn/spawn_complete`) envelope so the sidebar session-row spinner
+ *  (gated on `useAllTasksBySession()` reporting at least one
+ *  `spawned`/`running` task) fires immediately — no dependency on the
+ *  2.5 s task-watcher poll, which is currently broken upstream by a
+ *  server-side `session_key` filter mismatch in `task_supervisor.rs`
+ *  (the WS-side `snapshot_excluding` path clears the supervisor's
+ *  session_key, so `/api/sessions/.../tasks` returns `[]` for the very
+ *  tasks the running session has).
+ *
+ *  The watcher poll path is left intact upstream as a redundant safety
+ *  net once the server bug is fixed; this hydration is the primary
+ *  source of truth for the sidebar today.
+ *
+ *  Unknown / un-mappable states are ignored (no row written), so a
+ *  forward-compat server adding a new state cannot pollute the store
+ *  with `unknown`-status rows. */
+function mergeLiveTask(
+  sessionId: string,
+  topic: string | undefined,
+  taskId: string,
+  toolCallId: string,
+  state: string | undefined,
+  title?: string,
+  runtimeDetail?: string,
+): void {
+  const status =
+    state === "spawned" || state === "pending"
+      ? "spawned"
+      : state === "running"
+        ? "running"
+        : state === "completed"
+          ? "completed"
+          : state === "failed" || state === "errored"
+            ? "failed"
+            : null;
+  if (!status) return;
+
+  const existing = TaskStore.getTasks(sessionId, topic).find(
+    (t) => t.id === taskId,
+  );
+  const nowIso = new Date().toISOString();
+
+  TaskStore.mergeTask(
+    sessionId,
+    {
+      id: taskId,
+      tool_name: title ?? existing?.tool_name ?? "Background task",
+      tool_call_id: toolCallId || existing?.tool_call_id,
+      status,
+      started_at: existing?.started_at ?? nowIso,
+      completed_at:
+        status === "completed" || status === "failed" ? nowIso : null,
+      output_files: existing?.output_files ?? [],
+      error: status === "failed" ? (runtimeDetail ?? null) : null,
+      session_key: sessionId,
+    },
+    topic,
+  );
 }
 
 export function handleTaskOutputDelta(


### PR DESCRIPTION
## Summary

- The wire path is working (server PR #975 + client PR #133 both deployed; server emits `task/updated state="running"` with `tool_call_id` correctly).
- `handleTaskUpdated` in `src/runtime/ui-protocol-event-router.ts` was missing the `TaskStore.mergeTask` call — only the watcher poll populated TaskStore, and the poll is currently broken upstream by a `session_key` filter mismatch on the server's `/api/sessions/.../tasks` path (`task_supervisor.rs:1753-1758`: the WS-side `snapshot_excluding` path clears the supervisor's `session_key`, so the endpoint returns `[]` for the very tasks the running session has).
- Fix: hydrate TaskStore directly from the live envelope so the sidebar spinner works regardless of poll state.

Sidebar spinner now fires within ms of `task/updated state="running"` arriving instead of waiting on a 2.5 s watcher poll that returns `[]`. The 2.5 s poll path is left intact as a redundant safety net once the server bug is tracked + fixed.

The server-side `session_key` snapshot bug is intentionally out of scope here — separate issue worth tracking.

## What changed

- `src/runtime/ui-protocol-event-router.ts`: new `mergeLiveTask` helper next to `resolveToolCallIdForTask`. Wired into `handleTaskUpdated` (between tool-call resolution and the state switch) and `handleSpawnComplete` (after the chip-status flip, before the bubble append — belt-and-braces).
- `src/runtime/ui-protocol-event-router.test.ts`: 3 new tests.

## Defence-in-depth

- PR #132 (codex round-2 spinner fixes) and PR #133 (wire-borne `tool_call_id` for chip status) both stay — this is a separate gap on the sidebar, not the chip.

## Test plan

- [x] `npx tsc --noEmit` clean
- [x] `npm run build` clean — new bundle `dist/assets/index-CGfZmD_y.js`
- [x] `npm run test:unit` — 483 passed / 1 failed; the failing test (`router seq preservation > persisted message stamps seq onto the late-artifact response`) is pre-existing on `origin/main` and unrelated
- [x] Pre-fix the 3 new tests fail with `expected [] to have a length of 1 but got +0` (TaskStore empty)
- [ ] Live verify on mini5 that the sidebar spinner fires immediately when a spawn_only task starts