### PR TITLE
fix(chat): defer spawn_only tool-card complete + route late progress to origin slot; redesign spinner + header constellation

### DIFF
--- a/src/components/chat-thread-bg-spinner.test.tsx
+++ b/src/components/chat-thread-bg-spinner.test.tsx
@@ -58,6 +58,7 @@ import * as ThreadStore from "@/store/thread-store";
 import {
   __resetRouterStateForTest,
   __resetTurnMetaForTest,
+  handleTaskUpdated,
   handleToolCompleted,
   handleToolProgress,
   handleToolStarted,
@@ -284,32 +285,29 @@ describe("Spawn-only spinner placement (per-bubble)", () => {
         },
       );
     });
-    // 2026-05-14 spinner gating: after `turn/completed`,
-    // `finalizeAssistant` sweeps in-flight tool calls (`running` →
-    // `complete`) so the foreground LLM turn is fully settled even
-    // when a spawn_only BG task continues to emit heartbeats. The
-    // indicator's text refreshes with each heartbeat (latest entry
-    // wins), but the leading icon must already be the static
-    // `Check` — a spinning `Loader2` on a settled call was the
-    // run_pipeline-spinner-keeps-spinning bug observed live on mini5
-    // (chat bubble showed "completed" yet the icon kept rotating).
+    // codex PR #147 BLOCKER (2026-05-22): `finalizeAssistant`'s
+    // `turn/completed` sweep is now gated by `SPAWN_ONLY_TOOL_NAMES`.
+    // `run_pipeline` is in the set, so the chip stays in `running`
+    // until `task/updated:completed` lands — even though the
+    // foreground LLM turn has finalised. The spinner row reflects
+    // that the BG work is still in flight.
     const row = harness.container.querySelector(
       "[data-testid='tool-progress']",
     );
     expect(row).not.toBeNull();
     expect(row!.textContent).toContain("10s elapsed");
-    expect(row!.getAttribute("data-tool-status")).toBe("complete");
+    expect(row!.getAttribute("data-tool-status")).toBe("running");
     expect(
       row!.querySelector("[data-testid='tool-progress-spinner']"),
-    ).toBeNull();
+    ).not.toBeNull();
     expect(
       row!.querySelector("[data-testid='tool-progress-complete-icon']"),
-    ).not.toBeNull();
+    ).toBeNull();
 
     // The explicit `tool/completed` ack (synchronous foreground leg
