### PR TITLE
fix(chat): don't clobber live TaskStore entries on empty watcher poll

### DIFF
--- a/src/runtime/task-watcher.test.ts
+++ b/src/runtime/task-watcher.test.ts
@@ -1,0 +1,139 @@
+/**
+ * task-watcher unit tests.
+ *
+ * Coverage:
+ *   - `pollSession` with `tasks: []` AND a TaskStore entry already
+ *     hydrated by the live `task/updated` envelope: the empty poll
+ *     response MUST NOT clobber the live row (2026-05-15 fix).
+ *   - `pollSession` with `tasks: [completed]`: the non-empty branch
+ *     still calls `replaceTasks` and persists terminal state.
+ *
+ * Why: server's WS per-turn registry uses `snapshot_excluding` which
+ * constructs a fresh `TaskSupervisor` with cleared `session_key`. The
+ * `session/tasks.list` filter is `task.session_key == Some(session_key)`,
+ * so the response is always `[]` for spawn_only running tasks. Before
+ * this fix the watcher's `pollSession` called
+ * `TaskStore.replaceTasks(entry.sessionId, [], topic)` and wiped the
+ * row that `mergeLiveTask` just hydrated from the live `task/updated`
+ * state="running" envelope.
+ */
+
+import {
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  vi,
+} from "vitest";
+
+const { getSessionTasksSpy, getMessagesSpy } = vi.hoisted(() => ({
+  getSessionTasksSpy: vi.fn(),
+  getMessagesSpy: vi.fn(),
+}));
+
+vi.mock("@/api/sessions", async () => {
+  const actual = await vi.importActual<typeof import("@/api/sessions")>(
+    "@/api/sessions",
+  );
+  return {
+    ...actual,
+    getSessionTasks: getSessionTasksSpy,
+    getMessages: getMessagesSpy,
+  };
+});
+
+import * as TaskStore from "@/store/task-store";
+import {
+  __pollSessionForTest,
+  unwatchSession,
+  watchSession,
+} from "./task-watcher";
+import type { BackgroundTaskInfo } from "@/api/types";
+
+const SESSION = "sess-task-watcher";
+
+function clearTaskStoreEntries() {
+  // No explicit reset helper — `clearTasks` plus a topic-less call
+  // wipes all keys that prefix-match `SESSION`.
+  TaskStore.clearTasks(SESSION);
+}
+
+beforeEach(() => {
+  getSessionTasksSpy.mockReset();
+  getMessagesSpy.mockReset();
+  getMessagesSpy.mockResolvedValue([]);
+  clearTaskStoreEntries();
+});
+
+afterEach(() => {
+  // Unwatch to stop the interval timer leaking across tests.
+  unwatchSession(SESSION);
+  clearTaskStoreEntries();
+});
+
+describe("pollSession empty-response defence (2026-05-15)", () => {
+  it("does NOT clobber a live-hydrated running task when server returns []", async () => {
+    // Simulate live wire path: `mergeLiveTask` from a `task/updated`
+    // state="running" envelope has hydrated TaskStore. The watcher
+    // poll then fires and the server returns [] because
+    // `snapshot_excluding` cleared `session_key`.
+    const liveTask: BackgroundTaskInfo = {
+      id: "task_pipeline_live",
+      tool_name: "deep_research",
+      tool_call_id: "task_pipeline_live",
+      status: "running",
+      started_at: "2026-05-15T00:00:00Z",
+      error: null,
+    };
+    TaskStore.mergeTask(SESSION, liveTask);
+    expect(TaskStore.getTasks(SESSION).map((t) => t.id)).toEqual([
+      "task_pipeline_live",
+    ]);
+
+    getSessionTasksSpy.mockResolvedValue([] as BackgroundTaskInfo[]);
+
+    watchSession(SESSION);
+    // Drive one poll cycle synchronously via the test helper so the
+    // assertion observes the post-`replaceTasks` state.
+    await __pollSessionForTest(SESSION);
+
+    // After the empty poll: the live row MUST still be present.
+    const tasks = TaskStore.getTasks(SESSION);
+    expect(tasks).toHaveLength(1);
+    expect(tasks[0].id).toBe("task_pipeline_live");
+    expect(tasks[0].status).toBe("running");
+  });
+
+  it("non-empty response still calls replaceTasks and writes terminal state", async () => {
+    // The non-empty branch must remain unchanged: a watcher poll that
+    // sees a completed task should overwrite the live row with the
+    // server's authoritative terminal payload.
+    const liveTask: BackgroundTaskInfo = {
+      id: "task_pipeline_done",
+      tool_name: "deep_research",
+      tool_call_id: "task_pipeline_done",
+      status: "running",
+      started_at: "2026-05-15T00:00:00Z",
+      error: null,
+    };
+    TaskStore.mergeTask(SESSION, liveTask);
+
+    const completed: BackgroundTaskInfo = {
+      ...liveTask,
+      status: "completed",
+      completed_at: "2026-05-15T00:00:10Z",
+      output_files: ["/tmp/result.json"],
+    };
+    getSessionTasksSpy.mockResolvedValue([completed]);
+
+    watchSession(SESSION);
+    await __pollSessionForTest(SESSION);
+
+    const tasks = TaskStore.getTasks(SESSION);
+    expect(tasks).toHaveLength(1);
+    expect(tasks[0].id).toBe("task_pipeline_done");
+    expect(tasks[0].status).toBe("completed");
+    expect(tasks[0].output_files).toEqual(["/tmp/result.json"]);
+  });
+});

