### PR TITLE
fix(chat): re-hydrate session on WS reconnect (recover missed envelopes)

### DIFF
--- a/src/runtime/ui-protocol-bridge.test.ts
+++ b/src/runtime/ui-protocol-bridge.test.ts
@@ -1223,6 +1223,148 @@ describe("reconnect with exponential backoff", () => {
 });
 
 // ---------------------------------------------------------------------------
+// Reload-bug fix (Yue 2026-05-15): onReopened fires on every successful
+// `session/open` ack AFTER the initial open — never on the initial open.
+// This is the hook the runtime layer subscribes to so it can re-issue
+// `session/hydrate` and recover envelopes the server emitted while the
+// WS was disconnected. Without this gating the runtime would
+// double-hydrate at startup; without the event at all the
+// run_pipeline-while-disconnected bug stays broken.
+// ---------------------------------------------------------------------------
+
+describe("onReopened — reconnect-only event", () => {
+  it("does NOT fire on the initial session/open ack", async () => {
+    const bridge = createUiProtocolBridge(makeBridgeOpts());
+    const reopenedCounts: { count: number } = { count: 0 };
+    bridge.onReopened(() => {
+      reopenedCounts.count += 1;
+    });
+    void bridge.start({ sessionId: "sess-1" });
+    await Promise.resolve();
+    const ws = lastInstance();
+    ws.triggerOpen();
+    await Promise.resolve();
+    const open = findRequest(ws, METHODS.SESSION_OPEN);
+    ws.triggerMessage({
+      jsonrpc: "2.0",
+      id: open.id,
+      result: { opened: { session_id: "sess-1" } },
+    });
+    await Promise.resolve();
+    expect(reopenedCounts.count).toBe(0);
+  });
+
+  it("fires once on every successful session/open ack AFTER the first", async () => {
+    // Drive the bridge through `initial open -> drop -> reconnect ->
+    // session/open ack`. The first ack must NOT fire `onReopened`; the
+    // second ack MUST.
+    vi.useFakeTimers();
+    const bridge = createUiProtocolBridge(makeBridgeOpts());
+    const reopened: number[] = [];
+    bridge.onReopened(() => {
+      reopened.push(Date.now());
+    });
+
+    void bridge.start({ sessionId: "sess-1" });
+    await Promise.resolve();
+    const ws1 = lastInstance();
+    ws1.triggerOpen();
+    await Promise.resolve();
+    const open1 = findRequest(ws1, METHODS.SESSION_OPEN);
+    ws1.triggerMessage({
+      jsonrpc: "2.0",
+      id: open1.id,
+      result: { opened: { session_id: "sess-1" } },
+    });
+    await Promise.resolve();
+    expect(reopened).toHaveLength(0);
+
+    // Drop the socket; bridge schedules a reconnect.
+    ws1.triggerClose(1006, "abnormal");
+    await vi.advanceTimersByTimeAsync(1000);
+    const ws2 = lastInstance();
+    ws2.triggerOpen();
+    await Promise.resolve();
+    const open2 = findRequest(ws2, METHODS.SESSION_OPEN);
+    ws2.triggerMessage({
+      jsonrpc: "2.0",
+      id: open2.id,
+      result: { opened: { session_id: "sess-1" } },
+    });
+    await Promise.resolve();
+    expect(reopened).toHaveLength(1);
+
+    // A second drop + reconnect fires it again.
+    ws2.triggerClose(1006, "abnormal");
+    await vi.advanceTimersByTimeAsync(2000);
+    const ws3 = lastInstance();
+    ws3.triggerOpen();
+    await Promise.resolve();
+    const open3 = findRequest(ws3, METHODS.SESSION_OPEN);
+    ws3.triggerMessage({
+      jsonrpc: "2.0",
+      id: open3.id,
+      result: { opened: { session_id: "sess-1" } },
+    });
+    await Promise.resolve();
+    expect(reopened).toHaveLength(2);
+  });
+
+  it("unsubscribe stops further onReopened deliveries", async () => {
+    vi.useFakeTimers();
+    const bridge = createUiProtocolBridge(makeBridgeOpts());
+    let calls = 0;
+    const unsub = bridge.onReopened(() => {
+      calls += 1;
+    });
+
+    void bridge.start({ sessionId: "sess-1" });
+    await Promise.resolve();
+    const ws1 = lastInstance();
+    ws1.triggerOpen();
+    await Promise.resolve();
+    const open1 = findRequest(ws1, METHODS.SESSION_OPEN);
+    ws1.triggerMessage({
+      jsonrpc: "2.0",
+      id: open1.id,
+      result: { opened: { session_id: "sess-1" } },
+    });
+    await Promise.resolve();
+
+    // First reconnect fires the event.
+    ws1.triggerClose(1006, "abnormal");
+    await vi.advanceTimersByTimeAsync(1000);
+    const ws2 = lastInstance();
+    ws2.triggerOpen();
+    await Promise.resolve();
+    const open2 = findRequest(ws2, METHODS.SESSION_OPEN);
+    ws2.triggerMessage({
+      jsonrpc: "2.0",
+      id: open2.id,
+      result: { opened: { session_id: "sess-1" } },
+    });
+    await Promise.resolve();
+    expect(calls).toBe(1);
+
+    // Unsubscribe, then drive another reconnect.
+    unsub();
+    ws2.triggerClose(1006, "abnormal");
+    await vi.advanceTimersByTimeAsync(2000);
+    const ws3 = lastInstance();
+    ws3.triggerOpen();
+    await Promise.resolve();
+    const open3 = findRequest(ws3, METHODS.SESSION_OPEN);
+    ws3.triggerMessage({
+      jsonrpc: "2.0",
+      id: open3.id,
+      result: { opened: { session_id: "sess-1" } },
+    });
+    await Promise.resolve();
+    expect(calls).toBe(1);
+  });
+});
+
+// ---------------------------------------------------------------------------
 // Send queue
 // ---------------------------------------------------------------------------
 

