### PR TITLE
fix(chat): widen seqless dedup to 5-min proximity window (live vs polled timestamp drift)

### DIFF
--- a/src/store/thread-store.test.ts
+++ b/src/store/thread-store.test.ts
@@ -1498,7 +1498,13 @@ describe.each(FLAG_STATES)("thread-store [$label]", ({ projectionV1 }) => {
       role: "assistant" as const,
       content: liveRow.content,
       thread_id: "cm-poll",
-      timestamp: liveRow.timestamp,
+      // PR #149 followup: server's `persisted_at` and the live row's
+      // `r.timestamp` (`Date.now()` at append time) NEVER line up
+      // exactly. Polled rows on dspfac arrive ~150ms-2s after the
+      // live row. Drift the polled timestamp on purpose so the
+      // regression test pins the 5-min proximity window, not strict
+      // equality.
+      timestamp: "2026-04-28T10:00:07Z",
     };
     for (let i = 0; i < 8; i += 1) {
       ThreadStore.appendPersistedMessage(SESSION, undefined, polledRow);
@@ -1510,7 +1516,7 @@ describe.each(FLAG_STATES)("thread-store [$label]", ({ projectionV1 }) => {
     );
     expect(
       acks,
-      "polled rows that re-echo a live persisted row must dedupe via (role,text,timestamp)",
+      "polled rows within the 5-min proximity window must dedupe even when timestamps drift",
     ).toHaveLength(1);
   });
 

--- a/src/store/thread-store.ts
+++ b/src/store/thread-store.ts
@@ -2796,18 +2796,23 @@ export function appendPersistedMessage(
       ? new Date(message.timestamp).getTime()
       : null;
     const incomingText = typeof message.content === "string" ? message.content : "";
-    // Non-empty text gate (codex MINOR on #148): an empty-content
-    // media-only assistant row with the same timestamp as a prior
-    // empty-content row would otherwise collide here. The dspfac bug
-    // pattern (spawn_only "Background work started..." ack) always
-    // carries stable non-empty text, so this gate doesn't weaken the
-    // fix; it just prevents a hypothetical empty-content false-positive.
+    // PR #148 fixup (2026-05-22 dspfac re-repro): strict timestamp
+    // equality was too narrow — the live wire row's `r.timestamp` is
+    // stamped via `Date.now()` at append time (browser clock), while
+    // the polled `session/messages_page` row carries the server's
+    // RFC3339 `persisted_at`. They never line up exactly, so the
+    // dedupe missed and "Background work started..." duplicated again.
+    // Widen to a 5-minute proximity window: polled echo will land
+    // within seconds of the live row, while distinct repeated content
+    // is typically minutes apart. Non-empty text gate kept (codex
+    // MINOR on #148) so empty-content media-only rows don't collide.
+    const PROXIMITY_MS = 5 * 60 * 1000;
     if (incomingTs !== null && incomingText.trim().length > 0) {
       for (const r of thread.responses) {
         if (
           r.role === message.role &&
           r.text === incomingText &&
-          r.timestamp === incomingTs
+          Math.abs(r.timestamp - incomingTs) < PROXIMITY_MS
         ) {
           return;
         }


### PR DESCRIPTION
Live wire row timestamp = browser `Date.now()` at append; polled `MessageInfo` timestamp = server `persisted_at` RFC3339. They never line up exactly, so PR #148's strict equality dedup missed and "Background work started..." duplicated again on dspfac. Widen to 5-min proximity window. Regression test updated to use drifted timestamps.