### PR TITLE
fix(chat): timestamp-tolerant dedup for seqless session/messages_page polls

### DIFF
--- a/src/store/thread-store.test.ts
+++ b/src/store/thread-store.test.ts
@@ -1469,6 +1469,51 @@ describe.each(FLAG_STATES)("thread-store [$label]", ({ projectionV1 }) => {
     ).toHaveLength(1);
   });
 
+  it("appendPersistedMessage_seqless_poll_dedupes_against_live_persisted_row", () => {
+    // Regression: dspfac reproducer — `task-watcher.ts` polls
+    // `session/messages_page` every 2500ms during a long-running
+    // `run_pipeline` (deep_research) turn. The server's `MessageInfo`
+    // struct strips `seq`/`message_id`, so polled rows arrive with
+    // `message.seq === undefined`. Pre-fix the seq-only dedupe always
+    // missed and the same persisted row (typically the spawn_only
+    // "Background work started for `run_pipeline`..." ack) got
+    // appended on every tick — producing the runaway 5+ duplicate
+    // bubble pattern. The (role, content, timestamp) fallback
+    // identity catches this without needing a server change.
+    makeUser("深度研究 ...", "cm-poll");
+    const liveRow = {
+      seq: 4,
+      role: "assistant" as const,
+      content: "Background work started for `run_pipeline`. The final result will be delivered automatically when it is ready.",
+      response_to_client_message_id: "cm-poll",
+      thread_id: "cm-poll",
+      timestamp: "2026-04-28T10:00:05Z",
+    };
+    // 1. live wire row arrives WITH seq
+    ThreadStore.appendPersistedMessage(SESSION, undefined, liveRow);
+    // 2. polling task-watcher fetches the same row 8 times in 20 seconds,
+    // but the server strips seq and message_id from the MessageInfo
+    // response — only role/content/timestamp/thread_id survive
+    const polledRow = {
+      role: "assistant" as const,
+      content: liveRow.content,
+      thread_id: "cm-poll",
+      timestamp: liveRow.timestamp,
+    };
+    for (let i = 0; i < 8; i += 1) {
+      ThreadStore.appendPersistedMessage(SESSION, undefined, polledRow);
+    }
+
+    const [thread] = ThreadStore.getThreads(SESSION);
+    const acks = thread.responses.filter((r) =>
+      r.text.startsWith("Background work started"),
+    );
+    expect(
+      acks,
+      "polled rows that re-echo a live persisted row must dedupe via (role,text,timestamp)",
+    ).toHaveLength(1);
+  });
+
   it("appendPersistedMessage_falls_back_to_legacy_thread_id_when_thread_id_missing", () => {
     // Legacy daemon: server omits thread_id. Helper must derive it from
     // client_message_id / response_to_client_message_id and find the

--- a/src/store/thread-store.ts
+++ b/src/store/thread-store.ts
@@ -2796,7 +2796,13 @@ export function appendPersistedMessage(
       ? new Date(message.timestamp).getTime()
       : null;
     const incomingText = typeof message.content === "string" ? message.content : "";
-    if (incomingTs !== null) {
+    // Non-empty text gate (codex MINOR on #148): an empty-content
+    // media-only assistant row with the same timestamp as a prior
+    // empty-content row would otherwise collide here. The dspfac bug
+    // pattern (spawn_only "Background work started..." ack) always
+    // carries stable non-empty text, so this gate doesn't weaken the
+    // fix; it just prevents a hypothetical empty-content false-positive.
+    if (incomingTs !== null && incomingText.trim().length > 0) {
       for (const r of thread.responses) {
         if (
           r.role === message.role &&

--- a/src/store/thread-store.ts
+++ b/src/store/thread-store.ts
@@ -2775,12 +2775,37 @@ export function appendPersistedMessage(
 
   // Idempotency: skip if a response with the same historySeq is already in
   // the thread. The server-side seq is per-session monotonic so this is a
-  // safe identity check — and the only one available since `MessageInfo`
-  // has no stable id field.
+  // safe identity check when available.
   const incomingSeq = typeof message.seq === "number" ? message.seq : undefined;
   if (incomingSeq !== undefined) {
     for (const r of thread.responses) {
       if (r.historySeq === incomingSeq) return;
+    }
+  } else {
+    // Fallback identity for legacy `session/messages_page` poll responses.
+    // The server's `MessageInfo` struct (`crates/octos-cli/src/api/handlers.rs`
+    // `MessageInfo`) strips `seq` and `message_id`, so polled rows arrive
+    // with `message.seq === undefined`. `task-watcher.ts` polls every
+    // ~2500ms, so without this fallback the same persisted row (e.g. the
+    // spawn_only "Background work started" ack) gets appended on every
+    // tick — producing the runaway duplicate-bubble pattern reported
+    // against `run_pipeline` deep_research. (role, content, timestamp)
+    // is the only deterministic identity available in the polled
+    // response shape.
+    const incomingTs = message.timestamp
+      ? new Date(message.timestamp).getTime()
+      : null;
+    const incomingText = typeof message.content === "string" ? message.content : "";
+    if (incomingTs !== null) {
+      for (const r of thread.responses) {
+        if (
+          r.role === message.role &&
+          r.text === incomingText &&
+          r.timestamp === incomingTs
+        ) {
+          return;
+        }
+      }
     }
   }
 


### PR DESCRIPTION
## Summary
Re-applies the client-side dedup fallback for `session/messages_page` poll responses that strip `seq` from `MessageInfo`. Without this, the polled rows from `task-watcher.ts` (2500ms cadence) re-append the same persisted assistant row every tick during long-running spawn_only turns — producing the runaway duplicate "Background work started for run_pipeline..." bubbles reported on dspfac.

## Why it regressed
The original edit was uncommitted local work that got wiped when main was pulled. New regression test pins it so this can't happen again.

## Test plan
- [x] `appendPersistedMessage_seqless_poll_dedupes_against_live_persisted_row` — simulates 1 live row + 8 polled echoes; only 1 bubble survives
- [x] Existing tests still pass