### PR TITLE
feat(chat): make session title editable

### DIFF
--- a/src/components/content-browser.tsx
+++ b/src/components/content-browser.tsx
@@ -20,6 +20,7 @@ import type { ContentEntry } from "@/api/content";
 import { downloadContent } from "@/api/content";
 import { useFileStore, type FileEntry } from "@/store/file-store";
 import { AudioPlayer } from "@/components/viewers/audio-player";
+import { SessionTitleEditor } from "@/components/session-title-editor";
 
 interface ContentBrowserProps {
   open: boolean;
@@ -30,46 +31,6 @@ interface ContentBrowserProps {
   sessionId: string;
   sessionTitle: string;
   onRenameTitle?: (title: string) => void;
-}
-
-function EditableTitle({
-  value,
-  onSave,
-}: {
-  value: string;
-  onSave?: (value: string) => void;
-}) {
-  const [editing, setEditing] = useState(false);
-
-  if (editing && onSave) {
-    return (
-      <input
-        defaultValue={value}
-        className="mt-2 w-full rounded-[12px] border border-accent/40 bg-surface-container px-3 py-2.5 text-[1.08rem] font-semibold tracking-tight text-text outline-none"
-        autoFocus
-        onBlur={(e) => {
-          const next = e.target.value.trim();
-          if (next && next !== value) onSave(next);
-          setEditing(false);
-        }}
-        onKeyDown={(e) => {
-          if (e.key === "Enter") e.currentTarget.blur();
-          if (e.key === "Escape") setEditing(false);
-        }}
-      />
-    );
-  }
-
-  return (
-    <button
-      type="button"
-      className="mt-2 block w-full truncate text-left text-[1.24rem] font-semibold tracking-tight text-text-strong transition hover:text-accent"
-      title="Click to rename session"
-      onClick={() => onSave && setEditing(true)}
-    >
-      {value}
-    </button>
-  );
 }
 
 function inferCategory(filename: string): ContentEntry["category"] {
@@ -198,7 +159,13 @@ export function ContentBrowser({
           <div className="min-w-0 flex-1">
             <div className="min-w-0 flex-1">
               <div className="shell-kicker">Session Files</div>
-              <EditableTitle value={sessionTitle} onSave={onRenameTitle} />
+              <SessionTitleEditor
+                value={sessionTitle}
+                onSave={onRenameTitle}
+                buttonClassName="mt-2 w-full text-left text-[1.24rem] font-semibold tracking-tight text-text-strong transition hover:text-accent"
+                inputClassName="mt-2 w-full rounded-[12px] border border-accent/40 bg-surface-container px-3 py-2.5 text-[1.08rem] font-semibold tracking-tight text-text outline-none"
+                testId="content-session-title"
+              />
             </div>
           </div>
           <div className="flex items-center gap-2">

--- a/src/components/session-title-editor.test.tsx
+++ b/src/components/session-title-editor.test.tsx
@@ -1,0 +1,140 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import * as React from "react";
+import { act } from "react";
+import { createRoot, type Root } from "react-dom/client";
+
+(globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT =
+  true;
+
+import { SessionTitleEditor } from "./session-title-editor";
+
+interface MountedHarness {
+  container: HTMLDivElement;
+  root: Root;
+  unmount: () => void;
+}
+
+function mount(node: React.ReactElement): MountedHarness {
+  const container = document.createElement("div");
+  document.body.appendChild(container);
+  const root = createRoot(container);
+  act(() => {
+    root.render(node);
+  });
+  return {
+    container,
+    root,
+    unmount: () => {
+      act(() => root.unmount());
+      container.remove();
+    },
+  };
+}
+
+function setInputValue(input: HTMLInputElement, value: string) {
+  input.value = value;
+  input.dispatchEvent(new Event("input", { bubbles: true }));
+}
+
+function commitInput(input: HTMLInputElement) {
+  input.dispatchEvent(new FocusEvent("focusout", { bubbles: true }));
+}
+
+afterEach(() => {
+  for (const node of [...document.body.children]) node.remove();
+});
+
+describe("SessionTitleEditor", () => {
+  it("commits a trimmed title on blur", () => {
+    const onSave = vi.fn();
+    const harness = mount(
+      <SessionTitleEditor value="Original title" onSave={onSave} />,
+    );
+    try {
+      const button = harness.container.querySelector(
+        "[data-testid='session-title-editor']",
+      ) as HTMLButtonElement;
+      act(() => button.click());
+
+      const input = harness.container.querySelector(
+        "[data-testid='session-title-editor-input']",
+      ) as HTMLInputElement;
+      expect(input.value).toBe("Original title");
+
+      act(() => {
+        setInputValue(input, "  Renamed session  ");
+        commitInput(input);
+      });
+
+      expect(onSave).toHaveBeenCalledWith("Renamed session");
+    } finally {
+      harness.unmount();
+    }
+  });
+
+  it("ignores empty and unchanged titles", () => {
+    const onSave = vi.fn();
+    const harness = mount(
+      <SessionTitleEditor value="Original title" onSave={onSave} />,
+    );
+    try {
+      const button = harness.container.querySelector(
+        "[data-testid='session-title-editor']",
+      ) as HTMLButtonElement;
+      act(() => button.click());
+      let input = harness.container.querySelector(
+        "[data-testid='session-title-editor-input']",
+      ) as HTMLInputElement;
+      act(() => {
+        setInputValue(input, "   ");
+        commitInput(input);
+      });
+
+      const nextButton = harness.container.querySelector(
+        "[data-testid='session-title-editor']",
+      ) as HTMLButtonElement;
+      act(() => nextButton.click());
+      input = harness.container.querySelector(
+        "[data-testid='session-title-editor-input']",
+      ) as HTMLInputElement;
+      act(() => {
+        setInputValue(input, "Original title");
+        commitInput(input);
+      });
+
+      expect(onSave).not.toHaveBeenCalled();
+    } finally {
+      harness.unmount();
+    }
+  });
+
+  it("cancels editing on Escape", () => {
+    const onSave = vi.fn();
+    const harness = mount(
+      <SessionTitleEditor value="Original title" onSave={onSave} />,
+    );
+    try {
+      const button = harness.container.querySelector(
+        "[data-testid='session-title-editor']",
+      ) as HTMLButtonElement;
+      act(() => button.click());
+      const input = harness.container.querySelector(
+        "[data-testid='session-title-editor-input']",
+      ) as HTMLInputElement;
+
+      act(() => {
+        setInputValue(input, "Should not save");
+        input.dispatchEvent(
+          new KeyboardEvent("keydown", { key: "Escape", bubbles: true }),
+        );
+      });
+
+      expect(onSave).not.toHaveBeenCalled();
+      expect(
+        harness.container.querySelector("[data-testid='session-title-editor']"),
+      ).not.toBeNull();
+    } finally {
+      harness.unmount();
+    }
+  });
+});

--- a/src/components/session-title-editor.tsx
+++ b/src/components/session-title-editor.tsx
@@ -1,0 +1,81 @@
+import { useRef, useState } from "react";
+import { PencilLine } from "lucide-react";
+
+interface SessionTitleEditorProps {
+  value: string;
+  onSave?: (value: string) => void;
+  buttonClassName?: string;
+  inputClassName?: string;
+  testId?: string;
+}
+
+export function SessionTitleEditor({
+  value,
+  onSave,
+  buttonClassName = "w-full text-left text-[1.24rem] font-semibold tracking-tight text-text-strong transition hover:text-accent",
+  inputClassName = "w-full rounded-[12px] border border-accent/40 bg-surface-container px-3 py-2.5 text-[1.08rem] font-semibold tracking-tight text-text outline-none",
+  testId = "session-title-editor",
+}: SessionTitleEditorProps) {
+  const [editing, setEditing] = useState(false);
+  const cancelNextBlur = useRef(false);
+
+  const commit = (raw: string) => {
+    if (cancelNextBlur.current) {
+      cancelNextBlur.current = false;
+      return;
+    }
+    const next = raw.trim();
+    if (next && next !== value) onSave?.(next);
+    setEditing(false);
+  };
+
+  const cancel = () => {
+    cancelNextBlur.current = true;
+    setEditing(false);
+  };
+
+  if (editing && onSave) {
+    return (
+      <input
+        data-testid={`${testId}-input`}
+        aria-label="Session title"
+        defaultValue={value}
+        className={inputClassName}
+        autoFocus
+        onBlur={(e) => commit(e.currentTarget.value)}
+        onKeyDown={(e) => {
+          if (e.key === "Enter") e.currentTarget.blur();
+          if (e.key === "Escape") cancel();
+        }}
+      />
+    );
+  }
+
+  if (!onSave) {
+    return (
+      <div data-testid={testId} className={buttonClassName}>
+        {value}
+      </div>
+    );
+  }
+
+  return (
+    <button
+      type="button"
+      data-testid={testId}
+      className={`group inline-flex min-w-0 items-center gap-2 ${buttonClassName}`}
+      title="Rename session"
+      aria-label={`Rename session ${value}`}
+      onClick={() => {
+        cancelNextBlur.current = false;
+        setEditing(true);
+      }}
+    >
+      <span className="min-w-0 flex-1 truncate">{value}</span>
+      <PencilLine
+        aria-hidden="true"
+        className="h-4 w-4 shrink-0 opacity-55 transition group-hover:opacity-100"
+      />
+    </button>
+  );
+}

--- a/src/layouts/chat-layout.test.tsx
+++ b/src/layouts/chat-layout.test.tsx
@@ -1,0 +1,223 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import * as React from "react";
+import { act } from "react";
+import { createRoot, type Root } from "react-dom/client";
+
+(globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT =
+  true;
+
+vi.mock("@/auth/auth-context", () => ({
+  useAuth: () => ({
+    user: { email: "ada@example.test" },
+    portal: { can_access_admin_portal: false },
+    logout: vi.fn(),
+  }),
+}));
+
+vi.mock("@/hooks/use-octos-status", () => ({
+  useOctosStatus: () => ({ provider: "none", model: "none" }),
+}));
+
+vi.mock("@/hooks/use-theme", () => ({
+  useTheme: () => ({ theme: "dark", toggleTheme: vi.fn() }),
+}));
+
+vi.mock("@/hooks/use-resizable-panel", () => ({
+  useResizablePanel: () => ({
+    effectiveWidth: 320,
+    isMaximized: false,
+    onMouseDown: vi.fn(),
+    toggleMaximize: vi.fn(),
+  }),
+}));
+
+vi.mock("@/components/content-viewer", () => ({
+  useContentViewer: () => ({
+    state: { kind: null },
+    openViewer: vi.fn(),
+    closeViewer: vi.fn(),
+    closeAudio: vi.fn(),
+  }),
+  ContentViewerOverlay: () => null,
+}));
+
+vi.mock("@/store/file-store", () => ({
+  useFileStore: () => [],
+}));
+
+import { ChatLayout } from "./chat-layout";
+import { SessionContext, type SessionContextValue } from "@/runtime/session-context";
+
+const SESSION_ID = "web-1777700000000-title";
+
+interface MountedHarness {
+  container: HTMLDivElement;
+  root: Root;
+  unmount: () => void;
+}
+
+function makeSessionCtx(
+  renameSession: SessionContextValue["renameSession"],
+  title = "Original title",
+): SessionContextValue {
+  return {
+    sessions: [{ id: SESSION_ID, message_count: 2, title }],
+    currentSessionId: SESSION_ID,
+    historyTopic: undefined,
+    currentSessionTitle: title,
+    currentSessionStats: null,
+    initialMessages: [],
+    activeTaskOnServer: false,
+    queueMode: null,
+    adaptiveMode: null,
+    setServerTaskActive: () => {},
+    renameSession,
+    updateSessionStats: () => {},
+    switchSession: () => {},
+    goBack: async () => false,
+    createSession: () => SESSION_ID,
+    removeSession: async () => {},
+    refreshSessions: async () => {},
+    markSessionActive: () => {},
+  };
+}
+
+function chatLayoutTree(
+  renameSession: SessionContextValue["renameSession"],
+  title = "Original title",
+) {
+  return (
+    <SessionContext.Provider value={makeSessionCtx(renameSession, title)}>
+      <ChatLayout>
+        <div data-testid="chat-body">thread</div>
+      </ChatLayout>
+    </SessionContext.Provider>
+  );
+}
+
+function mount(
+  renameSession: SessionContextValue["renameSession"],
+  title = "Original title",
+): MountedHarness {
+  const container = document.createElement("div");
+  document.body.appendChild(container);
+  const root = createRoot(container);
+  act(() => {
+    root.render(chatLayoutTree(renameSession, title));
+  });
+  return {
+    container,
+    root,
+    unmount: () => {
+      act(() => root.unmount());
+      container.remove();
+    },
+  };
+}
+
+function renameFromEditor(
+  container: HTMLElement,
+  testId: string,
+  nextTitle: string,
+) {
+  const button = container.querySelector(
+    `[data-testid='${testId}']`,
+  ) as HTMLButtonElement;
+  expect(button).not.toBeNull();
+  act(() => button.click());
+
+  const input = container.querySelector(
+    `[data-testid='${testId}-input']`,
+  ) as HTMLInputElement;
+  expect(input).not.toBeNull();
+  act(() => {
+    input.value = nextTitle;
+    input.dispatchEvent(new Event("input", { bubbles: true }));
+    input.dispatchEvent(new FocusEvent("focusout", { bubbles: true }));
+  });
+}
+
+afterEach(() => {
+  for (const node of [...document.body.children]) node.remove();
+});
+
+describe("ChatLayout session title editing", () => {
+  it("wires the main header and files panel titles to renameSession", () => {
+    const renameSession = vi.fn();
+    const harness = mount(renameSession);
+    try {
+      renameFromEditor(
+        harness.container,
+        "chat-session-title",
+        "Renamed from header",
+      );
+      expect(renameSession).toHaveBeenCalledWith(
+        SESSION_ID,
+        "Renamed from header",
+      );
+
+      const filesButton = harness.container.querySelector(
+        "button[title='Open files panel']",
+      ) as HTMLButtonElement;
+      expect(filesButton).not.toBeNull();
+      act(() => filesButton.click());
+
+      renameFromEditor(
+        harness.container,
+        "content-session-title",
+        "Renamed from files",
+      );
+      expect(renameSession).toHaveBeenCalledWith(
+        SESSION_ID,
+        "Renamed from files",
+      );
+    } finally {
+      harness.unmount();
+    }
+  });
+
+  it("renders server title updates across header, history, and files surfaces", () => {
+    const renameSession = vi.fn();
+    const harness = mount(renameSession, "Original title");
+    try {
+      const filesButton = harness.container.querySelector(
+        "button[title='Open files panel']",
+      ) as HTMLButtonElement;
+      act(() => filesButton.click());
+
+      expect(
+        harness.container.querySelector("[data-testid='chat-session-title']")
+          ?.textContent,
+      ).toContain("Original title");
+      expect(
+        harness.container.querySelector("[data-testid='content-session-title']")
+          ?.textContent,
+      ).toContain("Original title");
+      expect(
+        harness.container.querySelector(
+          `[data-testid='session-item-${SESSION_ID}']`,
+        )?.textContent,
+      ).toContain("Original title");
+
+      act(() => {
+        harness.root.render(chatLayoutTree(renameSession, "Server title"));
+      });
+
+      expect(
+        harness.container.querySelector("[data-testid='chat-session-title']")
+          ?.textContent,
+      ).toContain("Server title");
+      expect(
+        harness.container.querySelector("[data-testid='content-session-title']")
+          ?.textContent,
+      ).toContain("Server title");
+      expect(
+        harness.container.querySelector(
+          `[data-testid='session-item-${SESSION_ID}']`,
+        )?.textContent,
+      ).toContain("Server title");
+    } finally {
+      harness.unmount();
+    }
+  });
+});

--- a/src/layouts/chat-layout.tsx
+++ b/src/layouts/chat-layout.tsx
@@ -8,6 +8,7 @@ import { RouterModeSwitcher } from "@/components/router-mode-switcher";
 import { RouterFailoverBanner } from "@/components/router-failover-banner";
 import { SessionList } from "@/components/session-list";
 import { ContentBrowser } from "@/components/content-browser";
+import { SessionTitleEditor } from "@/components/session-title-editor";
 import { SessionTaskIndicator } from "@/components/session-task-dock";
 import { useSession } from "@/runtime/session-context";
 import { eventMatchesScope } from "@/runtime/event-scope";
@@ -163,9 +164,13 @@ export function ChatLayout({ children }: { children: ReactNode }) {
               <div className="flex items-start gap-4">
                 <div className="min-w-0 flex-1">
                   <div className="shell-kicker">Current Session</div>
-                  <div className="truncate pr-3 text-[1.24rem] font-semibold tracking-tight text-text-strong">
-                    {currentSessionTitle}
-                  </div>
+                  <SessionTitleEditor
+                    value={currentSessionTitle}
+                    onSave={(title) => renameSession(currentSessionId, title)}
+                    buttonClassName="mt-1 w-full pr-3 text-left text-[1.24rem] font-semibold tracking-tight text-text-strong transition hover:text-accent"
+                    inputClassName="mt-1 w-full rounded-[12px] border border-accent/40 bg-surface-container px-3 py-2 text-[1.08rem] font-semibold tracking-tight text-text outline-none"
+                    testId="chat-session-title"
+                  />
                 </div>
                 <SessionTaskIndicator />
                 <button


### PR DESCRIPTION
## Summary
- add a shared `SessionTitleEditor` used by both the main chat header and the session files panel
- route header/file-panel title edits through the existing `renameSession` path, preserving the `session/title.set` persistence and rollback behavior
- add unit coverage for title validation/cancel behavior and for header/history/files title propagation

Closes octos-org/octos#334

## Validation
- `npm run test:unit -- src/components/session-title-editor.test.tsx src/layouts/chat-layout.test.tsx`
- `npx eslint src/components/session-title-editor.tsx src/components/session-title-editor.test.tsx src/layouts/chat-layout.tsx src/layouts/chat-layout.test.tsx src/components/content-browser.tsx`
- `npm run build`
- `git diff --check`

Note: full `npm run lint` still fails on existing repository-wide lint debt outside this slice; touched-file ESLint passes.