### PR TITLE
test(layout): cover chat panel resize shell

### DIFF
--- a/src/layouts/chat-layout.test.tsx
+++ b/src/layouts/chat-layout.test.tsx
@@ -6,6 +6,27 @@ import { createRoot, type Root } from "react-dom/client";
 (globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT =
   true;
 
+const resizableMocks = vi.hoisted(() => {
+  const filesMouseDown = vi.fn();
+  const historyMouseDown = vi.fn();
+  const toggleMaximize = vi.fn();
+  const useResizablePanel = vi.fn((options?: { storageKey?: string }) => {
+    const isHistory = options?.storageKey === "octos_history_panel_width";
+    return {
+      effectiveWidth: isHistory ? 288 : 320,
+      isMaximized: false,
+      onMouseDown: isHistory ? historyMouseDown : filesMouseDown,
+      toggleMaximize,
+    };
+  });
+  return {
+    filesMouseDown,
+    historyMouseDown,
+    toggleMaximize,
+    useResizablePanel,
+  };
+});
+
 vi.mock("@/auth/auth-context", () => ({
   useAuth: () => ({
     user: { email: "ada@example.test" },
@@ -23,12 +44,7 @@ vi.mock("@/hooks/use-theme", () => ({
 }));
 
 vi.mock("@/hooks/use-resizable-panel", () => ({
-  useResizablePanel: () => ({
-    effectiveWidth: 320,
-    isMaximized: false,
-    onMouseDown: vi.fn(),
-    toggleMaximize: vi.fn(),
-  }),
+  useResizablePanel: resizableMocks.useResizablePanel,
 }));
 
 vi.mock("@/components/content-viewer", () => ({
@@ -59,10 +75,11 @@ interface MountedHarness {
 function makeSessionCtx(
   renameSession: SessionContextValue["renameSession"],
   title = "Original title",
+  sessionId = SESSION_ID,
 ): SessionContextValue {
   return {
-    sessions: [{ id: SESSION_ID, message_count: 2, title }],
-    currentSessionId: SESSION_ID,
+    sessions: [{ id: sessionId, message_count: 2, title }],
+    currentSessionId: sessionId,
     historyTopic: undefined,
     currentSessionTitle: title,
     currentSessionStats: null,
@@ -85,9 +102,10 @@ function makeSessionCtx(
 function chatLayoutTree(
   renameSession: SessionContextValue["renameSession"],
   title = "Original title",
+  sessionId = SESSION_ID,
 ) {
   return (
-    <SessionContext.Provider value={makeSessionCtx(renameSession, title)}>
+    <SessionContext.Provider value={makeSessionCtx(renameSession, title, sessionId)}>
       <ChatLayout>
         <div data-testid="chat-body">thread</div>
       </ChatLayout>
@@ -98,12 +116,13 @@ function chatLayoutTree(
 function mount(
   renameSession: SessionContextValue["renameSession"],
   title = "Original title",
+  sessionId = SESSION_ID,
 ): MountedHarness {
   const container = document.createElement("div");
   document.body.appendChild(container);
   const root = createRoot(container);
   act(() => {
-    root.render(chatLayoutTree(renameSession, title));
+    root.render(chatLayoutTree(renameSession, title, sessionId));
   });
   return {
     container,
@@ -139,6 +158,110 @@ function renameFromEditor(
 
 afterEach(() => {
   for (const node of [...document.body.children]) node.remove();
+  resizableMocks.filesMouseDown.mockClear();
+  resizableMocks.historyMouseDown.mockClear();
+  resizableMocks.toggleMaximize.mockClear();
+  resizableMocks.useResizablePanel.mockClear();
+});
+
+describe("ChatLayout panel layout", () => {
+  it("renders the shared glass shell with left/right resize handles", () => {
+    const renameSession = vi.fn();
+    const harness = mount(renameSession);
+    try {
+      const sidebar = harness.container.querySelector(
+        "aside.sidebar-scope",
+      ) as HTMLElement;
+      const main = harness.container.querySelector("main") as HTMLElement;
+      expect(sidebar).not.toBeNull();
+      expect(main).not.toBeNull();
+      expect(sidebar.className).toContain("glass-panel");
+      expect(main.className).toContain("glass-panel");
+      expect(sidebar.style.width).toBe("288px");
+
+      const historyTitle = [...harness.container.querySelectorAll("div")].find(
+        (node) => node.textContent === "Chat History",
+      );
+      expect(historyTitle).toBeTruthy();
+      expect(historyTitle?.className).not.toContain("text-center");
+      expect(historyTitle?.closest(".items-start")).not.toBeNull();
+
+      const initialHandles =
+        harness.container.querySelectorAll(".panel-resize-handle");
+      expect(initialHandles).toHaveLength(1);
+      expect(initialHandles[0].getAttribute("title")).toBe(
+        "Resize chat history",
+      );
+
+      const filesButton = harness.container.querySelector(
+        "button[title='Open files panel']",
+      ) as HTMLButtonElement;
+      act(() => filesButton.click());
+
+      const handles = harness.container.querySelectorAll(".panel-resize-handle");
+      expect(handles).toHaveLength(2);
+      expect(
+        harness.container.querySelector("[data-testid='content-session-title']")
+          ?.closest(".glass-panel"),
+      ).not.toBeNull();
+      const contentPanelWrapper = harness.container
+        .querySelector("[data-testid='content-session-title']")
+        ?.closest("[style]");
+      expect((contentPanelWrapper as HTMLElement | null)?.style.width).toBe(
+        "320px",
+      );
+      expect(resizableMocks.useResizablePanel).toHaveBeenCalledWith({
+        minWidth: 240,
+        maxWidth: 520,
+        defaultWidth: 288,
+        storageKey: "octos_history_panel_width",
+        side: "left",
+      });
+    } finally {
+      harness.unmount();
+    }
+  });
+
+  it("keeps the panel shell stable across session context refreshes", () => {
+    const renameSession = vi.fn();
+    const harness = mount(renameSession, "Original title", SESSION_ID);
+    try {
+      const filesButton = harness.container.querySelector(
+        "button[title='Open files panel']",
+      ) as HTMLButtonElement;
+      act(() => filesButton.click());
+      expect(
+        harness.container.querySelectorAll(".panel-resize-handle"),
+      ).toHaveLength(2);
+
+      const nextSessionId = "web-1777700000001-layout";
+      act(() => {
+        harness.root.render(
+          chatLayoutTree(renameSession, "Switched session", nextSessionId),
+        );
+      });
+
+      expect(
+        harness.container.querySelectorAll(".panel-resize-handle"),
+      ).toHaveLength(2);
+      expect(
+        (
+          harness.container.querySelector("aside.sidebar-scope") as HTMLElement
+        ).style.width,
+      ).toBe("288px");
+      expect(
+        harness.container.querySelector("[data-testid='content-session-title']")
+          ?.textContent,
+      ).toContain("Switched session");
+      expect(
+        harness.container.querySelector(
+          `[data-testid='session-item-${nextSessionId}']`,
+        )?.textContent,
+      ).toContain("Switched session");
+    } finally {
+      harness.unmount();
+    }
+  });
 });
 
 describe("ChatLayout session title editing", () => {


### PR DESCRIPTION
## Summary
- add regression coverage for the chat shell layout used by the production web client
- assert the history sidebar and main chat use the shared glass-panel surface language
- assert the left history resize handle is present, opening the files panel adds the right resize handle, and panel widths remain stable across a session-context rerender

The implementation already lives on current `octos-web` main; this PR adds the missing regression evidence for the cross-repo Octos issue.

Closes octos-org/octos#333

## Validation
- `npm run test:unit -- src/layouts/chat-layout.test.tsx`
- `npx eslint src/layouts/chat-layout.test.tsx`
- `npm run test:unit`
- `npm run build`
