### PR TITLE
fix(bridge): visibility-driven reset of reconnectAbandoned (closes #137)

### DIFF
--- a/src/runtime/ui-protocol-bridge.test.ts
+++ b/src/runtime/ui-protocol-bridge.test.ts
@@ -1365,6 +1365,288 @@ describe("onReopened — reconnect-only event", () => {
 });
 
 // ---------------------------------------------------------------------------
+// Issue #137 (Yue 2026-05-15): visibility-driven reset of `reconnectAbandoned`.
+//
+// PR #136 wired `onReopened` → `session/hydrate(["messages"])` so reconnects
+// WITHIN the 121s window now pick up missed envelopes. But after the bridge's
+// 8 attempts elapse (cumulative ~121s), `reconnectAbandoned=true` latches and
+// the bridge stops trying — live state is stranded until manual refresh.
+//
+// Fix: when `document.visibilitychange` fires with `visibilityState='visible'`
+// and the bridge has latched via the *attempt-exhaustion* path (NOT the auth-
+// rejected path — the token is still dead there), clear the latch, reset the
+// attempt counter, and kick off ONE fresh reconnect through the existing
+// `openSocket()` → `onWsOpen()` → `onReopened` flow.
+// ---------------------------------------------------------------------------
+
+describe("visibility-driven reset of reconnectAbandoned (#137)", () => {
+  /** Helper: drive the bridge to `state==="error"` + `reconnectAbandoned=true`
+   *  via the attempt-exhaustion path (NOT the auth-rejected path). */
+  async function drainToAbandoned(maxAttempts = 2): Promise<void> {
+    // Caller has already called bridge.start(); just trigger close cycles.
+    // After `maxAttempts` close events, scheduleReconnect latches.
+    for (let i = 0; i < maxAttempts + 1; i++) {
+      const ws = lastInstance();
+      ws.triggerClose(1006, "abnormal");
+      // Use the longest backoff (16s should cover the first few schedule slots).
+      await vi.advanceTimersByTimeAsync(16000);
+    }
+  }
+
+  function dispatchVisibilityChange(state: "visible" | "hidden"): void {
+    Object.defineProperty(document, "visibilityState", {
+      value: state,
+      configurable: true,
+    });
+    document.dispatchEvent(new Event("visibilitychange"));
+  }
+
+  it("after attempt-exhaustion latch, visibilitychange='visible' triggers ONE fresh reconnect", async () => {
+    vi.useFakeTimers();
+    const bridge = createUiProtocolBridge(
+      makeBridgeOpts({ maxReconnectAttempts: 2 }),
+    );
+    void bridge.start({ sessionId: "sess-1" });
+    await Promise.resolve();
+
+    // Initial open succeeds → hasEverOpened = true.
+    const ws1 = lastInstance();
+    ws1.triggerOpen();
+    await Promise.resolve();
+    const open1 = findRequest(ws1, METHODS.SESSION_OPEN);
+    ws1.triggerMessage({
+      jsonrpc: "2.0",
+      id: open1.id,
+      result: { opened: { session_id: "sess-1" } },
+    });
+    await Promise.resolve();
+
+    // Exhaust reconnects. We start with 1 ws instance.
+    const instancesBeforeExhaustion = MockWebSocket.instances.length;
+    await drainToAbandoned(2);
+    const instancesAfterExhaustion = MockWebSocket.instances.length;
+    expect(instancesAfterExhaustion).toBeGreaterThan(instancesBeforeExhaustion);
+    expect(bridge.getConnectionState()).toBe("error");
+
+    // Dispatch visibilitychange='visible' → bridge should clear the latch
+    // and call openSocket() exactly once.
+    const instancesBeforeVisibility = MockWebSocket.instances.length;
+    dispatchVisibilityChange("visible");
+    await Promise.resolve();
+    const instancesAfterVisibility = MockWebSocket.instances.length;
+    expect(instancesAfterVisibility - instancesBeforeVisibility).toBe(1);
+    expect(bridge.getConnectionState()).toBe("connecting");
+
+    await bridge.stop();
+  });
+
+  it("visibilitychange='visible' while NOT abandoned is a no-op", async () => {
+    vi.useFakeTimers();
+    const bridge = createUiProtocolBridge(makeBridgeOpts());
+    void bridge.start({ sessionId: "sess-1" });
+    await Promise.resolve();
+    const ws1 = lastInstance();
+    ws1.triggerOpen();
+    await Promise.resolve();
+    const open1 = findRequest(ws1, METHODS.SESSION_OPEN);
+    ws1.triggerMessage({
+      jsonrpc: "2.0",
+      id: open1.id,
+      result: { opened: { session_id: "sess-1" } },
+    });
+    await Promise.resolve();
+    expect(bridge.getConnectionState()).toBe("connected");
+
+    const instancesBefore = MockWebSocket.instances.length;
+    dispatchVisibilityChange("visible");
+    await Promise.resolve();
+    const instancesAfter = MockWebSocket.instances.length;
+    expect(instancesAfter).toBe(instancesBefore);
+    expect(bridge.getConnectionState()).toBe("connected");
+
+    await bridge.stop();
+  });
+
+  it("visibilitychange='hidden' is a no-op even when abandoned", async () => {
+    vi.useFakeTimers();
+    const bridge = createUiProtocolBridge(
+      makeBridgeOpts({ maxReconnectAttempts: 2 }),
+    );
+    void bridge.start({ sessionId: "sess-1" });
+    await Promise.resolve();
+    const ws1 = lastInstance();
+    ws1.triggerOpen();
+    await Promise.resolve();
+    const open1 = findRequest(ws1, METHODS.SESSION_OPEN);
+    ws1.triggerMessage({
+      jsonrpc: "2.0",
+      id: open1.id,
+      result: { opened: { session_id: "sess-1" } },
+    });
+    await Promise.resolve();
+
+    await drainToAbandoned(2);
+    expect(bridge.getConnectionState()).toBe("error");
+
+    const instancesBefore = MockWebSocket.instances.length;
+    dispatchVisibilityChange("hidden");
+    await Promise.resolve();
+    const instancesAfter = MockWebSocket.instances.length;
+    expect(instancesAfter).toBe(instancesBefore);
+    expect(bridge.getConnectionState()).toBe("error");
+
+    await bridge.stop();
+  });
+
+  it("auth-rejected latch (close-code 1008) is NOT recovered by visibilitychange (token still dead)", async () => {
+    vi.useFakeTimers();
+    const bridge = createUiProtocolBridge(makeBridgeOpts());
+    void bridge.start({ sessionId: "sess-1" });
+    await Promise.resolve();
+    const ws1 = lastInstance();
+    // Server rejects upgrade with 1008. Bridge latches reconnectAbandoned
+    // for the auth-rejected reason (token is dead) — do NOT retry on
+    // visibility flip.
+    ws1.triggerClose(1008, "auth_rejected");
+    await Promise.resolve();
+    expect(bridge.getConnectionState()).toBe("error");
+
+    const instancesBefore = MockWebSocket.instances.length;
+    dispatchVisibilityChange("visible");
+    await Promise.resolve();
+    const instancesAfter = MockWebSocket.instances.length;
+    expect(instancesAfter).toBe(instancesBefore);
+    expect(bridge.getConnectionState()).toBe("error");
+
+    await bridge.stop();
+  });
+
+  it("post-visibility reconnect fires onReopened so the hydrate path runs", async () => {
+    // The whole point of this fix: a visibility-driven reconnect must
+    // route through the same `openSocket()` → `session/open` → `onReopened`
+    // path the bounded loop uses, so PR #136's hydrate hook still fires
+    // and `session/hydrate` replays envelopes that landed during the
+    // long offline window.
+    vi.useFakeTimers();
+    const bridge = createUiProtocolBridge(
+      makeBridgeOpts({ maxReconnectAttempts: 2 }),
+    );
+    const reopened: number[] = [];
+    bridge.onReopened(() => {
+      reopened.push(Date.now());
+    });
+
+    void bridge.start({ sessionId: "sess-1" });
+    await Promise.resolve();
+    const ws1 = lastInstance();
+    ws1.triggerOpen();
+    await Promise.resolve();
+    const open1 = findRequest(ws1, METHODS.SESSION_OPEN);
+    ws1.triggerMessage({
+      jsonrpc: "2.0",
+      id: open1.id,
+      result: { opened: { session_id: "sess-1" } },
+    });
+    await Promise.resolve();
+    expect(reopened).toHaveLength(0);
+
+    await drainToAbandoned(2);
+    expect(bridge.getConnectionState()).toBe("error");
+    expect(reopened).toHaveLength(0);
+
+    dispatchVisibilityChange("visible");
+    await Promise.resolve();
+    const wsAfter = lastInstance();
+    wsAfter.triggerOpen();
+    await Promise.resolve();
+    const openAfter = findRequest(wsAfter, METHODS.SESSION_OPEN);
+    wsAfter.triggerMessage({
+      jsonrpc: "2.0",
+      id: openAfter.id,
+      result: { opened: { session_id: "sess-1" } },
+    });
+    await Promise.resolve();
+    expect(bridge.getConnectionState()).toBe("connected");
+    // onReopened must have fired exactly once — the visibility-driven
+    // reconnect is a "reopen" in every meaningful sense.
+    expect(reopened).toHaveLength(1);
+
+    await bridge.stop();
+  });
+
+  it("multiple rapid visibilitychange events do not stack additional reconnects (idempotent)", async () => {
+    // Mobile browsers can fire visibilitychange multiple times in quick
+    // succession when the user app-switches. Once we have started a
+    // reconnect attempt, additional `visible` events must not pile on
+    // more sockets.
+    vi.useFakeTimers();
+    const bridge = createUiProtocolBridge(
+      makeBridgeOpts({ maxReconnectAttempts: 2 }),
+    );
+    void bridge.start({ sessionId: "sess-1" });
+    await Promise.resolve();
+    const ws1 = lastInstance();
+    ws1.triggerOpen();
+    await Promise.resolve();
+    const open1 = findRequest(ws1, METHODS.SESSION_OPEN);
+    ws1.triggerMessage({
+      jsonrpc: "2.0",
+      id: open1.id,
+      result: { opened: { session_id: "sess-1" } },
+    });
+    await Promise.resolve();
+
+    await drainToAbandoned(2);
+    expect(bridge.getConnectionState()).toBe("error");
+
+    const instancesBefore = MockWebSocket.instances.length;
+    dispatchVisibilityChange("visible");
+    await Promise.resolve();
+    // While the new socket is still `connecting` (no triggerOpen yet),
+    // fire another visibilitychange. It must be a no-op.
+    dispatchVisibilityChange("visible");
+    await Promise.resolve();
+    dispatchVisibilityChange("visible");
+    await Promise.resolve();
+    const instancesAfter = MockWebSocket.instances.length;
+    expect(instancesAfter - instancesBefore).toBe(1);
+
+    await bridge.stop();
+  });
+
+  it("removes the visibilitychange listener on stop()", async () => {
+    vi.useFakeTimers();
+    const bridge = createUiProtocolBridge(
+      makeBridgeOpts({ maxReconnectAttempts: 2 }),
+    );
+    void bridge.start({ sessionId: "sess-1" });
+    await Promise.resolve();
+    const ws1 = lastInstance();
+    ws1.triggerOpen();
+    await Promise.resolve();
+    const open1 = findRequest(ws1, METHODS.SESSION_OPEN);
+    ws1.triggerMessage({
+      jsonrpc: "2.0",
+      id: open1.id,
+      result: { opened: { session_id: "sess-1" } },
+    });
+    await Promise.resolve();
+
+    await drainToAbandoned(2);
+    expect(bridge.getConnectionState()).toBe("error");
+
+    await bridge.stop();
+
+    // After stop, visibilitychange must NOT spin up a new socket.
+    const instancesBefore = MockWebSocket.instances.length;
+    dispatchVisibilityChange("visible");
+    await Promise.resolve();
+    const instancesAfter = MockWebSocket.instances.length;
+    expect(instancesAfter).toBe(instancesBefore);
+  });
+});
+
+// ---------------------------------------------------------------------------
 // Send queue
 // ---------------------------------------------------------------------------
 

--- a/src/runtime/ui-protocol-bridge.ts
+++ b/src/runtime/ui-protocol-bridge.ts
@@ -1271,6 +1271,27 @@ class UiProtocolBridgeImpl implements UiProtocolBridge {
    *  to avoid rejecting sends queued during the brief `onerror -> onclose`
    *  window of an otherwise recoverable network hiccup. */
   private reconnectAbandoned = false;
+  /** Issue #137 (Yue 2026-05-15): the visibility-driven reset needs to
+   *  distinguish *why* the bridge gave up. `"attempts_exhausted"` =
+   *  `scheduleReconnect` ran out of attempts after a network outage;
+   *  the visibility flip means the user is back and we should retry
+   *  once. `"auth_rejected"` = the token was dead (1008 close,
+   *  permission_denied on `session/open`, or 401 on the upgrade
+   *  fallback); retrying is wasted load until the user re-logs in.
+   *  `null` = not abandoned (sentinel for cleared state). */
+  private latchReason: "attempts_exhausted" | "auth_rejected" | null = null;
+  /** Issue #137: idempotency guard for the visibilitychange handler.
+   *  Mobile browsers can fire `visibilitychange` multiple times in
+   *  quick succession during app-switches; once we have already
+   *  scheduled a visibility-driven reconnect attempt, additional
+   *  events must be no-ops until either the attempt finishes (success
+   *  resets the flag in `onWsOpen`) or fails (the bounded reconnect
+   *  loop takes over and eventually re-latches the abandonment). */
+  private visibilityReconnectInFlight = false;
+  /** Issue #137: bound visibilitychange listener. Stashed so `stop()`
+   *  can remove it; React strict-mode and SPA session-switch flows
+   *  call start() → stop() → start() back-to-back. */
+  private visibilityListener: (() => void) | null = null;
   private reconnectTimer: unknown = null;
   private keepaliveTimer: unknown = null;
   private lastInboundAt = 0;
@@ -1463,8 +1484,11 @@ class UiProtocolBridgeImpl implements UiProtocolBridge {
     this.topicScope = t && t.length > 0 ? t : null;
     this.reconnectAttempts = 0;
     this.reconnectAbandoned = false;
+    this.latchReason = null;
+    this.visibilityReconnectInFlight = false;
     this.hasEverOpened = false;
     this.authExpiredDispatched = false;
+    this.installVisibilityListener();
     await this.openSocket();
   }
 
@@ -1473,6 +1497,7 @@ class UiProtocolBridgeImpl implements UiProtocolBridge {
     this.stopped = true;
     this.cancelReconnectTimer();
     this.cancelKeepalive();
+    this.removeVisibilityListener();
     this.setState("closed");
     const ws = this.ws;
     this.ws = null;
@@ -1789,6 +1814,10 @@ class UiProtocolBridgeImpl implements UiProtocolBridge {
       if (this.stopped) return;
       this.reconnectAttempts = 0;
       this.reconnectAbandoned = false;
+      // Issue #137: a successful (re)open clears the latch reason and
+      // releases the visibility-reconnect idempotency flag.
+      this.latchReason = null;
+      this.visibilityReconnectInFlight = false;
       // Snapshot whether this is a reopen BEFORE flipping `hasEverOpened`,
       // so the emit below only fires after a reconnect (subsequent
       // `session/open` ack) and not on the initial open — the runtime
@@ -1826,6 +1855,9 @@ class UiProtocolBridgeImpl implements UiProtocolBridge {
       if (err instanceof BridgeRpcError && err.code === RPC_ERROR_PERMISSION_DENIED) {
         this.dispatchAuthExpired("permission_denied:session/open");
         this.reconnectAbandoned = true;
+        // Issue #137: tag as auth-rejected so the visibilitychange-driven
+        // reset does NOT retry — the token is dead, retrying is wasted load.
+        this.latchReason = "auth_rejected";
         this.setState("error");
         this.rejectAllPending(new BridgeStoppedError("auth permission denied"));
         return;
@@ -1967,6 +1999,9 @@ class UiProtocolBridgeImpl implements UiProtocolBridge {
       // Stop reconnect attempts — the token is dead, retrying is
       // wasted load on the server and noise on the client.
       this.reconnectAbandoned = true;
+      // Issue #137: auth-rejected latch — the visibility-driven reset
+      // must NOT retry here. The visibility listener gates on this.
+      this.latchReason = "auth_rejected";
       this.setState("error");
       this.rejectAllPending(new BridgeStoppedError("auth expired"));
       return;
@@ -2020,6 +2055,8 @@ class UiProtocolBridgeImpl implements UiProtocolBridge {
       if (resp.status === 401) {
         this.dispatchAuthExpired("upgrade_401");
         this.reconnectAbandoned = true;
+        // Issue #137: probe-driven auth-rejected latch.
+        this.latchReason = "auth_rejected";
       }
     } catch {
       // Network probe failed — leave reconnect scheduling alone.
@@ -2030,6 +2067,10 @@ class UiProtocolBridgeImpl implements UiProtocolBridge {
     if (this.stopped) return;
     if (this.reconnectAttempts >= this.cfg.maxReconnectAttempts) {
       this.reconnectAbandoned = true;
+      // Issue #137: attempt-exhaustion latch. Distinct from the
+      // auth-rejected latch sites above — the visibilitychange
+      // handler ONLY retries when the latch is for this reason.
+      this.latchReason = "attempts_exhausted";
       this.setState("error");
       this.rejectAllPending(new BridgeStoppedError("max reconnect attempts"));
       return;
@@ -2050,6 +2091,105 @@ class UiProtocolBridgeImpl implements UiProtocolBridge {
       this.cfg.clearTimeout(this.reconnectTimer);
       this.reconnectTimer = null;
     }
+  }
+
+  /**
+   * Issue #137 (Yue 2026-05-15): visibility-driven reset of
+   * `reconnectAbandoned`.
+   *
+   * PR #136 wired `onReopened` → `session/hydrate(["messages"])` so
+   * reconnects WITHIN the bounded loop's 121s envelope now replay missed
+   * envelopes correctly. But after the 8 attempts elapse,
+   * `reconnectAbandoned=true` latches and live state is stranded until
+   * the user manually refreshes — exactly the lid-open / phone-unlock /
+   * long-network-drop scenario the user reported.
+   *
+   * The fix is conservative: we only revive the bridge when (1) the
+   * user is demonstrably back at the tab (`visibilityState='visible'`),
+   * (2) the bridge has *given up* (`reconnectAbandoned=true`), and (3)
+   * the reason for giving up was *attempt exhaustion* (NOT an
+   * auth-rejected latch — the token is still dead in that case, so
+   * retrying just spams the server). We also require (4) we have
+   * actually connected once in this bridge lifecycle (`hasEverOpened`),
+   * because the visibility flip during the initial-connection phase is
+   * the user simply switching to the tab as the page loads — the
+   * regular reconnect loop is still in flight and should not be
+   * shoved aside.
+   *
+   * On the trigger we clear the latch + reset the attempt counter +
+   * call `openSocket()`. That routes through the same code path the
+   * bounded loop uses, so `onWsOpen` will see `hasEverOpened=true` and
+   * fire `subReopened`, which the runtime layer subscribes to in order
+   * to re-issue `session/hydrate` and recover the missed envelopes.
+   *
+   * SSR / non-browser env: `document` may be undefined (e.g. Node
+   * worker, vitest's default environment is jsdom but consumers may
+   * inject the bridge in a server-side context); guard accordingly.
+   */
+  private installVisibilityListener(): void {
+    if (typeof document === "undefined") return;
+    if (this.visibilityListener) return; // already installed
+    const handler = () => {
+      this.onVisibilityChange();
+    };
+    this.visibilityListener = handler;
+    try {
+      document.addEventListener("visibilitychange", handler);
+    } catch {
+      // Defensive: some sandbox envs may forbid event listeners.
+      this.visibilityListener = null;
+    }
+  }
+
+  private removeVisibilityListener(): void {
+    if (typeof document === "undefined") return;
+    const handler = this.visibilityListener;
+    if (!handler) return;
+    this.visibilityListener = null;
+    try {
+      document.removeEventListener("visibilitychange", handler);
+    } catch {
+      // best-effort
+    }
+  }
+
+  private onVisibilityChange(): void {
+    if (this.stopped) return;
+    if (typeof document === "undefined") return;
+    if (document.visibilityState !== "visible") return;
+    // Gate: only fire when the bridge has *given up* via attempt
+    // exhaustion. An auth-rejected latch (`"auth_rejected"`) means the
+    // token is dead — retrying is wasted load until the user
+    // re-authenticates; AuthProvider's `crew:auth_expired` subscriber
+    // has already kicked off that flow.
+    if (!this.reconnectAbandoned) return;
+    if (this.latchReason !== "attempts_exhausted") return;
+    // Skip the trigger during the bridge's initial-connection phase.
+    // If we have never reached `connected` in this lifecycle, the
+    // regular reconnect loop is still working on it (or the bridge is
+    // mid-`openSocket()`); the user can wait for the regular path.
+    if (!this.hasEverOpened) return;
+    // Idempotency: mobile browsers fire `visibilitychange` repeatedly
+    // during app-switches. Once we have started a reconnect attempt
+    // from this trigger and it's still in flight, swallow further
+    // visible events until either `onWsOpen` resets the flag or the
+    // bounded reconnect loop re-latches the abandonment.
+    if (this.visibilityReconnectInFlight) return;
+    this.visibilityReconnectInFlight = true;
+
+    // Clear the latch + reset the attempt counter. The reset is
+    // important: pre-fix, `reconnectAttempts` was at
+    // `maxReconnectAttempts` after the bounded loop gave up, so even
+    // if we cleared `reconnectAbandoned` without resetting the
+    // counter, the very next `scheduleReconnect` call (e.g. from an
+    // `onWsClose` after this new socket fails to open) would
+    // immediately re-latch.
+    this.reconnectAbandoned = false;
+    this.latchReason = null;
+    this.reconnectAttempts = 0;
+    // Start ONE reconnect attempt through the existing flow so
+    // `onWsOpen` fires `subReopened` (the hydrate hook) on success.
+    void this.openSocket();
   }
 
   private startKeepalive(): void {


### PR DESCRIPTION
## Summary

PR #136 wired `onReopened` → `session/hydrate(['messages'])` so reconnects **within** the bounded loop's 121s envelope (8 attempts; 1+2+4+8+16+30+30+30s backoff) replay missed envelopes correctly. But once `reconnectAbandoned=true` latches at `ui-protocol-bridge.ts:2032`, the bridge stops trying and live state is stranded until manual refresh — the lid-open / phone-unlock / long-network-drop case (#137).

This PR adds a **visibility-driven** reset of the latch:

- When `document.visibilitychange` fires with `visibilityState='visible'`,
- AND the bridge has latched specifically via *attempt exhaustion* (NOT an auth-rejection latch — the token is still dead there, retrying is wasted load),
- AND the bridge has connected at least once in this lifecycle (`hasEverOpened`),

clear the latch, reset the attempt counter, and kick off **one** fresh reconnect through `openSocket()` — the same code path the bounded loop uses, so `onWsOpen` still sees `isReopen=true` and fires `subReopened`. PR #136's hydrate hook keeps working through this trigger and `session/hydrate` replays envelopes the server emitted while the WS was dead.

Out of scope (issue lists both as alternatives; both deferred):
- Raising `DEFAULT_MAX_RECONNECT_ATTEMPTS` or extending the backoff envelope
- Adding a manual "Reconnect" pill to the UI

## Implementation

- New `latchReason` field distinguishes `"auth_rejected"` (1008 close, permission_denied on `session/open`, 401 on the upgrade probe) from `"attempts_exhausted"`. Visibility handler only retries on the latter.
- `visibilityReconnectInFlight` flag for idempotency (mobile browsers fire `visibilitychange` repeatedly during app-switches).
- `start()` installs the listener (guarded with `typeof document !== 'undefined'` for SSR); `stop()` removes it (avoids leaks across SPA session switches).
- Successful `onWsOpen` clears both flags.

## Test plan

- [x] `npx tsc --noEmit` clean
- [x] `npm run build` clean → bundle `index-DqWO7NZZ.js`
- [x] Vitest: 80/80 on `ui-protocol-bridge.test.ts` (7 new). Pre-fix failure for the headline assertion: `expected +0 to be 1 // Object.is equality`.
- [x] Live soak on mini5 (`dspfac.ocean.ominix.io`): extended the PR #136 soak to hold the offline window for **150s** (past the 121s envelope, so the bridge truly latches via attempt exhaustion). After unblock + `dispatchEvent(new Event('visibilitychange'))` with `visibilityState='visible'`, the completion bubble + mp3 attachment landed in **1s** — well under the 15s budget. WS ctor log confirms the bridge had exhausted all 8 retries (10 entries: 2 initial mounts under React strict mode + 8 reconnect attempts on the 1+2+4+8+16+30+30+30 schedule) before the visibility event triggered the recovery attempt.

New e2e spec lives in the octos repo at `e2e/tests/mini5-visibility-reset-long-offline.spec.ts`.