### PR TITLE
Fix queued web message rendering and M12 polish tests

### DIFF
--- a/src/lib/feature-flags.test.ts
+++ b/src/lib/feature-flags.test.ts
@@ -13,7 +13,7 @@
  *   - UNSET (null)                                                 → ON
  */
 
-import { afterEach, describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 
 import {
   AUX_REST_TO_WS_V1_FLAG_KEY,
@@ -107,5 +107,22 @@ describe("isAuxRestToWsV1Enabled — opt-out token semantics", () => {
   it('empty string → ON (not a disable token)', () => {
     setRaw("");
     expect(isAuxRestToWsV1Enabled()).toBe(true);
+  });
+
+  it("warns once when localStorage changes after the flag has been latched", () => {
+    setRaw("1");
+    expect(isAuxRestToWsV1Enabled()).toBe(true);
+
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    localStorage.setItem(AUX_REST_TO_WS_V1_FLAG_KEY, "0");
+
+    expect(isAuxRestToWsV1Enabled()).toBe(true);
+    expect(isAuxRestToWsV1Enabled()).toBe(true);
+    expect(warn).toHaveBeenCalledTimes(1);
+    expect(warn).toHaveBeenCalledWith(
+      `[octos] ${AUX_REST_TO_WS_V1_FLAG_KEY} changed mid-session; ` +
+        "the new value is ignored until reload to keep wrapper " +
+        "routing consistent across the page load.",
+    );
   });
 });

--- a/src/runtime/session-context.test.ts
+++ b/src/runtime/session-context.test.ts
@@ -13,19 +13,49 @@
  * These tests cover the pure {@link mergeSessionLists} helper.
  */
 
-import { describe, expect, it } from "vitest";
+import * as React from "react";
+import { act } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+(
+  globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }
+).IS_REACT_ACT_ENVIRONMENT = true;
+
+const apiMocks = vi.hoisted(() => ({
+  listSessions: vi.fn(),
+  getMessages: vi.fn(),
+  getMessagesPage: vi.fn(),
+  getSessionTasks: vi.fn(),
+  deleteSession: vi.fn(),
+  setSessionTitle: vi.fn(),
+}));
+
+vi.mock("@/api/sessions", () => ({
+  listSessions: apiMocks.listSessions,
+  getMessages: apiMocks.getMessages,
+  getMessagesPage: apiMocks.getMessagesPage,
+  getSessionTasks: apiMocks.getSessionTasks,
+  deleteSession: apiMocks.deleteSession,
+  setSessionTitle: apiMocks.setSessionTitle,
+}));
+
 import {
   applyOptimisticRename,
   mergeSessionLists,
   rollbackOptimisticRename,
   sessionTimestamp,
+  SessionProvider,
   SESSION_LIST_RENDER_CAP,
+  useSession,
+  type SessionContextValue,
   type SessionWithTitle,
 } from "./session-context";
 import type { SessionInfo } from "@/api/types";
 
 const NO_TITLES: Record<string, string> = {};
 const NO_DELETES = new Set<string>();
+const SESSION_TITLES_KEY = "octos_session_titles";
 
 // `sessionTimestamp` rejects ms timestamps < 1700000000000 (~Nov 2023) so
 // fixtures need a realistic base.
@@ -42,6 +72,75 @@ function webSession(
 function idAt(offsetMs: number, suffix = "abc"): string {
   return `web-${TS_BASE + offsetMs}-${suffix}`;
 }
+
+interface MountedHarness {
+  container: HTMLDivElement;
+  root: Root;
+  unmount: () => void;
+}
+
+function CaptureSessionContext({
+  onValue,
+}: {
+  onValue: (ctx: SessionContextValue) => void;
+}) {
+  onValue(useSession());
+  return null;
+}
+
+function mountSessionProvider(
+  onValue: (ctx: SessionContextValue) => void,
+): MountedHarness {
+  const container = document.createElement("div");
+  document.body.appendChild(container);
+  const root = createRoot(container);
+  act(() => {
+    root.render(
+      React.createElement(
+        SessionProvider,
+        null,
+        React.createElement(CaptureSessionContext, { onValue }),
+      ),
+    );
+  });
+  return {
+    container,
+    root,
+    unmount: () => {
+      act(() => root.unmount());
+      container.remove();
+    },
+  };
+}
+
+async function flushReactWork(cycles = 8): Promise<void> {
+  await act(async () => {
+    for (let i = 0; i < cycles; i += 1) {
+      await Promise.resolve();
+    }
+  });
+}
+
+beforeEach(() => {
+  localStorage.clear();
+  vi.clearAllMocks();
+  apiMocks.listSessions.mockResolvedValue([]);
+  apiMocks.getMessages.mockResolvedValue([]);
+  apiMocks.getMessagesPage.mockResolvedValue({
+    messages: [],
+    has_more: false,
+    next_offset: null,
+  });
+  apiMocks.getSessionTasks.mockResolvedValue([]);
+  apiMocks.deleteSession.mockResolvedValue(undefined);
+  apiMocks.setSessionTitle.mockResolvedValue(undefined);
+});
+
+afterEach(() => {
+  for (const node of [...document.body.children]) node.remove();
+  localStorage.clear();
+  vi.restoreAllMocks();
+});
 
 describe("sessionTimestamp", () => {
   it("parses web-{ms}-{rand} format", () => {
@@ -213,6 +312,86 @@ describe("mergeSessionLists", () => {
     const ids = merged.map((s) => s.id);
     expect(ids).toContain(idAt(500, "mine"));
     expect(merged).toHaveLength(31);
+  });
+});
+
+describe("SessionProvider title integration", () => {
+  it("rolls back renameSession through the actual provider callback when setSessionTitle rejects", async () => {
+    const sessionId = idAt(42, "rename");
+    apiMocks.listSessions.mockResolvedValue([
+      { id: sessionId, message_count: 3, title: "old title" },
+    ] satisfies SessionInfo[]);
+    apiMocks.setSessionTitle.mockRejectedValueOnce(
+      new Error("forbidden: invalid title"),
+    );
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+
+    let latest: SessionContextValue | null = null;
+    const harness = mountSessionProvider((ctx) => {
+      latest = ctx;
+    });
+    try {
+      await flushReactWork();
+      expect(latest?.sessions.find((s) => s.id === sessionId)?.title).toBe(
+        "old title",
+      );
+
+      act(() => {
+        latest?.renameSession(sessionId, "  doomed rename  ");
+      });
+      expect(apiMocks.setSessionTitle).toHaveBeenCalledWith(
+        sessionId,
+        "doomed rename",
+      );
+
+      await flushReactWork();
+      expect(latest?.sessions.find((s) => s.id === sessionId)?.title).toBe(
+        "old title",
+      );
+      expect(JSON.parse(localStorage.getItem(SESSION_TITLES_KEY) || "{}")).toEqual({
+        [sessionId]: "old title",
+      });
+      expect(warn).toHaveBeenCalledWith(
+        `renameSession failed for ${sessionId}: forbidden: invalid title`,
+      );
+    } finally {
+      harness.unmount();
+    }
+  });
+
+  it("applies cross-tab session title updates from the runtime subscriber event", async () => {
+    const sessionId = idAt(84, "title-event");
+    apiMocks.listSessions.mockResolvedValue([
+      { id: sessionId, message_count: 2, title: "old title" },
+    ] satisfies SessionInfo[]);
+
+    let latest: SessionContextValue | null = null;
+    const harness = mountSessionProvider((ctx) => {
+      latest = ctx;
+    });
+    try {
+      await flushReactWork();
+      expect(latest?.sessions.find((s) => s.id === sessionId)?.title).toBe(
+        "old title",
+      );
+
+      act(() => {
+        window.dispatchEvent(
+          new CustomEvent("crew:session_title_updated", {
+            detail: { session_id: sessionId, title: "server title" },
+          }),
+        );
+      });
+
+      expect(latest?.sessions.find((s) => s.id === sessionId)?.title).toBe(
+        "server title",
+      );
+      expect(JSON.parse(localStorage.getItem(SESSION_TITLES_KEY) || "{}")).toEqual({
+        [sessionId]: "server title",
+      });
+    } finally {
+      harness.unmount();
+    }
   });
 });
 

--- a/src/runtime/ui-protocol-bridge.test.ts
+++ b/src/runtime/ui-protocol-bridge.test.ts
@@ -945,9 +945,9 @@ describe("connection lifecycle", () => {
       // duplicated. A double `push` in `getUiProtocolFeatures()` would
       // pass the `toContain` check above but break the server-side
       // capability set comparison.
-      const auxOccurrences = ws.url.split(
-        `ui_feature=${AUX_REST_TO_WS_V1_FEATURE}`,
-      ).length - 1;
+      const auxOccurrences = new URL(ws.url).searchParams
+        .getAll("ui_feature")
+        .filter((feature) => feature === AUX_REST_TO_WS_V1_FEATURE).length;
       expect(auxOccurrences).toBe(1);
       await bridge.stop();
     } finally {

--- a/src/runtime/ui-protocol-event-router.test.ts
+++ b/src/runtime/ui-protocol-event-router.test.ts
@@ -1746,6 +1746,7 @@ describe("router seq preservation", () => {
         source: "background",
         cursor: { stream: SESSION, seq: 42 },
         persisted_at: "2026-04-30T00:00:00Z",
+        content: "late artifact",
       },
     );
     const [thread] = ThreadStore.getThreads(SESSION);

--- a/src/runtime/ui-protocol-send.test.ts
+++ b/src/runtime/ui-protocol-send.test.ts
@@ -574,9 +574,10 @@ describe("sendMessage", () => {
 
   // Codex P2 round 4 (M10 follow-up Bug B): the user message must be
   // mirrored before subsequent sends process. Issue #109.1 reordered the
-  // mirror to run AFTER `startBridgeForSession` resolves (so a failed
-  // start cannot orphan a bubble); the queue chain entry is still
-  // installed synchronously so per-session FIFO ordering survives.
+  // no-active-bridge path to run AFTER `startBridgeForSession` resolves
+  // (so a failed start cannot orphan a bubble); once a same-scope bridge
+  // is already active, queued follow-ups can mirror immediately while
+  // `sendTurn` remains serialized behind the prior lifecycle gate.
   it("mirrors queued v1 user messages once the bridge has confirmed start", async () => {
     const bridge = makeBridge();
     __setActiveBridgeForTest(SESSION, bridge);
@@ -606,13 +607,14 @@ describe("sendMessage", () => {
       clientMessageId: "cmid-Q2",
     });
 
-    // After the bridge-start await resolves and the chain advances Q1
-    // through to its sendTurn, the Q1 mirror is present and Q2 is
-    // parked behind the lifecycle gate.
+    // Both user bubbles render promptly because the same-scope bridge
+    // is already active. Only Q1 has reached sendTurn; Q2 is still
+    // parked behind Q1's lifecycle gate.
     for (let i = 0; i < 12; i++) await Promise.resolve();
     let threads = ThreadStore.getThreads(SESSION);
-    expect(threads.map((t) => t.id)).toEqual(["cmid-Q1"]);
+    expect(threads.map((t) => t.id)).toEqual(["cmid-Q1", "cmid-Q2"]);
     expect(threads[0].userMsg.text).toBe("Q1");
+    expect(threads[1].userMsg.text).toBe("Q2");
     expect(bridge.sendTurn).toHaveBeenCalledTimes(1);
     expect(bridge.sendTurn).toHaveBeenLastCalledWith(
       "cmid-Q1",
@@ -625,7 +627,6 @@ describe("sendMessage", () => {
     expect(bridge.sendTurn).toHaveBeenCalledTimes(2);
     threads = ThreadStore.getThreads(SESSION);
     expect(threads.map((t) => t.id)).toEqual(["cmid-Q1", "cmid-Q2"]);
-    expect(threads[1].userMsg.text).toBe("Q2");
   });
 
   // Codex P2 round 3 (M10 follow-up Bug B): a throwing `onComplete`

--- a/src/runtime/ui-protocol-send.ts
+++ b/src/runtime/ui-protocol-send.ts
@@ -258,58 +258,18 @@ async function enqueueSendV1(opts: SendOptions): Promise<void> {
   // bubble.
   const clientMessageId = opts.clientMessageId ?? crypto.randomUUID();
   const pinnedOpts: SendOptions = { ...opts, clientMessageId };
+  let optimisticMirrored = false;
 
-  // The signal we hand to `sendMessageV1`. The lifecycle handler resolves
-  // it on `turn/completed` or `turn/error` (or on early failure inside
-  // `sendMessageV1`). The next chained call awaits this signal before
-  // issuing its own `bridge.sendTurn`.
-  let release!: () => void;
-  const lifecycleDone = new Promise<void>((resolve) => {
-    release = resolve;
-  });
-  // Build the chain entry as a fresh promise we keep a stable reference to,
-  // so the cleanup compare-and-delete is correct. Issue #109.1: the chain
-  // entry must be installed SYNCHRONOUSLY (before the bridge-start await)
-  // so that rapid back-to-back sendMessage() calls observe each other in
-  // `turnQueues.get(key)` and serialise correctly. Pre-fix, awaiting the
-  // bridge start before `turnQueues.set` let two rapid sends each read
-  // `Promise.resolve()` as their `prev`, defeating the per-session FIFO.
-  const chained = prev.then(() => lifecycleDone);
-  turnQueues.set(key, chained);
-  // Wave4-A: surface the push BEFORE awaiting the prior turn so the
-  // toolbar pill updates synchronously with the user's submit. The
-  // matching `decrementQueueTotal` runs in the `finally` block below.
-  incrementQueueTotal(key, clientMessageId);
-
-  try {
-    await prev;
-    // Issue #109.1: ensure the bridge is usable BEFORE mutating
-    // ThreadStore / firing `onSessionActive`. Pre-fix, the optimistic
-    // row + session-active callback ran unconditionally, so a failed
-    // bridge start left an orphan user bubble + an "active" session
-    // row that never reached JSONL. `startBridgeForSession` is
-    // idempotent for same-scope already-started bridges so the happy
-    // path stays cheap.
-    try {
-      await startBridgeForSession(
-        pinnedOpts.sessionId,
-        pinnedOpts.historyTopic,
-      );
-    } catch {
-      if (typeof console !== "undefined" && console.warn) {
-        console.warn(
-          "ui-protocol-send: bridge start failed; aborting optimistic projection",
-        );
-      }
-      pinnedOpts.onComplete?.();
-      release();
-      return;
-    }
+  const mirrorOptimisticUserMessage = () => {
+    if (optimisticMirrored) return;
+    optimisticMirrored = true;
 
     // Codex round 4-6 P2: mirror the user message into ThreadStore
     // before issuing `sendTurn`, so the bubble is visible the instant
-    // the bridge is confirmed available. The mirror runs once per
-    // send; the WS path's own listener never re-mirrors.
+    // the bridge is confirmed available. Queued follow-ups with an
+    // already-active bridge mirror before the FIFO wait below, so the
+    // user's just-submitted message renders while it is parked behind
+    // the in-flight turn.
     const localFiles = pinnedOpts.media.map((path) => ({
       filename: displayFilenameFromPath(path),
       path,
@@ -336,6 +296,70 @@ async function enqueueSendV1(opts: SendOptions): Promise<void> {
       );
     }
     pinnedOpts.onSessionActive?.(pinnedOpts.text);
+  };
+
+  // The signal we hand to `sendMessageV1`. The lifecycle handler resolves
+  // it on `turn/completed` or `turn/error` (or on early failure inside
+  // `sendMessageV1`). The next chained call awaits this signal before
+  // issuing its own `bridge.sendTurn`.
+  let release!: () => void;
+  const lifecycleDone = new Promise<void>((resolve) => {
+    release = resolve;
+  });
+  // Build the chain entry as a fresh promise we keep a stable reference to,
+  // so the cleanup compare-and-delete is correct. Issue #109.1: the chain
+  // entry must be installed SYNCHRONOUSLY (before the bridge-start await)
+  // so that rapid back-to-back sendMessage() calls observe each other in
+  // `turnQueues.get(key)` and serialise correctly. Pre-fix, awaiting the
+  // bridge start before `turnQueues.set` let two rapid sends each read
+  // `Promise.resolve()` as their `prev`, defeating the per-session FIFO.
+  const chained = prev.then(() => lifecycleDone);
+  turnQueues.set(key, chained);
+  // Wave4-A: surface the push BEFORE awaiting the prior turn so the
+  // toolbar pill updates synchronously with the user's submit. The
+  // matching `decrementQueueTotal` runs in the `finally` block below.
+  incrementQueueTotal(key, clientMessageId);
+
+  try {
+    // If the runtime already has a same-scope bridge, the queued user
+    // message is accepted by the client now even though its `turn/start`
+    // must wait for the prior lifecycle gate. Render that user bubble
+    // immediately so follow-up sends do not look lost while queued.
+    if (getActiveBridge(pinnedOpts.sessionId, pinnedOpts.historyTopic)) {
+      mirrorOptimisticUserMessage();
+    }
+
+    await prev;
+    // Issue #109.1: ensure the bridge is usable BEFORE mutating
+    // ThreadStore / firing `onSessionActive`. Pre-fix, the optimistic
+    // row + session-active callback ran unconditionally, so a failed
+    // bridge start left an orphan user bubble + an "active" session
+    // row that never reached JSONL. `startBridgeForSession` is
+    // idempotent for same-scope already-started bridges so the happy
+    // path stays cheap.
+    try {
+      await startBridgeForSession(
+        pinnedOpts.sessionId,
+        pinnedOpts.historyTopic,
+      );
+    } catch {
+      if (typeof console !== "undefined" && console.warn) {
+        console.warn(
+          "ui-protocol-send: bridge start failed; aborting optimistic projection",
+        );
+      }
+      if (optimisticMirrored) {
+        ThreadStore.finalizeAssistant(clientMessageId, { status: "error" });
+      }
+      pinnedOpts.onComplete?.();
+      release();
+      return;
+    }
+
+    // The no-active-bridge path still waits for `startBridgeForSession`
+    // before mutating ThreadStore, preserving the #109.1 failed-start /
+    // no-orphan contract. Already-active queued sends mirrored above.
+    mirrorOptimisticUserMessage();
 
     // M9-β-1 (UPCR-2026-015 / server PR #860): the three previously
     // unsupported variants — media-bearing, /queue-rewrite, and


### PR DESCRIPTION
## Summary
- render queued same-scope UI Protocol follow-up messages immediately while preserving serialized sendTurn execution
- add M12 polish coverage for latched feature flag warnings and URL query parsing
- add SessionProvider title subscriber/rollback integration coverage

Closes #105.
Closes #107.
Closes #141.

## Tests
- npm run test:unit -- src/lib/feature-flags.test.ts src/runtime/ui-protocol-bridge.test.ts src/runtime/session-context.test.ts src/runtime/ui-protocol-send.test.ts
- npm run test:unit
- npm run test:unit -- src/runtime/ui-protocol-send.test.ts src/runtime/session-context.test.ts