### PR TITLE
fix(thread-store): seq-based dedup across hydration + live events (WEB-NEW-17)

### DIFF
--- a/src/store/thread-store.test.ts
+++ b/src/store/thread-store.test.ts
@@ -1520,6 +1520,230 @@ describe.each(FLAG_STATES)("thread-store [$label]", ({ projectionV1 }) => {
     ).toHaveLength(1);
   });
 
+  // WEB-NEW-17: seq-based dedup across hydration + live events.
+  // mini3 repro (2026-05-23): JSONL has 6 unique assistant rows, the
+  // SPA renders each one twice — the live `message/persisted` WS event
+  // and the `session/messages_page` hydration both reach
+  // `appendPersistedMessage` / `replayHistory` without an authoritative
+  // cross-path dedup. The per-thread `r.historySeq === incomingSeq`
+  // walk misses because `replayHistory` rebuilds the thread state and
+  // server's legacy `MessageInfo` strips `seq` from polled rows
+  // (handlers.rs:810), so the rebuilt responses lose their seq.
+  it("dedups_when_hydration_precedes_live_message_persisted_with_same_seq", () => {
+    // Step 1 — hydrate the store from `session/messages_page`. Three
+    // unique assistant rows committed under the same user prompt. The
+    // hydration path carries `seq` (matching the live wire) so the
+    // per-session seenSeqs cache is primed.
+    ThreadStore.replayHistory(SESSION, [
+      {
+        seq: 0,
+        role: "user",
+        content: "Q",
+        client_message_id: "cm-1",
+        thread_id: "cm-1",
+        timestamp: "2026-05-23T10:00:00Z",
+      },
+      {
+        seq: 1,
+        role: "assistant",
+        content: "A1",
+        response_to_client_message_id: "cm-1",
+        thread_id: "cm-1",
+        timestamp: "2026-05-23T10:00:01Z",
+      },
+      {
+        seq: 2,
+        role: "assistant",
+        content: "A2",
+        response_to_client_message_id: "cm-1",
+        thread_id: "cm-1",
+        timestamp: "2026-05-23T10:00:02Z",
+      },
+      {
+        seq: 3,
+        role: "assistant",
+        content: "A3",
+        response_to_client_message_id: "cm-1",
+        thread_id: "cm-1",
+        timestamp: "2026-05-23T10:00:03Z",
+      },
+    ]);
+
+    // Step 2 — the live `message/persisted` WS event re-fires for the
+    // same three committed rows (covers the reconnect / hydrate replay
+    // case where the daemon re-emits durable rows). Same seqs, same
+    // content. Without WEB-NEW-17 each one appends a duplicate bubble.
+    for (let i = 1; i <= 3; i += 1) {
+      ThreadStore.appendPersistedMessage(SESSION, undefined, {
+        seq: i,
+        role: "assistant",
+        content: `A${i}`,
+        response_to_client_message_id: "cm-1",
+        thread_id: "cm-1",
+        // Drift the timestamp like a re-emission would (Date.now() at
+        // append time != server `persisted_at`) so a content+timestamp
+        // fallback alone cannot rescue the dedup.
+        timestamp: "2026-05-23T10:05:30Z",
+      });
+    }
+
+    const [thread] = ThreadStore.getThreads(SESSION);
+    const assistants = thread.responses.filter((r) => r.role === "assistant");
+    expect(
+      assistants,
+      "hydration-then-live overlap must dedup on seq, not double-render",
+    ).toHaveLength(3);
+    expect(assistants.map((r) => r.text)).toEqual(["A1", "A2", "A3"]);
+  });
+
+  it("dedups_when_live_message_persisted_precedes_hydration_with_same_seq", () => {
+    // Inverse path: live wire delivers first (the typical reload-mid-
+    // stream scenario), then hydration arrives carrying the same seqs.
+    // The store must end with one row per seq.
+    makeUser("Q", "cm-1");
+    for (let i = 1; i <= 3; i += 1) {
+      ThreadStore.appendPersistedMessage(SESSION, undefined, {
+        seq: i,
+        role: "assistant",
+        content: `A${i}`,
+        response_to_client_message_id: "cm-1",
+        thread_id: "cm-1",
+        timestamp: `2026-05-23T10:00:0${i}Z`,
+      });
+    }
+
+    // Now `replayHistory` runs (e.g. `loadHistory(..., { force: true })`
+    // on a session switch). It wipes `thread.responses` and rebuilds
+    // from the JSONL. Without WEB-NEW-17 the live rows survive only as
+    // their JSONL siblings — but on the next post-rebuild live event
+    // for the same seq, the per-thread walk would miss (the rebuilt
+    // rows lost `historySeq` for `messages_page` polls that strip it).
+    ThreadStore.replayHistory(SESSION, [
+      {
+        seq: 0,
+        role: "user",
+        content: "Q",
+        client_message_id: "cm-1",
+        thread_id: "cm-1",
+        timestamp: "2026-05-23T10:00:00Z",
+      },
+      {
+        seq: 1,
+        role: "assistant",
+        content: "A1",
+        response_to_client_message_id: "cm-1",
+        thread_id: "cm-1",
+        timestamp: "2026-05-23T10:00:01Z",
+      },
+      {
+        seq: 2,
+        role: "assistant",
+        content: "A2",
+        response_to_client_message_id: "cm-1",
+        thread_id: "cm-1",
+        timestamp: "2026-05-23T10:00:02Z",
+      },
+      {
+        seq: 3,
+        role: "assistant",
+        content: "A3",
+        response_to_client_message_id: "cm-1",
+        thread_id: "cm-1",
+        timestamp: "2026-05-23T10:00:03Z",
+      },
+    ]);
+
+    // Post-rebuild live re-emit: another live `message/persisted` for
+    // an already-seen seq. The seenSeqs cache survives the rebuild and
+    // catches it at the gate.
+    ThreadStore.appendPersistedMessage(SESSION, undefined, {
+      seq: 2,
+      role: "assistant",
+      content: "A2",
+      response_to_client_message_id: "cm-1",
+      thread_id: "cm-1",
+      timestamp: "2026-05-23T10:10:00Z",
+    });
+
+    const [thread] = ThreadStore.getThreads(SESSION);
+    const assistants = thread.responses.filter((r) => r.role === "assistant");
+    expect(
+      assistants,
+      "live-first-then-hydrate overlap must dedup on seq across the rebuild boundary",
+    ).toHaveLength(3);
+    expect(assistants.map((r) => r.text)).toEqual(["A1", "A2", "A3"]);
+  });
+
+  it("clearSession_resets_seenSeqs_so_a_re_streamed_seq_renders_again", () => {
+    // Edge case: after a session is cleared (delete or topic flip) the
+    // seq cache must NOT persist — a fresh send under the same
+    // session/topic with a re-cycled seq must render.
+    makeUser("Q", "cm-1");
+    ThreadStore.appendPersistedMessage(SESSION, undefined, {
+      seq: 5,
+      role: "assistant",
+      content: "First answer.",
+      response_to_client_message_id: "cm-1",
+      thread_id: "cm-1",
+      timestamp: "2026-05-23T10:00:00Z",
+    });
+    ThreadStore.clearSession(SESSION);
+
+    // Fresh send post-clear under a brand-new thread; the same seq
+    // value must NOT be suppressed.
+    makeUser("Q-new", "cm-2");
+    ThreadStore.appendPersistedMessage(SESSION, undefined, {
+      seq: 5,
+      role: "assistant",
+      content: "Second answer.",
+      response_to_client_message_id: "cm-2",
+      thread_id: "cm-2",
+      timestamp: "2026-05-23T11:00:00Z",
+    });
+
+    const threads = ThreadStore.getThreads(SESSION);
+    const allAssistantRows = threads.flatMap((t) =>
+      t.responses.filter((r) => r.role === "assistant"),
+    );
+    expect(
+      allAssistantRows.map((r) => r.text),
+      "clearSession must release the seenSeqs cache",
+    ).toEqual(["Second answer."]);
+  });
+
+  it("seenSeqs_are_per_session_so_the_same_seq_renders_in_a_different_session", () => {
+    // Edge case: seq=N in session A must NOT block seq=N in session B
+    // — the cache is keyed per `(sessionId, topic)`.
+    const SESS_A = "sess-A";
+    const SESS_B = "sess-B";
+    ThreadStore.addUserMessage(SESS_A, { text: "QA", clientMessageId: "cm-A" });
+    ThreadStore.addUserMessage(SESS_B, { text: "QB", clientMessageId: "cm-B" });
+
+    ThreadStore.appendPersistedMessage(SESS_A, undefined, {
+      seq: 7,
+      role: "assistant",
+      content: "Answer A",
+      response_to_client_message_id: "cm-A",
+      thread_id: "cm-A",
+      timestamp: "2026-05-23T10:00:00Z",
+    });
+    ThreadStore.appendPersistedMessage(SESS_B, undefined, {
+      seq: 7,
+      role: "assistant",
+      content: "Answer B",
+      response_to_client_message_id: "cm-B",
+      thread_id: "cm-B",
+      timestamp: "2026-05-23T10:00:00Z",
+    });
+
+    const [tA] = ThreadStore.getThreads(SESS_A);
+    const [tB] = ThreadStore.getThreads(SESS_B);
+    expect(tA.responses.filter((r) => r.role === "assistant")).toHaveLength(1);
+    expect(tB.responses.filter((r) => r.role === "assistant")).toHaveLength(1);
+    expect(tA.responses[0].text).toBe("Answer A");
+    expect(tB.responses[0].text).toBe("Answer B");
+  });
+
   it("appendPersistedMessage_falls_back_to_legacy_thread_id_when_thread_id_missing", () => {
     // Legacy daemon: server omits thread_id. Helper must derive it from
     // client_message_id / response_to_client_message_id and find the

--- a/src/store/thread-store.ts
+++ b/src/store/thread-store.ts
@@ -145,6 +145,48 @@ let version = 0;
 const snapshotCache = new Map<string, { version: number; data: Thread[] }>();
 
 /**
+ * WEB-NEW-17 — per-session set of server-side `seq` values seen by
+ * `appendPersistedMessage` (live `message/persisted` events) and
+ * `replayHistory` (hydration from `session/messages_page`).
+ *
+ * Why a top-level set instead of relying on the per-thread
+ * `r.historySeq === incomingSeq` walk inside `appendPersistedMessage`:
+ *   • `replayHistory` wipes `sessionsByKey[key]` and rebuilds — the
+ *     rebuilt rows lose `historySeq` for `messages_page` polls (server's
+ *     legacy `MessageInfo` struct strips `seq`, handlers.rs:810). After
+ *     the rebuild the per-thread seq dedup misses, so a re-emitted live
+ *     `message/persisted` carrying the same seq slips through.
+ *   • The per-session `seenSeqsByKey` set survives `replayHistory`
+ *     rebuilds (we only clear it on `clearSession`/`__resetForTests`),
+ *     so a live event whose seq was already covered by an earlier
+ *     live event OR by an earlier hydrate row is recognised as a
+ *     duplicate even when the rebuilt thread responses have no seq.
+ *
+ * Keyed by `storeKey(sessionId, topic)`. The set holds only well-typed
+ * non-negative integer seqs; rows without a seq (legacy daemons,
+ * stripped polled rows) bypass the set and fall back to the existing
+ * content+timestamp 5-min proximity dedupe.
+ *
+ * Memory: O(persisted-rows-per-session). Each entry is ~8 bytes; for a
+ * 10k-message session that's ~80KB — comparable to the thread state the
+ * set guards. `clearSession` releases it on session forget.
+ */
+const seenSeqsByKey = new Map<string, Set<number>>();
+
+function rememberSeq(key: string, seq: number): void {
+  let set = seenSeqsByKey.get(key);
+  if (!set) {
+    set = new Set();
+    seenSeqsByKey.set(key, set);
+  }
+  set.add(seq);
+}
+
+function hasSeenSeq(key: string, seq: number): boolean {
+  return seenSeqsByKey.get(key)?.has(seq) ?? false;
+}
+
+/**
  * M10 Phase 6.2 (Bug C): per-session WS `session/hydrate` snapshot
  * cached so that subsequent `replayHistory` calls (the forced retries
  * in chat-thread.tsx fire at 2s/5s/12s) can replay the dedup pass on
@@ -1337,6 +1379,22 @@ export function appendCompletionBubble(
   // we proceed to append a fresh row, which is the correct M10
   // separate-bubble semantic.
 
+  // WEB-NEW-17: track the host session key once so every early-return
+  // branch below can mark the completion's seq seen without re-walking
+  // `sessionsByKey`. Falls back to `(sessionId, topic)` if the host
+  // wasn't found via the sessionsByKey walk (orphan-host paths above).
+  const hostKey: string | null = (() => {
+    for (const [k, s] of sessionsByKey.entries()) {
+      if (s === host.state) return k;
+    }
+    return opts.sessionId ? storeKey(opts.sessionId, opts.topic) : null;
+  })();
+  const markCompletionSeqSeen = (): void => {
+    if (typeof opts.historySeq === "number" && hostKey) {
+      rememberSeq(hostKey, opts.historySeq);
+    }
+  };
+
   if (opts.messageId) {
     for (let i = 0; i < thread.responses.length; i += 1) {
       const r = thread.responses[i];
@@ -1345,14 +1403,17 @@ export function appendCompletionBubble(
       // Upgrade-in-place if it's a placeholder (the persisted-only
       // shape), no-op if it's already the full completion.
       if (r.text.length > 0) {
+        markCompletionSeqSeen();
         return true;
       }
       thread.responses[i] = upgradePlaceholderRow(r, opts, threadId);
       sortResponsesInThread(thread);
+      markCompletionSeqSeen();
       notify();
       return true;
     }
     if (thread.pendingAssistant?.id === opts.messageId) {
+      markCompletionSeqSeen();
       return true;
     }
   }
@@ -1375,16 +1436,19 @@ export function appendCompletionBubble(
       // text + same media list"; if that matches, treat as no-op.
       if (r.text.length > 0) {
         if (rowMatchesCompletionContent(r, opts)) {
+          markCompletionSeqSeen();
           return true;
         }
         continue; // (a): merged-ack row, not our target
       }
       thread.responses[i] = upgradePlaceholderRow(r, opts, threadId);
       sortResponsesInThread(thread);
+      markCompletionSeqSeen();
       notify();
       return true;
     }
     if (thread.pendingAssistant?.historySeq === opts.historySeq) {
+      markCompletionSeqSeen();
       return true;
     }
   }
@@ -1407,6 +1471,11 @@ export function appendCompletionBubble(
   };
   thread.responses.push(completion);
   sortResponsesInThread(thread);
+  // WEB-NEW-17: mark the completion's seq so a follow-up
+  // `message/persisted` carrying the same seq (the legacy companion row
+  // the server's `event.spawn_complete.v1` suppression doesn't always
+  // cover for older daemons) is suppressed at the dedup gate.
+  markCompletionSeqSeen();
   notify();
 
   // M9-γ-3 dual-write: completion bubble → assistant_persisted envelope.
@@ -1702,6 +1771,20 @@ export function finalizeAssistant(
     thread.responses.push(finalized);
     sortResponsesInThread(thread);
     thread.pendingAssistant = null;
+    // WEB-NEW-17: mark the finalised row's seq so a follow-up
+    // `message/persisted` with the same seq (re-emitted on reconnect or
+    // through `session/hydrate` replay) is suppressed at the dedup gate
+    // in `appendPersistedMessage`. We walk `sessionsByKey` to find the
+    // hosting key since this entry point takes only `threadId` and the
+    // legacy reducer keys by `(sessionId, topic)`.
+    if (typeof finalized.historySeq === "number") {
+      for (const [k, s] of sessionsByKey.entries()) {
+        if (s === state) {
+          rememberSeq(k, finalized.historySeq);
+          break;
+        }
+      }
+    }
     notify();
 
     // M9-γ-3 dual-write: finalize → turn_completed envelope (the
@@ -1955,6 +2038,16 @@ export function replayHistory(
   const ctx = { currentThreadId: null as string | null };
   for (const apiMessage of apiMessages) {
     if (apiMessage.role === "system") continue;
+    // WEB-NEW-17: every hydrated row whose server seq is present joins
+    // the per-session seenSeqs set. The post-replay live wire (and any
+    // re-emit of the same persisted row from a reconnect /
+    // `session/hydrate`) then short-circuits at the top of
+    // `appendPersistedMessage`, even though the rebuilt
+    // `thread.responses[]` may have lost `historySeq` for sibling rows
+    // delivered via `messages_page` (which strips seq).
+    if (typeof apiMessage.seq === "number") {
+      rememberSeq(key, apiMessage.seq);
+    }
     const threadId = deriveLegacyThreadId(apiMessage, ctx);
     let thread = state.byId.get(threadId);
 
@@ -2778,6 +2871,15 @@ export function appendPersistedMessage(
   // safe identity check when available.
   const incomingSeq = typeof message.seq === "number" ? message.seq : undefined;
   if (incomingSeq !== undefined) {
+    // WEB-NEW-17: per-session set guards against the live-after-hydrate
+    // (and hydrate-after-live) overlap. `replayHistory` wipes
+    // `thread.responses` and rebuilds, dropping `historySeq` on rows that
+    // came from `messages_page` (server strips seq). Without this set,
+    // a re-emitted live `message/persisted` carrying the same seq
+    // double-counts. The per-thread `r.historySeq === incomingSeq` walk
+    // below is retained as a redundant safety net for any future caller
+    // that bypasses this top-level gate.
+    if (hasSeenSeq(key, incomingSeq)) return;
     for (const r of thread.responses) {
       if (r.historySeq === incomingSeq) return;
     }
@@ -2849,6 +2951,10 @@ export function appendPersistedMessage(
     const dupIdx = findDuplicateAssistantWithFile(thread.responses, built);
     if (dupIdx !== -1) {
       mergeDuplicateAssistantFile(thread.responses[dupIdx], built);
+      // WEB-NEW-17: mark the seq seen even when the row merges into an
+      // existing file-bearing response — a re-delivery of the same seq
+      // must not double-merge.
+      if (incomingSeq !== undefined) rememberSeq(key, incomingSeq);
       notify();
       return;
     }
@@ -2856,6 +2962,11 @@ export function appendPersistedMessage(
 
   thread.responses.push(built);
   sortResponsesInThread(thread);
+  // WEB-NEW-17: record the seq so a subsequent live-or-hydrate replay
+  // of the same persisted row short-circuits at the top-level gate
+  // above, even after `replayHistory` rebuilds the thread state
+  // (legacy `messages_page` rows lose `historySeq`).
+  if (incomingSeq !== undefined) rememberSeq(key, incomingSeq);
   notify();
 
   // M9-γ-3 dual-write: a persisted assistant row corresponds to an
@@ -3066,6 +3177,7 @@ export function clearSession(sessionId: string, topic?: string): void {
     loadingPromises.delete(key);
     hydrateSnapshotByKey.delete(key);
     pendingClientMessageIds.delete(key);
+    seenSeqsByKey.delete(key);
   } else {
     for (const k of [...sessionsByKey.keys()]) {
       if (k === sessionId || k.startsWith(`${sessionId}#`)) {
@@ -3074,6 +3186,7 @@ export function clearSession(sessionId: string, topic?: string): void {
         loadingPromises.delete(k);
         hydrateSnapshotByKey.delete(k);
         pendingClientMessageIds.delete(k);
+        seenSeqsByKey.delete(k);
       }
     }
     // Codex round-5 P3: a hydrate snapshot may exist without a
@@ -3085,6 +3198,14 @@ export function clearSession(sessionId: string, topic?: string): void {
     for (const k of [...hydrateSnapshotByKey.keys()]) {
       if (k === sessionId || k.startsWith(`${sessionId}#`)) {
         hydrateSnapshotByKey.delete(k);
+      }
+    }
+    // WEB-NEW-17: same orphan-key concern for the seen-seqs cache —
+    // sweep it independently so a clear-then-stream sequence doesn't
+    // suppress a fresh re-fired live row.
+    for (const k of [...seenSeqsByKey.keys()]) {
+      if (k === sessionId || k.startsWith(`${sessionId}#`)) {
+        seenSeqsByKey.delete(k);
       }
     }
   }
@@ -3185,6 +3306,7 @@ export function __resetForTests(): void {
   snapshotCache.clear();
   hydrateSnapshotByKey.clear();
   pendingClientMessageIds.clear();
+  seenSeqsByKey.clear();
   version = 0;
   idCounter = 0;
 }


### PR DESCRIPTION
## Summary
- Per-session `seenSeqsByKey: Map<sessionId, Set<number>>` survives `replayHistory` rebuilds and catches the **live-after-hydrate** (and hydrate-after-live) overlap that the per-thread `r.historySeq === incomingSeq` walk misses — the rebuilt rows lose `historySeq` when they came from `messages_page` (server's legacy `MessageInfo` strips `seq`).
- Marked on `appendPersistedMessage`, `appendCompletionBubble`, `finalizeAssistant`, and `replayHistory`; cleared on `clearSession` and `__resetForTests`.
- Legacy rows without `seq` keep the existing content+timestamp 5-min proximity fallback.

## Bug
mini3 repro (2026-05-23): JSONL had 6 unique assistant rows; the SPA rendered each one twice. Server-side JSONL is correct (verified — NEW-16 / `6edfb677`). The thread store was appending from **both** the live `message/persisted` WS event **and** the `session/messages_page` hydration without an authoritative cross-path dedup. The existing 5-min proximity fallback (PR #150) only catches polled rows that arrive AFTER a live row — once `replayHistory` wipes the state and rebuilds from `messages_page` (no seq), a later re-emitted live event slips through.

## Test plan
- [x] `npx vitest run` — 541 / 541 unit tests pass
- [x] `tsc -b --noEmit` — clean
- [x] `pnpm lint` — no new lint errors (pre-existing 119 errors in `tests/*.spec.ts` Playwright files unrelated)
- [x] 4 new test cases × 2 (projectionV1 OFF/ON) covering:
  - hydration first, then live `message/persisted` for the same seqs → exactly 3 rows (not 6)
  - live first, then hydration, then post-rebuild live re-emit of an already-seen seq → exactly 3 rows
  - `clearSession` releases the seq cache (recycled seq under a fresh thread still renders)
  - per-session isolation (seq=7 in session A does NOT block seq=7 in session B)
- [ ] Manual: deploy to mini3 + reload the affected chat → expect 6/6 not 6/12