### PR TITLE
fix(chat): drive showLiveIndicators from TaskStore so live UI survives spawn_only background work

### DIFF
--- a/src/components/chat-thread.tsx
+++ b/src/components/chat-thread.tsx
@@ -49,6 +49,7 @@ import { getActiveBridge } from "@/runtime/ui-protocol-runtime";
 import { MarkdownContent } from "./markdown-renderer";
 import { ThinkingIndicator } from "./thinking-indicator";
 import { ToolProgressIndicator } from "./tool-progress-indicator";
+import { useTasks } from "@/store/task-store";
 import { GhostBubble } from "./GhostBubble";
 import { UserBubbleShell } from "./user-bubble-shell";
 import { CopyMarkdownButton } from "./copy-markdown-button";
@@ -947,6 +948,22 @@ function ThreadView({
   const visibleResponses = thread.responses.filter((r) =>
     isVisibleResponse(r, hideFileOnlyAssistantMessages),
   );
+  // Drive `showLiveIndicators` from the same TaskStore the header
+  // `SessionTaskIndicator` uses. For spawn_only tools (run_pipeline /
+  // podcast / mofa_*) the `pendingAssistant.status` flips to
+  // "complete" within ~30ms of the ack returning, but the background
+  // work runs for minutes — pre-fix the inside-bubble
+  // `ThinkingIndicator` unmounted at that 30ms boundary, taking the
+  // status_word rotator + elapsed timer with it. The header dock
+  // already had the right signal (running task count); we mirror it
+  // here so the in-bubble live surface stays visible for the same
+  // window. Single-thread cases are unaffected (the streaming gate
+  // flips first; the bg-task gate takes over at turn/completed).
+  const { currentSessionId, historyTopic } = useSession();
+  const sessionTasks = useTasks(currentSessionId, historyTopic);
+  const hasRunningBackgroundTask = sessionTasks.some(
+    (t) => t.status === "spawned" || t.status === "running",
+  );
   return (
     <div data-testid="chat-thread-bundle" data-thread-id={thread.id}>
       <ThreadUserBubble message={thread.userMsg} threadId={thread.id} />
@@ -964,7 +981,10 @@ function ThreadView({
           key={thread.pendingAssistant.id}
           message={thread.pendingAssistant}
           isStreaming={thread.pendingAssistant.status === "streaming"}
-          showLiveIndicators={thread.pendingAssistant.status === "streaming"}
+          showLiveIndicators={
+            thread.pendingAssistant.status === "streaming" ||
+            hasRunningBackgroundTask
+          }
           threadId={thread.id}
         />
       )}

--- a/src/store/thread-store.test.ts
+++ b/src/store/thread-store.test.ts
@@ -1469,6 +1469,51 @@ describe.each(FLAG_STATES)("thread-store [$label]", ({ projectionV1 }) => {
     ).toHaveLength(1);
   });
 
+  it("appendPersistedMessage_seqless_poll_dedupes_against_live_persisted_row", () => {
+    // Regression: dspfac reproducer — `task-watcher.ts` polls
+    // `session/messages_page` every 2500ms during a long-running
+    // `run_pipeline` (deep_research) turn. The server's `MessageInfo`
+    // struct strips `seq`/`message_id`, so polled rows arrive with
+    // `message.seq === undefined`. Pre-fix the seq-only dedupe always
+    // missed and the same persisted row (typically the spawn_only
+    // "Background work started for `run_pipeline`..." ack) got
+    // appended on every tick — producing the runaway 5+ duplicate
+    // bubble pattern. The (role, content, timestamp) fallback
+    // identity catches this without needing a server change.
+    makeUser("深度研究 ...", "cm-poll");
+    const liveRow = {
+      seq: 4,
+      role: "assistant" as const,
+      content: "Background work started for `run_pipeline`. The final result will be delivered automatically when it is ready.",
+      response_to_client_message_id: "cm-poll",
+      thread_id: "cm-poll",
+      timestamp: "2026-04-28T10:00:05Z",
+    };
+    // 1. live wire row arrives WITH seq
+    ThreadStore.appendPersistedMessage(SESSION, undefined, liveRow);
+    // 2. polling task-watcher fetches the same row 8 times in 20 seconds,
+    // but the server strips seq and message_id from the MessageInfo
+    // response — only role/content/timestamp/thread_id survive
+    const polledRow = {
+      role: "assistant" as const,
+      content: liveRow.content,
+      thread_id: "cm-poll",
+      timestamp: liveRow.timestamp,
+    };
+    for (let i = 0; i < 8; i += 1) {
+      ThreadStore.appendPersistedMessage(SESSION, undefined, polledRow);
+    }
+
+    const [thread] = ThreadStore.getThreads(SESSION);
+    const acks = thread.responses.filter((r) =>
+      r.text.startsWith("Background work started"),
+    );
+    expect(
+      acks,
+      "polled rows that re-echo a live persisted row must dedupe via (role,text,timestamp)",
+    ).toHaveLength(1);
+  });
+
   it("appendPersistedMessage_falls_back_to_legacy_thread_id_when_thread_id_missing", () => {
     // Legacy daemon: server omits thread_id. Helper must derive it from
     // client_message_id / response_to_client_message_id and find the

--- a/src/store/thread-store.ts
+++ b/src/store/thread-store.ts
@@ -2796,7 +2796,13 @@ export function appendPersistedMessage(
       ? new Date(message.timestamp).getTime()
       : null;
     const incomingText = typeof message.content === "string" ? message.content : "";
-    if (incomingTs !== null) {
+    // Non-empty text gate (codex MINOR on #148): an empty-content
+    // media-only assistant row with the same timestamp as a prior
+    // empty-content row would otherwise collide here. The dspfac bug
+    // pattern (spawn_only "Background work started..." ack) always
+    // carries stable non-empty text, so this gate doesn't weaken the
+    // fix; it just prevents a hypothetical empty-content false-positive.
+    if (incomingTs !== null && incomingText.trim().length > 0) {
       for (const r of thread.responses) {
         if (
           r.role === message.role &&

--- a/src/store/thread-store.ts
+++ b/src/store/thread-store.ts
@@ -2775,12 +2775,37 @@ export function appendPersistedMessage(
 
   // Idempotency: skip if a response with the same historySeq is already in
   // the thread. The server-side seq is per-session monotonic so this is a
-  // safe identity check — and the only one available since `MessageInfo`
-  // has no stable id field.
+  // safe identity check when available.
   const incomingSeq = typeof message.seq === "number" ? message.seq : undefined;
   if (incomingSeq !== undefined) {
     for (const r of thread.responses) {
       if (r.historySeq === incomingSeq) return;
+    }
+  } else {
+    // Fallback identity for legacy `session/messages_page` poll responses.
+    // The server's `MessageInfo` struct (`crates/octos-cli/src/api/handlers.rs`
+    // `MessageInfo`) strips `seq` and `message_id`, so polled rows arrive
+    // with `message.seq === undefined`. `task-watcher.ts` polls every
+    // ~2500ms, so without this fallback the same persisted row (e.g. the
+    // spawn_only "Background work started" ack) gets appended on every
+    // tick — producing the runaway duplicate-bubble pattern reported
+    // against `run_pipeline` deep_research. (role, content, timestamp)
+    // is the only deterministic identity available in the polled
+    // response shape.
+    const incomingTs = message.timestamp
+      ? new Date(message.timestamp).getTime()
+      : null;
+    const incomingText = typeof message.content === "string" ? message.content : "";
+    if (incomingTs !== null) {
+      for (const r of thread.responses) {
+        if (
+          r.role === message.role &&
+          r.text === incomingText &&
+          r.timestamp === incomingTs
+        ) {
+          return;
+        }
+      }
     }
   }
 


### PR DESCRIPTION
## Summary
- `ThreadView` now reads `useTasks(currentSessionId, historyTopic)` and OR's the streaming gate with "has running background task"
- Same signal the header `SessionTaskIndicator` dock uses — single source of truth
- Fixes the dspfac-reported regression: status_word buzz words emitted by the server during spawn_only background work were never rendered because the inside-bubble `ThinkingIndicator` unmounted at turn/completed

## Why
Diagnostic on dspfac confirmed:
- Server emits 5 distinct status_word frames in 45s during a run_pipeline turn
- DOM `[data-testid='thinking-indicator']` is present at T+5s, GONE at T+15s/+30s/+45s
- `crew:thinking false` fires at turn/completed (~T+15s for spawn_only); pre-fix `showLiveIndicators` flipped to false; the bubble's ThinkingIndicator unmounted

## Test plan
- [x] cargo build clean
- [x] All 30 chat-thread tests pass