### PR TITLE
fix(sites): sandbox preview iframe (closes #993)

### DIFF
--- a/src/sites/components/site-preview.test.tsx
+++ b/src/sites/components/site-preview.test.tsx
@@ -1,0 +1,210 @@
+/**
+ * Tests for issue #993 — site-preview iframe XSS bridge fix.
+ *
+ * The bug: `src/sites/components/site-preview.tsx` rendered the preview
+ * iframe with NO `sandbox` attribute. Because `API_BASE === ""` in
+ * `src/lib/constants.ts`, the preview loads same-origin with the SPA.
+ * Tokens stored in `localStorage` (`octos_session_token` +
+ * `octos_auth_token`) are therefore reachable from inside the iframe via
+ * `window.parent.localStorage` — any LLM-authored HTML/JS in the preview
+ * can exfiltrate them.
+ *
+ * Codex recommended Option A: add `sandbox` without `allow-same-origin`.
+ * This file pins that choice:
+ *
+ *   1. iframe MUST have a `sandbox` attribute (anti-regression)
+ *   2. sandbox attribute MUST include `allow-scripts` + `allow-forms`
+ *   3. sandbox attribute MUST NOT include `allow-same-origin` (the
+ *      whole point — granting it defeats the fix)
+ *   4. `handleLoad` MUST NOT throw when `iframe.contentDocument` is
+ *      blocked by the sandbox (the previous title-sniff path read it)
+ *   5. The "Open preview in new tab" anchor MUST be removed — opening
+ *      the same-origin URL as a top-level doc still exposes tokens.
+ *
+ * Test rig matches the rest of the repo — `react-dom/client` + `act`,
+ * no `@testing-library/react`.
+ */
+
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import * as React from "react";
+import { act } from "react";
+import { createRoot, type Root } from "react-dom/client";
+
+(
+  globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }
+).IS_REACT_ACT_ENVIRONMENT = true;
+
+import { SitePreview } from "./site-preview";
+
+interface MountedHarness {
+  container: HTMLDivElement;
+  root: Root;
+  unmount: () => void;
+}
+
+function mount(node: React.ReactElement): MountedHarness {
+  const container = document.createElement("div");
+  document.body.appendChild(container);
+  const root = createRoot(container);
+  act(() => {
+    root.render(node);
+  });
+  return {
+    container,
+    root,
+    unmount: () => {
+      act(() => root.unmount());
+      container.remove();
+    },
+  };
+}
+
+function queryIframe(container: HTMLElement): HTMLIFrameElement | null {
+  return container.querySelector("iframe");
+}
+
+const baseProps = {
+  previewUrl: "/api/preview/profile/session/slug/index.html",
+  siteName: "Demo Site",
+  template: "Next.js",
+  sessionId: "session-123",
+};
+
+beforeEach(() => {
+  // Ensure a clean DOM for each test.
+  for (const node of [...document.body.children]) {
+    node.remove();
+  }
+});
+
+afterEach(() => {
+  for (const node of [...document.body.children]) {
+    node.remove();
+  }
+});
+
+describe("SitePreview — issue #993 iframe sandbox (XSS bridge fix)", () => {
+  it("renders iframe with a `sandbox` attribute (anti-regression)", () => {
+    const { container, unmount } = mount(<SitePreview {...baseProps} />);
+    try {
+      const iframe = queryIframe(container);
+      expect(iframe).not.toBeNull();
+      // Pre-fix failure mode: `iframe.getAttribute("sandbox") === null`.
+      // This is the headline regression guard for issue #993.
+      expect(iframe?.getAttribute("sandbox")).not.toBeNull();
+    } finally {
+      unmount();
+    }
+  });
+
+  it('iframe sandbox attribute equals "allow-scripts allow-forms"', () => {
+    const { container, unmount } = mount(<SitePreview {...baseProps} />);
+    try {
+      const iframe = queryIframe(container);
+      const sandboxAttr = iframe?.getAttribute("sandbox") ?? "";
+      expect(sandboxAttr).toBe("allow-scripts allow-forms");
+    } finally {
+      unmount();
+    }
+  });
+
+  it("iframe sandbox includes `allow-scripts`", () => {
+    const { container, unmount } = mount(<SitePreview {...baseProps} />);
+    try {
+      const iframe = queryIframe(container);
+      const tokens = (iframe?.getAttribute("sandbox") ?? "")
+        .split(/\s+/)
+        .filter(Boolean);
+      expect(tokens).toContain("allow-scripts");
+    } finally {
+      unmount();
+    }
+  });
+
+  it("iframe sandbox includes `allow-forms`", () => {
+    const { container, unmount } = mount(<SitePreview {...baseProps} />);
+    try {
+      const iframe = queryIframe(container);
+      const tokens = (iframe?.getAttribute("sandbox") ?? "")
+        .split(/\s+/)
+        .filter(Boolean);
+      expect(tokens).toContain("allow-forms");
+    } finally {
+      unmount();
+    }
+  });
+
+  it("iframe sandbox MUST NOT include `allow-same-origin` (defeats the fix)", () => {
+    const { container, unmount } = mount(<SitePreview {...baseProps} />);
+    try {
+      const iframe = queryIframe(container);
+      const tokens = (iframe?.getAttribute("sandbox") ?? "")
+        .split(/\s+/)
+        .filter(Boolean);
+      // This is the explicit anti-assertion called out in issue #993.
+      // Granting `allow-same-origin` here would re-enable
+      // `window.parent.localStorage` reads from inside the iframe and
+      // re-open the XSS bridge.
+      expect(tokens).not.toContain("allow-same-origin");
+    } finally {
+      unmount();
+    }
+  });
+
+  it("handleLoad does not throw when iframe.contentDocument access is blocked", () => {
+    const { container, unmount } = mount(<SitePreview {...baseProps} />);
+    try {
+      const iframe = queryIframe(container);
+      expect(iframe).not.toBeNull();
+
+      // Simulate the cross-origin-blocked case: a real sandboxed
+      // iframe with no `allow-same-origin` returns `null` from
+      // `contentDocument`; some browsers throw `SecurityError`. We
+      // install a getter that throws to model the worst case — the
+      // load handler MUST be resilient.
+      if (iframe) {
+        Object.defineProperty(iframe, "contentDocument", {
+          configurable: true,
+          get(): Document | null {
+            throw new DOMException("Blocked a frame", "SecurityError");
+          },
+        });
+      }
+
+      // Pre-fix `handleLoad` read `frame.contentDocument?.title` which
+      // would throw under the getter above. Post-fix it ignores the
+      // frame entirely.
+      expect(() => {
+        act(() => {
+          iframe?.dispatchEvent(new Event("load"));
+        });
+      }).not.toThrow();
+    } finally {
+      unmount();
+    }
+  });
+
+  it("does NOT render an `Open preview in new tab` link", () => {
+    const { container, unmount } = mount(<SitePreview {...baseProps} />);
+    try {
+      // The link was an `<a target="_blank" rel="noreferrer">` pointing
+      // at the same-origin preview URL. Opening it as a top-level
+      // document hands the LLM-authored HTML full `localStorage`
+      // access, so it's removed until the signed-URL endpoint ships.
+      const externalLink = container.querySelector(
+        'a[target="_blank"]',
+      );
+      expect(externalLink).toBeNull();
+
+      // Defensive: also assert there is no anchor whose href matches
+      // the preview URL, in case a future refactor swaps the
+      // target/_blank attribute for something else.
+      const anchors = container.querySelectorAll("a[href]");
+      for (const a of anchors) {
+        expect(a.getAttribute("href")).not.toBe(baseProps.previewUrl);
+      }
+    } finally {
+      unmount();
+    }
+  });
+});

