### PR TITLE
Render tool call argument summaries

### DIFF
--- a/src/components/chat-thread-tool-call-args.test.tsx
+++ b/src/components/chat-thread-tool-call-args.test.tsx
@@ -1,0 +1,149 @@
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import * as React from "react";
+import { act } from "react";
+import { createRoot, type Root } from "react-dom/client";
+
+(globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT =
+  true;
+
+import { ChatThread } from "./chat-thread";
+import { SessionContext, type SessionContextValue } from "@/runtime/session-context";
+import * as ThreadStore from "@/store/thread-store";
+import {
+  __resetRouterStateForTest,
+  __resetTurnMetaForTest,
+  handleToolStarted,
+  handleTurnStarted,
+} from "@/runtime/ui-protocol-event-router";
+
+const SESSION = "sess-tool-call-args";
+
+interface MountedHarness {
+  container: HTMLDivElement;
+  root: Root;
+  unmount: () => void;
+}
+
+function makeSessionCtx(): SessionContextValue {
+  return {
+    sessions: [],
+    currentSessionId: SESSION,
+    historyTopic: undefined,
+    currentSessionTitle: "",
+    currentSessionStats: null,
+    initialMessages: [],
+    activeTaskOnServer: false,
+    queueMode: null,
+    adaptiveMode: null,
+    setServerTaskActive: () => {},
+    renameSession: () => {},
+    updateSessionStats: () => {},
+    switchSession: () => {},
+    goBack: async () => false,
+    createSession: () => SESSION,
+    removeSession: async () => {},
+    refreshSessions: async () => {},
+    markSessionActive: () => {},
+  };
+}
+
+function mount(): MountedHarness {
+  const container = document.createElement("div");
+  document.body.appendChild(container);
+  const root = createRoot(container);
+  act(() => {
+    root.render(
+      <SessionContext.Provider value={makeSessionCtx()}>
+        <ChatThread />
+      </SessionContext.Provider>,
+    );
+  });
+  return {
+    container,
+    root,
+    unmount: () => {
+      act(() => root.unmount());
+      container.remove();
+    },
+  };
+}
+
+beforeEach(() => {
+  localStorage.clear();
+  if (!("randomUUID" in crypto)) {
+    (
+      crypto as unknown as { randomUUID: () => string }
+    ).randomUUID = () => "00000000-0000-0000-0000-000000000000";
+  }
+});
+
+afterEach(() => {
+  for (const node of [...document.body.children]) node.remove();
+  ThreadStore.__resetForTests();
+  __resetRouterStateForTest();
+  __resetTurnMetaForTest();
+});
+
+const CASES = [
+  {
+    name: "shell",
+    args: { command: "cargo test -p octos-web" },
+    kind: "command",
+    value: "cargo test -p octos-web",
+  },
+  {
+    name: "read_file",
+    args: { path: "src/slides/components/slides-chat.tsx" },
+    kind: "path",
+    value: "src/slides/components/slides-chat.tsx",
+  },
+  {
+    name: "deep_search",
+    args: { query: "octos web bridge events" },
+    kind: "query",
+    value: "octos web bridge events",
+  },
+] as const;
+
+describe("ToolCallBubble argument summaries", () => {
+  it.each(CASES)("renders $kind for $name tool calls", ({ args, kind, name, value }) => {
+    const cmid = `turn-${kind}`;
+    const toolCallId = `tc-${kind}`;
+    act(() => {
+      ThreadStore.addUserMessage(SESSION, {
+        text: "run tool",
+        clientMessageId: cmid,
+      });
+    });
+
+    const harness = mount();
+    try {
+      act(() => {
+        handleTurnStarted(
+          { sessionId: SESSION },
+          { session_id: SESSION, turn_id: cmid },
+        );
+        handleToolStarted(
+          { sessionId: SESSION },
+          {
+            session_id: SESSION,
+            turn_id: cmid,
+            tool_call_id: toolCallId,
+            tool_name: name,
+            arguments: args,
+          },
+        );
+      });
+
+      const argsNode = harness.container.querySelector(
+        "[data-testid='tool-call-args']",
+      );
+      expect(argsNode).not.toBeNull();
+      expect(argsNode!.getAttribute("data-tool-call-args-kind")).toBe(kind);
+      expect(argsNode!.textContent).toContain(`${kind}:`);
+      expect(argsNode!.textContent).toContain(value);
+    } finally {
+      harness.unmount();
+    }
+  });
+});

--- a/src/components/chat-thread.tsx
+++ b/src/components/chat-thread.tsx
@@ -78,23 +78,119 @@ function visibleAttachmentCaption(caption?: string): string {
   return caption;
 }
 
+interface ToolArgumentSummary {
+  label: "command" | "path" | "query";
+  value: string;
+}
+
+function objectArgs(args: unknown): Record<string, unknown> | null {
+  if (!args || typeof args !== "object" || Array.isArray(args)) return null;
+  return args as Record<string, unknown>;
+}
+
+function stringifyArg(value: unknown): string | null {
+  if (typeof value === "string") {
+    const trimmed = value.trim();
+    return trimmed.length > 0 ? trimmed : null;
+  }
+  if (typeof value === "number" || typeof value === "boolean") {
+    return String(value);
+  }
+  if (Array.isArray(value)) {
+    const parts = value
+      .map((entry) => stringifyArg(entry))
+      .filter((entry): entry is string => Boolean(entry));
+    return parts.length > 0 ? parts.join(", ") : null;
+  }
+  return null;
+}
+
+function pickArg(
+  args: Record<string, unknown>,
+  keys: string[],
+): string | null {
+  for (const key of keys) {
+    const value = stringifyArg(args[key]);
+    if (value) return value;
+  }
+  return null;
+}
+
+function toolArgumentSummary(
+  toolCall: ThreadToolCall,
+): ToolArgumentSummary | null {
+  const args = objectArgs(toolCall.args);
+  if (!args) return null;
+  const name = toolCall.name.toLowerCase();
+  const shellCommand = pickArg(args, ["command", "cmd", "shell_command"]);
+  const filePath = pickArg(args, [
+    "path",
+    "file_path",
+    "file",
+    "filename",
+    "dir",
+    "directory",
+  ]);
+  const searchQuery = pickArg(args, [
+    "query",
+    "q",
+    "pattern",
+    "regex",
+    "search",
+    "needle",
+  ]);
+
+  if (
+    shellCommand &&
+    (name.includes("shell") ||
+      name.includes("bash") ||
+      name.includes("terminal") ||
+      name === "exec" ||
+      name === "run_command")
+  ) {
+    return { label: "command", value: shellCommand };
+  }
+  if (
+    filePath &&
+    (name.includes("file") ||
+      name.includes("read") ||
+      name.includes("write") ||
+      name.includes("edit") ||
+      name.includes("list_dir") ||
+      name.includes("glob"))
+  ) {
+    return { label: "path", value: filePath };
+  }
+  if (
+    searchQuery &&
+    (name.includes("search") || name.includes("grep") || name === "rg")
+  ) {
+    return { label: "query", value: searchQuery };
+  }
+
+  if (shellCommand) return { label: "command", value: shellCommand };
+  if (filePath) return { label: "path", value: filePath };
+  if (searchQuery) return { label: "query", value: searchQuery };
+  return null;
+}
+
 // ---------------------------------------------------------------------------
 // File attachment renderer
 // ---------------------------------------------------------------------------
 
 /** Fetch a file with auth and return an object URL. */
 function useBlobUrl(filePath: string): string | undefined {
-  const [blobUrl, setBlobUrl] = useState<string | undefined>(undefined);
+  const isExternal = filePath.startsWith("http");
+  const [blobState, setBlobState] = useState<{
+    filePath: string;
+    url?: string;
+  }>({ filePath: "" });
 
   useEffect(() => {
+    if (isExternal) return;
+
     let revoked = false;
     let url: string | undefined;
-
-    // External URLs don't need auth
-    if (filePath.startsWith("http")) {
-      setBlobUrl(filePath);
-      return;
-    }
 
     const token = getToken();
     const apiUrl = buildFileUrl(filePath);
@@ -108,7 +204,7 @@ function useBlobUrl(filePath: string): string | undefined {
       .then((blob) => {
         if (revoked) return;
         url = URL.createObjectURL(blob);
-        setBlobUrl(url);
+        setBlobState({ filePath, url });
       })
       .catch(() => {
         // Fallback: leave undefined, media element will show broken state
@@ -118,9 +214,10 @@ function useBlobUrl(filePath: string): string | undefined {
       revoked = true;
       if (url) URL.revokeObjectURL(url);
     };
-  }, [filePath]);
+  }, [filePath, isExternal]);
 
-  return blobUrl;
+  if (isExternal) return filePath;
+  return blobState.filePath === filePath ? blobState.url : undefined;
 }
 
 function FileAttachment({ file }: { file: MessageFile }) {
@@ -506,32 +603,20 @@ function ToolCallBubble({
   // dominates the chat scrollback. Default these to collapsed so the
   // chat reads cleanly; user can still click to expand on demand.
   const isSpawnOnly = SPAWN_ONLY_TOOL_NAMES.has(toolCall.name);
-  const [expanded, setExpanded] = useState(
-    toolCall.status === "running" && !isSpawnOnly,
-  );
-  // Track whether the user has manually toggled — if so, respect their
-  // choice and skip the auto-collapse on the running -> settled
-  // transition. Without this, a user who hand-expands a completed bubble
-  // would see it stay expanded only until the next render.
-  const userOverrodeRef = useRef(false);
-  const prevStatusRef = useRef(toolCall.status);
-  useEffect(() => {
-    const wasRunning = prevStatusRef.current === "running";
-    const isSettled = toolCall.status !== "running";
-    if (wasRunning && isSettled && !userOverrodeRef.current) {
-      setExpanded(false);
-    }
-    prevStatusRef.current = toolCall.status;
-  }, [toolCall.status]);
+  const defaultExpanded = toolCall.status === "running" && !isSpawnOnly;
+  // `null` means the user has not chosen yet, so expansion follows the
+  // status-derived default and auto-collapses once the tool settles.
+  const [userExpanded, setUserExpanded] = useState<boolean | null>(null);
+  const expanded = userExpanded ?? defaultExpanded;
 
   const handleToggle = useCallback(() => {
-    userOverrodeRef.current = true;
-    setExpanded((v) => !v);
-  }, []);
+    setUserExpanded((value) => !(value ?? defaultExpanded));
+  }, [defaultExpanded]);
 
   const progressCount = toolCall.progress.length;
   const latestProgress =
     progressCount > 0 ? toolCall.progress[progressCount - 1] : null;
+  const argSummary = toolArgumentSummary(toolCall);
   // Toggle only makes sense when there's more than one chip to hide.
   // For a single-chip list, the "collapsed" view would render the same
   // line as the expanded view, so we skip the chrome.
@@ -643,6 +728,17 @@ function ToolCallBubble({
           {retryBadge}
         </span>
       </span>
+      {argSummary && (
+        <span
+          data-testid="tool-call-args"
+          data-tool-call-args-kind={argSummary.label}
+          title={`${argSummary.label}: ${argSummary.value}`}
+          className="flex min-w-0 items-start gap-1 text-[9px] leading-4 opacity-85"
+        >
+          <span className="shrink-0 text-current/70">{argSummary.label}:</span>
+          <span className="min-w-0 break-all">{argSummary.value}</span>
+        </span>
+      )}
       {progressCount > 0 && (
         <>
           {showToggle && (

--- a/src/runtime/ui-protocol-event-router.ts
+++ b/src/runtime/ui-protocol-event-router.ts
@@ -1266,7 +1266,12 @@ export function handleToolStarted(
   // the pattern `handleTaskUpdated` uses for spawn_only / background
   // tasks. `addToolCall` is idempotent on `(turn_id, tool_call_id)`,
   // so a replayed `tool/started` is safe.
-  ThreadStore.addToolCall(event.turn_id, event.tool_call_id, event.tool_name);
+  ThreadStore.addToolCall(
+    event.turn_id,
+    event.tool_call_id,
+    event.tool_name,
+    event.arguments,
+  );
   dispatchToolProgressEvent(cfg, event.turn_id, event.tool_name, "running");
 }
 

--- a/src/runtime/ui-protocol-types.ts
+++ b/src/runtime/ui-protocol-types.ts
@@ -841,7 +841,7 @@ interface AssistantPersistedPayload {
 
 interface ToolStartPayload {
   type: "tool_start";
-  data: { tool_call_id: string; name: string };
+  data: { tool_call_id: string; name: string; arguments?: unknown };
 }
 
 interface ToolProgressPayload {

--- a/src/store/projection.test.ts
+++ b/src/store/projection.test.ts
@@ -65,9 +65,13 @@ const aPersisted = (text: string, meta: MessageMeta = META): Payload => ({
   data: { text, meta },
 });
 
-const tStart = (id: string, name: string): Payload => ({
+const tStart = (id: string, name: string, args?: unknown): Payload => ({
   type: "tool_start",
-  data: { tool_call_id: id, name },
+  data: {
+    tool_call_id: id,
+    name,
+    ...(args !== undefined ? { arguments: args } : {}),
+  },
 });
 
 const tProgress = (id: string, message: string): Payload => ({
@@ -371,6 +375,16 @@ describe("project — tool_start adds a toolCall", () => {
         error: null,
       },
     ]);
+  });
+
+  it("preserves optional tool arguments", () => {
+    const log: Envelope[] = [
+      env("t1", 0, tStart("tc-1", "shell", { command: "cargo test" })),
+    ];
+    const view = project(log);
+    expect(view.threads[0].toolCalls[0].args).toEqual({
+      command: "cargo test",
+    });
   });
 });
 

--- a/src/store/projection.ts
+++ b/src/store/projection.ts
@@ -71,6 +71,7 @@ export interface AssistantView {
 export interface ToolCallView {
   tool_call_id: string;
   name: string;
+  args?: unknown;
   progress: ReadonlyArray<string>;
   status: EnvelopeToolEndStatus | null;
   error: string | null;
@@ -188,6 +189,7 @@ function computeProjection(
   interface MutableToolCall {
     tool_call_id: string;
     name: string;
+    args?: unknown;
     progress: string[];
     status: EnvelopeToolEndStatus | null;
     error: string | null;
@@ -332,6 +334,7 @@ function computeProjection(
       return {
         tool_call_id: t.tool_call_id,
         name: t.name,
+        ...(t.args !== undefined ? { args: t.args } : {}),
         progress: t.progress.slice(),
         status: t.status,
         error: t.error,
@@ -408,6 +411,9 @@ function computeProjection(
         thread.tools.set(id, {
           tool_call_id: id,
           name: payload.data.name,
+          ...(payload.data.arguments !== undefined
+            ? { args: payload.data.arguments }
+            : {}),
           progress: [],
           status: null,
           error: null,

--- a/src/store/thread-store.test.ts
+++ b/src/store/thread-store.test.ts
@@ -142,6 +142,19 @@ describe.each(FLAG_STATES)("thread-store [$label]", ({ projectionV1 }) => {
     expect(tcs[1].progress.map((p) => p.message)).toEqual(["rendering audio"]);
   });
 
+  it("preserves_tool_start_arguments_on_tool_call_state", () => {
+    makeUser("run", "cmid-args");
+    ThreadStore.addToolCall("cmid-args", "tc-shell", "shell", {
+      command: "cargo test -p octos-web",
+    });
+
+    const [thread] = ThreadStore.getThreads(SESSION);
+    const tc = thread.pendingAssistant?.toolCalls.find(
+      (entry) => entry.id === "tc-shell",
+    );
+    expect(tc?.args).toEqual({ command: "cargo test -p octos-web" });
+  });
+
   it("late_arrival_assistant_lands_in_correct_thread", () => {
     // User sends two questions back-to-back; the slow answer arrives later.
     makeUser("slow news Q", "cmid-slow");

--- a/src/store/thread-store.ts
+++ b/src/store/thread-store.ts
@@ -55,6 +55,8 @@ export interface ThreadProgressEntry {
 export interface ThreadToolCall {
   id: string;
   name: string;
+  /** Raw arguments captured from the tool_start event. */
+  args?: unknown;
   status: "running" | "complete" | "error";
   progress: ThreadProgressEntry[];
   /** 0 for first call, 1 for first retry, etc. Tool retries with the same name
@@ -816,6 +818,7 @@ export function addToolCall(
   threadId: string,
   toolCallId: string,
   name: string,
+  args?: unknown,
 ): void {
   const found = ensureOrphanThread(threadId);
   if (!found) return;
@@ -856,9 +859,14 @@ export function addToolCall(
           existing.status === "complete" || existing.status === "error"
             ? existing.status
             : ("running" as const);
-        const newTcs = candidate.toolCalls.map((tc, i) =>
-          i === idx ? { ...tc, status: preservedStatus } : tc,
-        );
+        const newTcs = candidate.toolCalls.map((tc, i) => {
+          if (i !== idx) return tc;
+          return {
+            ...tc,
+            status: preservedStatus,
+            ...(args !== undefined ? { args } : {}),
+          };
+        });
         replaceAssistantSlot(found.thread, candidate, {
           ...candidate,
           toolCalls: newTcs,
@@ -887,9 +895,14 @@ export function addToolCall(
         existing.status === "complete" || existing.status === "error"
           ? existing.status
           : ("running" as const);
-      const newTcs = tcs.map((tc, i) =>
-        i === byId ? { ...tc, status: preservedStatus } : tc,
-      );
+      const newTcs = tcs.map((tc, i) => {
+        if (i !== byId) return tc;
+        return {
+          ...tc,
+          status: preservedStatus,
+          ...(args !== undefined ? { args } : {}),
+        };
+      });
       replaceAssistantSlot(found.thread, slot, {
         ...slot,
         toolCalls: newTcs,
@@ -905,6 +918,7 @@ export function addToolCall(
     const collapsed: ThreadToolCall = {
       ...last,
       id: toolCallId,
+      ...(args !== undefined ? { args } : {}),
       status: "running",
       retryCount: last.retryCount + 1,
       // Carry forward progress so the user keeps the running narration.
@@ -930,7 +944,11 @@ export function addToolCall(
       if (key) {
         shimIngest(key, threadId, {
           type: "tool_start",
-          data: { tool_call_id: toolCallId, name },
+          data: {
+            tool_call_id: toolCallId,
+            name,
+            ...(args !== undefined ? { arguments: args } : {}),
+          },
         });
       }
     }
@@ -942,6 +960,7 @@ export function addToolCall(
     {
       id: toolCallId,
       name,
+      ...(args !== undefined ? { args } : {}),
       status: "running" as const,
       progress: [],
       retryCount: 0,
@@ -963,7 +982,11 @@ export function addToolCall(
     if (key) {
       shimIngest(key, threadId, {
         type: "tool_start",
-        data: { tool_call_id: toolCallId, name },
+        data: {
+          tool_call_id: toolCallId,
+          name,
+          ...(args !== undefined ? { arguments: args } : {}),
+        },
       });
     }
   }


### PR DESCRIPTION
## Summary
- carry `tool/started` arguments into ThreadStore tool-call state and projection envelopes
- render command/path/query summaries in tool call cards for shell, file, and search tools
- add store, projection, and ChatThread regression coverage for tool argument display

## Validation
- npm run test:unit -- src/components/chat-thread-tool-call-args.test.tsx src/components/chat-thread-progress-toggle.test.tsx src/components/chat-thread-tool-call-status-icon.test.tsx src/store/thread-store.test.ts src/store/projection.test.ts src/runtime/ui-protocol-event-router.test.ts
- npx eslint src/components/chat-thread.tsx src/components/chat-thread-tool-call-args.test.tsx src/store/thread-store.ts src/store/thread-store.test.ts src/store/projection.ts src/store/projection.test.ts src/runtime/ui-protocol-event-router.ts src/runtime/ui-protocol-types.ts (exits 0 with existing cameraStream dependency warning)
- git diff --check
- npm run test:unit
- npm run build (passes with existing CSS/chunk warnings)

Closes #1