### PR TITLE
fix(layout): apply chat shell motion token

### DIFF
--- a/src/layouts/chat-layout.test.tsx
+++ b/src/layouts/chat-layout.test.tsx
@@ -176,7 +176,9 @@ describe("ChatLayout panel layout", () => {
       expect(sidebar).not.toBeNull();
       expect(main).not.toBeNull();
       expect(sidebar.className).toContain("glass-panel");
+      expect(sidebar.className).toContain("animate-shell-rise");
       expect(main.className).toContain("glass-panel");
+      expect(main.className).toContain("animate-shell-rise");
       expect(sidebar.style.width).toBe("288px");
 
       const historyTitle = [...harness.container.querySelectorAll("div")].find(
@@ -210,6 +212,15 @@ describe("ChatLayout panel layout", () => {
       expect((contentPanelWrapper as HTMLElement | null)?.style.width).toBe(
         "320px",
       );
+      expect((contentPanelWrapper as HTMLElement | null)?.className).toContain(
+        "animate-shell-rise",
+      );
+      expect((contentPanelWrapper as HTMLElement | null)?.className).toContain(
+        "transition-[width,opacity,transform]",
+      );
+      expect(
+        harness.container.querySelectorAll(".glass-toolbar"),
+      ).toHaveLength(3);
       expect(resizableMocks.useResizablePanel).toHaveBeenCalledWith({
         minWidth: 240,
         maxWidth: 520,

--- a/src/layouts/chat-layout.tsx
+++ b/src/layouts/chat-layout.tsx
@@ -78,7 +78,7 @@ export function ChatLayout({ children }: { children: ReactNode }) {
       {/* Sidebar */}
       <aside
         style={{ width: historyPanelWidth }}
-        className="sidebar-scope glass-panel flex shrink-0 flex-col overflow-hidden rounded-[16px]"
+        className="sidebar-scope glass-panel animate-shell-rise flex shrink-0 flex-col overflow-hidden rounded-[16px]"
       >
         {/* Header */}
         <div className="px-3 pt-3">
@@ -157,7 +157,7 @@ export function ChatLayout({ children }: { children: ReactNode }) {
 
       {/* Main + Media Panel */}
       <div className="flex flex-1 min-w-0 min-h-0 gap-3">
-        <main className="glass-panel flex flex-1 min-w-0 flex-col min-h-0 overflow-hidden rounded-[16px]">
+        <main className="glass-panel animate-shell-rise flex flex-1 min-w-0 flex-col min-h-0 overflow-hidden rounded-[16px]">
           {/* Top bar with title + cost + files toggle */}
           <div className="px-3 pt-3">
             <div className="glass-toolbar rounded-[14px] px-4 py-4">
@@ -223,7 +223,7 @@ export function ChatLayout({ children }: { children: ReactNode }) {
             />
             <div
               style={{ width: effectiveWidth }}
-              className="shrink-0 overflow-hidden"
+              className="animate-shell-rise shrink-0 overflow-hidden transition-[width,opacity,transform] duration-200 ease-out"
             >
               <ContentBrowser
                 open={mediaPanelOpen}
@@ -242,7 +242,7 @@ export function ChatLayout({ children }: { children: ReactNode }) {
 
       {/* Maximized content panel — covers entire window including sidebar */}
       {mediaPanelOpen && isMaximized && (
-        <div className="glass-backdrop fixed inset-0 z-40 p-3">
+        <div className="glass-backdrop animate-shell-rise fixed inset-0 z-40 p-3">
           <ContentBrowser
             open={mediaPanelOpen}
             onClose={() => { setMediaPanelOpen(false); toggleMaximize(); }}


### PR DESCRIPTION
## Summary
- apply the existing `animate-shell-rise` motion token to the chat sidebar, main chat panel, files panel, and maximized files backdrop
- keep the right files panel on the shared width/opacity/transform transition set when it opens
- extend layout regression coverage so the glass shell, shared toolbar surfaces, resize panels, and motion token stay wired together

Closes octos-org/octos#332

## Validation
- `npm run test:unit -- src/layouts/chat-layout.test.tsx`
- `npx eslint src/layouts/chat-layout.tsx src/layouts/chat-layout.test.tsx`
- `npm run test:unit`
- `npm run build`