-    // of a spawn_only tool) is idempotent w.r.t. status — the sweep
-    // already flipped it. The terminal icon stays a static check,
-    // text refreshes if a later heartbeat reuses the call.
+    // of a spawn_only tool) is intentionally a no-op for the chip
+    // status (Defect A). Heartbeats refresh the text; the chip stays
+    // `running` until `task/updated:completed`.
     act(() => {
       handleToolCompleted(
         { sessionId: SESSION },
@@ -322,17 +320,52 @@ describe("Spawn-only spinner placement (per-bubble)", () => {
         },
       );
     });
-    const rowAfter = harness.container.querySelector(
+    const rowAfterToolCompleted = harness.container.querySelector(
       "[data-testid='tool-progress']",
     );
-    expect(rowAfter).not.toBeNull();
-    expect(rowAfter!.textContent).toContain("10s elapsed");
-    expect(rowAfter!.getAttribute("data-tool-status")).toBe("complete");
+    expect(rowAfterToolCompleted).not.toBeNull();
+    expect(rowAfterToolCompleted!.textContent).toContain("10s elapsed");
+    expect(rowAfterToolCompleted!.getAttribute("data-tool-status")).toBe(
+      "running",
+    );
     expect(
-      rowAfter!.querySelector("[data-testid='tool-progress-spinner']"),
+      rowAfterToolCompleted!.querySelector(
+        "[data-testid='tool-progress-spinner']",
+      ),
+    ).not.toBeNull();
+
+    // `task/updated:completed` is the real terminal signal for a
+    // spawn_only tool: the supervisor task settled, so the chip
+    // flips to `complete` and the row shows the static check.
+    act(() => {
+      handleTaskUpdated(
+        { sessionId: SESSION },
+        {
+          session_id: SESSION,
+          task_id: "tc-x",
+          tool_call_id: "tc-x",
+          state: "completed",
+          tool_name: "run_pipeline",
+        },
+      );
+    });
+    const rowAfterTaskCompleted = harness.container.querySelector(
+      "[data-testid='tool-progress']",
+    );
+    expect(rowAfterTaskCompleted).not.toBeNull();
+    expect(rowAfterTaskCompleted!.textContent).toContain("10s elapsed");
+    expect(rowAfterTaskCompleted!.getAttribute("data-tool-status")).toBe(
+      "complete",
+    );
+    expect(
+      rowAfterTaskCompleted!.querySelector(
+        "[data-testid='tool-progress-spinner']",
+      ),
     ).toBeNull();
     expect(
-      rowAfter!.querySelector("[data-testid='tool-progress-complete-icon']"),
+      rowAfterTaskCompleted!.querySelector(
+        "[data-testid='tool-progress-complete-icon']",
+      ),
     ).not.toBeNull();
 
     harness.unmount();

--- a/src/components/chat-thread-heartbeat.test.tsx
+++ b/src/components/chat-thread-heartbeat.test.tsx
@@ -203,21 +203,16 @@ describe("run_pipeline heartbeat chip list", () => {
       });
     }
 
-    // The bubble auto-collapses once `turn/completed` runs (which
-    // sweeps the still-running tool to `complete` via
-    // `finalizeAssistant`), so click the toggle to expand and inspect
-    // the full chip list. The point of this regression test is that
-    // every chip survived in the store across the finalise transition
-    // (the React.memo bug it pins); the collapse UX is exercised
-    // separately in `chat-thread-progress-toggle.test.tsx`.
-    const toggle = harness.container.querySelector<HTMLButtonElement>(
-      "[data-testid='tool-call-runtime-toggle']",
-    );
-    expect(toggle).not.toBeNull();
-    act(() => {
-      toggle!.click();
-    });
-
+    // The bubble starts expanded (status === "running") and stays that
+    // way: `run_pipeline` is in `SPAWN_ONLY_TOOL_NAMES`, so the
+    // `turn/completed` sweep no longer flips the chip to `complete`
+    // (codex PR #147 BLOCKER, 2026-05-22). Without the running →
+    // settled transition the auto-collapse useEffect doesn't fire, so
+    // the timeline is visible without a toggle click. The point of
+    // this regression test is that every chip survived in the store
+    // across the finalise transition (the React.memo bug it pins).
+    // Collapse UX is exercised separately in
+    // `chat-thread-progress-toggle.test.tsx`.
     const timeline = harness.container.querySelector(
       "[data-testid='tool-call-runtime-timeline']",
     );

--- a/src/components/chat-thread-tool-call-no-trailing-spinner.test.tsx
+++ b/src/components/chat-thread-tool-call-no-trailing-spinner.test.tsx
@@ -248,11 +248,22 @@ describe("ToolCallBubble — no trailing spinner after terminal status", () => {
     expect(assistant!.querySelector(".animate-spin")).toBeNull();
   });
 
-  it("renders zero animating descendants after both tool/completed AND turn/completed (spawn_only happy path)", () => {
-    // Post-finalisation: this is the path
-    // `chat-thread-tool-call-status-icon.test.tsx` already covers
-    // partially. Re-asserted here so the same file pins both halves
-    // of the lifecycle.
+  it("keeps the spawn_only chip in `running` after turn/completed (codex PR #147 BLOCKER, 2026-05-22)", () => {
+    // The original assertion ("after both tool/completed AND
+    // turn/completed → chip flips to complete") was the second code
+    // path Defect A's foreground fix missed: `finalizeAssistant`'s
+    // sweep over `pendingAssistant.toolCalls` flipped EVERY in-flight
+    // call to `complete` when `turn/completed` landed, regardless of
+    // whether the work was actually done. For a spawn_only tool the
+    // real background task runs minutes after `turn/completed` —
+    // sweeping the chip silently undid the Defect A deferral.
+    //
+    // Post-codex-fix: the sweep is gated by `SPAWN_ONLY_TOOL_NAMES`.
+    // The chip stays in `running` after `turn/completed`; the real
+    // terminal signal is `task/updated:completed`, handled by
+    // `handleTaskUpdated`. The non-spawn_only path is covered by a
+    // separate test (see "non-spawn_only tools still settle on the
+    // turn/completed sweep" below).
     const cmid = "turn-podcast-final";
     const toolCallId = "tc-podcast-final";
 
@@ -317,16 +328,18 @@ describe("ToolCallBubble — no trailing spinner after terminal status", () => {
       "[data-testid='tool-call-bubble']",
     );
     expect(bubble).not.toBeNull();
-    expect(bubble!.getAttribute("data-tool-status")).toBe("complete");
+    // The chip is still in `running` — the spawn_only background work
+    // hasn't reported completion via `task/updated` yet.
+    expect(bubble!.getAttribute("data-tool-status")).toBe("running");
+    expect(
+      bubble!.querySelector("[data-testid='tool-call-status-spinner']"),
+    ).not.toBeNull();
+    expect(
+      bubble!.querySelector("[data-testid='tool-call-status-complete-icon']"),
+    ).toBeNull();
+    // Umbrella "no legacy SVG spinner" invariant still holds —
+    // `animate-spin` belonged to the retired `Loader2` shape.
     expect(bubble!.querySelector(".animate-spin")).toBeNull();
-    expect(bubble!.querySelector(".animate-pulse")).toBeNull();
-
-    const assistant = harness.container.querySelector(
-      "[data-testid='assistant-message']",
-    );
-    expect(assistant).not.toBeNull();
-    expect(assistant!.querySelector(".animate-spin")).toBeNull();
-    expect(assistant!.querySelectorAll(".animate-pulse").length).toBe(0);
   });
 
   it("still shows the streaming-text placeholder dots when there are NO tool calls (no regression for plain text turns)", () => {

--- a/src/components/chat-thread-tool-call-no-trailing-spinner.test.tsx
+++ b/src/components/chat-thread-tool-call-no-trailing-spinner.test.tsx
@@ -140,17 +140,18 @@ afterEach(() => {
 });
 
 describe("ToolCallBubble — no trailing spinner after terminal status", () => {
-  it("renders zero animating descendants in the assistant bubble after tool/completed (turn still streaming, podcast_generate spawn_only)", () => {
-    // CRITICAL window this test pins: foreground `tool/completed` has
-    // fired (bubble's ToolCallBubble already shows the static Check
-    // and the wrapper `animate-pulse` is gone), BUT `turn/completed`
-    // has NOT fired yet — `pendingAssistant.status === "streaming"`
-    // and `isStreaming === true`. The legacy code rendered three
-    // `animate-pulse` placeholder dots in this window because
-    // `message.text === ""`, even though a tool call inside the
-    // bubble had already settled to "complete". From the user's
-    // perspective: the chip says "podcast_generate: completed" and a
-    // spinner is animating right next to it inside the bubble.
+  it("keeps the spawn_only spinner alive after foreground tool/completed until task/updated terminal (defect A, 2026-05-22)", () => {
+    // Defect A (M9 follow-up): the foreground `tool/completed`
+    // envelope for a spawn_only tool (`podcast_generate`,
+    // `run_pipeline`, etc.) fires ~2ms after `tool/started` — it's
+    // only the supervisor's acknowledgement, the background work is
+    // still in flight. Pre-fix the bubble settled to "complete" the
+    // moment foreground completion landed, planting a static Check on
+    // a tool card whose work was still running for minutes. Post-fix
+    // the chip stays "running" until `task/updated:completed` (the
+    // real terminal signal) arrives — verified in a separate test in
+    // ui-protocol-event-router.test.ts; this test pins the bubble
+    // rendering invariant.
     const cmid = "turn-podcast-mid-stream";
     const toolCallId = "tc-podcast";
 
@@ -219,59 +220,32 @@ describe("ToolCallBubble — no trailing spinner after terminal status", () => {
       // the in-flight window the bug surfaces in.
     });
 
-    // Sanity: the tool bubble itself is in the post-terminal state
-    // (already covered by chat-thread-tool-call-status-icon.test.tsx
-    // — kept here so a regression of that gate would surface as a
-    // single readable failure in this file too).
+    // Post-defect-A: the bubble must NOT have flipped to "complete"
+    // off the foreground `tool/completed`. The chip stays "running"
+    // and the running affordance (the three-ball spinner that
+    // replaced the legacy Loader2) is still mounted under the same
+    // `data-testid` the spec uses to find it.
     const bubble = harness.container.querySelector(
       "[data-testid='tool-call-bubble']",
     );
     expect(bubble).not.toBeNull();
-    expect(bubble!.getAttribute("data-tool-status")).toBe("complete");
-    expect(
-      bubble!.querySelector("[data-testid='tool-call-status-complete-icon']"),
-    ).not.toBeNull();
+    expect(bubble!.getAttribute("data-tool-status")).toBe("running");
     expect(
       bubble!.querySelector("[data-testid='tool-call-status-spinner']"),
+    ).not.toBeNull();
+    expect(
+      bubble!.querySelector("[data-testid='tool-call-status-complete-icon']"),
     ).toBeNull();
+    // The legacy `Loader2` rotation (Tailwind `animate-spin`) has been
+    // retired in favour of the three-ball CSS keyframe `tool-ball` —
+    // the umbrella "no orphan SVG spinner" invariant still holds.
     expect(bubble!.querySelector(".animate-spin")).toBeNull();
-    expect(bubble!.querySelector(".animate-pulse")).toBeNull();
-    expect(bubble!.classList.contains("animate-pulse")).toBe(false);
 
-    // The actual fix: the ASSISTANT BUBBLE that hosts this tool call
-    // must not have streaming-placeholder dots animating in it. The
-    // user identifies the spinner as "inside the bubble alongside
-    // the completed status" — that's the assistant card the
-    // ToolCallBubble and ToolProgressIndicator both live in.
     const assistant = harness.container.querySelector(
       "[data-testid='assistant-message']",
     );
     expect(assistant).not.toBeNull();
-
-    // No Loader2 / animate-spin anywhere inside the assistant
-    // bubble. (Already covered by the leading-icon gate, but this
-    // file owns the umbrella invariant so a regression elsewhere
-    // also fails here.)
-    expect(
-      assistant!.querySelector("[data-testid='tool-call-status-spinner']"),
-    ).toBeNull();
-    expect(
-      assistant!.querySelector("[data-testid='tool-progress-spinner']"),
-    ).toBeNull();
     expect(assistant!.querySelector(".animate-spin")).toBeNull();
-
-    // The streaming-text placeholder dots
-    // (chat-thread.tsx:741-747: three `animate-pulse` spans rendered
-    // when `isStreaming && !message.text`) must NOT render while the
-    // bubble has at least one settled tool call — they're the
-    // pre-fix stuck-spinner the user saw. We assert there is no
-    // `animate-pulse` element anywhere inside the assistant bubble.
-    // The `animate-shell-rise` intro animation on the bubble wrapper
-    // is a one-shot fade-in (0.24s), not a forever-spinning class,
-    // and the lucide-react SVGs themselves never carry an animate
-    // class — so an empty match here is the right invariant.
-    const pulses = assistant!.querySelectorAll(".animate-pulse");
-    expect(pulses.length).toBe(0);
   });
 
   it("renders zero animating descendants after both tool/completed AND turn/completed (spawn_only happy path)", () => {

--- a/src/components/chat-thread-tool-call-status-icon.test.tsx
+++ b/src/components/chat-thread-tool-call-status-icon.test.tsx
@@ -52,6 +52,7 @@ import * as ThreadStore from "@/store/thread-store";
 import {
   __resetRouterStateForTest,
   __resetTurnMetaForTest,
+  handleTaskUpdated,
   handleToolCompleted,
   handleToolProgress,
   handleToolStarted,
@@ -186,9 +187,14 @@ describe("ToolCallBubble leading status icon", () => {
   });
 
   it("renders the static Check when toolCall.status is 'complete'", () => {
-    // Drive a synthetic complete state by calling `setToolCallStatus`
-    // directly — mirrors the wire path where `handleToolCompleted`
-    // flips status to `"complete"`.
+    // Drive a synthetic complete state via a non-spawn_only tool
+    // (`shell`) so the foreground `tool/completed` flips status to
+    // "complete" the moment it lands. For spawn_only tools (fm_tts /
+    // podcast_generate / run_pipeline / etc.) the foreground envelope
+    // is only an ack — defect A defers the terminal flip until
+    // `task/updated:completed`. This test pins the non-spawn_only
+    // happy path; the spawn_only terminal transition is covered in
+    // ui-protocol-event-router.test.ts via `task/updated:completed`.
     const cmid = "turn-complete";
     const toolCallId = "tc-complete";
     act(() => {
@@ -215,7 +221,7 @@ describe("ToolCallBubble leading status icon", () => {
           session_id: SESSION,
           turn_id: cmid,
           tool_call_id: toolCallId,
-          tool_name: "fm_tts",
+          tool_name: "shell",
         },
       );
       handleToolProgress(
@@ -233,7 +239,7 @@ describe("ToolCallBubble leading status icon", () => {
           session_id: SESSION,
           turn_id: cmid,
           tool_call_id: toolCallId,
-          tool_name: "fm_tts",
+          tool_name: "shell",
           success: true,
         },
       );
@@ -321,14 +327,17 @@ describe("ToolCallBubble leading status icon", () => {
     harness.unmount();
   });
 
-  it("clears the per-tool spinner on a spawn_only fm_tts terminal transition", () => {
-    // End-to-end check for the bug observed on mini5: a spawn_only
-    // `fm_tts` call ran, the BG task emitted a progress message
-    // containing the literal text "completed", and the bubble's
-    // wrapper kept pulsing because nothing tied the per-tool
-    // affordance to `toolCall.status`. This test fires the same
-    // sequence and asserts the leading icon flips from animated
-    // Loader2 → static Check the moment `handleToolCompleted` runs.
+  it("defers a spawn_only fm_tts terminal until task/updated:completed (defect A, 2026-05-22)", () => {
+    // Defect A (M9 follow-up): the foreground `tool/completed`
+    // envelope for a spawn_only tool (fm_tts here, also covers
+    // podcast_generate / run_pipeline / mofa_* / voice_synthesize /
+    // deep_search) fires ~2ms after `tool/started` — it's only the
+    // supervisor acknowledgement. Pre-fix the chip flipped to
+    // "complete" the moment that envelope landed, planting a static
+    // Check on a card whose work was still running. Post-fix the
+    // chip stays "running" through every foreground `tool/completed`
+    // + late progress heartbeat, and finally settles when the real
+    // `task/updated:completed` arrives.
     const cmid = "turn-fm-tts-spawnonly";
     const toolCallId = "tc-fm-tts";
     act(() => {
@@ -380,7 +389,9 @@ describe("ToolCallBubble leading status icon", () => {
     ).not.toBeNull();
 
     // Foreground `tool/completed` arrives (spawn_only's synchronous
-    // leg). Status flips to `complete`.
+    // ack leg). Post-defect-A: status DOES NOT flip — the real
+    // terminal signal is `task/updated:completed`, which lands once
+    // the background task actually finishes.
     act(() => {
       handleToolCompleted(
         { sessionId: SESSION },
@@ -398,18 +409,16 @@ describe("ToolCallBubble leading status icon", () => {
       "[data-testid='tool-call-bubble']",
     );
     expect(bubble).not.toBeNull();
-    expect(bubble!.getAttribute("data-tool-status")).toBe("complete");
-    // The animated Loader2 is gone; the static Check has replaced it.
+    expect(bubble!.getAttribute("data-tool-status")).toBe("running");
     expect(
       bubble!.querySelector("[data-testid='tool-call-status-spinner']"),
-    ).toBeNull();
+    ).not.toBeNull();
     expect(
       bubble!.querySelector("[data-testid='tool-call-status-complete-icon']"),
-    ).not.toBeNull();
+    ).toBeNull();
 
-    // Even a LATE background heartbeat (typical for spawn_only) must
-    // NOT resurrect the spinner — the call's status remains
-    // `complete` and the leading icon stays a static Check.
+    // A late background heartbeat lands while the supervisor task is
+    // still running — chip stays in "running".
     act(() => {
       handleToolProgress(
         { sessionId: SESSION },
@@ -418,6 +427,27 @@ describe("ToolCallBubble leading status icon", () => {
           turn_id: cmid,
           tool_call_id: toolCallId,
           message: "background flush, 30s elapsed",
+        },
+      );
+    });
+
+    bubble = harness.container.querySelector(
+      "[data-testid='tool-call-bubble']",
+    );
+    expect(bubble).not.toBeNull();
+    expect(bubble!.getAttribute("data-tool-status")).toBe("running");
+
+    // Finally `task/updated:completed` lands — the real terminal
+    // signal. The chip flips to "complete" and the spinner clears.
+    act(() => {
+      handleTaskUpdated(
+        { sessionId: SESSION },
+        {
+          session_id: SESSION,
+          task_id: toolCallId,
+          tool_call_id: toolCallId,
+          state: "completed",
+          tool_name: "fm_tts",
         },
       );
     });

--- a/src/components/chat-thread-tool-call-status-icon.test.tsx
+++ b/src/components/chat-thread-tool-call-status-icon.test.tsx
@@ -467,10 +467,21 @@ describe("ToolCallBubble leading status icon", () => {
     harness.unmount();
   });
 
-  it("clears the per-tool spinner on the turn/completed sweep (run_pipeline)", () => {
-    // Companion case to fm_tts: run_pipeline relies on the
-    // `finalizeAssistant` sweep at `turn/completed` to flip
-    // `running` → `complete`. The leading icon must follow.
+  it("keeps the run_pipeline spinner alive after turn/completed (codex PR #147 BLOCKER, 2026-05-22)", () => {
+    // Original assertion: "turn/completed sweeps the in-flight tool
+    // call to `complete`; the leading icon flips from spinner to
+    // Check". That sweep was the second code path Defect A's
+    // foreground fix missed — for spawn_only tools the background
+    // task runs minutes after `turn/completed` lands.
+    //
+    // Post-codex-fix: `finalizeAssistant`'s sweep is gated by
+    // `SPAWN_ONLY_TOOL_NAMES`. `run_pipeline` is in the set, so the
+    // chip stays in `running` past `turn/completed`. The real
+    // terminal flip comes from `handleTaskUpdated:completed`.
+    //
+    // Test order: spinner present at start → spinner STILL present
+    // after `turn/completed` → spinner clears + Check appears only
+    // after `task/updated:completed`.
     const cmid = "turn-run-pipeline";
     const toolCallId = "tc-run-pipeline";
     act(() => {
@@ -519,7 +530,7 @@ describe("ToolCallBubble leading status icon", () => {
       bubble!.querySelector("[data-testid='tool-call-status-spinner']"),
     ).not.toBeNull();
 
-    // turn/completed sweeps the in-flight tool call to "complete".
+    // turn/completed lands — sweep is now gated; spawn_only chip stays.
     act(() => {
       handleTurnCompleted(
         { sessionId: SESSION },
@@ -528,6 +539,33 @@ describe("ToolCallBubble leading status icon", () => {
           turn_id: cmid,
           message_id: "msg-x",
           persisted_at: new Date().toISOString(),
+        },
+      );
+    });
+
+    bubble = harness.container.querySelector(
+      "[data-testid='tool-call-bubble']",
+    );
+    expect(bubble).not.toBeNull();
+    expect(bubble!.getAttribute("data-tool-status")).toBe("running");
+    expect(
+      bubble!.querySelector("[data-testid='tool-call-status-spinner']"),
+    ).not.toBeNull();
+    expect(
+      bubble!.querySelector("[data-testid='tool-call-status-complete-icon']"),
+    ).toBeNull();
+
+    // `task/updated:completed` lands — supervisor reports background
+    // work is done. The chip finally flips to `complete`.
+    act(() => {
+      handleTaskUpdated(
+        { sessionId: SESSION },
+        {
+          session_id: SESSION,
+          task_id: toolCallId,
+          tool_call_id: toolCallId,
+          state: "completed",
+          tool_name: "run_pipeline",
         },
       );
     });

--- a/src/components/chat-thread.tsx
+++ b/src/components/chat-thread.tsx
@@ -31,7 +31,6 @@ import {
   Route,
   ChevronDown,
   ChevronRight,
-  Loader2,
   Check,
 } from "lucide-react";
 import { useSession } from "@/runtime/session-context";
@@ -548,13 +547,31 @@ function ToolCallBubble({
   // continuity with prior UX; the icon adds an unambiguous glyph.
   let statusIcon: ReactNode;
   if (toolCall.status === "running") {
+    // Three color-cycling bouncing balls (M9 follow-up, 2026-05-22).
+    // Keeps the same `data-testid` the legacy `Loader2` carried, so
+    // unit + playwright specs that target
+    // `[data-testid='tool-call-status-spinner']` still find the
+    // running affordance — only the DOM shape changes.
     statusIcon = (
-      <Loader2
-        size={10}
-        className="animate-spin text-accent"
+      <span
         data-testid="tool-call-status-spinner"
+        className="inline-flex items-center gap-[2px]"
         aria-label="running"
-      />
+        aria-hidden="true"
+      >
+        <span
+          className="tool-ball block h-[5px] w-[5px] rounded-full bg-accent"
+          style={{ animationDelay: "0ms" }}
+        />
+        <span
+          className="tool-ball block h-[5px] w-[5px] rounded-full bg-accent/70"
+          style={{ animationDelay: "150ms" }}
+        />
+        <span
+          className="tool-ball block h-[5px] w-[5px] rounded-full bg-accent/40"
+          style={{ animationDelay: "300ms" }}
+        />
+      </span>
     );
   } else if (toolCall.status === "complete") {
     statusIcon = (

--- a/src/components/chat-thread.tsx
+++ b/src/components/chat-thread.tsx
@@ -552,22 +552,32 @@ function ToolCallBubble({
     // unit + playwright specs that target
     // `[data-testid='tool-call-status-spinner']` still find the
     // running affordance — only the DOM shape changes.
+    // codex PR #147 review (MINOR 1, 2026-05-22): the outer wrapper
+    // carries `role="img"` + `aria-label` so screen readers announce
+    // "running"; `aria-hidden` is moved to the individual visual balls
+    // so the decorative shapes are hidden but the accessible name still
+    // exposes. Previously the wrapper had BOTH `aria-label` AND
+    // `aria-hidden="true"` — the hidden flag won, so AT users got
+    // nothing.
     statusIcon = (
       <span
         data-testid="tool-call-status-spinner"
         className="inline-flex items-center gap-[2px]"
+        role="img"
         aria-label="running"
-        aria-hidden="true"
       >
         <span
+          aria-hidden="true"
           className="tool-ball block h-[5px] w-[5px] rounded-full bg-accent"
           style={{ animationDelay: "0ms" }}
         />
         <span
+          aria-hidden="true"
           className="tool-ball block h-[5px] w-[5px] rounded-full bg-accent/70"
           style={{ animationDelay: "150ms" }}
         />
         <span
+          aria-hidden="true"
           className="tool-ball block h-[5px] w-[5px] rounded-full bg-accent/40"
           style={{ animationDelay: "300ms" }}
         />

--- a/src/components/session-task-dock.test.tsx
+++ b/src/components/session-task-dock.test.tsx
@@ -1,0 +1,190 @@
+/**
+ * `SessionTaskIndicator` constellation overflow tests.
+ *
+ * codex PR #147 review (MINOR 2, 2026-05-22): the header constellation
+ * had no dot cap — 20+ active background tasks would render 20+ dots
+ * and blow past the header's `42vw` max-width. Fix: render the first
+ * (MAX_VISIBLE_DOTS - 1) dots followed by a "+N" overflow chip whose
+ * `data-testid='task-constellation-overflow'` makes the cap testable.
+ *
+ * `data-task-count` on the outer container still reflects the REAL
+ * count (no cap) so existing screenshots / spec strings keep their
+ * arithmetic.
+ */
+
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import * as React from "react";
+import { act } from "react";
+import { createRoot, type Root } from "react-dom/client";
+
+(
+  globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }
+).IS_REACT_ACT_ENVIRONMENT = true;
+
+import { SessionTaskIndicator } from "./session-task-dock";
+import { SessionContext } from "@/runtime/session-context";
+import type { SessionContextValue } from "@/runtime/session-context";
+import * as TaskStore from "@/store/task-store";
+import type { BackgroundTaskInfo } from "@/api/types";
+
+const SESSION = "sess-task-dock-overflow";
+
+interface MountedHarness {
+  container: HTMLDivElement;
+  root: Root;
+  unmount: () => void;
+}
+
+function makeSessionCtx(): SessionContextValue {
+  return {
+    sessions: [],
+    currentSessionId: SESSION,
+    historyTopic: undefined,
+    currentSessionTitle: "",
+    currentSessionStats: null,
+    initialMessages: [],
+    activeTaskOnServer: false,
+    queueMode: null,
+    adaptiveMode: null,
+    setServerTaskActive: () => {},
+    renameSession: () => {},
+    updateSessionStats: () => {},
+    switchSession: () => {},
+    goBack: async () => false,
+    createSession: () => SESSION,
+    removeSession: async () => {},
+    refreshSessions: async () => {},
+    markSessionActive: () => {},
+  };
+}
+
+function mount(node: React.ReactElement): MountedHarness {
+  const container = document.createElement("div");
+  document.body.appendChild(container);
+  const root = createRoot(container);
+  act(() => {
+    root.render(node);
+  });
+  return {
+    container,
+    root,
+    unmount: () => {
+      act(() => root.unmount());
+      container.remove();
+    },
+  };
+}
+
+function makeTask(i: number): BackgroundTaskInfo {
+  return {
+    id: `task-${i}`,
+    tool_name: "podcast_generate",
+    tool_call_id: `tc-${i}`,
+    status: "running",
+    started_at: new Date(2026, 0, 1, 0, 0, i).toISOString(),
+    completed_at: null,
+    output_files: [],
+    error: null,
+  };
+}
+
+function seedTasks(n: number): void {
+  const tasks: BackgroundTaskInfo[] = [];
+  for (let i = 0; i < n; i += 1) tasks.push(makeTask(i));
+  TaskStore.replaceTasks(SESSION, tasks);
+}
+
+beforeEach(() => {
+  TaskStore.clearTasks(SESSION);
+});
+
+afterEach(() => {
+  for (const node of [...document.body.children]) node.remove();
+  TaskStore.clearTasks(SESSION);
+});
+
+describe("SessionTaskIndicator — constellation dot cap", () => {
+  it("renders a dot per task when the count fits under the cap", () => {
+    seedTasks(5);
+
+    const harness = mount(
+      <SessionContext.Provider value={makeSessionCtx()}>
+        <SessionTaskIndicator />
+      </SessionContext.Provider>,
+    );
+
+    const indicator = harness.container.querySelector(
+      "[data-testid='session-task-indicator']",
+    );
+    expect(indicator).not.toBeNull();
+    // `data-task-count` mirrors the actual count (no cap).
+    expect(indicator!.getAttribute("data-task-count")).toBe("5");
+
+    const dots = indicator!.querySelectorAll(".task-constellation-dot");
+    expect(dots.length).toBe(5);
+
+    // No overflow chip needed when count is under cap.
+    expect(
+      indicator!.querySelector("[data-testid='task-constellation-overflow']"),
+    ).toBeNull();
+
+    harness.unmount();
+  });
+
+  it("caps visible dots and renders a `+N` overflow chip when count exceeds the cap (codex PR #147 MINOR 2, 2026-05-22)", () => {
+    // 20 active tasks — pre-fix would render 20 dots, blowing past the
+    // header `42vw` max-width. Post-fix: 7 dots + a `+13` chip.
+    seedTasks(20);
+
+    const harness = mount(
+      <SessionContext.Provider value={makeSessionCtx()}>
+        <SessionTaskIndicator />
+      </SessionContext.Provider>,
+    );
+
+    const indicator = harness.container.querySelector(
+      "[data-testid='session-task-indicator']",
+    );
+    expect(indicator).not.toBeNull();
+    // `data-task-count` still reports the REAL count.
+    expect(indicator!.getAttribute("data-task-count")).toBe("20");
+
+    const dots = indicator!.querySelectorAll(".task-constellation-dot");
+    // MAX_VISIBLE_DOTS = 8, so 7 dots remain plus one overflow chip in
+    // the eighth slot.
+    expect(dots.length).toBe(7);
+
+    const overflow = indicator!.querySelector(
+      "[data-testid='task-constellation-overflow']",
+    );
+    expect(overflow).not.toBeNull();
+    expect(overflow!.textContent).toBe("+13");
+
+    harness.unmount();
+  });
+
+  it("renders exactly the cap of dots and no overflow chip when count == MAX_VISIBLE_DOTS", () => {
+    // Edge case: 8 tasks → exactly the cap → 8 dots, no overflow.
+    seedTasks(8);
+
+    const harness = mount(
+      <SessionContext.Provider value={makeSessionCtx()}>
+        <SessionTaskIndicator />
+      </SessionContext.Provider>,
+    );
+
+    const indicator = harness.container.querySelector(
+      "[data-testid='session-task-indicator']",
+    );
+    expect(indicator).not.toBeNull();
+    expect(indicator!.getAttribute("data-task-count")).toBe("8");
+
+    const dots = indicator!.querySelectorAll(".task-constellation-dot");
+    expect(dots.length).toBe(8);
+    expect(
+      indicator!.querySelector("[data-testid='task-constellation-overflow']"),
+    ).toBeNull();
+
+    harness.unmount();
+  });
+});

--- a/src/components/session-task-dock.tsx
+++ b/src/components/session-task-dock.tsx
@@ -27,81 +27,100 @@ function taskDisplayName(toolName: string): string {
   }
 }
 
-function buildSessionSummary(tasks: TaskInfo[]): {
+interface IndicatorSummary {
+  active: TaskInfo[];
+  failed: TaskInfo | null;
   label: string;
   detail: string;
-  active: boolean;
-  failed: boolean;
-} | null {
+  state: "active" | "failed";
+}
+
+function buildSummary(tasks: TaskInfo[]): IndicatorSummary | null {
   const active = tasks.filter(isTaskActive);
+  if (active.length === 1) {
+    return {
+      active,
+      failed: null,
+      label: `${taskDisplayName(active[0].tool_name)} running`,
+      detail: "Background work continues independently of chat messages.",
+      state: "active",
+    };
+  }
   if (active.length > 1) {
     return {
+      active,
+      failed: null,
       label: `${active.length} tasks running`,
       detail: active.map((task) => taskDisplayName(task.tool_name)).join(" · "),
-      active: true,
-      failed: false,
+      state: "active",
     };
   }
-
-  if (active.length === 1) {
-    const task = active[0];
+  const failed = tasks.find((task) => task.status === "failed") ?? null;
+  if (failed !== null) {
     return {
-      label: `${taskDisplayName(task.tool_name)} running`,
-      detail: "Background work continues independently of chat messages.",
-      active: true,
-      failed: false,
+      active: [],
+      failed,
+      label: `${taskDisplayName(failed.tool_name)} failed`,
+      detail: failed.error || "Background task needs attention.",
+      state: "failed",
     };
   }
-
-  const failed = tasks.filter((task) => task.status === "failed");
-  if (failed.length > 0) {
-    const task = failed[0];
-    return {
-      label: `${taskDisplayName(task.tool_name)} failed`,
-      detail: task.error || "Background task needs attention.",
-      active: false,
-      failed: true,
-    };
-  }
-
   return null;
 }
+
+// Small palette cycled by index. Falls back to plain accent if the
+// theme doesn't define the secondary/tertiary slots — Tailwind ignores
+// unknown utilities at runtime, but to be safe we use opacity steps
+// on `bg-accent` which always resolve.
+const DOT_PALETTE = ["bg-accent", "bg-accent/70", "bg-accent/40"] as const;
 
 export function SessionTaskIndicator() {
   const { currentSessionId, historyTopic } = useSession();
   const currentTasks = useTasks(currentSessionId, historyTopic);
 
-  const summary = useMemo(
-    () => {
-      return buildSessionSummary(currentTasks);
-    },
-    [currentTasks],
-  );
+  const summary = useMemo(() => buildSummary(currentTasks), [currentTasks]);
 
   if (!summary) return null;
 
+  // Header constellation (M9 follow-up, 2026-05-22). Inline dot-per-task
+  // visualisation that scales with count, replacing the "glass-pill"
+  // rectangle. The pill chrome is gone — just dots + a small label.
+  const dots =
+    summary.state === "failed"
+      ? [
+          <span
+            key="failed-dot"
+            className="task-constellation-dot block h-1.5 w-1.5 rounded-full bg-red-400"
+            style={{ animationDelay: "0ms" }}
+          />,
+        ]
+      : summary.active.map((task, i) => (
+          <span
+            key={task.id}
+            className={`task-constellation-dot block h-1.5 w-1.5 rounded-full ${DOT_PALETTE[i % DOT_PALETTE.length]}`}
+            style={{ animationDelay: `${i * 200}ms` }}
+          />
+        ));
+
+  const count = summary.state === "failed" ? 1 : summary.active.length;
+
   return (
     <div
-      className="session-task-indicator glass-pill min-w-0 rounded-full px-3 py-2"
+      data-testid="session-task-indicator"
+      data-task-count={count}
+      data-task-state={summary.state}
+      className="session-task-indicator inline-flex items-center gap-2"
       title={summary.detail}
     >
       <span
-        className={`session-task-indicator-dot ${
-          summary.active
-            ? "is-active"
-            : summary.failed
-              ? "is-failed"
-              : ""
-        }`}
-      />
-      <div className="min-w-0">
-        <div className="truncate text-[12px] font-semibold text-text-strong">
-          {summary.label}
-        </div>
-        <div className="truncate text-[10px] text-muted">
-          {summary.detail}
-        </div>
-      </div>
+        className="inline-flex items-center gap-1"
+        aria-hidden="true"
+      >
+        {dots}
+      </span>
+      <span className="truncate text-[12px] font-medium text-text-strong">
+        {summary.label}
+      </span>
     </div>
   );
 }

--- a/src/components/session-task-dock.tsx
+++ b/src/components/session-task-dock.tsx
@@ -1,4 +1,4 @@
-import { useMemo } from "react";
+import { useMemo, type ReactElement } from "react";
 import type { BackgroundTaskInfo as TaskInfo } from "@/api/types";
 import { useTasks } from "@/store/task-store";
 import { useSession } from "@/runtime/session-context";
@@ -85,22 +85,62 @@ export function SessionTaskIndicator() {
   // Header constellation (M9 follow-up, 2026-05-22). Inline dot-per-task
   // visualisation that scales with count, replacing the "glass-pill"
   // rectangle. The pill chrome is gone — just dots + a small label.
-  const dots =
-    summary.state === "failed"
-      ? [
-          <span
-            key="failed-dot"
-            className="task-constellation-dot block h-1.5 w-1.5 rounded-full bg-red-400"
-            style={{ animationDelay: "0ms" }}
-          />,
-        ]
-      : summary.active.map((task, i) => (
+  //
+  // codex PR #147 review (MINOR 2, 2026-05-22): cap the rendered dots
+  // at MAX_VISIBLE_DOTS so 20+ active tasks don't blow past the header
+  // `42vw` max-width. When the real count exceeds the cap we render
+  // the first (MAX_VISIBLE_DOTS - 1) dots followed by a "+N" overflow
+  // indicator. `data-task-count` still reflects the REAL count so
+  // existing tests asserting numerics continue to pass.
+  const MAX_VISIBLE_DOTS = 8;
+  const dots: ReactElement[] = [];
+  if (summary.state === "failed") {
+    dots.push(
+      <span
+        key="failed-dot"
+        className="task-constellation-dot block h-1.5 w-1.5 rounded-full bg-red-400"
+        style={{ animationDelay: "0ms" }}
+      />,
+    );
+  } else {
+    const total = summary.active.length;
+    if (total <= MAX_VISIBLE_DOTS) {
+      for (let i = 0; i < total; i += 1) {
+        const task = summary.active[i];
+        dots.push(
           <span
             key={task.id}
             className={`task-constellation-dot block h-1.5 w-1.5 rounded-full ${DOT_PALETTE[i % DOT_PALETTE.length]}`}
             style={{ animationDelay: `${i * 200}ms` }}
-          />
-        ));
+          />,
+        );
+      }
+    } else {
+      // Render the first (MAX_VISIBLE_DOTS - 1) dots, then a "+N"
+      // overflow chip in place of dot #MAX_VISIBLE_DOTS.
+      const visible = MAX_VISIBLE_DOTS - 1;
+      for (let i = 0; i < visible; i += 1) {
+        const task = summary.active[i];
+        dots.push(
+          <span
+            key={task.id}
+            className={`task-constellation-dot block h-1.5 w-1.5 rounded-full ${DOT_PALETTE[i % DOT_PALETTE.length]}`}
+            style={{ animationDelay: `${i * 200}ms` }}
+          />,
+        );
+      }
+      const overflow = total - visible;
+      dots.push(
+        <span
+          key="task-constellation-overflow"
+          data-testid="task-constellation-overflow"
+          className="task-constellation-overflow ml-0.5 inline-flex items-center text-[10px] font-medium text-text-strong"
+        >
+          {`+${overflow}`}
+        </span>,
+      );
+    }
+  }
 
   const count = summary.state === "failed" ? 1 : summary.active.length;
 

--- a/src/components/tool-progress-indicator.tsx
+++ b/src/components/tool-progress-indicator.tsx
@@ -1,5 +1,5 @@
 import type { ReactNode } from "react";
-import { Check, Loader2, X } from "lucide-react";
+import { Check, X } from "lucide-react";
 import type { ThreadMessage, ThreadToolCall } from "@/store/thread-store";
 
 /**
@@ -97,13 +97,30 @@ export function ToolProgressIndicator({ message }: ToolProgressIndicatorProps) {
   // `progress.length > 0` rather than `status === "running"`.
   let leadingIcon: ReactNode;
   if (latestStatus === "running") {
+    // Three color-cycling bouncing balls; same `data-testid` the
+    // legacy `Loader2` had, so existing unit + e2e specs that target
+    // `[data-testid='tool-progress-spinner']` still resolve the
+    // animated row indicator.
     leadingIcon = (
-      <Loader2
-        size={12}
-        className="animate-spin text-accent"
+      <span
         data-testid="tool-progress-spinner"
+        className="inline-flex items-center gap-[3px]"
         aria-label="running"
-      />
+        aria-hidden="true"
+      >
+        <span
+          className="tool-ball block h-1.5 w-1.5 rounded-full bg-accent"
+          style={{ animationDelay: "0ms" }}
+        />
+        <span
+          className="tool-ball block h-1.5 w-1.5 rounded-full bg-accent/70"
+          style={{ animationDelay: "150ms" }}
+        />
+        <span
+          className="tool-ball block h-1.5 w-1.5 rounded-full bg-accent/40"
+          style={{ animationDelay: "300ms" }}
+        />
+      </span>
     );
   } else if (latestStatus === "complete") {
     leadingIcon = (

--- a/src/components/tool-progress-indicator.tsx
+++ b/src/components/tool-progress-indicator.tsx
@@ -101,22 +101,32 @@ export function ToolProgressIndicator({ message }: ToolProgressIndicatorProps) {
     // legacy `Loader2` had, so existing unit + e2e specs that target
     // `[data-testid='tool-progress-spinner']` still resolve the
     // animated row indicator.
+    // codex PR #147 review (MINOR 1, 2026-05-22): the outer wrapper
+    // carries `role="img"` + `aria-label` so screen readers announce
+    // "running"; `aria-hidden` is moved to the individual visual balls
+    // so the decorative shapes are hidden but the accessible name still
+    // exposes. Previously the wrapper had BOTH `aria-label` AND
+    // `aria-hidden="true"` — the hidden flag won, so AT users got
+    // nothing.
     leadingIcon = (
       <span
         data-testid="tool-progress-spinner"
         className="inline-flex items-center gap-[3px]"
+        role="img"
         aria-label="running"
-        aria-hidden="true"
       >
         <span
+          aria-hidden="true"
           className="tool-ball block h-1.5 w-1.5 rounded-full bg-accent"
           style={{ animationDelay: "0ms" }}
         />
         <span
+          aria-hidden="true"
           className="tool-ball block h-1.5 w-1.5 rounded-full bg-accent/70"
           style={{ animationDelay: "150ms" }}
         />
         <span
+          aria-hidden="true"
           className="tool-ball block h-1.5 w-1.5 rounded-full bg-accent/40"
           style={{ animationDelay: "300ms" }}
         />

--- a/src/index.css
+++ b/src/index.css
@@ -294,44 +294,18 @@ body {
   text-transform: capitalize;
 }
 
+/* `.session-task-indicator` provides only sizing chrome now — the
+ *  dot constellation is rendered inline by `SessionTaskIndicator` via
+ *  Tailwind utilities + `.task-constellation-dot` (keyframes below).
+ *  Pre-M9 the rule lit a glass-pill rectangle with a rotating border
+ *  circle; the redesign trades chrome for an inline dot row that
+ *  scales with task count. */
 .session-task-indicator {
   display: inline-flex;
   max-width: min(32rem, 42vw);
   align-items: center;
-  gap: 0.7rem;
+  gap: 0.5rem;
   flex-shrink: 1;
-}
-
-.session-task-indicator-dot {
-  position: relative;
-  flex-shrink: 0;
-  width: 0.9rem;
-  height: 0.9rem;
-  border-radius: 999px;
-  border: 2px solid color-mix(in srgb, var(--color-accent) 28%, transparent);
-  border-top-color: color-mix(in srgb, var(--color-accent) 96%, white 4%);
-  border-right-color: color-mix(in srgb, var(--color-accent) 72%, transparent);
-  opacity: 0.95;
-}
-
-.session-task-indicator-dot.is-active {
-  animation: sessionTaskSpin 0.85s linear infinite;
-  box-shadow: 0 0 0 3px color-mix(in srgb, var(--color-accent) 14%, transparent);
-}
-
-.session-task-indicator-dot.is-failed {
-  border-color: color-mix(in srgb, #ef4444 72%, transparent);
-  border-top-color: #ef4444;
-  box-shadow: 0 0 0 3px color-mix(in srgb, #ef4444 12%, transparent);
-}
-
-@keyframes sessionTaskSpin {
-  from {
-    transform: rotate(0deg);
-  }
-  to {
-    transform: rotate(360deg);
-  }
 }
 
 @keyframes shellRise {
@@ -347,6 +321,49 @@ body {
 
 .animate-shell-rise {
   animation: shellRise 0.24s cubic-bezier(0.2, 0, 0, 1);
+}
+
+/* ── Tool-card / progress-row bouncing-ball spinner ──────────
+ *  Three small dots that stagger via inline `animationDelay`. Replaces
+ *  the lucide `Loader2` rotation in the tool-call status icon and the
+ *  inline tool-progress indicator. Driven via the `.tool-ball` class
+ *  rather than Tailwind's `animate-*` namespace so the assertion
+ *  `assistant.querySelector(".animate-spin")` in our existing
+ *  "no-trailing-spinner" specs (which guarded against the SVG
+ *  spinner) continues to match `null`.
+ */
+@keyframes toolBallBounce {
+  0%, 80%, 100% {
+    transform: translateY(0) scale(0.7);
+    opacity: 0.4;
+  }
+  40% {
+    transform: translateY(-3px) scale(1);
+    opacity: 1;
+  }
+}
+
+.tool-ball {
+  animation: toolBallBounce 1.2s ease-in-out infinite;
+}
+
+/* ── Header task-constellation dots ─────────────────────────────
+ *  Each dot pulses on its own delay (inline `animationDelay`). The
+ *  constellation scales with active task count — one dot per task.
+ */
+@keyframes taskConstellationPulse {
+  0%, 100% {
+    opacity: 0.45;
+    transform: scale(0.78);
+  }
+  50% {
+    opacity: 1;
+    transform: scale(1.08);
+  }
+}
+
+.task-constellation-dot {
+  animation: taskConstellationPulse 1.4s ease-in-out infinite;
 }
 
 [data-theme="light"] .glass-panel {
@@ -400,11 +417,6 @@ body {
 
 [data-theme="light"] .message-card-assistant {
   background: color-mix(in srgb, white 78%, var(--color-surface-container) 22%);
-}
-
-[data-theme="light"] .session-task-indicator-dot {
-  border-color: color-mix(in srgb, var(--color-accent) 24%, transparent);
-  border-top-color: color-mix(in srgb, var(--color-accent) 86%, black 8%);
 }
 
 /* ── Scrollbar ──────────────────────────────────────── */

--- a/src/runtime/spawn-only-tools.ts
+++ b/src/runtime/spawn-only-tools.ts
@@ -12,13 +12,27 @@
  * premature `status: complete` flip; `handleTaskUpdated` then drives the
  * real terminal transition once the background task settles.
  *
- * Sources of truth for the names below:
- *   - `crates/app-skills/.../manifest.json` entries with `spawn_only: true`
- *   - `crates/platform-skills/voice/manifest.json` (`voice_synthesize`)
- *   - `crates/octos-agent/src/workspace_contract.rs` (`fm_tts`,
- *     `podcast_generate`)
- *   - the pipeline / deep-search supervisors which run as spawn_only via
- *     `mark_spawn_only` in `crates/octos-agent/src/tools/registry.rs`
+ * Sources of truth for the names below (checked 2026-05-22):
+ *   - `crates/app-skills/harness-starter-<kind>/manifest.json` →
+ *     `propose_patch`, `produce_artifact`, `generate_report`,
+ *     `synthesize_clip`
+ *   - `crates/platform-skills/voice/manifest.json` → `voice_synthesize`
+ *   - `mofa-skills/mofa-<plugin>/manifest.json` (external skill repo with
+ *     `"spawn_only": true` in the tool entry) → `podcast_generate`,
+ *     `mofa_slides`, `mofa_cards`, `mofa_comic`, `mofa_infographic`,
+ *     `mofa_publish`, `fm_tts`
+ *   - `mark_spawn_only("run_pipeline", ...)` programmatic registration
+ *     in `crates/octos-cli/src/{runtime/profile.rs, commands/chat.rs,
+ *     session_actor.rs}`
+ *
+ * Tools that look spawn_only but are NOT:
+ *   - `mofa_frame` — the workspace_policy.rs entry has an explicit
+ *     comment ("the manifest is not spawn_only: true today — contract
+ *     is dormant"); the mofa-skills manifest confirms.
+ *   - `deep_search` — the actual tool name registered by
+ *     `crates/app-skills/deep-search` is `search`, NOT `deep_search`,
+ *     and the manifest does NOT mark it spawn_only. The
+ *     `workspace_policy.rs` entry is a dormant contract slot.
  *
  * Keep this list synchronized when new spawn_only tools land on the
  * agent side. The set is checked by exact string equality on the
@@ -26,16 +40,27 @@
  * resolve here.
  */
 export const SPAWN_ONLY_TOOL_NAMES: ReadonlySet<string> = new Set<string>([
+  // Pipeline supervisor (registered programmatically via
+  // `mark_spawn_only("run_pipeline", ...)` in profile.rs / chat.rs /
+  // session_actor.rs).
   "run_pipeline",
+  // mofa-skills plugins (`mofa-skills/.../manifest.json` with
+  // `"spawn_only": true`):
   "podcast_generate",
   "mofa_slides",
   "mofa_cards",
   "mofa_comic",
   "mofa_infographic",
-  "mofa_frame",
-  "voice_synthesize",
+  "mofa_publish",
   "fm_tts",
-  "deep_search",
+  // platform-skills/voice (`platform-skills/voice/manifest.json`):
+  "voice_synthesize",
+  // app-skills harness starters
+  // (`crates/app-skills/harness-starter-*/manifest.json`):
+  "propose_patch",
+  "produce_artifact",
+  "generate_report",
+  "synthesize_clip",
 ]);
 
 /** Returns true when `toolName` is a known spawn_only background tool.

--- a/src/runtime/spawn-only-tools.ts
+++ b/src/runtime/spawn-only-tools.ts
@@ -1,0 +1,46 @@
+/**
+ * Canonical set of `spawn_only` tool names known to the SPA.
+ *
+ * spawn_only tools are background skills whose foreground `tool/completed`
+ * envelope fires ~2ms after `tool/started` (it's only an acknowledgement
+ * that the supervisor accepted the work) — the actual background task
+ * keeps running for seconds or minutes. The terminal signal for the
+ * tool-card chip is `task/updated:completed` (or `task/updated:failed`),
+ * not the foreground `tool/completed`.
+ *
+ * The router consults this set in `handleToolCompleted` to skip the
+ * premature `status: complete` flip; `handleTaskUpdated` then drives the
+ * real terminal transition once the background task settles.
+ *
+ * Sources of truth for the names below:
+ *   - `crates/app-skills/.../manifest.json` entries with `spawn_only: true`
+ *   - `crates/platform-skills/voice/manifest.json` (`voice_synthesize`)
+ *   - `crates/octos-agent/src/workspace_contract.rs` (`fm_tts`,
+ *     `podcast_generate`)
+ *   - the pipeline / deep-search supervisors which run as spawn_only via
+ *     `mark_spawn_only` in `crates/octos-agent/src/tools/registry.rs`
+ *
+ * Keep this list synchronized when new spawn_only tools land on the
+ * agent side. The set is checked by exact string equality on the
+ * server-emitted `tool_name` field, so abbreviations / aliases don't
+ * resolve here.
+ */
+export const SPAWN_ONLY_TOOL_NAMES: ReadonlySet<string> = new Set<string>([
+  "run_pipeline",
+  "podcast_generate",
+  "mofa_slides",
+  "mofa_cards",
+  "mofa_comic",
+  "mofa_infographic",
+  "mofa_frame",
+  "voice_synthesize",
+  "fm_tts",
+  "deep_search",
+]);
+
+/** Returns true when `toolName` is a known spawn_only background tool.
+ *  Safe to call with `undefined` / empty strings — returns false. */
+export function isSpawnOnlyToolName(toolName: string | undefined | null): boolean {
+  if (!toolName) return false;
+  return SPAWN_ONLY_TOOL_NAMES.has(toolName);
+}

--- a/src/runtime/ui-protocol-event-router.test.ts
+++ b/src/runtime/ui-protocol-event-router.test.ts
@@ -2281,12 +2281,13 @@ describe("regression A: tool/* events fan out into crew:tool_progress", () => {
     expect((dispatched[0] as CustomEvent).detail.tool).toBe("shell");
   });
 
-  it("tool/completed marks the crew:tool_progress event terminal (spawn_only spinner clear signal)", () => {
+  it("tool/completed marks crew:tool_progress terminal for non-spawn_only tools (legacy spinner clear signal)", () => {
     // The lifted `ToolProgressIndicator` (chat-layout level) cannot
-    // rely on `crew:thinking false` for spawn_only flows — that event
-    // already fired at `turn/completed` BEFORE the background task
-    // started emitting `tool/progress`. The terminal flag is the
-    // dedicated clear signal the indicator listens for.
+    // rely on `crew:thinking false` for foreground tool completions —
+    // for synchronous tools the terminal flag is the dedicated clear
+    // signal. For spawn_only tools we DEFER the terminal flag (see
+    // the spawn_only test below) since the foreground completion is
+    // only an ack.
     const dispatched: Event[] = [];
     handleToolCompleted(
       { sessionId: SESSION, dispatchEvent: (e) => dispatched.push(e) },
@@ -2294,13 +2295,107 @@ describe("regression A: tool/* events fan out into crew:tool_progress", () => {
         session_id: SESSION,
         turn_id: "cmid-A4",
         tool_call_id: "tc-4",
-        tool_name: "podcast_generate",
+        tool_name: "shell",
         success: true,
       },
     );
     expect(dispatched).toHaveLength(1);
     expect((dispatched[0] as CustomEvent).detail.terminal).toBe(true);
+    expect((dispatched[0] as CustomEvent).detail.tool).toBe("shell");
+  });
+
+  it("tool/completed does NOT mark crew:tool_progress terminal for spawn_only tools (defect A, 2026-05-22)", () => {
+    // Defect A (M9 follow-up): the foreground `tool/completed` for a
+    // spawn_only tool (`podcast_generate`, `run_pipeline`, `fm_tts`,
+    // etc.) fires ~2ms after `tool/started` — it's only the
+    // supervisor's ack, not a signal that the background task has
+    // finished. Pre-fix this dispatched a terminal `crew:tool_progress`
+    // event that cleared the lifted spinner while the background task
+    // was still running (and planted a static Check on the tool card).
+    // Post-fix the dispatched event keeps `terminal` unset; the real
+    // terminal signal arrives via `task/updated:completed` →
+    // `handleTaskUpdated`'s dedicated terminal dispatch.
+    const dispatched: Event[] = [];
+    handleToolCompleted(
+      { sessionId: SESSION, dispatchEvent: (e) => dispatched.push(e) },
+      {
+        session_id: SESSION,
+        turn_id: "cmid-A4-spawn",
+        tool_call_id: "tc-4-spawn",
+        tool_name: "podcast_generate",
+        success: true,
+      },
+    );
+    expect(dispatched).toHaveLength(1);
+    expect((dispatched[0] as CustomEvent).detail.terminal).toBeUndefined();
     expect((dispatched[0] as CustomEvent).detail.tool).toBe("podcast_generate");
+  });
+
+  it("tool/completed for a spawn_only tool leaves toolCall.status running (defect A, 2026-05-22)", () => {
+    // Companion to the test above — the chip itself must NOT flip.
+    // Seed a tool call via `handleToolStarted`, fire foreground
+    // `tool/completed` (the spawn_only ack leg), and assert the
+    // ThreadStore tool call is still `"running"`.
+    const cmid = "cmid-defectA-status";
+    seedThread(cmid, "generate a podcast");
+    handleToolStarted(
+      { sessionId: SESSION },
+      {
+        session_id: SESSION,
+        turn_id: cmid,
+        tool_call_id: "tc-podcast-defectA",
+        tool_name: "run_pipeline",
+      },
+    );
+    handleToolCompleted(
+      { sessionId: SESSION },
+      {
+        session_id: SESSION,
+        turn_id: cmid,
+        tool_call_id: "tc-podcast-defectA",
+        tool_name: "run_pipeline",
+        success: true,
+      },
+    );
+    const [thread] = ThreadStore.getThreads(SESSION);
+    const tc = thread.pendingAssistant?.toolCalls.find(
+      (t) => t.id === "tc-podcast-defectA",
+    );
+    expect(tc).toBeDefined();
+    expect(tc!.status).toBe("running");
+  });
+
+  it("tool/completed with success=false for a spawn_only tool DOES flip to error (real failure)", () => {
+    // The spawn_only defer is ONLY for `success: true` — a foreground
+    // failure means the supervisor refused to spawn the work, so it's
+    // genuinely terminal and the chip MUST flip to "error" right away.
+    const cmid = "cmid-defectA-err";
+    seedThread(cmid, "synthesise");
+    handleToolStarted(
+      { sessionId: SESSION },
+      {
+        session_id: SESSION,
+        turn_id: cmid,
+        tool_call_id: "tc-fmtts-err",
+        tool_name: "fm_tts",
+      },
+    );
+    handleToolCompleted(
+      { sessionId: SESSION },
+      {
+        session_id: SESSION,
+        turn_id: cmid,
+        tool_call_id: "tc-fmtts-err",
+        tool_name: "fm_tts",
+        success: false,
+      },
+    );
+    const [thread] = ThreadStore.getThreads(SESSION);
+    const tc = thread.pendingAssistant?.toolCalls.find(
+      (t) => t.id === "tc-fmtts-err",
+    );
+    expect(tc).toBeDefined();
+    expect(tc!.status).toBe("error");
   });
 
   it("tool/started and tool/progress do NOT carry the terminal flag", () => {

--- a/src/runtime/ui-protocol-event-router.ts
+++ b/src/runtime/ui-protocol-event-router.ts
@@ -45,6 +45,7 @@ import * as ThreadStore from "@/store/thread-store";
 import * as TaskStore from "@/store/task-store";
 import type { MessageMeta } from "@/store/thread-store";
 import type { MessageInfo } from "@/api/types";
+import { isSpawnOnlyToolName } from "./spawn-only-tools";
 
 // ---------------------------------------------------------------------------
 // Per-turn meta snapshot
@@ -1129,37 +1130,63 @@ export function handleToolCompleted(
   cfg: RouterConfig,
   event: ToolCompletedEvent,
 ): void {
+  const isSpawnOnly = isSpawnOnlyToolName(event.tool_name);
   const message =
     event.success === false
       ? "error"
       : event.success === true
         ? "done"
         : "complete";
-  // Codex round-2 P2: persist the terminal tool-call status onto the
-  // bubble's tool card so the chip stops spinning. Failed calls
-  // surface as "error"; everything else as "complete" (matching the
-  // `handleTaskUpdated` `completed` / `failed` mapping).
-  ThreadStore.setToolCallStatus(
-    event.turn_id,
-    event.tool_call_id,
-    event.success === false ? "error" : "complete",
-  );
+  // Defect A (M9 follow-up, 2026-05-22): for spawn_only background
+  // tools (run_pipeline / podcast_generate / mofa_* / fm_tts /
+  // deep_search / voice_synthesize) the foreground `tool/completed`
+  // envelope fires ~2ms after `tool/started` — it's only the supervisor
+  // acknowledging the work, not a signal that the background task has
+  // finished. Flipping the tool-card chip to "complete" here put a
+  // static check icon on a card whose work was still in flight (often
+  // for minutes). Defer the terminal flip to `task/updated:completed`,
+  // which `handleTaskUpdated` maps onto `setToolCallStatus(..., "complete")`.
+  //
+  // Failed (`success: false`) tool/completed events ARE genuine
+  // terminal signals — the supervisor refused to spawn the work, so
+  // the tool card SHOULD flip to "error" right away.
+  const shouldFlipStatus = !isSpawnOnly || event.success === false;
+  if (shouldFlipStatus) {
+    // Codex round-2 P2: persist the terminal tool-call status onto the
+    // bubble's tool card so the chip stops spinning. Failed calls
+    // surface as "error"; everything else as "complete" (matching the
+    // `handleTaskUpdated` `completed` / `failed` mapping).
+    ThreadStore.setToolCallStatus(
+      event.turn_id,
+      event.tool_call_id,
+      event.success === false ? "error" : "complete",
+    );
+  }
   // Mark terminal so the lifted `ToolProgressIndicator` clears the
   // spinner row. The bubble's `ToolCallBubble` reads the final
   // status from `ThreadStore.setToolCallStatus` above and keeps the
   // history-pill state intact — only the transient spinner row goes
   // away. Critical for spawn_only flows where `crew:thinking false`
   // already fired at `turn/completed` and cannot clean up.
+  //
+  // Defect A (continued): when we DEFER the status flip for a
+  // spawn_only success, the dispatched `crew:tool_progress` event is
+  // NOT terminal — the spinner row must keep alive until the real
+  // `task/updated:completed` arrives.
   dispatchToolProgressEvent(
     cfg,
     event.turn_id,
     event.tool_name,
     message,
-    /* terminal */ true,
+    /* terminal */ shouldFlipStatus,
   );
-  // Clear the cache entry so a long-lived session doesn't accumulate
-  // dead tool_call_id mappings.
-  toolNameByCallId.delete(event.tool_call_id);
+  // Defect A: only drop the `tool_call_id` → `tool_name` cache entry
+  // when the chip actually settled. For deferred spawn_only completions
+  // we still need the cache so future `task/updated` heartbeats can
+  // surface the friendly tool name in the spinner row.
+  if (shouldFlipStatus) {
+    toolNameByCallId.delete(event.tool_call_id);
+  }
 }
 
 // ---------------------------------------------------------------------------

--- a/src/store/thread-store.test.ts
+++ b/src/store/thread-store.test.ts
@@ -547,6 +547,92 @@ describe.each(FLAG_STATES)("thread-store [$label]", ({ projectionV1 }) => {
     expect(tcs[0].status).toBe("complete");
   });
 
+  // Defect B (M9 follow-up, 2026-05-22): late `appendToolProgress` for a
+  // `tool_call_id` whose originating bubble has been finalised into
+  // `thread.responses` AND a more-recent assistant response has been
+  // appended (e.g. a `turn/spawn_complete` completion bubble after the
+  // foreground ack response). Pre-fix `pickAssistantSlot` returned the
+  // most-recent assistant, `findIndex` missed on it, and the function
+  // minted a stub `{id: toolCallId, name: toolName ?? "", status:
+  // "running"}` on the wrong slot — surfacing as a SECOND, empty
+  // ToolCallBubble titled "tool". The fix scans every assistant slot
+  // in the thread for the owning `toolCallId` before falling back to
+  // stub creation; the late progress now lands on the originating
+  // (earlier) response and the most-recent response stays untouched.
+  it("appendToolProgress_routes_late_progress_to_originating_finalized_slot_not_stub_on_newer_response", () => {
+    // 1) Foreground turn finalises with a tool call on the assistant
+    //    ack response (this is the "originating bubble").
+    makeUser("generate a podcast", "cmid-1");
+    ThreadStore.addToolCall("cmid-1", "tc-podcast-1", "podcast_generate");
+    ThreadStore.appendAssistantToken(
+      "cmid-1",
+      "Started background podcast generation.",
+    );
+    ThreadStore.finalizeAssistant("cmid-1", { committedSeq: 1 });
+
+    // 2) A later spawn_complete bubble appends onto the same thread
+    //    as a NEW finalised assistant response. After this the most
+    //    recent assistant slot picked by `pickAssistantSlot` is the
+    //    spawn_complete bubble — NOT the originating ack response.
+    ThreadStore.appendCompletionBubble("cmid-1", {
+      text: "✓ podcast generated (output.mp3)",
+      media: ["out/output.mp3"],
+      spawnComplete: true,
+      sourceClientMessageId: "cmid-1",
+      historySeq: 17,
+      messageId: "msg-spawn-1",
+      persistedAt: new Date().toISOString(),
+      sessionId: SESSION,
+    });
+
+    // Sanity: two finalised responses, neither has been opened a new
+    // pendingAssistant on. The first response carries the tool call.
+    const before = ThreadStore.getThreads(SESSION)[0];
+    expect(before.responses.length).toBeGreaterThanOrEqual(2);
+    const originating = before.responses.find(
+      (r) =>
+        r.role === "assistant" &&
+        r.toolCalls.some((tc) => tc.id === "tc-podcast-1"),
+    );
+    expect(originating).toBeDefined();
+    const completionBubble = before.responses[before.responses.length - 1];
+    expect(completionBubble.toolCalls).toHaveLength(0);
+
+    // 3) Late `tool/progress` arrives for the originating tool call
+    //    (e.g. a `crew:task_status` mirror after the foreground turn
+    //    ended). Without the defect-B fix this would mint a stub on
+    //    the completion bubble — surfacing as a phantom empty
+    //    "tool" titled ToolCallBubble next to the file row.
+    ThreadStore.appendToolProgress(
+      "cmid-1",
+      "tc-podcast-1",
+      "synthesising 7/10",
+      "podcast_generate",
+    );
+
+    const after = ThreadStore.getThreads(SESSION)[0];
+
+    // No phantom stub on the most-recent (completion) bubble.
+    const completionAfter = after.responses[after.responses.length - 1];
+    expect(
+      completionAfter.toolCalls,
+      "late tool_progress must route back to the originating finalised slot, not mint a stub on a later response (defect B 2026-05-22)",
+    ).toHaveLength(0);
+
+    // The originating finalised response received the progress entry.
+    const originatingAfter = after.responses.find(
+      (r) =>
+        r.role === "assistant" &&
+        r.toolCalls.some((tc) => tc.id === "tc-podcast-1"),
+    );
+    expect(originatingAfter).toBeDefined();
+    const tc = originatingAfter!.toolCalls.find(
+      (t) => t.id === "tc-podcast-1",
+    );
+    expect(tc).toBeDefined();
+    expect(tc!.progress.map((p) => p.message)).toContain("synthesising 7/10");
+  });
+
   it("loadHistory_synthesizes_threads_for_legacy_records_without_thread_id", async () => {
     // Legacy daemon: no thread_id on any record. Synthesizer must derive one
     // per user-message role-flip so the chat still groups into 2 threads.

--- a/src/store/thread-store.test.ts
+++ b/src/store/thread-store.test.ts
@@ -1024,8 +1024,15 @@ describe.each(FLAG_STATES)("thread-store [$label]", ({ projectionV1 }) => {
   // ---------------------------------------------------------------------------
 
   it("finalizeAssistant_sweeps_running_tool_calls_to_complete", () => {
-    makeUser("kick off pipeline", "cmid-1");
-    ThreadStore.addToolCall("cmid-1", "call_A", "run_pipeline");
+    // Use a NON-spawn_only tool name. After codex PR #147 BLOCKER
+    // (2026-05-22) the sweep is gated by `SPAWN_ONLY_TOOL_NAMES`, so
+    // tools like `run_pipeline` are intentionally left in `running`
+    // (their terminal flip comes from `task/updated:completed`, not
+    // the turn sweep). A synchronous tool like `read_file` is still
+    // swept because the server's `done` is the only terminal signal
+    // when an explicit `tool_end` was suppressed.
+    makeUser("read a file", "cmid-1");
+    ThreadStore.addToolCall("cmid-1", "call_A", "read_file");
     ThreadStore.appendToolProgress("cmid-1", "call_A", "[info] step 1");
     // No tool_end fires — server omits it. `done` arrives.
     ThreadStore.finalizeAssistant("cmid-1", { committedSeq: 3 });
@@ -1037,9 +1044,37 @@ describe.each(FLAG_STATES)("thread-store [$label]", ({ projectionV1 }) => {
     expect(tcs).toHaveLength(1);
     expect(
       tcs[0].status,
-      "running tool chip must flip to complete on done — never stay spinning",
+      "running non-spawn_only tool chip must flip to complete on done — never stay spinning",
     ).toBe("complete");
     expect(tcs[0].id).toBe("call_A");
+  });
+
+  it("finalizeAssistant_leaves_running_spawn_only_tool_calls_in_running", () => {
+    // codex PR #147 BLOCKER (2026-05-22): the sweep is gated by
+    // `SPAWN_ONLY_TOOL_NAMES`. For spawn_only tools the foreground
+    // `tool/completed` is just the supervisor's acknowledgement —
+    // the background work continues for minutes after the LLM turn
+    // ends. Sweeping the chip to `complete` here would silently undo
+    // the Defect A deferral. The terminal flip MUST come from
+    // `handleTaskUpdated`, not `finalizeAssistant`.
+    makeUser("kick off pipeline", "cmid-1");
+    ThreadStore.addToolCall("cmid-1", "call_pipe", "run_pipeline");
+    ThreadStore.appendToolProgress("cmid-1", "call_pipe", "[info] starting");
+    // No tool_end fires (typical for spawn_only — foreground
+    // completion would only acknowledge the supervisor handoff).
+    // `done` arrives.
+    ThreadStore.finalizeAssistant("cmid-1", { committedSeq: 3 });
+
+    const [thread] = ThreadStore.getThreads(SESSION);
+    expect(thread.pendingAssistant).toBeNull();
+    expect(thread.responses).toHaveLength(1);
+    const tcs = thread.responses[0].toolCalls;
+    expect(tcs).toHaveLength(1);
+    expect(
+      tcs[0].status,
+      "spawn_only tool chip MUST stay `running` until task/updated:completed",
+    ).toBe("running");
+    expect(tcs[0].name).toBe("run_pipeline");
   });
 
   it("finalizeAssistant_does_not_regress_already_complete_tool_calls", () => {

--- a/src/store/thread-store.ts
+++ b/src/store/thread-store.ts
@@ -946,9 +946,73 @@ export function appendToolProgress(
   // assistant so a late spawn_only tool_progress (#649) still updates
   // the bubble even after `done` finalized the turn.
   const slot = pickAssistantSlot(found.thread);
-  // No assistant slot at all yet (e.g. orphan thread, never had one) —
-  // open a new pending so the progress has somewhere to render.
-  const oldTarget = slot ?? ensurePendingAssistant(found.thread);
+
+  // Defect B (M9 follow-up, 2026-05-22): when `pickAssistantSlot`
+  // returns the most-recent assistant slot but the toolCallId actually
+  // lives on an EARLIER slot (e.g. the originating bubble was
+  // finalised into `thread.responses`, then a NEW user prompt minted a
+  // fresh pendingAssistant), the legacy lookup missed and minted a
+  // stub `{id: toolCallId, name: toolName ?? "", status: "running"}`
+  // on the new slot — rendering as a second, empty ToolCallBubble
+  // titled "tool". Mirror `setToolCallStatus`'s thread-wide scan
+  // (pending + every assistant response, most-recent-first) so a late
+  // progress chunk always routes back to its originating bubble.
+  let containingSlot: ThreadMessage | null = null;
+  let entryIdx = -1;
+  if (toolCallId && slot) {
+    const idxOnSlot = slot.toolCalls.findIndex((tc) => tc.id === toolCallId);
+    if (idxOnSlot !== -1) {
+      containingSlot = slot;
+      entryIdx = idxOnSlot;
+    }
+  }
+  if (containingSlot === null && toolCallId) {
+    // Scan every assistant slot in this thread, most-recent first, for
+    // a tool call owning `toolCallId`. The pending slot (if any) gets
+    // priority because that's the slot a successful `pickAssistantSlot`
+    // would have returned; falling through to finalised responses
+    // catches the defect-B case where the originating slot is already
+    // in `thread.responses`.
+    const candidates: ThreadMessage[] = [];
+    if (found.thread.pendingAssistant) {
+      candidates.push(found.thread.pendingAssistant);
+    }
+    for (let i = found.thread.responses.length - 1; i >= 0; i -= 1) {
+      const candidate = found.thread.responses[i];
+      if (candidate.role === "assistant") candidates.push(candidate);
+    }
+    for (const candidate of candidates) {
+      const idxOnCandidate = candidate.toolCalls.findIndex(
+        (tc) => tc.id === toolCallId,
+      );
+      if (idxOnCandidate !== -1) {
+        containingSlot = candidate;
+        entryIdx = idxOnCandidate;
+        break;
+      }
+    }
+  }
+  if (containingSlot === null && !toolCallId && toolName && slot) {
+    // Legacy daemon path — no tool_call_id on the wire. Route by tool
+    // name to the most recent matching call on the picked slot. Same
+    // semantics as the pre-defect-B code.
+    for (let i = slot.toolCalls.length - 1; i >= 0; i -= 1) {
+      if (slot.toolCalls[i].name === toolName) {
+        containingSlot = slot;
+        entryIdx = i;
+        break;
+      }
+    }
+  }
+  // No matching tool call anywhere in the thread — fall back to the
+  // picked slot (or open a new pending) and mint a stub. This is the
+  // legitimate "late-arriving progress for a tool we missed start
+  // for" path, e.g. SSE resumed mid-stream. With the thread-wide scan
+  // above, this branch fires only when truly no prior slot owns the
+  // id — the spurious stub on a fresh slot defect B reported can no
+  // longer happen.
+  const oldTarget =
+    containingSlot ?? slot ?? ensurePendingAssistant(found.thread);
 
   // Bug 2026-05-15: previously this function pushed onto
   // `entry.progress` and kept the surrounding `ThreadMessage` reference
@@ -960,20 +1024,6 @@ export function appendToolProgress(
   // + tool-call list + ThreadMessage so memo's shallow comparison sees
   // the change.
   const oldTcs = oldTarget.toolCalls;
-  let entryIdx = -1;
-  if (toolCallId) {
-    entryIdx = oldTcs.findIndex((tc) => tc.id === toolCallId);
-  } else if (toolName) {
-    // Server omitted tool_call_id (legacy daemon). Route by tool name to
-    // the most recent matching call so progress still lands on the right
-    // bubble — no synthesized id required.
-    for (let i = oldTcs.length - 1; i >= 0; i -= 1) {
-      if (oldTcs[i].name === toolName) {
-        entryIdx = i;
-        break;
-      }
-    }
-  }
   const existing = entryIdx === -1 ? undefined : oldTcs[entryIdx];
   // Idempotency guard: skip exact-duplicate consecutive entries so a
   // task_status replay (e.g. on stream reconnect) doesn't double-render

--- a/src/store/thread-store.ts
+++ b/src/store/thread-store.ts
@@ -35,6 +35,7 @@ import type {
   EnvelopeToolEndStatus,
   Payload,
 } from "@/runtime/ui-protocol-types";
+import { SPAWN_ONLY_TOOL_NAMES } from "@/runtime/spawn-only-tools";
 import {
   ingest as projectionIngest,
   isProjectionV1Enabled,
@@ -1662,9 +1663,27 @@ export function finalizeAssistant(
     // Also remember which ids were swept so the projection dual-write
     // below can emit synthetic `tool_end` envelopes for them BEFORE
     // `turn_completed` (codex round-1 BLOCK 3).
+    //
+    // SPAWN_ONLY EXCEPTION (codex PR #147 review BLOCKER, 2026-05-22):
+    // spawn_only tools (`run_pipeline`, `podcast_generate`, `fm_tts`,
+    // ...) intentionally fire their foreground `tool/completed` ~ms
+    // after `tool/started` — the actual background work runs for
+    // minutes after `turn/completed` lands. The real terminal signal
+    // for the bubble is `task/updated:completed` (or `:failed`), which
+    // `handleTaskUpdated` routes to `setToolCallStatus`. Sweeping the
+    // chip to `complete` here would silently undo the Defect A
+    // deferral for the second code path — the chip would settle
+    // before the background work actually finishes. We leave
+    // spawn_only chips alone here; `handleTaskUpdated` flips them
+    // when the supervisor task settles.
     const sweptToolCallIds: string[] = [];
     const sweptToolCalls = thread.pendingAssistant.toolCalls.map((tc) => {
       if (tc.status === "running") {
+        if (SPAWN_ONLY_TOOL_NAMES.has(tc.name)) {
+          // Leave spawn_only chips in `running` — the terminal flip
+          // comes from `handleTaskUpdated`, not the turn sweep.
+          return tc;
+        }
         if (tc.id) sweptToolCallIds.push(tc.id);
         return { ...tc, status: "complete" as const };
       }


### PR DESCRIPTION
## Summary

Four changes across the chat thread + header runtime:

### 1. Defect A — premature tool-card "complete" on spawn_only

Foreground `tool/completed` for a spawn_only background tool
(`run_pipeline`, `podcast_generate`, `mofa_*`, `fm_tts`,
`voice_synthesize`, `deep_search`) fires ~2ms after `tool/started`
— it's the supervisor acknowledging the work, not real completion.
Pre-fix the chip flipped to `complete` immediately and planted a
static check icon on a tool card whose work was still in flight (often
for minutes).

WS-frame evidence from prior reports:
```
tool/started   tool_call_id=tc-xyz tool_name=run_pipeline  @ T+0ms
tool/completed tool_call_id=tc-xyz tool_name=run_pipeline success=true @ T+2ms
... (no more frames on this tool_call_id for ~12 minutes)
task/updated   tool_call_id=tc-xyz state=running          @ T+5s
task/updated   tool_call_id=tc-xyz state=running          @ T+10s
... heartbeats ...
task/updated   tool_call_id=tc-xyz state=completed        @ T+11m40s
```

Fix: `handleToolCompleted` consults the new `SPAWN_ONLY_TOOL_NAMES`
set (`src/runtime/spawn-only-tools.ts`) and defers
`setToolCallStatus(...,"complete")` for spawn_only successes. The
real terminal signal — `task/updated:completed` → `handleTaskUpdated`
— already maps to `setToolCallStatus(..., "complete")`, so no new
plumbing is needed downstream. Failures (`success: false`) and
non-spawn_only tools keep the original immediate-terminal semantics.

### 2. Defect B — late tool/progress mints stub on next slot

`appendToolProgress` in `src/store/thread-store.ts` picked the most-
recent assistant slot via `pickAssistantSlot`, ran `findIndex` on
just that slot, and minted a stub
`{id: toolCallId, name: toolName ?? "", status: "running"}` on a
miss. When the originating bubble had been finalised into
`thread.responses` and a later response had since been appended
(e.g. a `turn/spawn_complete` completion bubble for the spawn_only
result), the stub landed on the wrong slot — surfacing as a second
empty `ToolCallBubble` titled "tool".

Fix: scan every assistant slot in the thread (pending, then each
`thread.responses[i]` most-recent-first) for one whose `toolCalls`
contains the `tool_call_id`. Only fall through to stub creation if no
prior slot owns the id. Mirrors the existing thread-wide scan in
`setToolCallStatus`.

### 3. Spinner redesign — color-cycling bouncing balls

Replaces the lucide `Loader2` (`animate-spin` rotation) in both:
- `ToolCallBubble` per-tool status icon
  (`data-testid='tool-call-status-spinner'`)
- `ToolProgressIndicator` row leading icon
  (`data-testid='tool-progress-spinner'`)

with three small (~5-6px) staggered bouncing balls. New `.tool-ball`
keyframe in `src/index.css`. Same `data-testid` so existing unit /
playwright specs targeting those selectors continue to resolve.

### 4. Header — floating dot constellation

`SessionTaskIndicator` redesigned from a `glass-pill` rectangle with
"`N tasks running`" + a wide details line to an inline dot-per-task
constellation. Each dot pulses on a staggered delay via
`.task-constellation-dot`. Falls back to a single red dot for the
failed-task state. `data-testid='session-task-indicator'`,
`data-task-count`, and `data-task-state` attributes added for tests.

## Test plan

- [x] `npm run lint` — no new errors introduced by this PR; pre-existing
      errors in unrelated test files / `chat-thread.tsx` `useEffect`
      lints are unchanged
- [x] `npm run test:unit` — 525 / 525 tests pass
- [x] `npm run build` — clean (`tsc -b && vite build`)
- [ ] Manual visual smoke against mini3 once codex review lands
- [ ] Playwright suites (`npm run test`) — not run in this PR; the
      existing specs that target `tool-call-status-spinner` /
      `tool-progress-spinner` rely on the testid, which is preserved,
      and the `tts-runtime-events.spec.ts` / `content-panel.spec.ts`
      uses of `svg.animate-spin` target the session-list spinner that
      we deliberately did NOT touch