### PR TITLE
feat(sites): use signed-URL endpoint for preview iframe (closes #1001 follow-up)

### DIFF
--- a/src/sites/api.ts
+++ b/src/sites/api.ts
@@ -77,6 +77,59 @@ export function buildSitePreviewUrl(
   return `${API_BASE}/api/site-preview/${encodeURIComponent(sessionId)}/${encodeURIComponent(slug)}/index.html`;
 }
 
+/**
+ * Issue #1001 follow-up: `<iframe>` tags cannot inject the
+ * `Authorization: Bearer ...` header that the
+ * `/api/preview/{profile_id}/...` route requires post-PR #1001, so
+ * the iframe 401-loops. Codex's design: mint an opaque token via
+ * `POST /api/my/preview/sign`, point `iframe.src` at the returned
+ * `/api/preview-signed/{token}/index.html`, and let the public
+ * signed route consume the token as its auth credential.
+ *
+ * `signPreview` is the thin HTTP helper. The `<SitePreview>`
+ * component owns the renewal scheduling (re-sign at
+ * `expires_at - 60s`) and the iframe.src swap.
+ *
+ * The server validates that the authenticated identity is authorised
+ * for `profile_id` and 4xx-rejects mismatches — this helper throws on
+ * any non-2xx so callers can surface an error UI instead of silently
+ * pointing the iframe at a stale URL.
+ */
+export interface SignPreviewRequest {
+  profile_id: string;
+  session_id: string;
+  site_slug: string;
+}
+
+export interface SignedPreviewResponse {
+  token: string;
+  preview_url: string;
+  /** RFC 3339 timestamp. The component subtracts 60 s to schedule the renewal. */
+  expires_at: string;
+}
+
+export async function signPreview(
+  req: SignPreviewRequest,
+): Promise<SignedPreviewResponse> {
+  const response = await fetch(`${API_BASE}/api/my/preview/sign`, {
+    method: "POST",
+    headers: buildApiHeaders(
+      { "Content-Type": "application/json" },
+      req.profile_id,
+    ),
+    body: JSON.stringify(req),
+  });
+  if (!response.ok) {
+    // Surface the status code in the message so the iframe component
+    // can branch on 401/403/404 if it wants. Mirrors how the rest of
+    // this module reports HTTP failures (`throw new Error("HTTP ...")`).
+    throw new Error(
+      `HTTP ${response.status} signing preview for ${req.session_id}/${req.site_slug}`,
+    );
+  }
+  return (await response.json()) as SignedPreviewResponse;
+}
+
 export async function listSiteFiles(
   dirs: string | string[],
   options: ListSiteFilesOptions = {},

--- a/src/sites/components/site-preview-signed.test.tsx
+++ b/src/sites/components/site-preview-signed.test.tsx
@@ -208,8 +208,9 @@ describe("<SitePreview> signed-URL iframe", () => {
    * If `signPreview()` resolves AFTER the component unmounts, the
    * resolution handler must NOT call `setState` (no-op warning in
    * React 19) and MUST NOT schedule a renewal timer. The latest-wins
-   * guard in `refreshSignedToken` short-circuits on
-   * `mounted.current === false`.
+   * guard in `refreshSignedToken` short-circuits because the unmount
+   * cleanup bumps `signReqId.current`, so the captured `myReqId`
+   * differs from the live value.
    */
   it("drops the stale signPreview response when the component unmounts before it resolves", async () => {
     const now = Date.now();
@@ -251,8 +252,9 @@ describe("<SitePreview> signed-URL iframe", () => {
     const timersBeforeUnmount = vi.getTimerCount();
 
     // Unmount THEN resolve the sign. With the latest-wins guard,
-    // `mounted.current === false` should cause the resolution to
-    // bail before touching state or scheduling a renewal.
+    // the unmount cleanup bumps `signReqId.current` so the captured
+    // `myReqId` no longer matches — the resolution bails before
+    // touching state or scheduling a renewal.
     harness.unmount();
 
     await act(async () => {
@@ -434,6 +436,70 @@ describe("<SitePreview> signed-URL iframe", () => {
     expect(tokens).toContain("allow-scripts");
     expect(tokens).toContain("allow-forms");
     expect(tokens).not.toContain("allow-same-origin");
+
+    harness.unmount();
+  });
+
+  /**
+   * Codex round-3 HIGH — StrictMode double-mount / remount cycle.
+   *
+   * Pre-fixup bug (`site-preview.tsx:199`): the cleanup set
+   * `mounted.current = false` but never reset it to `true` on the
+   * next mount. React 19 StrictMode (`main.tsx`) runs effects twice
+   * in dev — mount → cleanup → mount-again. The first cleanup
+   * flipped `mounted.current` to `false`; the second mount ran
+   * without resetting it, so every `signPreview` resolution was
+   * silently dropped by the `!mounted.current` short-circuit in the
+   * latest-wins guard. The iframe was stuck on "Loading preview…"
+   * forever in dev.
+   *
+   * Post-fixup the `mounted` ref is removed entirely. The cleanup
+   * bumps `signReqId.current`, which is sufficient to invalidate
+   * in-flight resolutions; the next mount captures a fresh id and
+   * succeeds. We simulate StrictMode by wrapping the SUT in
+   * `<StrictMode>` so React runs the dev-only mount → cleanup →
+   * mount cycle.
+   */
+  it("should_recover_after_unmount_remount_cycle (StrictMode regression)", async () => {
+    const now = Date.now();
+    vi.setSystemTime(now);
+
+    // Two resolutions because StrictMode causes the effect to run
+    // twice — both must complete, but only the second matters for
+    // the rendered iframe. We give them distinct URLs so we can tell
+    // which one landed.
+    signPreviewMock.mockResolvedValue({
+      token: SIGNED_TOKEN,
+      preview_url: SIGNED_URL,
+      expires_at: new Date(now + 600_000).toISOString(),
+    });
+
+    let harness!: MountedHarness;
+    await act(async () => {
+      harness = mount(
+        <React.StrictMode>
+          <SitePreview
+            previewUrl="ignored"
+            siteName="Test Site"
+            template="astro-site"
+            sessionId="site-A"
+            profileId="tenant-a"
+            slug="test-site"
+          />
+        </React.StrictMode>,
+      );
+      // Flush both passes of StrictMode's mount → cleanup → mount.
+      await Promise.resolve();
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    // Pre-fixup: the iframe is absent because every signPreview
+    // resolution is dropped by the stale `!mounted.current` check.
+    // Post-fixup: the iframe renders against SIGNED_URL.
+    const iframe = harness.container.querySelector("iframe");
+    expect(iframe).not.toBeNull();
+    expect(iframe?.getAttribute("src")).toContain(SIGNED_URL);
 
     harness.unmount();
   });

--- a/src/sites/components/site-preview-signed.test.tsx
+++ b/src/sites/components/site-preview-signed.test.tsx
@@ -1,0 +1,204 @@
+/**
+ * `<SitePreview>` signed-URL iframe tests (#1001 follow-up).
+ *
+ * After PR #1001 the preview iframe at
+ * `<iframe src=/api/preview/{profile_id}/{session_id}/{slug}/index.html>`
+ * 401s because iframes don't send `Authorization`. The new contract:
+ *
+ *   1. On mount, the component calls `signPreview()` with the active
+ *      site coordinates and sets `iframe.src = response.preview_url`.
+ *   2. It schedules a renewal at `expires_at - 60s`, calling
+ *      `signPreview()` again and swapping `iframe.src` to the new URL.
+ *   3. If the sign call rejects (e.g. 403 for cross-tenant attempt),
+ *      the component shows an error UI and DOES NOT render the iframe.
+ *
+ * These three behaviours are exactly what the codex follow-up asked for
+ * — no rewrite of relative paths, no fallback to the legacy preview
+ * URL.
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import * as React from "react";
+import { act } from "react";
+import { createRoot, type Root } from "react-dom/client";
+
+(globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT =
+  true;
+
+// Mock the api module BEFORE importing the component so the SUT's
+// `import { signPreview } from "../api"` picks up the mock. `vi.mock`
+// is hoisted to the top of the file by vitest's transformer — so we
+// can NOT reference outer `let/const` from inside the factory. Use
+// `vi.hoisted` to create the mock function above the hoist line.
+const { signPreviewMock } = vi.hoisted(() => ({
+  signPreviewMock: vi.fn(),
+}));
+vi.mock("../api", () => ({
+  signPreview: signPreviewMock,
+  buildSitePreviewUrl: vi.fn(() => "/legacy/should-not-be-used"),
+}));
+
+import { SitePreview } from "./site-preview";
+
+interface MountedHarness {
+  container: HTMLDivElement;
+  root: Root;
+  unmount: () => void;
+}
+
+function mount(node: React.ReactElement): MountedHarness {
+  const container = document.createElement("div");
+  document.body.appendChild(container);
+  const root = createRoot(container);
+  act(() => {
+    root.render(node);
+  });
+  return {
+    container,
+    root,
+    unmount: () => {
+      act(() => root.unmount());
+      container.remove();
+    },
+  };
+}
+
+const SIGNED_TOKEN = "a".repeat(64);
+const SIGNED_URL = `/api/preview-signed/${SIGNED_TOKEN}/index.html`;
+const RENEWAL_URL = `/api/preview-signed/${"b".repeat(64)}/index.html`;
+
+beforeEach(() => {
+  vi.useFakeTimers();
+  signPreviewMock.mockReset();
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+  for (const node of [...document.body.children]) {
+    node.remove();
+  }
+});
+
+describe("<SitePreview> signed-URL iframe", () => {
+  it("calls signPreview on mount and sets iframe.src to the returned preview_url", async () => {
+    const now = Date.now();
+    signPreviewMock.mockResolvedValueOnce({
+      token: SIGNED_TOKEN,
+      preview_url: SIGNED_URL,
+      expires_at: new Date(now + 600_000).toISOString(),
+    });
+
+    let harness!: MountedHarness;
+    await act(async () => {
+      harness = mount(
+        <SitePreview
+          previewUrl="ignored-by-signed-flow"
+          siteName="Test Site"
+          template="astro-site"
+          sessionId="site-A-1234567890"
+          profileId="tenant-a"
+          slug="test-site"
+        />,
+      );
+      // Flush the awaited signPreview promise.
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    expect(signPreviewMock).toHaveBeenCalledTimes(1);
+    expect(signPreviewMock).toHaveBeenCalledWith({
+      profile_id: "tenant-a",
+      session_id: "site-A-1234567890",
+      site_slug: "test-site",
+    });
+
+    const iframe = harness.container.querySelector("iframe");
+    expect(iframe).not.toBeNull();
+    expect(iframe?.getAttribute("src")).toContain(SIGNED_URL);
+
+    harness.unmount();
+  });
+
+  it("schedules a renewal at expires_at - 60s and updates iframe.src", async () => {
+    const now = Date.now();
+    vi.setSystemTime(now);
+    // First mint: expires in 5 seconds so the test doesn't have to
+    // advance the clock by 9 minutes.
+    signPreviewMock
+      .mockResolvedValueOnce({
+        token: SIGNED_TOKEN,
+        preview_url: SIGNED_URL,
+        expires_at: new Date(now + 5_000).toISOString(),
+      })
+      .mockResolvedValueOnce({
+        token: "b".repeat(64),
+        preview_url: RENEWAL_URL,
+        expires_at: new Date(now + 605_000).toISOString(),
+      });
+
+    let harness!: MountedHarness;
+    await act(async () => {
+      harness = mount(
+        <SitePreview
+          previewUrl="ignored"
+          siteName="Test Site"
+          template="astro-site"
+          sessionId="site-A"
+          profileId="tenant-a"
+          slug="test-site"
+        />,
+      );
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    expect(signPreviewMock).toHaveBeenCalledTimes(1);
+    const iframe = harness.container.querySelector("iframe");
+    expect(iframe?.getAttribute("src")).toContain(SIGNED_URL);
+
+    // The renewal scheduler subtracts 60 s from expires_at; with a
+    // 5-second TTL and a 60-second renewal window the timer fires
+    // immediately (the helper clamps to a minimum positive value).
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(1_000);
+      // Flush the renewal sign promise.
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    expect(signPreviewMock).toHaveBeenCalledTimes(2);
+    const refreshedIframe = harness.container.querySelector("iframe");
+    expect(refreshedIframe?.getAttribute("src")).toContain(RENEWAL_URL);
+
+    harness.unmount();
+  });
+
+  it("shows an error UI when signPreview rejects (e.g. 403 cross-tenant)", async () => {
+    signPreviewMock.mockRejectedValueOnce(new Error("HTTP 403"));
+
+    let harness!: MountedHarness;
+    await act(async () => {
+      harness = mount(
+        <SitePreview
+          previewUrl="ignored"
+          siteName="Test Site"
+          template="astro-site"
+          sessionId="site-A"
+          profileId="tenant-b"
+          slug="test-site"
+        />,
+      );
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    expect(harness.container.querySelector("iframe")).toBeNull();
+    expect(
+      harness.container.querySelector(
+        "[data-testid='site-preview-error']",
+      ),
+    ).not.toBeNull();
+
+    harness.unmount();
+  });
+});

--- a/src/sites/components/site-preview-signed.test.tsx
+++ b/src/sites/components/site-preview-signed.test.tsx
@@ -201,4 +201,240 @@ describe("<SitePreview> signed-URL iframe", () => {
 
     harness.unmount();
   });
+
+  /**
+   * Codex GAP 2 — stale signPreview response after unmount.
+   *
+   * If `signPreview()` resolves AFTER the component unmounts, the
+   * resolution handler must NOT call `setState` (no-op warning in
+   * React 19) and MUST NOT schedule a renewal timer. The latest-wins
+   * guard in `refreshSignedToken` short-circuits on
+   * `mounted.current === false`.
+   */
+  it("drops the stale signPreview response when the component unmounts before it resolves", async () => {
+    const now = Date.now();
+    vi.setSystemTime(now);
+
+    // Slow sign — kept in a deferred so we can resolve it AFTER unmount.
+    let resolveSign!: (value: {
+      token: string;
+      preview_url: string;
+      expires_at: string;
+    }) => void;
+    signPreviewMock.mockImplementationOnce(
+      () =>
+        new Promise((resolve) => {
+          resolveSign = resolve;
+        }),
+    );
+
+    let harness!: MountedHarness;
+    await act(async () => {
+      harness = mount(
+        <SitePreview
+          previewUrl="ignored"
+          siteName="Test Site"
+          template="astro-site"
+          sessionId="site-A"
+          profileId="tenant-a"
+          slug="test-site"
+        />,
+      );
+      // signPreview is invoked but does NOT resolve yet.
+      await Promise.resolve();
+    });
+    expect(signPreviewMock).toHaveBeenCalledTimes(1);
+
+    // Snapshot the active-timer count so we can prove no renewal was
+    // scheduled by the stale resolution. With `vi.useFakeTimers()` the
+    // count is observable via `vi.getTimerCount()`.
+    const timersBeforeUnmount = vi.getTimerCount();
+
+    // Unmount THEN resolve the sign. With the latest-wins guard,
+    // `mounted.current === false` should cause the resolution to
+    // bail before touching state or scheduling a renewal.
+    harness.unmount();
+
+    await act(async () => {
+      resolveSign({
+        token: SIGNED_TOKEN,
+        preview_url: SIGNED_URL,
+        expires_at: new Date(now + 600_000).toISOString(),
+      });
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    // No new timers (i.e. no renewal scheduled by the stale response).
+    expect(vi.getTimerCount()).toBeLessThanOrEqual(timersBeforeUnmount);
+    // The unmounted container has no iframe — the stale setState was
+    // dropped, so no React warning + no leaked state.
+    expect(harness.container.querySelector("iframe")).toBeNull();
+  });
+
+  /**
+   * Codex GAP 3 — rapid re-render race.
+   *
+   * Three previews fire in quick succession before any resolves. Only
+   * the THIRD signed URL must end up in the iframe.src — earlier
+   * resolutions are dropped because their captured `myReqId` is stale.
+   */
+  it("handles rapid preview changes — only the latest signPreview wins", async () => {
+    const now = Date.now();
+    vi.setSystemTime(now);
+
+    // Three previews, three URLs. We deliberately resolve out of
+    // order: 3rd first, then 1st, then 2nd. The latest-wins guard
+    // must accept only the 3rd's result.
+    const urls = [
+      `/api/preview-signed/${"1".repeat(64)}/index.html`,
+      `/api/preview-signed/${"2".repeat(64)}/index.html`,
+      `/api/preview-signed/${"3".repeat(64)}/index.html`,
+    ];
+    const deferreds: Array<(value: {
+      token: string;
+      preview_url: string;
+      expires_at: string;
+    }) => void> = [];
+    signPreviewMock.mockImplementation(
+      () =>
+        new Promise((resolve) => {
+          deferreds.push(resolve);
+        }),
+    );
+
+    let harness!: MountedHarness;
+    await act(async () => {
+      harness = mount(
+        <SitePreview
+          previewUrl="ignored"
+          siteName="Test Site"
+          template="astro-site"
+          sessionId="site-A"
+          profileId="tenant-a"
+          slug="slug-1"
+        />,
+      );
+      await Promise.resolve();
+    });
+    // Re-render with two more slugs in succession. Each prop change
+    // re-runs the `useEffect` that calls `refreshSignedToken()`,
+    // bumping `signReqId.current` and capturing a fresh `myReqId`.
+    await act(async () => {
+      harness.root.render(
+        <SitePreview
+          previewUrl="ignored"
+          siteName="Test Site"
+          template="astro-site"
+          sessionId="site-A"
+          profileId="tenant-a"
+          slug="slug-2"
+        />,
+      );
+      await Promise.resolve();
+    });
+    await act(async () => {
+      harness.root.render(
+        <SitePreview
+          previewUrl="ignored"
+          siteName="Test Site"
+          template="astro-site"
+          sessionId="site-A"
+          profileId="tenant-a"
+          slug="slug-3"
+        />,
+      );
+      await Promise.resolve();
+    });
+
+    // We expect THREE in-flight signs.
+    expect(signPreviewMock).toHaveBeenCalledTimes(3);
+    expect(deferreds.length).toBe(3);
+
+    // Resolve out of order: 3rd, then 1st, then 2nd.
+    await act(async () => {
+      deferreds[2]({
+        token: "3".repeat(64),
+        preview_url: urls[2],
+        expires_at: new Date(now + 600_000).toISOString(),
+      });
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+    // After the latest resolves, the iframe must point at urls[2].
+    let iframe = harness.container.querySelector("iframe");
+    expect(iframe?.getAttribute("src")).toContain(urls[2]);
+
+    // Now resolve the stale 1st and 2nd. They must NOT clobber the
+    // iframe — the latest-wins guard drops them.
+    await act(async () => {
+      deferreds[0]({
+        token: "1".repeat(64),
+        preview_url: urls[0],
+        expires_at: new Date(now + 600_000).toISOString(),
+      });
+      deferreds[1]({
+        token: "2".repeat(64),
+        preview_url: urls[1],
+        expires_at: new Date(now + 600_000).toISOString(),
+      });
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    iframe = harness.container.querySelector("iframe");
+    expect(iframe?.getAttribute("src")).toContain(urls[2]);
+    expect(iframe?.getAttribute("src")).not.toContain(urls[0]);
+    expect(iframe?.getAttribute("src")).not.toContain(urls[1]);
+
+    harness.unmount();
+  });
+
+  /**
+   * Codex GAP 5 — iframe sandbox attribute (mirrors PR #139's #993
+   * test). The preview is same-origin with the SPA; without `sandbox`
+   * the LLM-authored HTML in the preview can read
+   * `window.parent.localStorage` and exfiltrate auth tokens. The
+   * sandbox attribute must equal `"allow-scripts allow-forms"`
+   * (NOT `allow-same-origin` — that defeats the fix).
+   */
+  it("renders iframe with sandbox=\"allow-scripts allow-forms\" (issue #993 / PR #139)", async () => {
+    const now = Date.now();
+    signPreviewMock.mockResolvedValueOnce({
+      token: SIGNED_TOKEN,
+      preview_url: SIGNED_URL,
+      expires_at: new Date(now + 600_000).toISOString(),
+    });
+
+    let harness!: MountedHarness;
+    await act(async () => {
+      harness = mount(
+        <SitePreview
+          previewUrl="ignored"
+          siteName="Test Site"
+          template="astro-site"
+          sessionId="site-A"
+          profileId="tenant-a"
+          slug="test-site"
+        />,
+      );
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    const iframe = harness.container.querySelector("iframe");
+    expect(iframe).not.toBeNull();
+    const sandboxAttr = iframe?.getAttribute("sandbox") ?? "";
+    expect(sandboxAttr).toBe("allow-scripts allow-forms");
+
+    // Anti-regression for the headline #993 anti-assertion: granting
+    // `allow-same-origin` here would re-enable
+    // `window.parent.localStorage` reads from inside the iframe.
+    const tokens = sandboxAttr.split(/\s+/).filter(Boolean);
+    expect(tokens).toContain("allow-scripts");
+    expect(tokens).toContain("allow-forms");
+    expect(tokens).not.toContain("allow-same-origin");
+
+    harness.unmount();
+  });
 });

--- a/src/sites/components/site-preview.tsx
+++ b/src/sites/components/site-preview.tsx
@@ -77,11 +77,19 @@ export function SitePreview({
    * Implementation: each call site increments `signReqId.current` and
    * captures its own id. When the promise resolves, it checks the
    * latest id; if they differ the result is dropped on the floor.
-   * Cleanup runs bump `signReqId.current` via the `mounted` flag —
-   * `mounted.current === false` is the unmount sentinel.
+   * The unmount cleanup ALSO bumps `signReqId.current` so any
+   * in-flight resolutions see the bumped id and short-circuit.
+   *
+   * This single-ref design replaces an earlier `mounted` boolean ref
+   * (codex round-3 HIGH): a `mounted` ref set to `false` in cleanup
+   * would never reset on remount under React 19 StrictMode dev mode,
+   * so every signPreview resolution after the first effect cleanup
+   * was silently dropped → the iframe was stuck on "Loading preview…"
+   * in dev. The request-id check alone is sufficient: bumping
+   * `signReqId.current` on cleanup makes every in-flight resolution
+   * stale relative to any subsequent mount.
    */
   const signReqId = useRef(0);
-  const mounted = useRef(true);
 
   const triggerRefresh = useCallback(() => {
     setRefreshTick((value) => value + 1);
@@ -133,7 +141,9 @@ export function SitePreview({
       // the component unmounted. Without this, a slow `signPreview`
       // followed by a rapid prop change or unmount leaks state +
       // schedules a renewal timer that fires on a dead component.
-      if (!mounted.current || signReqId.current !== myReqId) {
+      // Unmount cleanup bumps `signReqId.current`, so a stale
+      // resolution sees a different id and bails.
+      if (signReqId.current !== myReqId) {
         return;
       }
       setSigned(response);
@@ -154,13 +164,13 @@ export function SitePreview({
       const delay = Math.max(250, expiresMs - nowMs - 60_000);
       renewalTimer.current = window.setTimeout(() => {
         renewalTimer.current = null;
-        if (!mounted.current || signReqId.current !== myReqId) return;
+        if (signReqId.current !== myReqId) return;
         void refreshSignedToken();
       }, delay);
     } catch (error) {
       // Same guard on the error path: don't surface an old failure
       // after the user has navigated to a different preview.
-      if (!mounted.current || signReqId.current !== myReqId) {
+      if (signReqId.current !== myReqId) {
         return;
       }
       const message = error instanceof Error ? error.message : "sign failed";
@@ -193,10 +203,14 @@ export function SitePreview({
 
   useEffect(() => {
     return () => {
-      // Mark unmounted so any in-flight `signPreview()` resolution
-      // (codex GAP 2/3 latest-wins guard) returns without touching
-      // state or scheduling timers.
-      mounted.current = false;
+      // Bump the request id so any in-flight `signPreview()`
+      // resolution returns without touching state or scheduling
+      // timers (codex GAP 2/3 latest-wins guard). The earlier
+      // implementation used a `mounted` boolean ref but never
+      // reset it on remount, which under React 19 StrictMode dev
+      // mode silently dropped every subsequent sign — see the
+      // `should_recover_after_unmount_remount_cycle` test.
+      signReqId.current += 1;
       if (autoRefreshTimer.current !== null) {
         window.clearTimeout(autoRefreshTimer.current);
       }

--- a/src/sites/components/site-preview.tsx
+++ b/src/sites/components/site-preview.tsx
@@ -8,27 +8,61 @@ import {
   useState,
 } from "react";
 
+import { type SignedPreviewResponse, signPreview } from "../api";
+
 interface Props {
+  /** Legacy plain preview URL — used for the "open in new tab" button
+   * and the copyable URL row. The iframe `src` is computed from the
+   * signed-URL flow below. */
   previewUrl?: string;
   siteName: string;
   template: string;
   sessionId?: string;
   scaffoldError?: string;
+  /** Profile id the active site lives under. Required for signing. */
+  profileId?: string | null;
+  /** Site slug. Required for signing. */
+  slug?: string;
 }
 
+/**
+ * `<SitePreview>` post-PR #1001.
+ *
+ * PR #1001 closed the cross-tenant `/api/preview/{profile_id}/...`
+ * data-read by requiring `Authorization: Bearer ...` on every request.
+ * That regressed the iframe UX (iframes cannot inject headers), so
+ * codex's design (PR #1006-ish): mint a signed-URL token via
+ * `POST /api/my/preview/sign` and point `iframe.src` at the returned
+ * `preview_url` — the token IS the credential for the iframe GETs.
+ *
+ * Renewal cadence: re-sign at `expires_at - 60s` so the in-flight
+ * iframe never hits a 404 on a freshly-expired token. The component
+ * tracks the latest signed URL in state and updates `iframe.src` when
+ * the renewal returns.
+ *
+ * If the sign call rejects (e.g. 403 because the user logged out, or
+ * the profile no longer matches), the component renders an error UI
+ * with a retry button rather than silently pointing the iframe at the
+ * stale URL.
+ */
 export function SitePreview({
   previewUrl,
   siteName,
   template,
   sessionId,
   scaffoldError,
+  profileId,
+  slug,
 }: Props) {
   const [refreshTick, setRefreshTick] = useState(0);
   const [status, setStatus] = useState<string | null>(null);
   const [copied, setCopied] = useState(false);
+  const [signed, setSigned] = useState<SignedPreviewResponse | null>(null);
+  const [signError, setSignError] = useState<string | null>(null);
   const autoRefreshAttempts = useRef(0);
   const autoRefreshTimer = useRef<number | null>(null);
   const eventRefreshTimer = useRef<number | null>(null);
+  const renewalTimer = useRef<number | null>(null);
   const copiedTimer = useRef<number | null>(null);
 
   const triggerRefresh = useCallback(() => {
@@ -36,13 +70,73 @@ export function SitePreview({
   }, []);
 
   const scheduleRetry = useCallback(() => {
-    if (autoRefreshAttempts.current >= 8 || autoRefreshTimer.current !== null) return;
+    if (autoRefreshAttempts.current >= 8 || autoRefreshTimer.current !== null)
+      return;
     autoRefreshAttempts.current += 1;
     autoRefreshTimer.current = window.setTimeout(() => {
       autoRefreshTimer.current = null;
       triggerRefresh();
     }, 2500);
   }, [triggerRefresh]);
+
+  /**
+   * Sign and (re-)mint a signed-URL token. Stashes the result in
+   * state so the iframe re-renders against `signed.preview_url`, and
+   * schedules a renewal at `expires_at - 60s`. We clamp the renewal
+   * window to a minimum of 250 ms so a clock skew or a very short TTL
+   * (test rigs use 5-second TTLs) doesn't pin the iframe on a stale
+   * URL while React batches the state update.
+   */
+  const refreshSignedToken = useCallback(async () => {
+    if (!profileId || !sessionId || !slug) {
+      // Missing coordinates — we cannot mint a signed token, but the
+      // caller's `previewUrl` row may still surface scaffold status,
+      // so don't surface an "error" here. The iframe will simply not
+      // render until the coordinates arrive (typically on first poll).
+      setSigned(null);
+      setSignError(null);
+      return;
+    }
+    try {
+      const response = await signPreview({
+        profile_id: profileId,
+        session_id: sessionId,
+        site_slug: slug,
+      });
+      setSigned(response);
+      setSignError(null);
+
+      // Schedule renewal at expires_at - 60s, clamped to a positive
+      // window so test rigs (5-second TTLs) don't no-op the timer.
+      if (renewalTimer.current !== null) {
+        window.clearTimeout(renewalTimer.current);
+      }
+      const expiresMs = Date.parse(response.expires_at);
+      const nowMs = Date.now();
+      const delay = Math.max(250, expiresMs - nowMs - 60_000);
+      renewalTimer.current = window.setTimeout(() => {
+        renewalTimer.current = null;
+        void refreshSignedToken();
+      }, delay);
+    } catch (error) {
+      const message = error instanceof Error ? error.message : "sign failed";
+      setSignError(message);
+      setSigned(null);
+    }
+  }, [profileId, sessionId, slug]);
+
+  // Mint on mount and whenever the coordinates change. The renewal
+  // is scheduled INSIDE refreshSignedToken (after each successful
+  // sign) so changing coordinates cancels any in-flight renewal.
+  useEffect(() => {
+    void refreshSignedToken();
+    return () => {
+      if (renewalTimer.current !== null) {
+        window.clearTimeout(renewalTimer.current);
+        renewalTimer.current = null;
+      }
+    };
+  }, [refreshSignedToken]);
 
   useEffect(() => {
     autoRefreshAttempts.current = 0;
@@ -60,6 +154,9 @@ export function SitePreview({
       }
       if (eventRefreshTimer.current !== null) {
         window.clearTimeout(eventRefreshTimer.current);
+      }
+      if (renewalTimer.current !== null) {
+        window.clearTimeout(renewalTimer.current);
       }
       if (copiedTimer.current !== null) {
         window.clearTimeout(copiedTimer.current);
@@ -125,10 +222,10 @@ export function SitePreview({
   }, [previewUrl, sessionId, triggerRefresh]);
 
   const iframeUrl = useMemo(() => {
-    if (!previewUrl) return "";
-    const separator = previewUrl.includes("?") ? "&" : "?";
-    return `${previewUrl}${separator}v=${refreshTick}`;
-  }, [previewUrl, refreshTick]);
+    if (!signed?.preview_url) return "";
+    const separator = signed.preview_url.includes("?") ? "&" : "?";
+    return `${signed.preview_url}${separator}v=${refreshTick}`;
+  }, [signed?.preview_url, refreshTick]);
 
   const handleCopyPreviewUrl = useCallback(() => {
     if (!previewUrl) return;
@@ -170,7 +267,8 @@ export function SitePreview({
   if (!previewUrl) {
     return (
       <div className="flex h-full items-center justify-center px-6 text-center text-sm text-muted">
-        {scaffoldError || "The preview URL will appear once the backend scaffold finishes."}
+        {scaffoldError ||
+          "The preview URL will appear once the backend scaffold finishes."}
       </div>
     );
   }
@@ -211,13 +309,34 @@ export function SitePreview({
       </div>
       <div className="min-h-0 flex-1 bg-surface-dark p-3">
         <div className="h-full overflow-hidden rounded-2xl border border-border bg-white shadow-2xl">
-          <iframe
-            key={iframeUrl}
-            src={iframeUrl}
-            title={`${siteName} preview`}
-            className="h-full w-full border-0"
-            onLoad={handleLoad}
-          />
+          {signError ? (
+            <div
+              data-testid="site-preview-error"
+              className="flex h-full flex-col items-center justify-center gap-3 px-6 text-center text-sm text-muted"
+            >
+              <div>
+                Preview is unavailable: <code>{signError}</code>
+              </div>
+              <button
+                onClick={() => void refreshSignedToken()}
+                className="rounded-lg border border-border px-3 py-1 text-xs text-text hover:bg-surface-container"
+              >
+                Retry
+              </button>
+            </div>
+          ) : iframeUrl ? (
+            <iframe
+              key={iframeUrl}
+              src={iframeUrl}
+              title={`${siteName} preview`}
+              className="h-full w-full border-0"
+              onLoad={handleLoad}
+            />
+          ) : (
+            <div className="flex h-full items-center justify-center text-xs text-muted">
+              Loading preview…
+            </div>
+          )}
         </div>
         {status && (
           <div className="px-1 pt-2 text-xs text-muted">{status}</div>

--- a/src/sites/components/site-preview.tsx
+++ b/src/sites/components/site-preview.tsx
@@ -64,6 +64,24 @@ export function SitePreview({
   const eventRefreshTimer = useRef<number | null>(null);
   const renewalTimer = useRef<number | null>(null);
   const copiedTimer = useRef<number | null>(null);
+  /**
+   * Latest-wins guard for in-flight `signPreview()` promises.
+   *
+   * `signPreview()` is async. Between the call site and its resolution,
+   * the component may have unmounted (cleanup ran) OR the preview
+   * coordinates may have changed (a newer sign is already in flight).
+   * In either case the resolution must NOT call `setState` or schedule
+   * a renewal — doing so leaks the old preview into the new render and,
+   * post-unmount, leaks the renewal timer forever.
+   *
+   * Implementation: each call site increments `signReqId.current` and
+   * captures its own id. When the promise resolves, it checks the
+   * latest id; if they differ the result is dropped on the floor.
+   * Cleanup runs bump `signReqId.current` via the `mounted` flag —
+   * `mounted.current === false` is the unmount sentinel.
+   */
+  const signReqId = useRef(0);
+  const mounted = useRef(true);
 
   const triggerRefresh = useCallback(() => {
     setRefreshTick((value) => value + 1);
@@ -93,21 +111,41 @@ export function SitePreview({
       // caller's `previewUrl` row may still surface scaffold status,
       // so don't surface an "error" here. The iframe will simply not
       // render until the coordinates arrive (typically on first poll).
+      // Bump the request id so any in-flight sign for the previous
+      // (valid) coordinates is dropped on resolution.
+      signReqId.current += 1;
       setSigned(null);
       setSignError(null);
       return;
     }
+    // Latest-wins guard (codex GAP 2/3): capture this call's request
+    // id BEFORE awaiting, so resolutions for stale coordinates / a
+    // previously-unmounted instance can be discarded by comparing
+    // against the live `signReqId.current` after the await.
+    const myReqId = ++signReqId.current;
     try {
       const response = await signPreview({
         profile_id: profileId,
         session_id: sessionId,
         site_slug: slug,
       });
+      // Drop the response if the coordinates changed mid-flight or
+      // the component unmounted. Without this, a slow `signPreview`
+      // followed by a rapid prop change or unmount leaks state +
+      // schedules a renewal timer that fires on a dead component.
+      if (!mounted.current || signReqId.current !== myReqId) {
+        return;
+      }
       setSigned(response);
       setSignError(null);
 
       // Schedule renewal at expires_at - 60s, clamped to a positive
       // window so test rigs (5-second TTLs) don't no-op the timer.
+      // The renewal is keyed to `myReqId` via the latest-wins guard
+      // INSIDE its `refreshSignedToken` recursion — a newer sign
+      // bumps `signReqId.current`, so when this timer's recursive
+      // call awaits and re-enters the guard, it'll see the bumped id
+      // and drop the result. The timer itself is cleared on cleanup.
       if (renewalTimer.current !== null) {
         window.clearTimeout(renewalTimer.current);
       }
@@ -116,9 +154,15 @@ export function SitePreview({
       const delay = Math.max(250, expiresMs - nowMs - 60_000);
       renewalTimer.current = window.setTimeout(() => {
         renewalTimer.current = null;
+        if (!mounted.current || signReqId.current !== myReqId) return;
         void refreshSignedToken();
       }, delay);
     } catch (error) {
+      // Same guard on the error path: don't surface an old failure
+      // after the user has navigated to a different preview.
+      if (!mounted.current || signReqId.current !== myReqId) {
+        return;
+      }
       const message = error instanceof Error ? error.message : "sign failed";
       setSignError(message);
       setSigned(null);
@@ -149,6 +193,10 @@ export function SitePreview({
 
   useEffect(() => {
     return () => {
+      // Mark unmounted so any in-flight `signPreview()` resolution
+      // (codex GAP 2/3 latest-wins guard) returns without touching
+      // state or scheduling timers.
+      mounted.current = false;
       if (autoRefreshTimer.current !== null) {
         window.clearTimeout(autoRefreshTimer.current);
       }
@@ -325,11 +373,33 @@ export function SitePreview({
               </button>
             </div>
           ) : iframeUrl ? (
+            /*
+             * Issue #993 / PR #139 — iframe sandbox (XSS bridge fix).
+             *
+             * The preview is same-origin with the SPA
+             * (`API_BASE === ""`). Without a `sandbox` attribute, the
+             * LLM-authored HTML/JS in the preview can read
+             * `window.parent.localStorage` and exfiltrate
+             * `octos_session_token` + `octos_auth_token`.
+             *
+             * `allow-scripts` + `allow-forms` are required for
+             * legitimate framework hydration (Next/Astro/React) and
+             * site forms. `allow-same-origin` is INTENTIONALLY OMITTED
+             * — granting it would defeat the fix because the iframe
+             * IS same-origin with the parent, so it could still reach
+             * `window.parent.localStorage`.
+             *
+             * This duplicates the attribute from PR #139
+             * (`fix/site-preview-iframe-sandbox`). If #139 merges
+             * first, this PR's rebase resolves to the same value; if
+             * this PR merges first, #139 has a clean rebase.
+             */
             <iframe
               key={iframeUrl}
               src={iframeUrl}
               title={`${siteName} preview`}
               className="h-full w-full border-0"
+              sandbox="allow-scripts allow-forms"
               onLoad={handleLoad}
             />
           ) : (

--- a/src/sites/pages/sites-editor-page.tsx
+++ b/src/sites/pages/sites-editor-page.tsx
@@ -22,6 +22,10 @@ function SitesEditorContent() {
           template={project?.template || "site"}
           sessionId={project?.id}
           scaffoldError={project?.scaffoldError}
+          // #1001 follow-up: signed-URL flow needs the profile id
+          // and slug to mint the iframe `src` server-side.
+          profileId={project?.profileId}
+          slug={project?.slug}
         />
       }
       chatPanel={

--- a/src/sites/signed-preview.test.ts
+++ b/src/sites/signed-preview.test.ts
@@ -1,0 +1,131 @@
+/**
+ * Tests for the signed-preview API helper introduced as the
+ * follow-up to PR #1001.
+ *
+ * Background
+ * ----------
+ * PR #1001 closed the cross-tenant `/api/preview/{profile_id}/...`
+ * data-read by requiring `Authorization: Bearer ...` on every
+ * request. That regressed the SPA iframe UX because the iframe
+ * tag cannot inject headers — the iframe 401-loops after the
+ * dashboard tab loads.
+ *
+ * Codex's design (verbatim in the issue thread): the SPA mints an
+ * opaque token via `POST /api/my/preview/sign` (which DOES send the
+ * bearer) and points `iframe.src` at the returned signed URL
+ * `/api/preview-signed/{token}/index.html`. The token is the auth
+ * credential for the iframe GETs.
+ *
+ * These tests pin the contract for the small `signPreview` helper:
+ *   - POSTs to `/api/my/preview/sign` with the correct body
+ *   - sends `Authorization` + `X-Profile-Id` via `buildApiHeaders`
+ *   - returns `{token, preview_url, expires_at}` on 2xx
+ *   - throws on 4xx
+ *
+ * The renewal scheduling behaviour is exercised by the iframe
+ * component tests under
+ * `src/sites/components/site-preview-signed.test.tsx`.
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("@/api/client", () => ({
+  buildApiHeaders: vi.fn(
+    (extras: Record<string, string> = {}, profileId?: string | null) => ({
+      ...extras,
+      Authorization: "Bearer TEST-BEARER",
+      ...(profileId ? { "X-Profile-Id": profileId } : {}),
+    }),
+  ),
+  ensureSelectedProfileId: vi.fn(async () => "tenant-a"),
+  getSelectedProfileId: vi.fn(() => "tenant-a"),
+}));
+
+import { signPreview } from "./api";
+
+describe("signPreview", () => {
+  const originalFetch = globalThis.fetch;
+
+  beforeEach(() => {
+    globalThis.fetch = vi.fn();
+  });
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+    vi.clearAllMocks();
+  });
+
+  it("POSTs the canonical body to /api/my/preview/sign", async () => {
+    const expiresAt = "2026-05-16T13:30:00.000Z";
+    (globalThis.fetch as ReturnType<typeof vi.fn>).mockResolvedValueOnce(
+      new Response(
+        JSON.stringify({
+          token: "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef",
+          preview_url:
+            "/api/preview-signed/0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef/index.html",
+          expires_at: expiresAt,
+        }),
+        { status: 200, headers: { "Content-Type": "application/json" } },
+      ),
+    );
+
+    const result = await signPreview({
+      profile_id: "tenant-a",
+      session_id: "site-A-1234567890",
+      site_slug: "test-site",
+    });
+
+    expect(globalThis.fetch).toHaveBeenCalledTimes(1);
+    const [url, init] = (globalThis.fetch as ReturnType<typeof vi.fn>).mock
+      .calls[0];
+    expect(url).toBe("/api/my/preview/sign");
+    expect(init?.method).toBe("POST");
+    const headers = init?.headers as Record<string, string>;
+    expect(headers).toMatchObject({
+      "Content-Type": "application/json",
+      Authorization: "Bearer TEST-BEARER",
+      "X-Profile-Id": "tenant-a",
+    });
+    expect(JSON.parse(init?.body as string)).toEqual({
+      profile_id: "tenant-a",
+      session_id: "site-A-1234567890",
+      site_slug: "test-site",
+    });
+
+    expect(result).toEqual({
+      token:
+        "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef",
+      preview_url:
+        "/api/preview-signed/0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef/index.html",
+      expires_at: expiresAt,
+    });
+  });
+
+  it("throws on 4xx so the iframe component can surface an error UI", async () => {
+    (globalThis.fetch as ReturnType<typeof vi.fn>).mockResolvedValueOnce(
+      new Response("forbidden", { status: 403 }),
+    );
+
+    await expect(
+      signPreview({
+        profile_id: "tenant-b",
+        session_id: "site-Z",
+        site_slug: "test-site",
+      }),
+    ).rejects.toThrow(/403/);
+  });
+
+  it("throws on 401 (sign endpoint requires auth)", async () => {
+    (globalThis.fetch as ReturnType<typeof vi.fn>).mockResolvedValueOnce(
+      new Response("unauthorized", { status: 401 }),
+    );
+
+    await expect(
+      signPreview({
+        profile_id: "tenant-a",
+        session_id: "site-A-1234567890",
+        site_slug: "test-site",
+      }),
+    ).rejects.toThrow(/401/);
+  });
+});


### PR DESCRIPTION
## Summary

Backend PR #1001 closed the cross-tenant `/api/preview/{profile_id}/...` data-read by requiring `Authorization: Bearer ...` on every request. That regressed the SPA's preview iframe — `<iframe src=...>` tags cannot inject headers, so the iframe 401-loops after the dashboard tab loads.

Codex's design: mint an opaque token via `POST /api/my/preview/sign` (which DOES send the bearer because the dashboard JS owns the request), then point `iframe.src` at the returned `/api/preview-signed/{token}/index.html`. The token is the auth credential for the iframe GETs.

This PR is the frontend half; the backend bridge lives in **octos-org/octos#1006**.

### Changes

- `src/sites/api.ts` — new `signPreview()` helper that POSTs to `/api/my/preview/sign` via `buildApiHeaders` so the bearer + X-Profile-Id ride along.
- `src/sites/components/site-preview.tsx` — calls `signPreview` on mount and on coordinate changes. Schedules a renewal at `expires_at - 60s` (clamped to >= 250 ms so test rigs with 5-second TTLs aren't no-ops) and swaps `iframe.src` to the new signed URL. On sign rejection (e.g. 403 cross-tenant) renders an inline error UI with a Retry button instead of pointing the iframe at a stale URL.
- `src/sites/pages/sites-editor-page.tsx` — passes `profileId` + `slug` through from the site project.

### Coordinated rollout

This PR pairs with the backend PR octos-org/octos#1006 adding `/api/preview-signed/{token}` and `POST /api/my/preview/sign`. **Both need to land together** so the dashboard's preview iframe doesn't 401-loop.

### Merge coordination — conflict with PR #139

Codex confirmed via `git merge-tree` that this PR and PR #139 (`fix/site-preview-iframe-sandbox`) touch overlapping lines in `src/sites/components/site-preview.tsx`. #139 changes `handleLoad`/`onError` AND removes the "open in new tab" link in addition to adding the same `sandbox` attribute that landed here in round 2. The conflict is expected and resolution is straightforward — both PRs apply the SAME `sandbox="allow-scripts allow-forms"` value:

- **If #139 lands first**: rebase this PR. Accept #139's `handleLoad`/`onError` changes and link removal; keep the sandbox attr (same value).
- **If this PR lands first**: rebase #139. Accept this PR's sandbox attr (same value); keep #139's `handleLoad`/`onError` changes.

Neither resolution introduces semantic ambiguity — the merge author just picks the larger superset of edits.

## Test plan

- [x] `npx tsc --noEmit` clean
- [x] `npm run build` clean (bundle: `dist/assets/index-APdRP7Zr.js`)
- [x] `npx vitest run src/sites` — 10/10 pass (3 in `signed-preview.test.ts`, 7 in `site-preview-signed.test.tsx` — including the new `should_recover_after_unmount_remount_cycle` StrictMode regression)
- [x] Full `vitest run` — 511/512 pass (the one failure in `ui-protocol-event-router.test.ts` is pre-existing on `origin/main`, unrelated to this PR)
- [ ] Reviewer: visually verify the iframe loads after backend PR #1006 deploys on a mini, then verify the renewal scheduler doesn't cause iframe flicker
- [ ] Reviewer: confirm the error UI surfaces gracefully when revoking a session mid-preview

### Round-3 codex fixups

- **HIGH (mounted-ref StrictMode bug)** — dropped the `mounted` boolean ref entirely. Pre-fixup, `mounted.current = false` was set on cleanup but never reset on remount, so under React 19 StrictMode dev mode every `signPreview` resolution was dropped (iframe stuck on "Loading preview…"). The request-id check (`signReqId.current !== myReqId`) is sufficient: cleanup now bumps `signReqId.current`, which invalidates in-flight resolutions, and the next mount captures a fresh id and succeeds. Added regression test `should_recover_after_unmount_remount_cycle` that wraps the SUT in `<StrictMode>`.
- **MEDIUM (#139 merge advisory)** — informational only; see "Merge coordination" above.

Scope kept minimal: this PR does NOT handle the "open in new tab" case from #139 (#139 owns that change) and does NOT touch other API auth flows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)