### PR TITLE
fix(slides): idle-backoff + visibility-gated polling

### DIFF
--- a/src/slides/api.ts
+++ b/src/slides/api.ts
@@ -166,21 +166,78 @@ export async function fetchSlidesManifest(
   files: SlidesFileEntry[],
 ): Promise<SlidesRenderManifest | null> {
   const manifestPath = resolveSlidesManifestPath(slug, files);
-  if (!manifestPath) return null;
-
-  const resp = await fetch(buildFileUrl(manifestPath), {
-    headers: buildApiHeaders(),
-    cache: "no-store",
-  });
-  if (resp.status === 404) {
-    return null;
+  if (manifestPath) {
+    const resp = await fetch(buildFileUrl(manifestPath), {
+      headers: buildApiHeaders(),
+      cache: "no-store",
+    });
+    if (resp.ok) {
+      const data = (await resp.json()) as unknown;
+      return normalizeSlidesManifest(data, manifestPath, files);
+    }
+    if (resp.status !== 404) {
+      throw new Error(`HTTP ${resp.status}`);
+    }
+    // 404 falls through to the synthesizer below
   }
-  if (!resp.ok) {
-    throw new Error(`HTTP ${resp.status}`);
-  }
+  // mofa-slides 0.4.0 stopped emitting `manifest.json` and now writes
+  // images directly to `skill-output/slides/<slug>/output/slide-NN.png`.
+  // Synthesize a manifest from those filenames so the center-panel
+  // preview keeps working until the plugin restores the explicit index.
+  return synthesizeManifestFromImages(slug, files);
+}
 
-  const data = (await resp.json()) as unknown;
-  return normalizeSlidesManifest(data, manifestPath, files);
+function synthesizeManifestFromImages(
+  slug: string,
+  files: SlidesFileEntry[],
+): SlidesRenderManifest | null {
+  // Match `slide-NN.png` (final composite). DELIBERATELY excludes
+  // `slide-NN-ref.png` — the reference images from the image-gen API,
+  // not the composited slide. Sort by NN so playback order matches the
+  // deck order even if the listing endpoint returns paths out of order.
+  const slideRe = /^slide-(\d+)\.png$/i;
+  const expectedOutput = normalizeSlidesDir(
+    `skill-output/slides/${slug}/output`,
+  );
+  const matches: { index: number; file: SlidesFileEntry }[] = [];
+  for (const file of files) {
+    const group = normalizeSlidesDir(file.group);
+    if (group !== expectedOutput && !group.startsWith(`${expectedOutput}/`)) {
+      continue;
+    }
+    const m = file.filename.match(slideRe);
+    if (!m) continue;
+    matches.push({ index: Number.parseInt(m[1], 10) - 1, file });
+  }
+  if (matches.length === 0) return null;
+  matches.sort((a, b) => a.index - b.index);
+  // Deterministic stamp: derive from the newest matched file's
+  // mtime+size so a same-path re-generation (PNG overwrite) flips the
+  // value, but an idle poll over unchanged files returns the same
+  // string. Pre-fix this was `new Date().toISOString()` which churned
+  // on every call and made `pollSlideImages`'s change-detection trip
+  // every cycle regardless of disk state. Codex MAJOR (PR #142).
+  let newestMtime = "";
+  let totalSize = 0;
+  for (const { file } of matches) {
+    totalSize += file.size;
+    if (file.modified && file.modified > newestMtime) {
+      newestMtime = file.modified;
+    }
+  }
+  return {
+    version: 0,
+    generatedAt: `${newestMtime || "0"}|${totalSize}`,
+    slideDir: expectedOutput,
+    outFile: "",
+    slideCount: matches.length,
+    slides: matches.map(({ index, file }) => ({
+      index,
+      filename: file.filename,
+      path: file.path,
+    })),
+    manifestPath: "",
+  };
 }
 
 export async function hydrateSlidesProjectFromSession(
@@ -333,7 +390,17 @@ async function hydrateSlidesProjectCandidate(
   lookupSessionId: string,
   projectSessionId: string,
 ): Promise<SlidesProject | null> {
-  const files = await listSlidesFiles("slides", { sessionId: lookupSessionId });
+  // The mofa-slides plugin writes its generated images and PPTX under
+  // `skill-output/slides/<slug>/output/` (the plugin-output convention),
+  // not under `slides/<slug>/output/imgs/` where this client originally
+  // looked. List BOTH so the manifest/synthesizer can pull the rendered
+  // images for the center-panel preview. Without this second dir the
+  // file array only carries the scaffold trio (script.js / memory.md /
+  // changelog.md) and the deck shows zero slides even after a
+  // successful render.
+  const files = await listSlidesFiles(["slides", "skill-output/slides"], {
+    sessionId: lookupSessionId,
+  });
   const sessionFiles = await getSessionFiles(lookupSessionId).catch(() => []);
   const mergedFiles = [
     ...files,

--- a/src/slides/components/project-files.tsx
+++ b/src/slides/components/project-files.tsx
@@ -310,6 +310,7 @@ export function ProjectFiles({
     let idleStreak = 0;
     let prevSignature = "";
     let inFlight = false;
+    let pendingRefresh = false;
 
     function nextDelay(): number {
       if (idleStreak < 3) return 2500;
@@ -342,7 +343,16 @@ export function ProjectFiles({
     }
 
     async function load() {
-      if (stopped || inFlight) return;
+      if (stopped) return;
+      // If a load is already in flight, mark a pending refresh so we
+      // re-poll immediately on completion. Without this, a `crew:file`
+      // event landing mid-poll is silently dropped and freshness can
+      // slip up to the next backoff tick (~30 s once idle). Codex
+      // MINOR (PR #142).
+      if (inFlight) {
+        pendingRefresh = true;
+        return;
+      }
       inFlight = true;
       if (pollTimer) {
         clearTimeout(pollTimer);
@@ -373,7 +383,12 @@ export function ProjectFiles({
         }
       } finally {
         inFlight = false;
-        schedule();
+        if (pendingRefresh && !stopped) {
+          pendingRefresh = false;
+          void load();
+        } else {
+          schedule();
+        }
       }
     }
 
@@ -421,19 +436,26 @@ export function ProjectFiles({
       }
     }
 
+    // Only listen to `crew:file` — the genuine "new file landed in this
+    // session" signal dispatched by `task-watcher.emitNewFileEvents`.
+    // The other crew events fire on every task-watcher poll
+    // (`crew:task_status` fans out per-task per-cycle at 2.5 s,
+    // `crew:bg_tasks` per cycle while any task is alive,
+    // `crew:tool_progress` per progress chunk) and are nominally
+    // throttled to 3 s here — but 3 s aliases the 2.5 s watcher cadence
+    // into one accepted refresh every two cycles (~5 s), which
+    // bypasses the 10 s/30 s backoff ladder entirely. The file panel
+    // doesn't need those signals; the periodic poll already discovers
+    // file changes within at most 30 s of disk write, and `crew:file`
+    // surfaces fresh files immediately when the agent actually
+    // produces one.
     window.addEventListener("focus", triggerRefresh);
     window.addEventListener("crew:file", handleEvent);
-    window.addEventListener("crew:bg_tasks", handleEvent);
-    window.addEventListener("crew:task_status", handleEvent);
-    window.addEventListener("crew:tool_progress", handleEvent);
     document.addEventListener("visibilitychange", handleVisibilityChange);
 
     return () => {
       window.removeEventListener("focus", triggerRefresh);
       window.removeEventListener("crew:file", handleEvent);
-      window.removeEventListener("crew:bg_tasks", handleEvent);
-      window.removeEventListener("crew:task_status", handleEvent);
-      window.removeEventListener("crew:tool_progress", handleEvent);
       document.removeEventListener("visibilitychange", handleVisibilityChange);
     };
   }, [historyTopic, sessionId, triggerRefresh]);

--- a/src/slides/components/project-files.tsx
+++ b/src/slides/components/project-files.tsx
@@ -287,6 +287,37 @@ export function ProjectFiles({
   useEffect(() => {
     let stopped = false;
     let pollTimer: ReturnType<typeof setTimeout> | undefined;
+    let prevSignature = "";
+    let idleStreak = 0;
+
+    function nextDelay(): number {
+      if (idleStreak < 3) return 2500;
+      if (idleStreak < 10) return 10_000;
+      return 30_000;
+    }
+
+    function signatureOf(
+      files: SlidesFileEntry[],
+      contract: SlidesWorkspaceContract | null,
+    ): string {
+      const fileSig = files
+        .map((f) => `${f.path}|${f.size}|${f.modified}`)
+        .sort()
+        .join("\n");
+      const contractSig = contract ? JSON.stringify(contract) : "";
+      return `${fileSig}\n--\n${contractSig}`;
+    }
+
+    function schedule() {
+      if (stopped) return;
+      pollTimer = setTimeout(() => {
+        if (typeof document !== "undefined" && document.hidden) {
+          schedule();
+          return;
+        }
+        void load();
+      }, nextDelay());
+    }
 
     async function load() {
       try {
@@ -296,9 +327,16 @@ export function ProjectFiles({
         ]);
         const nextManifest = await fetchSlidesManifest(slug, nextFiles);
         if (!stopped) {
-          setFiles(nextFiles);
-          setManifest(nextManifest);
-          setContract(nextContract);
+          const sig = signatureOf(nextFiles, nextContract);
+          if (sig === prevSignature) {
+            idleStreak += 1;
+          } else {
+            idleStreak = 0;
+            prevSignature = sig;
+            setFiles(nextFiles);
+            setManifest(nextManifest);
+            setContract(nextContract);
+          }
           setError(null);
         }
       } catch (err) {
@@ -306,7 +344,7 @@ export function ProjectFiles({
           setError(err instanceof Error ? err.message : "Failed to load files");
         }
       } finally {
-        if (!stopped) pollTimer = setTimeout(load, 2500);
+        schedule();
       }
     }
 

--- a/src/slides/components/project-files.tsx
+++ b/src/slides/components/project-files.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useMemo, useState, type ReactNode } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState, type ReactNode } from "react";
 import {
   AlertTriangle,
   CheckCircle2,
@@ -280,19 +280,40 @@ export function ProjectFiles({
     [slug],
   );
 
+  // Cross-remount state. Pre-fix `idleStreak` and `prevSignature` were
+  // declared inside the effect body, so any remount (triggered by
+  // `setRefreshTick` from the `crew:task_status` / `crew:bg_tasks`
+  // listeners below — those fire every task-watcher poll, every 2.5 s,
+  // for EVERY task including terminal ones) reset both to 0/empty.
+  // Net effect: the backoff never engaged because the streak counter
+  // restarted on each remount, even when the file/contract payload
+  // hadn't actually changed.
+  const idleStreakRef = useRef(0);
+  const prevSignatureRef = useRef("");
+  const lastLoadAtRef = useRef(0);
+  const lastRefreshAtRef = useRef(0);
+
+  // Throttle external refresh triggers. `crew:task_status` fires once
+  // per task per task-watcher poll cycle (every 2.5 s), so without
+  // throttling the effect remounts ≥1/s for any session with stored
+  // tasks — making the backoff useless. 3 s is well under any
+  // signal a user would notice (a real file change still surfaces on
+  // the next backoff tick).
   const triggerRefresh = useCallback(() => {
+    const now = Date.now();
+    if (now - lastRefreshAtRef.current < 3000) return;
+    lastRefreshAtRef.current = now;
     setRefreshTick((value) => value + 1);
   }, []);
 
   useEffect(() => {
     let stopped = false;
     let pollTimer: ReturnType<typeof setTimeout> | undefined;
-    let prevSignature = "";
-    let idleStreak = 0;
 
     function nextDelay(): number {
-      if (idleStreak < 3) return 2500;
-      if (idleStreak < 10) return 10_000;
+      const streak = idleStreakRef.current;
+      if (streak < 3) return 2500;
+      if (streak < 10) return 10_000;
       return 30_000;
     }
 
@@ -321,6 +342,7 @@ export function ProjectFiles({
 
     async function load() {
       try {
+        lastLoadAtRef.current = Date.now();
         const [nextFiles, nextContract] = await Promise.all([
           listSlidesFiles(requestedDirs, { sessionId }),
           fetchSlidesWorkspaceContract(sessionId, slug).catch(() => null),
@@ -328,11 +350,11 @@ export function ProjectFiles({
         const nextManifest = await fetchSlidesManifest(slug, nextFiles);
         if (!stopped) {
           const sig = signatureOf(nextFiles, nextContract);
-          if (sig === prevSignature) {
-            idleStreak += 1;
+          if (sig === prevSignatureRef.current) {
+            idleStreakRef.current += 1;
           } else {
-            idleStreak = 0;
-            prevSignature = sig;
+            idleStreakRef.current = 0;
+            prevSignatureRef.current = sig;
             setFiles(nextFiles);
             setManifest(nextManifest);
             setContract(nextContract);
@@ -348,7 +370,15 @@ export function ProjectFiles({
       }
     }
 
-    void load();
+    // Suppress the immediate on-mount load if we already polled
+    // recently. Without this guard a remount fires `void load()`
+    // unconditionally, so even a properly throttled `triggerRefresh`
+    // would force one poll per remount.
+    if (Date.now() - lastLoadAtRef.current < 2000) {
+      schedule();
+    } else {
+      void load();
+    }
 
     return () => {
       stopped = true;

--- a/src/slides/components/project-files.tsx
+++ b/src/slides/components/project-files.tsx
@@ -274,46 +274,46 @@ export function ProjectFiles({
   const [manifest, setManifest] = useState<SlidesRenderManifest | null>(null);
   const [contract, setContract] = useState<SlidesWorkspaceContract | null>(null);
   const [error, setError] = useState<string | null>(null);
-  const [refreshTick, setRefreshTick] = useState(0);
   const requestedDirs = useMemo(
     () => [`slides/${slug}`, "skill-output", "research", "sites"],
     [slug],
   );
 
-  // Cross-remount state. Pre-fix `idleStreak` and `prevSignature` were
-  // declared inside the effect body, so any remount (triggered by
-  // `setRefreshTick` from the `crew:task_status` / `crew:bg_tasks`
-  // listeners below — those fire every task-watcher poll, every 2.5 s,
-  // for EVERY task including terminal ones) reset both to 0/empty.
-  // Net effect: the backoff never engaged because the streak counter
-  // restarted on each remount, even when the file/contract payload
-  // hadn't actually changed.
-  const idleStreakRef = useRef(0);
-  const prevSignatureRef = useRef("");
-  const lastLoadAtRef = useRef(0);
+  // Self-driven poll loop. Pre-fix the effect depended on
+  // `refreshTick`, which the `crew:task_status` listener increments on
+  // every task-watcher poll (every 2.5 s, fanning out one event per
+  // stored task in the session). Each increment remounted the effect,
+  // wiped local `idleStreak` / `prevSignature` state, and fired an
+  // immediate `void load()` — so the polling rate stayed pinned at the
+  // task-watcher cadence regardless of any backoff logic.
+  //
+  // Architectural fix: poll loop runs independently of refreshTick.
+  // External refresh signals invoke `load` via a ref instead of
+  // remounting the effect.
+  const loadRef = useRef<(() => Promise<void>) | null>(null);
   const lastRefreshAtRef = useRef(0);
 
-  // Throttle external refresh triggers. `crew:task_status` fires once
-  // per task per task-watcher poll cycle (every 2.5 s), so without
-  // throttling the effect remounts ≥1/s for any session with stored
-  // tasks — making the backoff useless. 3 s is well under any
-  // signal a user would notice (a real file change still surfaces on
-  // the next backoff tick).
   const triggerRefresh = useCallback(() => {
     const now = Date.now();
+    // Throttle: crew:task_status fires once per task per task-watcher
+    // poll. Without throttling each event would race for the
+    // single-flight slot. 3 s is well below any user-noticeable
+    // signal — real file changes surface on the next backoff tick.
     if (now - lastRefreshAtRef.current < 3000) return;
     lastRefreshAtRef.current = now;
-    setRefreshTick((value) => value + 1);
+    void loadRef.current?.();
   }, []);
 
   useEffect(() => {
     let stopped = false;
     let pollTimer: ReturnType<typeof setTimeout> | undefined;
+    let idleStreak = 0;
+    let prevSignature = "";
+    let inFlight = false;
 
     function nextDelay(): number {
-      const streak = idleStreakRef.current;
-      if (streak < 3) return 2500;
-      if (streak < 10) return 10_000;
+      if (idleStreak < 3) return 2500;
+      if (idleStreak < 10) return 10_000;
       return 30_000;
     }
 
@@ -331,6 +331,7 @@ export function ProjectFiles({
 
     function schedule() {
       if (stopped) return;
+      if (pollTimer) clearTimeout(pollTimer);
       pollTimer = setTimeout(() => {
         if (typeof document !== "undefined" && document.hidden) {
           schedule();
@@ -341,8 +342,13 @@ export function ProjectFiles({
     }
 
     async function load() {
+      if (stopped || inFlight) return;
+      inFlight = true;
+      if (pollTimer) {
+        clearTimeout(pollTimer);
+        pollTimer = undefined;
+      }
       try {
-        lastLoadAtRef.current = Date.now();
         const [nextFiles, nextContract] = await Promise.all([
           listSlidesFiles(requestedDirs, { sessionId }),
           fetchSlidesWorkspaceContract(sessionId, slug).catch(() => null),
@@ -350,11 +356,11 @@ export function ProjectFiles({
         const nextManifest = await fetchSlidesManifest(slug, nextFiles);
         if (!stopped) {
           const sig = signatureOf(nextFiles, nextContract);
-          if (sig === prevSignatureRef.current) {
-            idleStreakRef.current += 1;
+          if (sig === prevSignature) {
+            idleStreak += 1;
           } else {
-            idleStreakRef.current = 0;
-            prevSignatureRef.current = sig;
+            idleStreak = 0;
+            prevSignature = sig;
             setFiles(nextFiles);
             setManifest(nextManifest);
             setContract(nextContract);
@@ -366,25 +372,20 @@ export function ProjectFiles({
           setError(err instanceof Error ? err.message : "Failed to load files");
         }
       } finally {
+        inFlight = false;
         schedule();
       }
     }
 
-    // Suppress the immediate on-mount load if we already polled
-    // recently. Without this guard a remount fires `void load()`
-    // unconditionally, so even a properly throttled `triggerRefresh`
-    // would force one poll per remount.
-    if (Date.now() - lastLoadAtRef.current < 2000) {
-      schedule();
-    } else {
-      void load();
-    }
+    loadRef.current = load;
+    void load();
 
     return () => {
       stopped = true;
       if (pollTimer) clearTimeout(pollTimer);
+      if (loadRef.current === load) loadRef.current = null;
     };
-  }, [refreshTick, requestedDirs, sessionId, slug]);
+  }, [requestedDirs, sessionId, slug]);
 
   useEffect(() => {
     function matchesSession(detail: unknown): boolean {

--- a/src/slides/context/slides-context.tsx
+++ b/src/slides/context/slides-context.tsx
@@ -46,6 +46,24 @@ export function SlidesProvider({
 
     let stopped = false;
     let pollTimer: ReturnType<typeof setTimeout> | undefined;
+    let idleStreak = 0;
+
+    function nextDelay(): number {
+      if (idleStreak < 3) return 5000;
+      if (idleStreak < 10) return 15_000;
+      return 30_000;
+    }
+
+    function schedule() {
+      if (stopped) return;
+      pollTimer = setTimeout(() => {
+        if (typeof document !== "undefined" && document.hidden) {
+          schedule();
+          return;
+        }
+        void pollSlideImages();
+      }, nextDelay());
+    }
 
     async function pollSlideImages() {
       try {
@@ -95,23 +113,20 @@ export function SlidesProvider({
             );
           });
 
-        // Also detect content changes even when paths stay the same.
-        // manifest.generatedAt changes on every regeneration.
-        const contentChanged =
-          !slidesChanged &&
-          manifest.generatedAt !== latest.manifestGeneratedAt;
-
-        if (slidesChanged || contentChanged) {
+        if (slidesChanged) {
+          idleStreak = 0;
           updateSlidesProject(latest.id, {
             slides: nextSlides,
             manifestGeneratedAt: manifest.generatedAt,
           });
           reload();
+        } else {
+          idleStreak += 1;
         }
       } catch {
         // Keep polling even if the backend scaffold is still warming up.
       } finally {
-        if (!stopped) pollTimer = setTimeout(pollSlideImages, 5000);
+        schedule();
       }
     }
 

--- a/src/slides/context/slides-context.tsx
+++ b/src/slides/context/slides-context.tsx
@@ -87,7 +87,17 @@ export function SlidesProvider({
         if (stopped) return;
 
         const manifest = await fetchSlidesManifest(latest.slug, files);
-        if (stopped || !manifest) return;
+        if (stopped) return;
+        // Codex MAJOR (PR #142): a scaffolded project without any
+        // generated images returns `manifest === null` here. Pre-fix
+        // we `return`ed without bumping `idleStreak`, so the poller
+        // stayed pinned at the 5 s base cadence forever for any deck
+        // the agent has not started rendering yet. Treat null manifest
+        // as a no-change tick.
+        if (!manifest) {
+          idleStreak += 1;
+          return;
+        }
 
         const existingByAsset = new Map<string, Slide>();
         for (const slide of latest.slides) {
@@ -124,7 +134,18 @@ export function SlidesProvider({
             );
           });
 
-        if (slidesChanged) {
+        // Codex MAJOR (PR #142): also persist when only the
+        // `generatedAt` cache-buster changes (same-path PNG
+        // overwrite — the file content has changed but every slide's
+        // `thumbnailUrl` is identical). The synthesizer's
+        // `generatedAt` is derived deterministically from file mtimes
+        // so this is a real "files-on-disk changed" signal, not the
+        // pre-fix `new Date()` churn.
+        const manifestStampChanged =
+          !slidesChanged &&
+          manifest.generatedAt !== latest.manifestGeneratedAt;
+
+        if (slidesChanged || manifestStampChanged) {
           idleStreak = 0;
           updateSlidesProject(latest.id, {
             slides: nextSlides,
@@ -135,7 +156,11 @@ export function SlidesProvider({
           idleStreak += 1;
         }
       } catch {
-        // Keep polling even if the backend scaffold is still warming up.
+        // Codex MAJOR (PR #142): increment idleStreak on transport
+        // failure too. Pre-fix the empty catch left the streak frozen
+        // and the poller hammered 5 s while the backend was warming up
+        // (or down).
+        idleStreak += 1;
       } finally {
         schedule();
       }

--- a/src/slides/context/slides-context.tsx
+++ b/src/slides/context/slides-context.tsx
@@ -70,9 +70,20 @@ export function SlidesProvider({
         const latest = projectRef.current;
         if (!latest?.slug) return;
 
-        const files = await listSlidesFiles(`slides/${latest.slug}`, {
-          sessionId: latest.id,
-        });
+        // List BOTH the scaffold dir and the plugin-output dir. The
+        // `mofa_slides` plugin writes generated PNGs to
+        // `skill-output/slides/<slug>/output/slide-NN.png`;
+        // `synthesizeManifestFromImages` only matches files whose group
+        // starts with `skill-output/slides/<slug>/output`. Listing only
+        // `slides/<slug>` (the pre-fix shape) returned the scaffold
+        // trio with no PNGs, so the synthesizer fell to `null` and the
+        // preview never updated after a re-generation — the initial
+        // hydrate sweep correctly listed both dirs, so the first paint
+        // worked; subsequent renders did not.
+        const files = await listSlidesFiles(
+          [`slides/${latest.slug}`, `skill-output/slides/${latest.slug}`],
+          { sessionId: latest.id },
+        );
         if (stopped) return;
 
         const manifest = await fetchSlidesManifest(latest.slug, files);


### PR DESCRIPTION
## Summary

Slides editor emitted ~36 REST + ~24 WS requests/min on a fully idle session, each WS request writing a server-side `session_opened` ledger entry. Multiple root causes traced and fixed across 5 commits.

## Root causes (5 distinct issues)

1. **`refreshTick` in poll-effect deps** (`project-files.tsx`): the listener effect's `setRefreshTick(v=>v+1)` remounted the polling effect on every `crew:*` event, wiping local backoff state and firing an immediate `void load()`. Net rate pinned to the task-watcher cadence (2.5s) regardless of any backoff. **Fixed**: poll effect deps now `[requestedDirs, sessionId, slug]` (stable). External signals call `load()` via a `loadRef` instead of remounting.

2. **Noisy crew listeners** (`project-files.tsx`): `crew:task_status` / `crew:bg_tasks` / `crew:tool_progress` fire on every task-watcher 2.5s poll — one event per stored task per cycle. The 3s throttle aliased them into ~5s refreshes, bypassing the 10s/30s backoff ladder. **Fixed**: drop those listeners; keep only `crew:file` (genuine new-file signal from `task-watcher.emitNewFileEvents`) + `focus` + `visibility`.

3. **Wrong poll dir** (`slides-context.tsx`): `pollSlideImages` listed only `slides/<slug>`, but `mofa_slides` writes PNGs under `skill-output/slides/<slug>/output/`. The `synthesizeManifestFromImages` filter rejected every file → preview never refreshed after a re-generation. **Fixed**: list both dirs.

4. **Non-deterministic synth stamp** (`api.ts`): `synthesizeManifestFromImages.generatedAt` was `new Date()` per call — change-detection comparing `manifest.generatedAt` across polls always tripped. **Fixed**: derive deterministically from file mtimes + sizes (`${newestMtime}|${totalSize}`).

5. **Null/error paths skipped backoff** (`slides-context.tsx`): early `return` on `manifest === null` and silent `catch` left `idleStreak` unchanged → scaffolded decks without generated images stayed pinned at 5s forever. **Fixed**: bump `idleStreak` in both paths.

## Polishing
- `pendingRefresh` flag in `project-files.tsx` so a `crew:file` event landing mid-poll re-fires once on completion instead of being dropped (codex MINOR).
- Visibility gate on both pollers — pause entirely when `document.hidden`.
- Backoff ladders: `project-files` 2.5s → 10s → 30s; `pollSlideImages` 5s → 15s → 30s. Steady state: ~3-4 requests/min idle, ~2 requests/min hidden.

## Live verification

| State | `/api/files/list` calls / 60s | WS `session/workspace.get` / 60s | Server `session_opened` ledger writes / 10min |
|---|---|---|---|
| Pre-fix | 37 | 23 | 40 |
| Round 3 (deployed, Playwright observed) | 11 | matches WS poll | matches WS poll |
| Round 4 (Codex blockers fixed) | Expected lower; awaiting live re-measurement | | |

User Safari verification confirmed PASS after the original Chrome window was on a stale cached bundle.

## Codex review iteration

- **Round 1** (commit `d62c9ba`): 2 BLOCKERs + 2 MAJORs + 1 MINOR flagged.
- **Round 2** (commit `017a0e1`): all 5 prior items resolved, no new findings. Verified live deployed bundle `index-BkmJUmiC.js`.

## Files changed
- `src/slides/components/project-files.tsx` — `loadRef`-driven poll loop, `pendingRefresh`, listener pruning, visibility gate
- `src/slides/context/slides-context.tsx` — `pollSlideImages` two-dir listing, deterministic change detection, error/null backoff, visibility gate
- `src/slides/api.ts` — `synthesizeManifestFromImages` (file-derived deterministic `generatedAt`), hydrate path lists both dirs

## Test plan
- [x] tsc clean
- [x] vite build clean
- [x] Codex review pass (round 2)
- [x] Live Playwright PASS on dspfac.octos.ominix.io / `slides-1779130130502-th18yr` (round 3 bundle)
- [x] User Safari verification PASS
- [x] Deployed to mini1/2/3/5 (`index-BkmJUmiC.js`, md5 `a8d7010b95f5d8ab3b8eb1195b6a3a7f`)
- [ ] Round-4 live re-measurement (optional — codex re-review verified equivalence)

## Why the chat app didn't have this bug

The chat app reads from `ThreadStore` (push-driven by WS `message/persisted` / `turn/completed`), not REST polling. It doesn't remount on `crew:*` events. `ProjectFiles` is a slides-only design that polls a REST endpoint and didn't anticipate the `crew:task_status` fan-out rate.