--- a/src/sites/components/site-preview.tsx
+++ b/src/sites/components/site-preview.tsx
@@ -1,6 +1,5 @@
-import { Check, Copy, ExternalLink, RefreshCw } from "lucide-react";
+import { Check, Copy, RefreshCw } from "lucide-react";
 import {
-  type SyntheticEvent,
   useCallback,
   useEffect,
   useMemo,
@@ -144,28 +143,28 @@ export function SitePreview({
     });
   }, [previewUrl]);
 
-  const handleLoad = useCallback(
-    (event: SyntheticEvent<HTMLIFrameElement>) => {
-      const frame = event.currentTarget;
-      const title = frame.contentDocument?.title?.trim() || "";
-      const fallbackTitles = new Set([
-        "Site Preview Not Found",
-        "Missing Site Metadata",
-        "Preview Build Failed",
-        "Preview Asset Missing",
-      ]);
+  // Issue #993 fix: the iframe is sandboxed without `allow-same-origin`,
+  // so `frame.contentDocument` is no longer readable from the parent
+  // (cross-origin frame -> null / SecurityError). The previous
+  // title-sniffing fallback-detection path is therefore impossible.
+  //
+  // Replacement: trust the server. If `onLoad` fires AT ALL, the server
+  // returned a response and the browser rendered it. Hard failures
+  // (network error, 5xx with no body) are surfaced via `onError`. Soft
+  // failures (server returns 200 with a "Preview Build Failed" HTML
+  // page) are visible to the user via the iframe content itself; the
+  // automatic retry-on-title path is intentionally dropped — see the
+  // follow-up tracking issue for switching those server responses to
+  // proper HTTP 4xx/5xx so `onError` catches them.
+  const handleLoad = useCallback(() => {
+    setStatus(null);
+    autoRefreshAttempts.current = 0;
+  }, []);
 
-      if (fallbackTitles.has(title)) {
-        setStatus(`${title}. Retrying preview...`);
-        scheduleRetry();
-        return;
-      }
-
-      setStatus(null);
-      autoRefreshAttempts.current = 0;
-    },
-    [scheduleRetry],
-  );
+  const handleError = useCallback(() => {
+    setStatus("Preview failed to load. Retrying...");
+    scheduleRetry();
+  }, [scheduleRetry]);
 
   if (!previewUrl) {
     return (
@@ -198,25 +197,48 @@ export function SitePreview({
           >
             <RefreshCw size={16} />
           </button>
-          <a
-            href={previewUrl}
-            target="_blank"
-            rel="noreferrer"
-            className="rounded-lg p-2 text-muted transition hover:bg-surface-container hover:text-text"
-            title="Open preview in new tab"
-          >
-            <ExternalLink size={16} />
-          </a>
+          {/*
+           * Issue #993 fix: the "Open preview in new tab" link is
+           * intentionally removed. The preview URL is same-origin with
+           * the SPA (`API_BASE === ""`), so opening it as a top-level
+           * document gives any LLM-authored HTML/JS full read access to
+           * `localStorage` (auth + session tokens). Track restoration
+           * via Phase 3 signed-URL endpoint follow-up — once `/api/preview/*`
+           * returns a redirect to a sandbox-origin (or one-time signed
+           * URL) host, the link can come back.
+           */}
         </div>
       </div>
       <div className="min-h-0 flex-1 bg-surface-dark p-3">
         <div className="h-full overflow-hidden rounded-2xl border border-border bg-white shadow-2xl">
+          {/*
+           * Issue #993 fix: the iframe is sandboxed without
+           * `allow-same-origin`. The preview is served from the same
+           * origin as the SPA (`API_BASE === ""`), so without `sandbox`
+           * the LLM-authored HTML/JS inside the preview can read
+           * `window.parent.localStorage` -> exfiltrate
+           * `octos_session_token` + `octos_auth_token`.
+           *
+           * Tokens granted:
+           *   - allow-scripts: preview HTML legitimately needs JS for
+           *     framework hydration (Next/React templates).
+           *   - allow-forms: site templates may include sign-up / search
+           *     forms; harmless without same-origin since submissions
+           *     can't read parent state.
+           *
+           * Explicitly NOT granted: allow-same-origin. Granting it
+           * defeats the entire fix — sandbox + allow-same-origin still
+           * lets the frame reach `window.parent.localStorage` because
+           * it's same-origin with the parent.
+           */}
           <iframe
             key={iframeUrl}
             src={iframeUrl}
             title={`${siteName} preview`}
             className="h-full w-full border-0"
+            sandbox="allow-scripts allow-forms"
             onLoad={handleLoad}
+            onError={handleError}
           />
         </div>
         {status && (


### PR DESCRIPTION
## Summary

Closes #993 — P0 sev1 XSS bridge in the site-preview iframe.

Renders `<iframe sandbox="allow-scripts allow-forms">` for the site-preview frame and explicitly omits `allow-same-origin`. Before this fix the preview was loaded into a same-origin iframe (`API_BASE === ""` in `src/lib/constants.ts`), so any LLM-authored HTML/JS inside the preview could read `window.parent.localStorage` and exfiltrate `octos_session_token` and `octos_auth_token`.

## Option chosen — A (immediate, frontend-only)

Per the codex review on #993:

- **Option A** (this PR): add `sandbox` without `allow-same-origin`. Frontend-only, ships now, blocks the cross-frame DOM read.
- **Option B** (long-term, not in this PR): serve preview from a separate origin (signed-URL endpoint or sandbox subdomain). Needs backend work; tracked as a follow-up.
- **Option C** (out of scope): redesign token storage. Too large for a P0 fix.

Going with A buys time while Phase 3 (signed-URL backend) is built. No `allow-same-origin` is the load-bearing detail — granting it lets the frame reach `window.parent.localStorage` again because the frame would still be same-origin with the SPA.

## Companion changes required by the sandbox

### 1. `handleLoad` no longer reads `frame.contentDocument?.title`

`src/sites/components/site-preview.tsx:159-167` (was `:147-168`).

Cross-origin frames return `null` for `contentDocument` (or throw `SecurityError` in some browsers), so the old fallback-title detection path is impossible. Replaced with the "trust the server" variant — `onLoad` firing means the response rendered, `onError` covers hard failures. The retry-on-fallback-title flow is intentionally dropped. Follow-up: change the server's "Preview Build Failed" / "Site Preview Not Found" HTML pages to return proper HTTP 4xx/5xx so `onError` catches them automatically.

### 2. "Open preview in new tab" link removed

`src/sites/components/site-preview.tsx:200-209` (was `:201-209`).

Opening the same-origin preview URL as a top-level document still exposes `localStorage`. The link is removed (not disabled) per the spec — cleaner UX with a comment pointing at the Phase 3 follow-up. The link can return once `/api/preview/*` is moved to a separate origin or signed-URL host.

## Coordinated rollout — do NOT admin-merge

This PR plus the upcoming Phase 3 PR are a **coordinated pair**.

With sandbox enabled and no `allow-same-origin`, the existing same-origin preview frame still renders HTML/CSS/JS, but the previous title-sniff retry path is gone and the "open in new tab" affordance is removed. UX is temporarily degraded relative to before this PR; restoration depends on Phase 3 shipping the signed-URL endpoint.

Per spec: hold this PR until Phase 3 backend + frontend ship together. e2e tests deliberately not run — they would exercise the preview, which needs Phase 3 backend changes.

## Test plan

- [x] `npx tsc --noEmit` clean
- [x] `npm run build` clean — new bundle: `dist/assets/index-CD9F8JX0.js`
- [x] `npx vitest run src/sites/components/site-preview.test.tsx` — 7 new specs, all green
- [x] `npm run test:unit` — entire suite passes except one pre-existing failure in `src/runtime/ui-protocol-event-router.test.ts` (`router seq preservation > persisted message stamps seq onto the late-artifact response`) which reproduces on `origin/main` without this branch and is unrelated.
- [x] Sanity check: removing the `sandbox` attribute makes 4 of 7 new tests fail (regression guard works)
- [ ] **e2e: deferred** until Phase 3 ships the signed-URL endpoint so the iframe is actually loadable from the SPA again.

## Test coverage detail

`src/sites/components/site-preview.test.tsx` — 7 specs:

1. iframe has a `sandbox` attribute (anti-regression headline guard — pre-fix failure: `expected iframe to have sandbox attr but got null`)
2. exact value: `sandbox="allow-scripts allow-forms"`
3. tokens include `allow-scripts`
4. tokens include `allow-forms`
5. tokens **do NOT** include `allow-same-origin` (explicit anti-assertion — the load-bearing constraint)
6. `handleLoad` doesn't throw when `iframe.contentDocument` access throws `SecurityError` (models the sandboxed cross-origin case)
7. no `<a target="_blank">` anchor and no anchor pointing at the preview URL