### PR TITLE
fix(runtime): rehydrate background tasks on reload

### DIFF
--- a/src/runtime/session-context.test.ts
+++ b/src/runtime/session-context.test.ts
@@ -51,7 +51,9 @@ import {
   type SessionContextValue,
   type SessionWithTitle,
 } from "./session-context";
-import type { SessionInfo } from "@/api/types";
+import { SessionList } from "@/components/session-list";
+import * as TaskStore from "@/store/task-store";
+import type { BackgroundTaskInfo, SessionInfo } from "@/api/types";
 
 const NO_TITLES: Record<string, string> = {};
 const NO_DELETES = new Set<string>();
@@ -110,6 +112,39 @@ function mountSessionProvider(
       act(() => root.unmount());
       container.remove();
     },
+  };
+}
+
+function mountSessionList(): MountedHarness {
+  const container = document.createElement("div");
+  document.body.appendChild(container);
+  const root = createRoot(container);
+  act(() => {
+    root.render(
+      React.createElement(
+        SessionProvider,
+        null,
+        React.createElement(SessionList),
+      ),
+    );
+  });
+  return {
+    container,
+    root,
+    unmount: () => {
+      act(() => root.unmount());
+      container.remove();
+    },
+  };
+}
+
+function backgroundTask(id: string): BackgroundTaskInfo {
+  return {
+    id,
+    tool_name: "spawn_agent",
+    status: "running",
+    started_at: "2026-05-30T00:00:00.000Z",
+    error: null,
   };
 }
 
@@ -391,6 +426,45 @@ describe("SessionProvider title integration", () => {
       });
     } finally {
       harness.unmount();
+    }
+  });
+});
+
+describe("SessionProvider background task rehydration", () => {
+  it("rehydrates recent background tasks on reload so non-current sidebar rows show live", async () => {
+    const busySessionId = idAt(120, "busy");
+    const idleSessionId = idAt(240, "idle");
+    const busyTask = backgroundTask("task-running-after-reload");
+    apiMocks.listSessions.mockResolvedValue([
+      { id: busySessionId, message_count: 2, title: "busy chat" },
+      { id: idleSessionId, message_count: 2, title: "idle chat" },
+    ] satisfies SessionInfo[]);
+    apiMocks.getSessionTasks.mockImplementation(async (sessionId: string) =>
+      sessionId === busySessionId ? [busyTask] : [],
+    );
+
+    const harness = mountSessionList();
+    try {
+      await flushReactWork(16);
+
+      expect(apiMocks.getSessionTasks).toHaveBeenCalledWith(busySessionId);
+      expect(apiMocks.getSessionTasks).toHaveBeenCalledWith(idleSessionId);
+      expect(TaskStore.getTasks(busySessionId).map((task) => task.id)).toEqual([
+        busyTask.id,
+      ]);
+
+      const busyRow = harness.container.querySelector(
+        `[data-session-id="${busySessionId}"]`,
+      );
+      const idleRow = harness.container.querySelector(
+        `[data-session-id="${idleSessionId}"]`,
+      );
+      expect(busyRow?.textContent).toContain("Live session");
+      expect(idleRow?.textContent).toContain("Saved session");
+    } finally {
+      harness.unmount();
+      TaskStore.clearTasks(busySessionId);
+      TaskStore.clearTasks(idleSessionId);
     }
   });
 });

--- a/src/runtime/session-context.tsx
+++ b/src/runtime/session-context.tsx
@@ -27,6 +27,7 @@ const SESSION_TOPIC_STORAGE_KEY = "octos_session_topics";
 const SESSION_SYNC_STORAGE_KEY = "octos_sessions_sync";
 const SESSION_DELETED_STORAGE_KEY = "octos_deleted_sessions";
 const MAX_DELETED_SESSION_TOMBSTONES = 200;
+const BACKGROUND_TASK_REHYDRATE_SESSION_CAP = 50;
 
 function isTaskActive(task: BackgroundTaskInfo): boolean {
   return task.status === "spawned" || task.status === "running";
@@ -298,6 +299,25 @@ function setSessionActiveFlag(
     delete next[sessionId];
   }
   return next;
+}
+
+async function rehydrateBackgroundTasksForSessions(
+  sessions: SessionInfo[],
+  onActiveChange: (sessionId: string, active: boolean) => void,
+): Promise<void> {
+  await Promise.all(
+    sessions
+      .slice(0, BACKGROUND_TASK_REHYDRATE_SESSION_CAP)
+      .map(async (session) => {
+        try {
+          const tasks = await getSessionTasks(session.id);
+          TaskStore.replaceTasks(session.id, tasks);
+          onActiveChange(session.id, tasks.some(isTaskActive));
+        } catch {
+          // A task probe failure should not block the sidebar session list.
+        }
+      }),
+  );
 }
 
 /** Extract a sortable timestamp from a session ID.
@@ -601,6 +621,14 @@ export function SessionProvider({ children }: { children: ReactNode }) {
       // for the next 15s refresh tick.
       setSessions((prev) =>
         mergeSessionLists(prev, list, deletedIds, titleCache.current),
+      );
+      void rehydrateBackgroundTasksForSessions(
+        visibleCandidates,
+        (sessionId, active) => {
+          setServerTaskActiveBySession((prev) =>
+            setSessionActiveFlag(prev, sessionId, active),
+          );
+        },
       );
 
       // Codex NIT G: skip sessions whose fetch is already in flight or


### PR DESCRIPTION
## Summary
- query recent web sessions during `SessionProvider` refresh and hydrate `TaskStore` from `session/tasks.list`
- keep per-session server-active state in sync with the rehydrated task snapshot
- add a reload regression that renders the real sidebar and verifies a non-current busy session shows as live

Closes octos-org/octos#383

## Validation
- `npm run test:unit -- src/runtime/session-context.test.ts`
- `npm run test:unit`
- `npm run build`

## Notes
- `npm run lint` is not green on current `main`; it reports existing repo-wide React/compiler and no-explicit-any failures outside this change.