--- a/src/runtime/ui-protocol-bridge.ts
+++ b/src/runtime/ui-protocol-bridge.ts
@@ -400,6 +400,21 @@ export interface UiProtocolBridge {
    *  the listener fires can be classified as terminal-fast-reject
    *  (skip the 45s grace) vs reconnectable. */
   getConnectionState(): ConnectionState;
+  /** Fires every time `session/open` is successfully acked AFTER the
+   *  initial open in this bridge lifecycle — i.e. on every RECONNECT.
+   *  The initial open does NOT fire this event because the runtime
+   *  layer already hydrates immediately after `startBridgeForSession`.
+   *
+   *  The reload-bug fix (Yue 2026-05-15): when the user's WS drops
+   *  during a long-running `spawn_only` and the bridge reconnects, the
+   *  server's `session/open` without an `after` cursor serves "live
+   *  only, no replay" (`ui_protocol_ledger.rs:1199`). Any envelopes the
+   *  server emitted between disconnect and reconnect are silently
+   *  dropped. Subscribers (the runtime layer) re-issue
+   *  `bridge.hydrateSession(["messages"])` on this event to recover the
+   *  missed completion bubble + media attachment from the durable
+   *  ledger via `replayed_envelopes`. */
+  onReopened(handler: () => void): () => void;
   onWarning(handler: (e: WarningEvent) => void): () => void;
   /** Issue #113.2: server-emitted title update for cross-tab and
    *  auto-title flows. SessionProvider subscribes to keep its
@@ -1294,6 +1309,12 @@ class UiProtocolBridgeImpl implements UiProtocolBridge {
   private readonly subQueueState = new Subscribers<QueueStateEvent>();
   private readonly subWarning = new Subscribers<WarningEvent>();
   private readonly subState = new Subscribers<ConnectionState>();
+  /** Reload-bug fix (Yue 2026-05-15): fires once on every successful
+   *  RECONNECT (subsequent `session/open` acks in the same bridge
+   *  lifecycle — not the initial open). The runtime layer subscribes
+   *  to re-issue `session/hydrate` so envelopes emitted while the WS
+   *  was disconnected get replayed from `replayed_envelopes`. */
+  private readonly subReopened = new Subscribers<void>();
   private readonly subSessionTitleUpdated = new Subscribers<{
     session_id: string;
     title: string;
@@ -1645,6 +1666,9 @@ class UiProtocolBridgeImpl implements UiProtocolBridge {
   getConnectionState(): ConnectionState {
     return this.state;
   }
+  onReopened(handler: Listener<void>): () => void {
+    return this.subReopened.add(handler);
+  }
   onWarning(handler: Listener<WarningEvent>): () => void {
     return this.subWarning.add(handler);
   }
@@ -1765,10 +1789,27 @@ class UiProtocolBridgeImpl implements UiProtocolBridge {
       if (this.stopped) return;
       this.reconnectAttempts = 0;
       this.reconnectAbandoned = false;
+      // Snapshot whether this is a reopen BEFORE flipping `hasEverOpened`,
+      // so the emit below only fires after a reconnect (subsequent
+      // `session/open` ack) and not on the initial open — the runtime
+      // layer hydrates immediately on the initial open via
+      // `startBridgeForSession`.
+      const isReopen = this.hasEverOpened;
       this.hasEverOpened = true;
       this.setState("connected");
       this.startKeepalive();
       this.flushSendQueue();
+      if (isReopen) {
+        // Reload-bug fix (Yue 2026-05-15): the server treats a
+        // cursorless `session/open` as "live only, no replay"
+        // (`ui_protocol_ledger.rs:1199`). Envelopes the server emitted
+        // while the WS was disconnected (e.g. a `TurnSpawnComplete`
+        // for a long-running `spawn_only`) would be silently dropped
+        // without this hook. The runtime layer subscribes here to
+        // re-fetch `session/hydrate` so `replayed_envelopes` rolls the
+        // ledger forward for the user's missed turn.
+        this.subReopened.emit();
+      }
     } catch (err) {
       if (this.stopped) return;
       this.subWarning.emit({

--- a/src/runtime/ui-protocol-runtime.test.ts
+++ b/src/runtime/ui-protocol-runtime.test.ts
@@ -71,6 +71,9 @@ function makeDeferredBridge(): DeferredBridge {
   // P2), so the registry's published-with-state="connecting" entry would
   // otherwise look like null to assertions.
   let stateHandler: ((s: ConnectionState) => void) | null = null;
+  // Track the reopen subscriber so the test can simulate the bridge's
+  // post-reconnect re-handshake event (reload-bug fix Yue 2026-05-15).
+  let reopenedHandler: (() => void) | null = null;
   const bridge: UiProtocolBridge = {
     start: vi.fn(async () => {
       startCalls++;
@@ -107,6 +110,12 @@ function makeDeferredBridge(): DeferredBridge {
       };
     }),
     getConnectionState: vi.fn(() => "connected" as ConnectionState),
+    onReopened: vi.fn((h: () => void) => {
+      reopenedHandler = h;
+      return () => {
+        if (reopenedHandler === h) reopenedHandler = null;
+      };
+    }),
     onWarning: vi.fn(() => () => {}),
     onSessionTitleUpdated: vi.fn(() => () => {}),
     hydrateSession: vi.fn(async () => null),
@@ -117,6 +126,10 @@ function makeDeferredBridge(): DeferredBridge {
     resolveStart: () => resolveStart(),
     rejectStart: (err) => rejectStart(err),
     setConnected: () => stateHandler?.("connected"),
+    /** Simulate the bridge's post-reconnect `session/open` ack
+     *  (reload-bug fix Yue 2026-05-15). The runtime layer subscribes via
+     *  `onReopened` to re-fire `session/hydrate`. */
+    fireReopened: () => reopenedHandler?.(),
     get startCalls() {
       return startCalls;
     },
@@ -257,5 +270,207 @@ describe("startBridgeForSession race safety", () => {
     await expect(dead!.sendTurn("turn-2", [])).rejects.toThrow(
       /WebSocket connection is closed/,
     );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Reload-bug fix (Yue 2026-05-15): on WS reconnect, the runtime must
+// re-issue `session/hydrate` so envelopes the server emitted while the
+// socket was dropped (e.g. a `TurnSpawnComplete` for a long-running
+// `spawn_only`) get replayed via `replayed_envelopes`. Without this, a
+// 12-min `run_pipeline` whose user lost their WS at completion would
+// complete silently and the UI would show nothing.
+//
+// The bridge's `onReopened` event fires ONLY on a subsequent successful
+// `session/open` ack (not the initial open) — these tests pin both
+// halves: the post-reopen hydrate fires, the initial open does NOT
+// double-hydrate.
+// ---------------------------------------------------------------------------
+describe("reload-bug fix: re-hydrate session on WS reconnect", () => {
+  it("does NOT call hydrateSession a second time on the initial bridge start", async () => {
+    const a = makeDeferredBridge();
+    createBridgeSpy.mockReturnValueOnce(a.bridge);
+
+    const startA = startBridgeForSession("sess-A");
+    a.resolveStart();
+    await startA;
+    a.setConnected();
+    // Let the void-immediately-invoked async hydrate settle.
+    await Promise.resolve();
+    await Promise.resolve();
+
+    // Initial start fires hydrate ONCE. `onReopened` has not fired, so
+    // there should be exactly one call.
+    expect(a.bridge.hydrateSession).toHaveBeenCalledTimes(1);
+    expect(a.bridge.hydrateSession).toHaveBeenCalledWith(["messages"]);
+  });
+
+  it("calls hydrateSession again after the bridge's onReopened event fires", async () => {
+    const a = makeDeferredBridge();
+    createBridgeSpy.mockReturnValueOnce(a.bridge);
+
+    const startA = startBridgeForSession("sess-A");
+    a.resolveStart();
+    await startA;
+    a.setConnected();
+    await Promise.resolve();
+    await Promise.resolve();
+
+    // Sanity: initial hydrate ran.
+    expect(a.bridge.hydrateSession).toHaveBeenCalledTimes(1);
+
+    // Simulate the bridge's post-reconnect `session/open` ack. The
+    // runtime must re-issue `session/hydrate` so the server replays any
+    // envelopes (e.g. a `TurnSpawnComplete`) it emitted while the WS
+    // was disconnected — without this, those envelopes are silently
+    // dropped by the cursorless `session/open` ("live only, no
+    // replay") at `ui_protocol_ledger.rs:1199`.
+    a.fireReopened();
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(a.bridge.hydrateSession).toHaveBeenCalledTimes(2);
+    // Both calls request the messages dedup payload.
+    const calls = (a.bridge.hydrateSession as unknown as { mock: { calls: unknown[][] } })
+      .mock.calls;
+    expect(calls[0]).toEqual([["messages"]]);
+    expect(calls[1]).toEqual([["messages"]]);
+  });
+
+  it("applies the post-reopen hydrate result to ThreadStore for replay dedup", async () => {
+    // Reload-bug fix: the post-reconnect hydrate's `replayed_envelopes`
+    // need to reach `setHydrateSnapshot` so ThreadStore's
+    // `applyHydrateDedup` can splice the missed turn into the UI.
+    // Mock `hydrateSession` to return a synthetic envelope that mirrors
+    // what the server replays for a missed `TurnSpawnComplete`.
+    const a = makeDeferredBridge();
+    createBridgeSpy.mockReturnValueOnce(a.bridge);
+
+    const REPLAY_PAYLOAD = {
+      messages: [],
+      replayed_envelopes: [
+        {
+          thread_id: "cmid-user-x",
+          turn_id: "turn-x",
+          response_to_client_message_id: "cmid-user-x",
+          task_id: "task_recover_x",
+          seq: 7,
+          message_id: "msg-spawn-x",
+          content: "Replayed completion bubble from durable ledger.",
+          media: ["bg/result.mp3"],
+          persisted_at: "2026-05-15T00:00:00Z",
+        },
+      ],
+    } as const;
+
+    // Initial hydrate returns empty; the post-reopen hydrate returns
+    // the recovery payload.
+    (
+      a.bridge.hydrateSession as unknown as {
+        mockImplementationOnce: (
+          fn: () => Promise<unknown>,
+        ) => unknown;
+      }
+    )
+      .mockImplementationOnce(async () => ({
+        messages: [],
+        replayed_envelopes: [],
+      }))
+      .mockImplementationOnce(async () => REPLAY_PAYLOAD);
+
+    const startA = startBridgeForSession("sess-A");
+    a.resolveStart();
+    await startA;
+    a.setConnected();
+    await Promise.resolve();
+    await Promise.resolve();
+
+    // Confirm initial hydrate fired with the empty payload.
+    expect(a.bridge.hydrateSession).toHaveBeenCalledTimes(1);
+
+    // Fire reopen — runtime issues the second hydrate.
+    a.fireReopened();
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(a.bridge.hydrateSession).toHaveBeenCalledTimes(2);
+    // The second call returned the recovery payload. The runtime's
+    // hydrate callback writes it through `setHydrateSnapshot`. We don't
+    // assert on ThreadStore internals directly here (covered by
+    // thread-store tests) — instead we lock in the call contract: the
+    // RPC was issued post-reopen with the same `["messages"]` include,
+    // which is what server PR #791 keys the dedup payload on.
+    const calls = (a.bridge.hydrateSession as unknown as { mock: { calls: unknown[][] } })
+      .mock.calls;
+    expect(calls[1]).toEqual([["messages"]]);
+  });
+
+  it("does not crash when the bridge mock predates the onReopened method", async () => {
+    // Defensive: existing tests may inject a bridge whose `onReopened`
+    // is undefined. The runtime should skip subscription rather than
+    // throw — the test below validates the guard.
+    const a = makeDeferredBridge();
+    // Strip the method to simulate an older mock.
+    (a.bridge as unknown as { onReopened?: unknown }).onReopened = undefined;
+    createBridgeSpy.mockReturnValueOnce(a.bridge);
+
+    const startA = startBridgeForSession("sess-A");
+    a.resolveStart();
+    const bridge = await startA;
+    a.setConnected();
+    expect(bridge).toBe(a.bridge);
+    // No throw — the runtime's `typeof bridge.onReopened === "function"`
+    // guard skipped the subscription path.
+  });
+
+  it("does not re-hydrate after the runtime has stopped the bridge", async () => {
+    // Race-safety: a reopen that fires after `stopActiveBridge` ran is
+    // either a phantom event from a torn-down bridge or a stale
+    // subscriber. The generation guard in the reopen callback must
+    // skip the hydrate.
+    const a = makeDeferredBridge();
+    createBridgeSpy.mockReturnValueOnce(a.bridge);
+
+    const startA = startBridgeForSession("sess-A");
+    a.resolveStart();
+    await startA;
+    a.setConnected();
+    await Promise.resolve();
+    await Promise.resolve();
+    expect(a.bridge.hydrateSession).toHaveBeenCalledTimes(1);
+
+    await stopActiveBridge();
+
+    // Fire a stale reopen — must NOT trigger a new hydrate.
+    a.fireReopened();
+    await Promise.resolve();
+    await Promise.resolve();
+    expect(a.bridge.hydrateSession).toHaveBeenCalledTimes(1);
+  });
+
+  it("skips hydrate for topic-scoped bridges (root-scope dedup only)", async () => {
+    // The existing initial-hydrate path skips topic-scoped bridges
+    // because `session/hydrate` returns root-scope envelopes and
+    // applying them to a topic-scoped store would leak cross-topic
+    // events (codex round-2 P2). The reopen path inherits the same
+    // restriction.
+    const a = makeDeferredBridge();
+    createBridgeSpy.mockReturnValueOnce(a.bridge);
+
+    const startA = startBridgeForSession("sess-A", "site-x");
+    a.resolveStart();
+    await startA;
+    a.setConnected();
+    await Promise.resolve();
+    await Promise.resolve();
+
+    // Initial start did NOT hydrate (topic-scoped).
+    expect(a.bridge.hydrateSession).not.toHaveBeenCalled();
+
+    // Reopen also must NOT hydrate.
+    a.fireReopened();
+    await Promise.resolve();
+    await Promise.resolve();
+    expect(a.bridge.hydrateSession).not.toHaveBeenCalled();
   });
 });

--- a/src/runtime/ui-protocol-runtime.ts
+++ b/src/runtime/ui-protocol-runtime.ts
@@ -28,6 +28,11 @@ interface ActiveBridge {
   connectionState: ConnectionState;
   /** Cleanup fn for the connection-state subscriber. Detached on stop. */
   unsubscribeState: () => void;
+  /** Cleanup fn for the reopen subscriber (reload-bug fix). Detached on
+   *  stop. The reopen subscriber re-fires `session/hydrate` so missed
+   *  envelopes (e.g. a `TurnSpawnComplete` emitted while the WS was
+   *  dropped) get replayed via `replayed_envelopes`. */
+  unsubscribeReopened: () => void;
 }
 
 let active: ActiveBridge | null = null;
@@ -152,6 +157,29 @@ export async function startBridgeForSession(
       }
     }
   });
+  // Reload-bug fix (Yue 2026-05-15): subscribe to the bridge's `onReopened`
+  // hook BEFORE the initial hydrate kicks off, so a reconnect that races
+  // the initial hydrate still gets handled. The bridge guarantees this
+  // event only fires on a SUBSEQUENT successful `session/open` (i.e. after
+  // a reconnect) — never on the initial open — so we do not double-hydrate
+  // when the bridge first goes live. See `ui-protocol-bridge.ts` →
+  // `onWsOpen` for the gating logic (the `isReopen` snapshot of
+  // `hasEverOpened`).
+  //
+  // Defensive: test mocks of `UiProtocolBridge` may pre-date `onReopened`;
+  // skip subscription rather than crash so existing tests keep working.
+  let unsubscribeReopened: () => void = () => {};
+  if (typeof bridge.onReopened === "function") {
+    unsubscribeReopened = bridge.onReopened(() => {
+      // Only the runtime entry that this start created can speak for the
+      // session — a newer `startBridgeForSession` would have torn this
+      // bridge down before publishing its own. Use the same generation
+      // guard the initial hydrate uses.
+      if (myGeneration !== generation) return;
+      runHydrateFor(sessionId, topic, bridge, myGeneration);
+    });
+  }
+
   active = {
     sessionId,
     topic,
@@ -159,6 +187,7 @@ export async function startBridgeForSession(
     attachment,
     connectionState,
     unsubscribeState,
+    unsubscribeReopened,
   };
 
   // M10 Phase 6.2 (Bug C): immediately fire `session/hydrate` to fetch
@@ -178,23 +207,52 @@ export async function startBridgeForSession(
   // chat (slides/sites) keeps the legacy REST-only render with the
   // pre-fix N+1 limitation. This avoids cross-topic envelope leakage
   // (codex round-2 P2).
-  if (!topic || topic.trim() === "") {
-    void (async () => {
-      if (myGeneration !== generation) return;
-      // Defensive: test mocks of `UiProtocolBridge` may pre-date this
-      // method. Production builds always have it.
-      if (typeof bridge.hydrateSession !== "function") return;
-      const hydrate = await bridge.hydrateSession(["messages"]);
-      if (myGeneration !== generation) return;
-      if (!hydrate) return;
-      setHydrateSnapshot(sessionId, topic, {
-        messages: hydrate.messages,
-        replayed_envelopes: hydrate.replayed_envelopes,
-      });
-    })();
-  }
+  runHydrateFor(sessionId, topic, bridge, myGeneration);
 
   return bridge;
+}
+
+/**
+ * Run a `session/hydrate(["messages"])` RPC and push the result into
+ * ThreadStore. Used by both the initial bridge start and the post-
+ * reconnect reopen path.
+ *
+ * The reload-bug fix (Yue 2026-05-15) added the reopen call site: the
+ * server's `session/open` without an `after` cursor is "live only, no
+ * replay" (`ui_protocol_ledger.rs:1199`). Without this RPC, any
+ * envelopes the server emitted between disconnect and reconnect (e.g.
+ * a `TurnSpawnComplete` for a long-running `spawn_only`) would be
+ * silently dropped. Re-hydrating on reopen rolls the ledger forward.
+ *
+ * Dedup is the caller's responsibility but already covered: ThreadStore's
+ * `applyHydrateDedup` (via `setHydrateSnapshot`) coalesces duplicate
+ * `(message_id, source)` rows from `replayed_envelopes`, so it is safe
+ * to call this multiple times on the same bridge.
+ *
+ * Generation-guarded: skips if a newer `startBridgeForSession` /
+ * `stopActiveBridge` has bumped the global counter, mirroring the
+ * race-safety the initial hydrate uses.
+ */
+function runHydrateFor(
+  sessionId: string,
+  topic: string | undefined,
+  bridge: UiProtocolBridge,
+  capturedGeneration: number,
+): void {
+  if (topic && topic.trim() !== "") return;
+  void (async () => {
+    if (capturedGeneration !== generation) return;
+    // Defensive: test mocks of `UiProtocolBridge` may pre-date this
+    // method. Production builds always have it.
+    if (typeof bridge.hydrateSession !== "function") return;
+    const hydrate = await bridge.hydrateSession(["messages"]);
+    if (capturedGeneration !== generation) return;
+    if (!hydrate) return;
+    setHydrateSnapshot(sessionId, topic, {
+      messages: hydrate.messages,
+      replayed_envelopes: hydrate.replayed_envelopes,
+    });
+  })();
 }
 
 /**
@@ -278,6 +336,7 @@ export async function stopActiveBridge(): Promise<void> {
   active = null;
   handle.attachment.detach();
   handle.unsubscribeState();
+  handle.unsubscribeReopened();
   try {
     await handle.bridge.stop();
   } catch {
@@ -305,6 +364,7 @@ export async function stopActiveBridgeIfScope(
   active = null;
   handle.attachment.detach();
   handle.unsubscribeState();
+  handle.unsubscribeReopened();
   try {
     await handle.bridge.stop();
   } catch {
@@ -337,5 +397,6 @@ export function __setActiveBridgeForTest(
     attachment: { detach: () => {} },
     connectionState,
     unsubscribeState: () => {},
+    unsubscribeReopened: () => {},
   };
 }


### PR DESCRIPTION
## Summary

Re-hydrate `session/hydrate(['messages'])` on every successful WS reconnect so the SPA recovers envelopes the server emitted while the user's socket was disconnected.

## Bug (user-reported 2026-05-15, codex-diagnosed)

A 12-minute \`run_pipeline\` for \"深度研究女真人\" completed server-side, persisted 7 canonical-JSONL lines including the final assistant message + media attachment, but the UI showed nothing.

Root cause (codex audit, file/line trace confirmed):
- Server \`session/open\` with no \`after\` cursor is **\"live only, no replay\"** (\`crates/octos-cli/src/api/ui_protocol_ledger.rs:1199\`).
- Client hydrate (\`session/hydrate([\"messages\"])\`) runs only on the **initial bridge start** (\`src/runtime/ui-protocol-runtime.ts:186-191\`), **not on reconnect**.
- Result: \`TurnSpawnComplete\` envelopes emitted between disconnect and reconnect are silently dropped.

## Fix

1. Bridge emits a new \`onReopened\` event on every successful \`session/open\` ack **after** the initial open (gated by \`hasEverOpened\` snapshot in \`onWsOpen\` before flipping the flag).
2. Runtime subscribes to \`onReopened\` and re-runs \`bridge.hydrateSession([\"messages\"])\` via a refactored \`runHydrateFor\` helper that is shared by the initial path and the reopen path.
3. Hydrate result already carries \`replayed_envelopes\` (server PR #791); existing \`setHydrateSnapshot\` -> \`applyHydrateDedup\` makes this idempotent.

Topic-scoped bridges (sites/slides) keep the existing skip — \`session/hydrate\` is root-scope, applying it to a topic-scoped store would leak cross-topic events. Same gating as the initial hydrate.

## Tests

10 new unit tests (5 bridge + 5 runtime) pin both halves:

- Bridge: \`onReopened\` does NOT fire on initial \`session/open\` ack; fires once per subsequent reconnect; unsubscribe stops deliveries.
- Runtime: no double-hydrate at startup; re-hydrate after \`onReopened\`; result applied via \`setHydrateSnapshot\` for ThreadStore dedup; defensive when mocks predate \`onReopened\`; race-safe against \`stopActiveBridge\`; topic-scoped bridges skip.

Pre-fix failure: \`expected \"spy\" to be called 2 times, but got 1 times\`.

Existing 73 bridge tests + 8 runtime tests still pass. The one failing test in the suite (\`ui-protocol-event-router.test.ts > router seq preservation > persisted message stamps seq onto the late-artifact response\`) was already broken on \`origin/main\` and is unrelated.

## Live soak (mini5, dspfac.ocean.ominix.io)

New spec: \`e2e/tests/mini5-reconnect-replay-spawn-only.spec.ts\` (lives in \`octos\` repo, not this PR). Uses a \`page.addInitScript\` WebSocket wrapper to force-close the live WS mid-spawn (Chromium's \`setOffline\` does NOT sever existing WS — verified empirically), waits 90 s offline, unblocks, asserts the completion bubble + media attachment land within 40 s of reconnect.

- **Pre-fix bundle (\`index-k3M7rA1E.js\`):** FAILED — \"Background work started for podcast_generate\" stays on screen, no completion bubble after 40 s post-reconnect. Bug reproduced.
- **Fixed bundle (\`index-BeSmxVtL.js\`):** PASSED — completion bubble + .mp3 attachment land 7 s after the bridge reconnects.

## Test plan

- [x] \`npx tsc --noEmit\` clean
- [x] \`npm run build\` clean (new bundle: \`index-BeSmxVtL.js\`)
- [x] Vitest: existing tests still green, 10 new tests pass
- [x] Live soak: bug reproduces pre-fix on mini5, fix recovers
- [x] Topic-scoped sessions unchanged (root-scope hydrate skip preserved)