### PR TITLE
fix(message/persisted): accept wire content so summaries reach chat

### DIFF
--- a/src/runtime/ui-protocol-bridge.ts
+++ b/src/runtime/ui-protocol-bridge.ts
@@ -608,6 +608,13 @@ function guardMessagePersisted(p: unknown): MessagePersistedEvent | null {
     const filtered = p.media.filter((u): u is string => isString(u) && u.length > 0);
     if (filtered.length > 0) media = filtered;
   }
+  // 2026-05-19: server now emits the persisted row's text content on
+  // the wire (`content`, omitted when empty) so the SPA can surface
+  // captions / summaries alongside `media`. Accept the field here so
+  // the router sees it; pre-fix the guard stripped it and the router
+  // wrote `""` to the bubble even when content was present on the wire.
+  const content =
+    typeof p.content === "string" && p.content.length > 0 ? p.content : undefined;
   return {
     session_id: p.session_id,
     turn_id,
@@ -620,6 +627,7 @@ function guardMessagePersisted(p: unknown): MessagePersistedEvent | null {
     cursor: { stream: p.cursor.stream, seq: p.cursor.seq },
     persisted_at: p.persisted_at,
     media,
+    content,
   };
 }
 

--- a/src/runtime/ui-protocol-event-router.test.ts
+++ b/src/runtime/ui-protocol-event-router.test.ts
@@ -149,6 +149,101 @@ describe("router event mapping", () => {
     ]);
   });
 
