### PR TITLE
feat(runtime): render UI Protocol approvals

### DIFF
--- a/src/components/ui-protocol-approval-dialog.tsx
+++ b/src/components/ui-protocol-approval-dialog.tsx
@@ -1,0 +1,287 @@
+import { useEffect, useMemo, useState } from "react";
+import { METHODS } from "@/runtime/ui-protocol-bridge";
+import { getActiveBridge } from "@/runtime/ui-protocol-runtime";
+import type {
+  ApprovalDecision,
+  ApprovalRequestedEvent,
+} from "@/runtime/ui-protocol-types";
+
+interface UiProtocolApprovalDialogProps {
+  approval: ApprovalRequestedEvent | null;
+  sessionId: string;
+  topic?: string;
+  onResolved: () => void;
+}
+
+interface DiffPreviewResult {
+  status: string;
+  preview?: {
+    title?: string | null;
+    files?: DiffPreviewFile[];
+  };
+}
+
+interface DiffPreviewFile {
+  path: string;
+  old_path?: string | null;
+  status: string;
+  hunks?: Array<{
+    header: string;
+    lines?: Array<{
+      kind: string;
+      content: string;
+      old_line?: number | null;
+      new_line?: number | null;
+    }>;
+  }>;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return value !== null && typeof value === "object" && !Array.isArray(value);
+}
+
+function stringField(value: unknown, key: string): string | null {
+  return isRecord(value) && typeof value[key] === "string"
+    ? value[key].trim() || null
+    : null;
+}
+
+function approvalPreviewId(
+  approval: ApprovalRequestedEvent | null,
+): string | null {
+  if (!approval?.typed_details) return null;
+  const details = approval.typed_details;
+  return (
+    stringField(details, "preview_id") ??
+    stringField(details.diff, "preview_id") ??
+    stringField(details.details, "preview_id")
+  );
+}
+
+function approvalSummary(approval: ApprovalRequestedEvent): string[] {
+  const details = approval.typed_details;
+  const rows: string[] = [];
+  if (approval.risk) rows.push(`Risk: ${approval.risk}`);
+  if (approval.approval_kind) rows.push(`Kind: ${approval.approval_kind}`);
+  if (isRecord(details)) {
+    const operation =
+      stringField(details, "operation") ?? stringField(details.diff, "operation");
+    const summary =
+      stringField(details, "summary") ?? stringField(details.diff, "summary");
+    if (operation) rows.push(`Operation: ${operation}`);
+    if (summary) rows.push(summary);
+  }
+  return rows;
+}
+
+function linePrefix(kind: string): string {
+  if (kind === "added") return "+";
+  if (kind === "removed") return "-";
+  return " ";
+}
+
+function lineClass(kind: string): string {
+  if (kind === "added") return "text-emerald-300";
+  if (kind === "removed") return "text-rose-300";
+  return "text-muted";
+}
+
+export function UiProtocolApprovalDialog({
+  approval,
+  sessionId,
+  topic,
+  onResolved,
+}: UiProtocolApprovalDialogProps) {
+  const [responding, setResponding] = useState<ApprovalDecision | null>(null);
+  const [previewLoading, setPreviewLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [preview, setPreview] = useState<DiffPreviewResult | null>(null);
+  const approvalKey = approval?.approval_id ?? null;
+  const previewId = approvalPreviewId(approval);
+  const summaryRows = useMemo(
+    () => (approval ? approvalSummary(approval) : []),
+    [approval],
+  );
+
+  useEffect(() => {
+    setResponding(null);
+    setPreviewLoading(false);
+    setError(null);
+    setPreview(null);
+  }, [approvalKey]);
+
+  if (!approval) return null;
+  const currentApproval = approval;
+
+  async function respond(decision: ApprovalDecision) {
+    setError(null);
+    setResponding(decision);
+    try {
+      const bridge = getActiveBridge(sessionId, topic);
+      if (!bridge) throw new Error("UI Protocol bridge is not connected");
+      const result = await bridge.respondToApproval(
+        currentApproval.approval_id,
+        decision,
+        currentApproval.approval_scope,
+      );
+      if (!result.accepted) {
+        throw new Error(result.status || "approval response was rejected");
+      }
+      onResolved();
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "approval response failed");
+    } finally {
+      setResponding(null);
+    }
+  }
+
+  async function loadPreview() {
+    if (!previewId) return;
+    setError(null);
+    setPreviewLoading(true);
+    try {
+      const bridge = getActiveBridge(sessionId, topic);
+      if (!bridge) throw new Error("UI Protocol bridge is not connected");
+      const result = await bridge.callMethod<DiffPreviewResult>(
+        METHODS.DIFF_PREVIEW_GET,
+        {
+          session_id: currentApproval.session_id,
+          preview_id: previewId,
+        },
+      );
+      setPreview(result);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "diff preview failed");
+    } finally {
+      setPreviewLoading(false);
+    }
+  }
+
+  const approveLabel = approval.render_hints?.primary_label ?? "Approve";
+  const denyLabel = approval.render_hints?.secondary_label ?? "Deny";
+  const approveDanger = approval.render_hints?.danger === true;
+
+  return (
+    <div
+      className="fixed inset-0 z-50 flex items-center justify-center bg-black/55 p-4"
+      role="dialog"
+      aria-modal="true"
+      aria-labelledby="ui-protocol-approval-title"
+    >
+      <div className="glass-panel max-h-[88vh] w-full max-w-3xl overflow-hidden rounded-[16px] shadow-2xl">
+        <div className="border-b border-border px-5 py-4">
+          <div className="shell-kicker">Approval Requested</div>
+          <h2
+            id="ui-protocol-approval-title"
+            className="mt-1 text-lg font-semibold text-text-strong"
+          >
+            {approval.title}
+          </h2>
+          <p className="mt-1 text-sm text-muted">
+            {approval.tool_name}
+            {approval.approval_scope ? ` / ${approval.approval_scope}` : ""}
+          </p>
+        </div>
+
+        <div className="max-h-[58vh] overflow-auto px-5 py-4">
+          <p className="whitespace-pre-wrap text-sm leading-6 text-text">
+            {approval.body}
+          </p>
+          {summaryRows.length > 0 && (
+            <div className="mt-4 space-y-1 rounded-[12px] border border-border bg-surface-container px-3 py-2 text-sm text-muted">
+              {summaryRows.map((row) => (
+                <div key={row}>{row}</div>
+              ))}
+            </div>
+          )}
+
+          {previewId && (
+            <div className="mt-4">
+              <button
+                type="button"
+                className="glass-pill rounded-[10px] px-3 py-2 text-sm font-medium text-text hover:text-text-strong disabled:opacity-60"
+                onClick={() => void loadPreview()}
+                disabled={previewLoading}
+              >
+                {previewLoading ? "Loading diff..." : "Preview diff"}
+              </button>
+            </div>
+          )}
+
+          {preview?.preview && (
+            <div className="mt-4 rounded-[12px] border border-border bg-surface-container">
+              <div className="border-b border-border px-3 py-2 text-sm font-semibold text-text-strong">
+                {preview.preview.title || "Diff preview"}
+              </div>
+              <div className="space-y-4 px-3 py-3">
+                {(preview.preview.files ?? []).map((file) => (
+                  <div key={`${file.status}:${file.path}`}>
+                    <div className="mb-2 flex flex-wrap items-center gap-2 text-xs">
+                      <span className="rounded-[8px] bg-surface px-2 py-1 font-semibold uppercase text-muted">
+                        {file.status}
+                      </span>
+                      <span className="font-mono text-text">{file.path}</span>
+                      {file.old_path && (
+                        <span className="font-mono text-muted">
+                          from {file.old_path}
+                        </span>
+                      )}
+                    </div>
+                    <div className="overflow-x-auto rounded-[10px] bg-black/20 p-3 font-mono text-xs leading-5">
+                      {(file.hunks ?? []).map((hunk) => (
+                        <div key={hunk.header} className="mb-3 last:mb-0">
+                          <div className="text-muted">{hunk.header}</div>
+                          {(hunk.lines ?? []).map((line, index) => (
+                            <div
+                              key={`${hunk.header}:${index}:${line.content}`}
+                              className={lineClass(line.kind)}
+                            >
+                              {linePrefix(line.kind)}
+                              {line.content}
+                            </div>
+                          ))}
+                        </div>
+                      ))}
+                    </div>
+                  </div>
+                ))}
+                {(preview.preview.files ?? []).length === 0 && (
+                  <div className="text-sm text-muted">No file changes.</div>
+                )}
+              </div>
+            </div>
+          )}
+
+          {error && (
+            <div className="mt-4 rounded-[10px] border border-rose-400/40 bg-rose-500/10 px-3 py-2 text-sm text-rose-200">
+              {error}
+            </div>
+          )}
+        </div>
+
+        <div className="flex flex-wrap justify-end gap-2 border-t border-border px-5 py-4">
+          <button
+            type="button"
+            className="glass-pill rounded-[10px] px-4 py-2 text-sm font-medium text-text hover:text-text-strong disabled:opacity-60"
+            onClick={() => void respond("deny")}
+            disabled={responding !== null}
+          >
+            {responding === "deny" ? "Denying..." : denyLabel}
+          </button>
+          <button
+            type="button"
+            className={
+              approveDanger
+                ? "rounded-[10px] bg-rose-500 px-4 py-2 text-sm font-semibold text-white shadow-lg disabled:opacity-60"
+                : "rounded-[10px] bg-accent px-4 py-2 text-sm font-semibold text-white shadow-lg disabled:opacity-60"
+            }
+            onClick={() => void respond("approve")}
+            disabled={responding !== null}
+          >
+            {responding === "approve" ? "Approving..." : approveLabel}
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/layouts/chat-layout.test.tsx
+++ b/src/layouts/chat-layout.test.tsx
@@ -61,6 +61,14 @@ vi.mock("@/store/file-store", () => ({
   useFileStore: () => [],
 }));
 
+const bridgeMocks = vi.hoisted(() => ({
+  getActiveBridge: vi.fn(),
+}));
+
+vi.mock("@/runtime/ui-protocol-runtime", () => ({
+  getActiveBridge: bridgeMocks.getActiveBridge,
+}));
+
 import { ChatLayout } from "./chat-layout";
 import { SessionContext, type SessionContextValue } from "@/runtime/session-context";
 
@@ -162,6 +170,7 @@ afterEach(() => {
   resizableMocks.historyMouseDown.mockClear();
   resizableMocks.toggleMaximize.mockClear();
   resizableMocks.useResizablePanel.mockClear();
+  bridgeMocks.getActiveBridge.mockReset();
 });
 
 describe("ChatLayout panel layout", () => {
@@ -350,6 +359,137 @@ describe("ChatLayout session title editing", () => {
           `[data-testid='session-item-${SESSION_ID}']`,
         )?.textContent,
       ).toContain("Server title");
+    } finally {
+      harness.unmount();
+    }
+  });
+});
+
+describe("ChatLayout UI Protocol approvals", () => {
+  it("renders approval requests, previews diffs, and responds through the active bridge", async () => {
+    const respondToApproval = vi.fn().mockResolvedValue({
+      approval_id: "approval-1",
+      accepted: true,
+      status: "approved",
+    });
+    const callMethod = vi.fn().mockResolvedValue({
+      status: "ready",
+      preview: {
+        title: "Edit preview",
+        files: [
+          {
+            path: "src/app.ts",
+            status: "modified",
+            hunks: [
+              {
+                header: "@@ -1 +1 @@",
+                lines: [
+                  { kind: "removed", content: "old" },
+                  { kind: "added", content: "new" },
+                ],
+              },
+            ],
+          },
+        ],
+      },
+    });
+    bridgeMocks.getActiveBridge.mockReturnValue({
+      respondToApproval,
+      callMethod,
+    });
+
+    const harness = mount(vi.fn());
+    try {
+      act(() => {
+        window.dispatchEvent(
+          new CustomEvent("crew:approval_requested", {
+            detail: {
+              session_id: SESSION_ID,
+              approval_id: "approval-1",
+              turn_id: "turn-1",
+              tool_name: "apply_patch",
+              title: "Apply file edit?",
+              body: "Modify src/app.ts",
+              approval_scope: "turn",
+              typed_details: {
+                kind: "diff",
+                preview_id: "preview-1",
+                operation: "modify",
+                summary: "1 file changed",
+              },
+              render_hints: {
+                primary_label: "Apply",
+                secondary_label: "Reject",
+              },
+            },
+          }),
+        );
+      });
+
+      expect(
+        harness.container.querySelector("[role='dialog']")?.textContent,
+      ).toContain("Apply file edit?");
+      expect(
+        harness.container.querySelector("[role='dialog']")?.textContent,
+      ).toContain("1 file changed");
+
+      const previewButton = [...harness.container.querySelectorAll("button")].find(
+        (button) => button.textContent === "Preview diff",
+      ) as HTMLButtonElement;
+      expect(previewButton).toBeTruthy();
+      await act(async () => {
+        previewButton.click();
+      });
+
+      expect(callMethod).toHaveBeenCalledWith("diff/preview/get", {
+        session_id: SESSION_ID,
+        preview_id: "preview-1",
+      });
+      expect(
+        harness.container.querySelector("[role='dialog']")?.textContent,
+      ).toContain("src/app.ts");
+      expect(
+        harness.container.querySelector("[role='dialog']")?.textContent,
+      ).toContain("new");
+
+      const approveButton = [...harness.container.querySelectorAll("button")].find(
+        (button) => button.textContent === "Apply",
+      ) as HTMLButtonElement;
+      expect(approveButton).toBeTruthy();
+      await act(async () => {
+        approveButton.click();
+      });
+
+      expect(respondToApproval).toHaveBeenCalledWith(
+        "approval-1",
+        "approve",
+        "turn",
+      );
+      expect(harness.container.querySelector("[role='dialog']")).toBeNull();
+    } finally {
+      harness.unmount();
+    }
+  });
+
+  it("ignores approval requests for other sessions", () => {
+    const harness = mount(vi.fn());
+    try {
+      act(() => {
+        window.dispatchEvent(
+          new CustomEvent("crew:approval_requested", {
+            detail: {
+              session_id: "web-other",
+              approval_id: "approval-2",
+              turn_id: "turn-2",
+              tool_name: "shell",
+              title: "Run command?",
+              body: "cargo test",
+            },
+          }),
+        );
+      });
+
+      expect(harness.container.querySelector("[role='dialog']")).toBeNull();
     } finally {
       harness.unmount();
     }

--- a/src/layouts/chat-layout.tsx
+++ b/src/layouts/chat-layout.tsx
@@ -10,8 +10,10 @@ import { SessionList } from "@/components/session-list";
 import { ContentBrowser } from "@/components/content-browser";
 import { SessionTitleEditor } from "@/components/session-title-editor";
 import { SessionTaskIndicator } from "@/components/session-task-dock";
+import { UiProtocolApprovalDialog } from "@/components/ui-protocol-approval-dialog";
 import { useSession } from "@/runtime/session-context";
 import { eventMatchesScope } from "@/runtime/event-scope";
+import type { ApprovalRequestedEvent } from "@/runtime/ui-protocol-types";
 import {
   useContentViewer,
   ContentViewerOverlay,
@@ -49,8 +51,28 @@ export function ChatLayout({ children }: { children: ReactNode }) {
 
   // Notification toast state
   const [toast, setToast] = useState<string | null>(null);
+  const [approval, setApproval] = useState<ApprovalRequestedEvent | null>(null);
+  const scopedApproval =
+    approval && eventMatchesScope(approval, currentSessionId, historyTopic)
+      ? approval
+      : null;
 
   const openPanel = useCallback(() => setMediaPanelOpen(true), []);
+
+  useEffect(() => {
+    function onApprovalRequested(e: Event) {
+      const detail = (e as CustomEvent).detail;
+      if (!eventMatchesScope(detail, currentSessionId, historyTopic)) return;
+      setApproval(detail as ApprovalRequestedEvent);
+    }
+    window.addEventListener("crew:approval_requested", onApprovalRequested);
+    return () => {
+      window.removeEventListener(
+        "crew:approval_requested",
+        onApprovalRequested,
+      );
+    };
+  }, [currentSessionId, historyTopic]);
 
   // Listen for crew:file to show toast (crew:file_notification is a secondary
   // event dispatched by the file-store itself, so listening to both caused
@@ -261,6 +283,12 @@ export function ChatLayout({ children }: { children: ReactNode }) {
         state={viewerState}
         onClose={closeViewer}
         onCloseAudio={closeAudio}
+      />
+      <UiProtocolApprovalDialog
+        approval={scopedApproval}
+        sessionId={currentSessionId}
+        topic={historyTopic}
+        onResolved={() => setApproval(null)}
       />
     </div>
   );

--- a/src/runtime/ui-protocol-event-router.ts
+++ b/src/runtime/ui-protocol-event-router.ts
@@ -1555,11 +1555,10 @@ export function handleApprovalRequested(
   cfg: RouterConfig,
   event: ApprovalRequestedEvent,
 ): void {
-  // No approval modal exists yet (Phase C-4 territory). For now we surface
-  // the typed event verbatim through a CustomEvent so a future modal can
-  // listen without us having to touch this router again. The modal API
-  // shape is the bridge's `ApprovalRequestedEvent` directly — the typed
-  // shape is the contract.
+  // ChatLayout consumes this typed CustomEvent to render the approval
+  // dialog and respond via `approval/respond`. Keep the event shape as
+  // the bridge's `ApprovalRequestedEvent` so the UI does not parse
+  // ad-hoc string payloads.
   dispatch(
     cfg,
     new CustomEvent("crew:approval_requested", { detail: event }),


### PR DESCRIPTION
## Summary

- Render `approval/requested` as a scoped chat approval dialog instead of leaving it as an unconsumed DOM event.
- Respond through the active UI Protocol bridge via `approval/respond` for approve/deny decisions.
- Fetch and render `diff/preview/get` when an approval carries a `preview_id`, giving the web chat a user-facing diff review surface.
- Keep the router event payload typed as `ApprovalRequestedEvent` so the UI does not parse ad-hoc strings.

This is an adoption slice related to octos-org/octos#573. It is not intended to resolve that tracker yet. The remaining evidence should include a real manual/browser smoke against a UI Protocol backend showing approvals, task state/output, committed results, and diff preview together without legacy REST/SSE chat dependency.

## Validation

- `npm run test:unit -- src/layouts/chat-layout.test.tsx src/runtime/ui-protocol-adoption.test.ts` — 9 tests passed
- `npx eslint src/components/ui-protocol-approval-dialog.tsx src/layouts/chat-layout.tsx src/layouts/chat-layout.test.tsx src/runtime/ui-protocol-event-router.ts src/runtime/ui-protocol-adoption.test.ts`
- `git diff --check`
- `npm run test:unit` — 35 files, 587 tests passed
- `npm run build` — passed; existing Vite/CSS/chunk warnings only
- `rg -n "\\b(fetch|EventSource)\\s*\\([^\\n]*(/api/chat|/chat\\?)" src --glob '!**/node_modules/**'` returned no production matches

Reference: octos-org/octos#573.