--- a/src/runtime/task-watcher.ts
+++ b/src/runtime/task-watcher.ts
@@ -286,6 +286,19 @@ async function pollAll(): Promise<void> {
   await Promise.all(entries.map(([, entry]) => pollSession(entry)));
 }
 
+/**
+ * Test-only: drive a single `pollSession` cycle and await it.
+ * Production code reaches `pollSession` via the interval timer.
+ */
+export async function __pollSessionForTest(
+  sessionId: string,
+  topic?: string,
+): Promise<void> {
+  const entry = watchedSessions.get(watchKey(sessionId, topic));
+  if (!entry) return;
+  await pollSession(entry);
+}
+
 async function pollSession(entry: WatchedSession): Promise<void> {
   try {
     const key = watchKey(entry.sessionId, entry.topic);
@@ -303,7 +316,21 @@ async function pollSession(entry: WatchedSession): Promise<void> {
       ),
     ]);
 
-    TaskStore.replaceTasks(entry.sessionId, tasks, entry.topic);
+    // 2026-05-15: server-side `snapshot_excluding` (UI protocol per-turn
+    // registry) clears `session_key`, making `session/tasks.list` return
+    // [] for live spawn_only tasks even while they're running. Don't let
+    // an empty poll response clobber rows that the live `task/updated`
+    // envelope hydrated via `mergeLiveTask`. The live envelope is
+    // authoritative for status transitions; the watcher poll only
+    // supplements with output-files and post-mortem terminal state we
+    // may have missed.
+    if (tasks.length > 0) {
+      TaskStore.replaceTasks(entry.sessionId, tasks, entry.topic);
+    } else {
+      // Keep existing TaskStore entries untouched. The live wire path
+      // (task/updated + turn/spawn_complete -> mergeLiveTask) flips
+      // terminal status when the work actually finishes.
+    }
     for (const task of tasks) {
       dispatchTaskStatusEvent(entry.sessionId, entry.topic, task);
     }


### PR DESCRIPTION
## Summary

Sidebar session-row spinner for spawn_only tasks (podcast_generate, run_pipeline, fm_tts) never appeared in DOM despite PR #134's `mergeLiveTask` writing to `TaskStore` correctly. Codex root-caused: server's WS per-turn registry builds with `snapshot_excluding` which constructs a fresh `TaskSupervisor` with cleared `session_key` (`task_supervisor.rs:1752-1758`). The watcher's `session/tasks.list` query filters by `task.session_key == Some(session_key)`, so the response is always `[]` for live spawn_only tasks. The watcher then calls `TaskStore.replaceTasks(entry.sessionId, [], topic)` at `task-watcher.ts:306` and **wipes the row PR #134 just hydrated from the live `task/updated state="running"` envelope.**

## Fix

`task-watcher.ts:306` — skip `replaceTasks` when `tasks.length === 0`. Live envelope is authoritative for status transitions; an empty poll shouldn't erase entries the wire just wrote.

## Live soak

Reran `mini5-sidebar-spinner-spawn-only.spec.ts` against the deployed bundle on https://dspfac.ocean.ominix.io:
- **Assertion 1 (spinner appears): PASS** — Loader2 visible on session A within 15–28s of submitting a real podcast prompt. Pre-fix: never within 3-min window.
- Assertion 2/3: test design flaw blocks them (helper expects sessionId in URL; SPA route is `/chat/*` without segment). Indirect evidence shows the fix is sufficient — session A still shows "Live session" after switching to a new session.

## Tests

`task-watcher.test.ts` — 2 new tests:
- empty-poll preserves an existing `running` entry (pre-fix: `AssertionError: expected length 1, got 0`)
- non-empty poll still calls replaceTasks as before

485 pass, 1 pre-existing fail in `ui-protocol-event-router.test.ts:1618` (verified on main, unrelated).

## Follow-ups (separate)

- Server-side: rework `snapshot_excluding` to preserve `session_key` (proper fix; this client defence stays as belt-and-suspenders).
- Spec: fix `waitForActiveSessionId` to handle the `/chat/*` route shape so assertions 2 and 3 can run.

## Test plan
- [x] `npx tsc --noEmit` clean
- [x] `npm run build` clean — bundle `index-k3M7rA1E.js`
- [x] Live Playwright soak — assertion 1 PASS on real mini5 podcast run