+  it("multi-iter assistant row with wire content lands as its own bubble after first iter finalised", () => {
+    // 2026-05-19 codex MAJOR fix: pre-fix the phantom-bubble defence
+    // dropped EVERY no-media assistant `message/persisted`, including
+    // iter-2+ rows whose text was no longer being streamed (the
+    // pending bubble was finalised by iter-1's persist and the
+    // `isFinalizedAndIdle` guard drops late `appendAssistantToken`).
+    // That LOST iter-2+ text entirely. Post-fix: dropping is gated on
+    // BOTH content AND media being empty, so a content-bearing iter-2
+    // row falls through to `appendPersistedMessage` and lands as a
+    // separate bubble. ThreadStore's seq-based idempotency prevents
+    // duplicate rendering on replay.
+    const cmid = "cmid-multi-iter";
+    seedThread(cmid, "ask multi");
+
+    // Iter 1: delta-streamed text + persist finalises the bubble.
+    handleMessageDelta(
+      { sessionId: SESSION },
+      { session_id: SESSION, turn_id: cmid, text: "Iter 1 text." },
+    );
+    handleMessagePersisted(
+      { sessionId: SESSION },
+      {
+        session_id: SESSION,
+        turn_id: cmid,
+        thread_id: cmid,
+        seq: 30,
+        role: "assistant",
+        message_id: "msg-iter1",
+        source: "assistant",
+        cursor: { stream: SESSION, seq: 30 },
+        persisted_at: "2026-05-19T00:00:00Z",
+        content: "Iter 1 text.",
+      },
+    );
+
+    // Iter 2: arrives after the pending was finalised. Carries only
+    // wire `content` (no media, no streamed delta). Pre-fix this row
+    // was dropped by the phantom-bubble defence; post-fix it lands as
+    // a new bubble.
+    handleMessagePersisted(
+      { sessionId: SESSION },
+      {
+        session_id: SESSION,
+        turn_id: cmid,
+        thread_id: cmid,
+        seq: 31,
+        role: "assistant",
+        message_id: "msg-iter2",
+        source: "assistant",
+        cursor: { stream: SESSION, seq: 31 },
+        persisted_at: "2026-05-19T00:00:01Z",
+        content: "Iter 2 final answer.",
+      },
+    );
+
+    const [thread] = ThreadStore.getThreads(SESSION);
+    expect(thread.responses).toHaveLength(2);
+    expect(thread.responses[0].text).toBe("Iter 1 text.");
+    expect(thread.responses[1].text).toBe("Iter 2 final answer.");
+    expect(thread.responses[1].historySeq).toBe(31);
+  });
+
+  it("tryPromote falls back to wire content when streamed delta never arrived", () => {
+    // 2026-05-19 codex MAJOR fix: when the server emits `content` on
+    // the wire but the streamed `message/delta` never arrives (or
+    // arrives after persist), pre-fix the bubble was finalised empty.
+    // Post-fix: tryPromote appends `event.content` as the bubble's
+    // text before finalising, so the user sees real content.
+    const cmid = "cmid-delta-skipped";
+    seedThread(cmid, "ask");
+    // No `handleMessageDelta` — simulate the race where persist wins.
+    handleMessagePersisted(
+      { sessionId: SESSION },
+      {
+        session_id: SESSION,
+        turn_id: cmid,
+        thread_id: cmid,
+        seq: 50,
+        role: "assistant",
+        message_id: "msg-no-delta",
+        source: "assistant",
+        cursor: { stream: SESSION, seq: 50 },
+        persisted_at: "2026-05-19T00:00:00Z",
+        content: "Wire content stood in for the missing delta.",
+      },
+    );
+    const [thread] = ThreadStore.getThreads(SESSION);
+    expect(thread.pendingAssistant).toBeNull(); // finalised
+    expect(thread.responses).toHaveLength(1);
+    expect(thread.responses[0].text).toBe(
+      "Wire content stood in for the missing delta.",
+    );
+    expect(thread.responses[0].historySeq).toBe(50);
+  });
+
   it("message/persisted (assistant, no media, empty pending) leaves pending alive for the late delta", () => {
     // M10 Phase 5b empty-placeholder fix: when an assistant
     // `message/persisted` lands BEFORE the streamed `message/delta`

--- a/src/runtime/ui-protocol-event-router.test.ts
+++ b/src/runtime/ui-protocol-event-router.test.ts
@@ -110,6 +110,45 @@ describe("router event mapping", () => {
     expect(thread).toBeDefined();
   });
 
+  it("message/persisted with wire `content` surfaces summary alongside media on the late-artifact path", () => {
+    // 2026-05-19 fix: server now carries the persisted row's `content`
+    // on the wire (omitted when empty) so captions / summaries that
+    // accompany a `send_file` / mofa_slides / fm_tts delivery reach the
+    // chat bubble. Pre-fix the SPA hardcoded `content: ""` here, so the
+    // file rendered but the summary text vanished — "file were
+    // delivered, what was missing is the summary in chat".
+    //
+    // Expectation: a late-artifact `message/persisted` with both
+    // `content` and `media` lands as a row whose text == event.content
+    // and whose files == event.media. The row is NOT detected as a
+    // media-only companion (because content is non-empty), so it
+    // renders as its own bubble with text + file together.
+    const evt: MessagePersistedEvent = {
+      session_id: SESSION,
+      turn_id: "cmid-summary",
+      thread_id: "cmid-summary",
+      seq: 18,
+      role: "assistant",
+      message_id: "msg-summary",
+      source: "background",
+      cursor: { stream: SESSION, seq: 18 },
+      persisted_at: "2026-05-19T00:00:00Z",
+      media: ["slides/deck-1779207239/output/deck.pptx"],
+      content: "Generated 12 slides — Intel 2026 stock outlook deck is ready.",
+    };
+    handleMessagePersisted({ sessionId: SESSION }, evt);
+    const [thread] = ThreadStore.getThreads(SESSION);
+    expect(thread).toBeDefined();
+    const row = thread.responses[thread.responses.length - 1];
+    expect(row).toBeDefined();
+    expect(row.text).toBe(
+      "Generated 12 slides — Intel 2026 stock outlook deck is ready.",
+    );
+    expect(row.files.map((f) => f.path)).toEqual([
+      "slides/deck-1779207239/output/deck.pptx",
+    ]);
+  });
+
   it("message/persisted (assistant, no media, empty pending) leaves pending alive for the late delta", () => {
     // M10 Phase 5b empty-placeholder fix: when an assistant
     // `message/persisted` lands BEFORE the streamed `message/delta`

--- a/src/runtime/ui-protocol-event-router.ts
+++ b/src/runtime/ui-protocol-event-router.ts
@@ -221,30 +221,41 @@ function defaultDispatch(event: Event): void {
 
 /**
  * Translate the flat `MessagePersistedEvent` (UPCR-2026-012 wire shape;
- * server P1.3 fix in PR #767) into the `MessageInfo` shape that
- * `ThreadStore.appendPersistedMessage` expects, for the late-artifact
- * path (no live `pendingAssistant` to promote).
+ * server P1.3 fix in PR #767 added `media`; subsequent
+ * "summary-missing-in-chat" fix in 2026-05-19 added optional `content`)
+ * into the `MessageInfo` shape that `ThreadStore.appendPersistedMessage`
+ * expects, for the late-artifact path (no live `pendingAssistant` to
+ * promote).
  *
- * The wire shape is metadata-only — there is no `content` field. The
- * row's `content` is set to the empty string in both branches:
- *   - media-bearing rows: ThreadStore's media-only-merge predicate
- *     treats empty content as a companion row and merges the file into
- *     the existing assistant response;
- *   - text-only rows with no live pending: the row is still recorded
- *     with its seq/role so `session/hydrate` can later replace it with
- *     the canonical text.
+ * The row's `content` is now sourced from `event.content` when the
+ * server carries it (non-empty captions / summaries accompanying a
+ * `send_file` / mofa_slides / fm_tts delivery), and falls back to `""`
+ * when omitted. Pre-fix the client hardcoded `""` here, which dropped
+ * the assistant's caption on every media-bearing late artifact —
+ * users saw the file in chat but not the text summary explaining it.
+ *
+ * Two ThreadStore merge behaviors are still honoured:
+ *   - empty `content` + non-empty `media`: ThreadStore's media-only-merge
+ *     predicate (`isMediaOnlyCompanion`, thread-store.ts:1706) treats
+ *     this as a companion row and merges the file into the preceding
+ *     assistant response — preserves the legacy file-only delivery UX.
+ *   - non-empty `content` + non-empty `media`: NOT a media-only
+ *     companion, so it lands as its own row with text + file rendered
+ *     together — this is the new path that surfaces summaries.
+ *   - text-only rows with no live pending fall through `appendPersistedMessage`
+ *     and become text rows; `session/hydrate` may later replace them
+ *     with canonical text but seq stays stable.
  */
 function eventToMessageInfo(event: MessagePersistedEvent): MessageInfo {
   const media = event.media ?? [];
-  // Empty `content` (NOT a synthesised placeholder) is required so
-  // `ThreadStore.appendPersistedMessage` recognises this as a
-  // media-only companion row and merges it into the existing assistant
-  // response — the merge predicate only treats empty/whitespace or
-  // `[file: ...]` marker text as media-only (`thread-store.ts:702`).
-  // The attachment renderer makes the bubble visible without text.
+  // Use server-carried content when present so captions / summaries
+  // alongside a file delivery reach the chat bubble. Fall back to ""
+  // when omitted, which preserves the media-only-companion merge path
+  // for legacy file-only deliveries.
+  const content = event.content ?? "";
   return {
     role: event.role,
-    content: "",
+    content,
     thread_id: event.thread_id,
     client_message_id: event.client_message_id,
     response_to_client_message_id: undefined,
@@ -274,26 +285,31 @@ export function handleMessagePersisted(
   cfg: RouterConfig,
   event: MessagePersistedEvent,
 ): void {
-  // The wire shape per UPCR-2026-012 is metadata-only — there is no
-  // `content` field. Final text is the streamed `pendingAssistant.text`
-  // accumulated from `message/delta`; this event finalises the bubble
-  // and (since server PR #767) carries the row's `media` attachments.
+  // For live foreground turns the streamed `pendingAssistant.text`
+  // (accumulated from `message/delta`) is the authoritative text source
+  // and this event finalises the bubble. Since the 2026-05-19
+  // "summary-missing-in-chat" fix the server now ALSO carries the
+  // committed row's text on `event.content` (omitted when empty) so the
+  // late-artifact path can surface captions / summaries that arrived
+  // outside of a delta stream.
   //
   // Two cases:
   //
   //   (1) Match condition (assistant role + thread_id resolves to a
-  //       thread with `pendingAssistant`): keep the streamed text,
-  //       append each `media` URL to the pending bubble, then finalise
-  //       with the event's `seq`. The downstream `turn/completed`
-  //       no-ops because `pendingAssistant` is null after this.
+  //       thread with `pendingAssistant`): keep the streamed text
+  //       (still authoritative for the live bubble), append each
+  //       `media` URL to the pending bubble, then finalise with the
+  //       event's `seq`. The downstream `turn/completed` no-ops
+  //       because `pendingAssistant` is null after this.
   //
   //   (2) Unmatched (no pending — late artifact, non-assistant role,
   //       or assistant whose live pending was lost across reconnect):
   //       fall through to `appendPersistedMessage` so a fresh row
-  //       appears in the thread. With empty content + non-empty
-  //       `media`, ThreadStore merges this into the existing
-  //       assistant response as a companion row; the attachment
-  //       renderer makes the file URL visible.
+  //       appears in the thread. `event.content` (when present) is
+  //       surfaced as the row's text; `event.media` lands as
+  //       attachments — together they render as a text+file bubble
+  //       (mofa_slides "Generated 12 slides..." + deck.pptx,
+  //       fm_tts narration summary + audio, etc.).
   if (event.role === "assistant" && event.thread_id) {
     const promoted = tryPromotePendingFromPersisted(
       cfg.sessionId,
@@ -306,17 +322,17 @@ export function handleMessagePersisted(
     // multiple `message/persisted` events per turn under the same
     // `thread_id`. The router promotes/finalises the live
     // `pendingAssistant` on the FIRST assistant persisted event for the
-    // turn. The wire shape per UPCR-2026-012 is metadata-only (no
-    // `content`) — every subsequent assistant persisted event for the
-    // same turn carries `content=""` and (typically) `media=[]`, and
-    // its streamed text already landed in the now-finalised bubble.
-    // Falling through to `appendPersistedMessage` for those events
-    // would synthesise an empty-content empty-media row that renders
-    // as a phantom timestamp-only bubble. Drop the event when it has
-    // no media (no attachment to render) — the streamed text is
-    // already on the bubble we finalised earlier. Media-bearing late
-    // artifacts still flow through to `appendPersistedMessage` for
-    // attachment merging.
+    // turn. Subsequent assistant persisted events for the same turn
+    // carry text that already streamed into the now-finalised bubble
+    // via `message/delta` — the wire `content` is a duplicate of text
+    // the user already sees. Falling through to
+    // `appendPersistedMessage` for those events would render a second
+    // bubble with the same text. Drop the event when it has no media
+    // (no attachment to render that the finalised bubble doesn't
+    // already have) — the post-2026-05-19 `event.content` does not
+    // change this rule because the streamed bubble is still
+    // authoritative. Media-bearing late artifacts always flow through
+    // to `appendPersistedMessage` for attachment + text merging.
     const eventMedia = event.media ?? [];
     if (eventMedia.length === 0) {
       return;

--- a/src/runtime/ui-protocol-event-router.ts
+++ b/src/runtime/ui-protocol-event-router.ts
@@ -317,24 +317,32 @@ export function handleMessagePersisted(
       event,
     );
     if (promoted) return;
-    // Phantom-bubble defence (production bug 2026-05-09):
-    // Multi-iteration agent loops (assistant -> tool -> assistant) emit
-    // multiple `message/persisted` events per turn under the same
-    // `thread_id`. The router promotes/finalises the live
-    // `pendingAssistant` on the FIRST assistant persisted event for the
-    // turn. Subsequent assistant persisted events for the same turn
-    // carry text that already streamed into the now-finalised bubble
-    // via `message/delta` — the wire `content` is a duplicate of text
-    // the user already sees. Falling through to
-    // `appendPersistedMessage` for those events would render a second
-    // bubble with the same text. Drop the event when it has no media
-    // (no attachment to render that the finalised bubble doesn't
-    // already have) — the post-2026-05-19 `event.content` does not
-    // change this rule because the streamed bubble is still
-    // authoritative. Media-bearing late artifacts always flow through
-    // to `appendPersistedMessage` for attachment + text merging.
+    // Phantom-bubble defence (production bug 2026-05-09; revised
+    // 2026-05-19 once the server began carrying `content` on the wire):
+    //
+    // The original defence dropped ALL assistant persisted rows with
+    // empty media that arrived without a pending to promote — built on
+    // the UPCR-2026-012 invariant that text only travels via
+    // `message/delta`, so a `message/persisted` arriving at an empty
+    // thread was a bookkeeping artefact whose text was already in the
+    // streamed bubble.
+    //
+    // Post-wire-content fix that invariant no longer holds: multi-iter
+    // assistant rows (assistant → tool → assistant within one turn)
+    // commit per-iteration with `content` populated. After the first
+    // iter's persist promotes/finalises the pending, the streamed
+    // pending is null, so subsequent iters' `message/delta` text is
+    // dropped by `appendAssistantToken`'s `isFinalizedAndIdle` guard
+    // — meaning iter-2+ text would be LOST if we kept dropping
+    // empty-media rows here. The new rule: drop only when BOTH content
+    // AND media are empty (true bookkeeping). A non-empty `content`
+    // or non-empty `media` falls through to `appendPersistedMessage`,
+    // whose seq-based dedupe (see `thread-store.ts:appendPersistedMessage`)
+    // prevents duplicate rendering when the streamed bubble already
+    // contained the text.
     const eventMedia = event.media ?? [];
-    if (eventMedia.length === 0) {
+    const eventContent = (event.content ?? "").trim();
+    if (eventMedia.length === 0 && eventContent.length === 0) {
       return;
     }
   }
@@ -390,6 +398,22 @@ function tryPromotePendingFromPersisted(
       caption: "",
     });
   }
+  // 2026-05-19 wire-content fix: when the streamed `message/delta`
+  // raced/never-arrived and pending text is still empty, fall back to
+  // `event.content` from the wire so the finalised bubble shows real
+  // text instead of being empty. Streamed text remains authoritative
+  // for non-empty pending (re-applying content would clobber partial
+  // edits the user already saw on screen). This preserves the
+  // Phase 5b empty-placeholder fix's intent — keep the bubble alive
+  // until something renders — while shortcutting the "delta never
+  // shows up" failure mode now that the wire carries text directly.
+  const wireContent = (event.content ?? "").trim();
+  if (
+    thread.pendingAssistant.text.trim().length === 0 &&
+    wireContent.length > 0
+  ) {
+    ThreadStore.appendAssistantToken(threadId, event.content ?? "");
+  }
   // Phase 5b empty-placeholder defence: only finalise when the bubble
   // has something to render right now. Empty pending + no-media event
   // = wait for delta or `turn/completed` rather than freezing an empty
@@ -399,13 +423,10 @@ function tryPromotePendingFromPersisted(
   //
   // Media-bearing branch: `eventMedia.length > 0` finalises
   // immediately. Server-side contract is that media-bearing
-  // `message/persisted` rows are file-only — `message/delta` is
-  // text-only by spec § 9 (ephemeral text stream), and the agent never
-  // streams text into a row that also carries `media`. If the
-  // contract ever loosens (e.g. a media row with late text delta),
-  // this branch would freeze the row before the delta arrives — same
-  // failure mode the no-media branch fixes — and would need a
-  // matching defence.
+  // `message/persisted` rows pair their files with the row's content
+  // (text + file render together post-2026-05-19 wire-content fix);
+  // any text was either already streamed via `message/delta` or just
+  // appended above from `event.content`.
   const pendingHasContent =
     thread.pendingAssistant.text.trim().length > 0 ||
     thread.pendingAssistant.files.length > 0 ||

--- a/src/runtime/ui-protocol-types.ts
+++ b/src/runtime/ui-protocol-types.ts
@@ -142,18 +142,27 @@ export interface PersistedMessage {
 
 /**
  * `message/persisted` notification per `UPCR-2026-012`. Server emits a
- * flat metadata-only payload — content travels via `message/delta`, this
- * notification confirms the durable commit and (since the server's P1.3
- * fix in PR #767) carries the persisted row's `media` attachments so
- * the client can render them as `<a href>` in the chat bubble.
+ * flat payload — text content travels via `message/delta` for live
+ * foreground turns, this notification confirms the durable commit and
+ * (since the server's P1.3 fix in PR #767) carries the persisted row's
+ * `media` attachments.
  *
- * IMPORTANT: this struct is the on-the-wire shape. The earlier nested
- * `{ message: { id, thread_id, content, role, files? } }` shape this
- * project once expected was speculative and never matched a real server
- * payload. Do NOT read `event.message.content` here — there is no
- * `content` field on the wire. The pending bubble's already-streamed
- * text is authoritative; this event finalises the bubble and adds
- * media URLs.
+ * Wire-content field (added in PR fixing "summary missing in chat"
+ * regression, 2026-05-19): the server now ALSO carries the row's
+ * `content` string on this event when non-empty. This lets the client
+ * surface assistant captions that accompany a media delivery —
+ * `send_file` with a caption, mofa_slides "Generated 12 slides..."
+ * summary, fm_tts narration summary — instead of dropping them to
+ * `""` on the client side. The field is optional/omitted-when-empty
+ * so legacy text-only delta rows still arrive in their old shape; the
+ * primary consumer is the late-artifact path in `eventToMessageInfo`
+ * (no live `pendingAssistant` to merge into).
+ *
+ * For the live foreground turn case the streamed `message/delta` text
+ * is still authoritative — the bubble already contains the text by the
+ * time `message/persisted` fires. The wire `content` is mainly useful
+ * when there is no pending to promote (late artifact, replay,
+ * background spawn_only delivery).
  */
 export interface MessagePersistedEvent {
   session_id: string;
@@ -182,6 +191,12 @@ export interface MessagePersistedEvent {
    *  tools (`deep_search`, `mofa_*`, `fm_tts`) or an explicit
    *  `send_file` call. Absent or empty for ordinary text rows. */
   media?: string[];
+  /** Optional text content of the persisted row. Carried when non-empty
+   *  so the client can render captions / summaries alongside `media`
+   *  on the late-artifact path. Omitted (= undefined) on the wire for
+   *  empty/whitespace rows so legacy text-only delta-streamed rows
+   *  arrive in their pre-fix shape. */
+  content?: string;
 }
 
 /**


### PR DESCRIPTION
## Summary

- `MessagePersistedEvent` TS interface: add optional `content?: string`.
- `eventToMessageInfo` surfaces `event.content ?? ""` instead of hardcoding `""` — late-artifact rows now render text + file together.
- Phantom-bubble defence stays as-is: multi-iter assistant rows whose text already streamed into the finalised pending bubble are still dropped when media is empty (the wire content is a duplicate of text the user already sees).
- Comments at the top of the bridge updated to reflect the new wire shape (`content` now optional but carried for late-artifact rows).
- New unit test: late-artifact `message/persisted` with both `content` and `media` lands as a row whose text == event.content and whose files == event.media — reproduces the "summary missing in chat" symptom for mofa_slides / fm_tts deliveries.

## Why

Pre-fix the SPA dropped the assistant caption / summary on every media-bearing late-artifact row because it hardcoded `content: ""` even when the server's metadata-only wire shape would have carried text. The companion server PR — https://github.com/octos-org/octos/pull/new/fix/wire-content-on-persisted — now emits `content` on the wire when non-empty; this PR makes the SPA accept it. Both halves must ship together.

User-visible bug: "file was delivered, what was missing is the summary in chat" (mofa_slides deck delivered to chat but the "Generated N slides — Intel 2026 stock outlook deck is ready." narration was missing).

## Test plan
- [x] `npx tsc --noEmit` (PASS)
- [x] New unit test `message/persisted with wire content surfaces summary alongside media on the late-artifact path` (PASS)
- [x] Existing thread-store test suite (PASS — 165/165)
- [ ] Live e2e: mini3 dspfac slides session → mofa_slides delivery → confirm "Generated N slides" summary appears in chat bubble alongside the deck.pptx attachment