### PR TITLE
Add chat session template selector

### DIFF
--- a/src/components/session-list-template-selector.test.tsx
+++ b/src/components/session-list-template-selector.test.tsx
@@ -1,0 +1,238 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import * as React from "react";
+import { act } from "react";
+import { createRoot, type Root } from "react-dom/client";
+
+(globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT =
+  true;
+
+const bridgeSendMock = vi.hoisted(() => vi.fn());
+
+vi.mock("@/runtime/ui-protocol-send", () => ({
+  sendMessage: bridgeSendMock,
+}));
+
+import { SessionContext, type SessionContextValue } from "@/runtime/session-context";
+import {
+  persistSessionTemplates,
+  SESSION_TEMPLATE_STORAGE_KEY,
+  type SessionTemplateRecord,
+} from "@/runtime/session-templates";
+import { SessionList } from "./session-list";
+
+const SESSION_ID = "web-1777700000000-template";
+
+interface MountedHarness {
+  container: HTMLDivElement;
+  root: Root;
+  unmount: () => void;
+}
+
+function makeSessionCtx(
+  overrides: Partial<SessionContextValue> = {},
+): SessionContextValue {
+  return {
+    sessions: [],
+    currentSessionId: "web-current",
+    historyTopic: undefined,
+    currentSessionTitle: "Current",
+    currentSessionStats: null,
+    initialMessages: [],
+    activeTaskOnServer: false,
+    queueMode: null,
+    adaptiveMode: null,
+    setServerTaskActive: () => {},
+    renameSession: () => {},
+    updateSessionStats: () => {},
+    switchSession: () => {},
+    goBack: async () => false,
+    createSession: () => SESSION_ID,
+    removeSession: async () => {},
+    refreshSessions: async () => {},
+    markSessionActive: () => {},
+    ...overrides,
+  };
+}
+
+function mount(ctx: SessionContextValue): MountedHarness {
+  const container = document.createElement("div");
+  document.body.appendChild(container);
+  const root = createRoot(container);
+  act(() => {
+    root.render(
+      <SessionContext.Provider value={ctx}>
+        <SessionList />
+      </SessionContext.Provider>,
+    );
+  });
+  return {
+    container,
+    root,
+    unmount: () => {
+      act(() => root.unmount());
+      container.remove();
+    },
+  };
+}
+
+function mountNode(node: React.ReactElement): MountedHarness {
+  const container = document.createElement("div");
+  document.body.appendChild(container);
+  const root = createRoot(container);
+  act(() => {
+    root.render(node);
+  });
+  return {
+    container,
+    root,
+    unmount: () => {
+      act(() => root.unmount());
+      container.remove();
+    },
+  };
+}
+
+function StatefulSessionList({
+  createSessionSpy,
+  markSessionActive,
+  refreshSessions,
+}: {
+  createSessionSpy: (title?: string) => void;
+  markSessionActive: SessionContextValue["markSessionActive"];
+  refreshSessions: SessionContextValue["refreshSessions"];
+}) {
+  const [currentSessionId, setCurrentSessionId] = React.useState("web-current");
+  const ctx = makeSessionCtx({
+    currentSessionId,
+    createSession: (title?: string) => {
+      createSessionSpy(title);
+      setCurrentSessionId(SESSION_ID);
+      return SESSION_ID;
+    },
+    markSessionActive,
+    refreshSessions,
+  });
+
+  return (
+    <SessionContext.Provider value={ctx}>
+      <SessionList />
+    </SessionContext.Provider>
+  );
+}
+
+async function flushReactWork() {
+  await act(async () => {
+    await Promise.resolve();
+  });
+}
+
+function click(container: HTMLElement, selector: string) {
+  const button = container.querySelector(selector) as HTMLButtonElement | null;
+  expect(button).not.toBeNull();
+  act(() => button!.click());
+}
+
+beforeEach(() => {
+  localStorage.clear();
+  bridgeSendMock.mockReset();
+});
+
+afterEach(() => {
+  for (const node of [...document.body.children]) node.remove();
+  localStorage.clear();
+});
+
+describe("SessionList template selector", () => {
+  it("creates a slides template session and sends the scaffold command", async () => {
+    const createSession = vi.fn();
+    const markSessionActive = vi.fn();
+    const refreshSessions = vi.fn(async () => {});
+    const harness = mountNode(
+      <StatefulSessionList
+        createSessionSpy={createSession}
+        markSessionActive={markSessionActive}
+        refreshSessions={refreshSessions}
+      />,
+    );
+    try {
+      click(harness.container, "[data-testid='new-chat-button']");
+      expect(harness.container.textContent).toContain("What can I help with?");
+
+      const slidesButton = [...harness.container.querySelectorAll("button")].find(
+        (button) => button.textContent?.includes("Slides"),
+      ) as HTMLButtonElement;
+      expect(slidesButton).not.toBeNull();
+      act(() => slidesButton.click());
+
+      const input = harness.container.querySelector("input") as HTMLInputElement;
+      expect(input).not.toBeNull();
+      act(() => {
+        const setter = Object.getOwnPropertyDescriptor(
+          window.HTMLInputElement.prototype,
+          "value",
+        )?.set;
+        setter?.call(input, "Westlake Project");
+        input.dispatchEvent(new InputEvent("input", { bubbles: true }));
+      });
+      const createButton = [...harness.container.querySelectorAll("button")].find(
+        (button) => button.textContent === "Create",
+      ) as HTMLButtonElement;
+      expect(createButton).not.toBeNull();
+      act(() => createButton.click());
+      await flushReactWork();
+
+      expect(createSession).toHaveBeenCalledWith("Westlake Project");
+      expect(bridgeSendMock).toHaveBeenCalledTimes(1);
+      const send = bridgeSendMock.mock.calls[0][0] as {
+        sessionId: string;
+        historyTopic?: string;
+        text: string;
+        onSessionActive?: (message: string) => void;
+        onComplete?: () => void;
+      };
+      expect(send.sessionId).toBe(SESSION_ID);
+      expect(send.historyTopic).toBe("slides westlake-project");
+      expect(send.text).toBe("/new slides westlake-project");
+
+      send.onSessionActive?.(send.text);
+      expect(markSessionActive).toHaveBeenCalledWith(send.text);
+      send.onComplete?.();
+      expect(refreshSessions).toHaveBeenCalled();
+
+      const stored = JSON.parse(
+        localStorage.getItem(SESSION_TEMPLATE_STORAGE_KEY) || "{}",
+      ) as Record<string, SessionTemplateRecord>;
+      expect(stored[SESSION_ID]).toEqual({
+        kind: "slides",
+        title: "Westlake Project",
+        topic: "slides westlake-project",
+      });
+    } finally {
+      harness.unmount();
+    }
+  });
+
+  it("renders template-specific sidebar labels for stored template sessions", () => {
+    persistSessionTemplates({
+      [SESSION_ID]: {
+        kind: "podcast",
+        title: "Async Audio",
+      },
+    });
+    const harness = mount(
+      makeSessionCtx({
+        sessions: [{ id: SESSION_ID, message_count: 2, title: "Async Audio" }],
+        currentSessionId: SESSION_ID,
+      }),
+    );
+    try {
+      const row = harness.container.querySelector(`[data-session-id="${SESSION_ID}"]`);
+      expect(row).not.toBeNull();
+      expect(row!.getAttribute("data-session-template")).toBe("podcast");
+      expect(row!.textContent).toContain("Async Audio");
+      expect(row!.textContent).toContain("Podcast Studio");
+    } finally {
+      harness.unmount();
+    }
+  });
+});

--- a/src/components/session-list.tsx
+++ b/src/components/session-list.tsx
@@ -1,7 +1,30 @@
-import { useState, useCallback, useMemo } from "react";
+import { useState, useCallback, useMemo, useEffect } from "react";
 import { useSession } from "@/runtime/session-context";
 import { useAllTasksBySession } from "@/store/task-store";
-import { Plus, MessageSquare, Trash2, Check, X, Loader2 } from "lucide-react";
+import { sendMessage as bridgeSend } from "@/runtime/ui-protocol-send";
+import {
+  buildSessionTemplateStart,
+  clearSessionTemplate,
+  loadSessionTemplates,
+  persistSessionTemplates,
+  setSessionTemplate,
+  templateDisplayName,
+  SESSION_TEMPLATE_STORAGE_KEY,
+  type SessionTemplateKind,
+  type SessionTemplateRecord,
+} from "@/runtime/session-templates";
+import {
+  Plus,
+  MessageSquare,
+  Trash2,
+  Check,
+  X,
+  Loader2,
+  Presentation,
+  Search,
+  Mic,
+  ArrowLeft,
+} from "lucide-react";
 
 /**
  * Sidebar session list.
@@ -15,11 +38,28 @@ import { Plus, MessageSquare, Trash2, Check, X, Loader2 } from "lucide-react";
  * the single transport boundary the wrappers establish.
  */
 export function SessionList() {
-  const { sessions, currentSessionId, switchSession, createSession, removeSession } =
-    useSession();
+  const {
+    sessions,
+    currentSessionId,
+    switchSession,
+    createSession,
+    removeSession,
+    markSessionActive,
+    refreshSessions,
+  } = useSession();
   const taskEntries = useAllTasksBySession();
   const [confirmingDelete, setConfirmingDelete] = useState<string | null>(null);
   const [deletingId, setDeletingId] = useState<string | null>(null);
+  const [selectorOpen, setSelectorOpen] = useState(false);
+  const [pendingTemplate, setPendingTemplate] =
+    useState<Exclude<SessionTemplateKind, "chat"> | null>(null);
+  const [templateTitle, setTemplateTitle] = useState("");
+  const [sessionTemplates, setSessionTemplates] = useState(loadSessionTemplates);
+  const [queuedStart, setQueuedStart] = useState<{
+    sessionId: string;
+    text: string;
+    historyTopic?: string;
+  } | null>(null);
   // M9-α-5/α-6 (ADR PR #830): the legacy `StreamManager.isActive` poll
   // (driven by SSE) is gone. The WS bridge owns the active-turn signal
   // via `task/updated` + `turn/started/completed`, which feed
@@ -37,31 +77,217 @@ export function SessionList() {
     return s;
   }, [taskEntries]);
 
+  useEffect(() => {
+    function onStorage(event: StorageEvent) {
+      if (event.key === SESSION_TEMPLATE_STORAGE_KEY) {
+        setSessionTemplates(loadSessionTemplates());
+      }
+    }
+    window.addEventListener("storage", onStorage);
+    return () => window.removeEventListener("storage", onStorage);
+  }, []);
+
+  const rememberTemplate = useCallback(
+    (sessionId: string, record: SessionTemplateRecord) => {
+      setSessionTemplates((prev) => {
+        const next = setSessionTemplate(prev, sessionId, record);
+        persistSessionTemplates(next);
+        return next;
+      });
+    },
+    [],
+  );
+
+  const forgetTemplate = useCallback((sessionId: string) => {
+    setSessionTemplates((prev) => {
+      const next = clearSessionTemplate(prev, sessionId);
+      persistSessionTemplates(next);
+      return next;
+    });
+  }, []);
+
   const handleDelete = useCallback(async (id: string) => {
     setDeletingId(id);
     try {
       await new Promise((r) => setTimeout(r, 250));
       await removeSession(id);
+      forgetTemplate(id);
       setConfirmingDelete(null);
     } catch (error) {
       console.error("Failed to delete session", error);
     } finally {
       setDeletingId(null);
     }
-  }, [removeSession]);
+  }, [forgetTemplate, removeSession]);
+
+  const closeSelector = useCallback(() => {
+    setSelectorOpen(false);
+    setPendingTemplate(null);
+    setTemplateTitle("");
+  }, []);
+
+  const handleTemplatePick = useCallback(
+    (kind: SessionTemplateKind) => {
+      if (kind === "chat") {
+        const sessionId = createSession("General chat");
+        rememberTemplate(sessionId, {
+          kind,
+          title: "General chat",
+        });
+        closeSelector();
+        return;
+      }
+
+      setPendingTemplate(kind);
+      setTemplateTitle("");
+    },
+    [closeSelector, createSession, rememberTemplate],
+  );
+
+  const handleTemplateSubmit = useCallback(() => {
+    if (!pendingTemplate) return;
+    const start = buildSessionTemplateStart(pendingTemplate, templateTitle);
+    const sessionId = createSession(start.title);
+    rememberTemplate(sessionId, {
+      kind: pendingTemplate,
+      title: start.title,
+      ...(start.historyTopic ? { topic: start.historyTopic } : {}),
+    });
+    setQueuedStart({
+      sessionId,
+      historyTopic: start.historyTopic,
+      text: start.text,
+    });
+    closeSelector();
+  }, [
+    closeSelector,
+    createSession,
+    pendingTemplate,
+    rememberTemplate,
+    templateTitle,
+  ]);
+
+  useEffect(() => {
+    if (!queuedStart || queuedStart.sessionId !== currentSessionId) return;
+    bridgeSend({
+      sessionId: queuedStart.sessionId,
+      historyTopic: queuedStart.historyTopic,
+      text: queuedStart.text,
+      requestText: queuedStart.text,
+      media: [],
+      onSessionActive: (firstMessage) => markSessionActive(firstMessage),
+      onComplete: () => {
+        void refreshSessions();
+      },
+    });
+    setQueuedStart(null);
+  }, [currentSessionId, markSessionActive, queuedStart, refreshSessions]);
+
+  const pendingTemplateName = pendingTemplate
+    ? templateDisplayName(pendingTemplate)
+    : "";
 
   return (
     <div className="flex flex-1 flex-col overflow-hidden">
       <div className="px-3 pb-2 pt-3">
         <button
           data-testid="new-chat-button"
-          onClick={() => createSession()}
+          onClick={() => setSelectorOpen(true)}
           className="glass-pill flex w-full items-center justify-center gap-2.5 rounded-[12px] px-4 py-3 text-sm font-medium text-text hover:text-text-strong"
         >
           <Plus size={16} />
           New chat
         </button>
       </div>
+      {selectorOpen && (
+        <div
+          className="fixed inset-0 z-50 flex items-center justify-center bg-black/55 px-4"
+          role="dialog"
+          aria-modal="true"
+          aria-labelledby="session-template-title"
+        >
+          <div className="glass-panel w-full max-w-[440px] rounded-[16px] p-4 shadow-2xl">
+            <div className="mb-4 flex items-start justify-between gap-3">
+              <div>
+                <div className="shell-kicker">New Session</div>
+                <div
+                  id="session-template-title"
+                  className="mt-1 text-lg font-semibold text-text-strong"
+                >
+                  {pendingTemplate
+                    ? pendingTemplateName
+                    : "What can I help with?"}
+                </div>
+              </div>
+              <button
+                type="button"
+                onClick={closeSelector}
+                className="glass-icon-button rounded-[10px] p-2"
+                title="Close"
+                aria-label="Close"
+              >
+                <X size={14} />
+              </button>
+            </div>
+            {pendingTemplate ? (
+              <div className="space-y-3">
+                <label className="block">
+                  <span className="mb-1.5 block text-xs font-medium text-muted">
+                    {pendingTemplate === "slides" ? "Project name" : "Topic"}
+                  </span>
+                  <input
+                    autoFocus
+                    value={templateTitle}
+                    onChange={(event) => setTemplateTitle(event.target.value)}
+                    onKeyDown={(event) => {
+                      if (event.key === "Enter" && templateTitle.trim()) {
+                        handleTemplateSubmit();
+                      }
+                    }}
+                    className="w-full rounded-[12px] border border-border bg-surface-container px-3 py-2.5 text-sm text-text outline-none focus:border-accent"
+                  />
+                </label>
+                <div className="flex items-center justify-between gap-2 pt-1">
+                  <button
+                    type="button"
+                    onClick={() => setPendingTemplate(null)}
+                    className="glass-pill flex items-center gap-2 rounded-[10px] px-3 py-2 text-xs text-muted hover:text-text"
+                  >
+                    <ArrowLeft size={13} />
+                    Templates
+                  </button>
+                  <button
+                    type="button"
+                    onClick={handleTemplateSubmit}
+                    disabled={!templateTitle.trim()}
+                    className="rounded-[10px] bg-accent px-4 py-2 text-xs font-semibold text-white disabled:cursor-not-allowed disabled:opacity-50"
+                  >
+                    Create
+                  </button>
+                </div>
+              </div>
+            ) : (
+              <div className="grid grid-cols-2 gap-2">
+                {TEMPLATE_OPTIONS.map((option) => {
+                  const Icon = TEMPLATE_ICONS[option.kind];
+                  return (
+                    <button
+                      key={option.kind}
+                      type="button"
+                      onClick={() => handleTemplatePick(option.kind)}
+                      className="glass-list-item flex min-h-[92px] flex-col items-start gap-2 rounded-[12px] p-3 text-left text-sm text-text hover:text-text-strong"
+                    >
+                      <Icon size={18} className={option.iconClassName} />
+                      <span className="font-semibold">{option.label}</span>
+                      <span className="text-xs text-muted">{option.caption}</span>
+                    </button>
+                  );
+                })}
+              </div>
+            )}
+          </div>
+        </div>
+      )}
       <div className="px-4 pb-2">
         <div className="shell-kicker">Recent Sessions</div>
       </div>
@@ -77,11 +303,19 @@ export function SessionList() {
                 streamingSessions.has(s.id) ||
                 backgroundTaskSessions.has(s.id);
               const isActive = s.id === currentSessionId;
+              const template = sessionTemplates[s.id];
+              const SessionIcon = template
+                ? TEMPLATE_ICONS[template.kind]
+                : MessageSquare;
+              const sessionLabel = template
+                ? templateDisplayName(template.kind)
+                : "Saved session";
               return (
                 <div
                   key={s.id}
                   data-testid={`session-item-${s.id}`}
                   data-session-id={s.id}
+                  data-session-template={template?.kind}
                   data-active={isActive}
                   className={`glass-list-item session-row group flex w-full items-center gap-2.5 rounded-[12px] px-4 py-3 text-left text-sm transition-all duration-250 ${
                     deletingId === s.id
@@ -130,7 +364,7 @@ export function SessionList() {
                         {isBusy ? (
                           <Loader2 size={15} className="shrink-0 animate-spin text-accent" />
                         ) : (
-                          <MessageSquare
+                          <SessionIcon
                             size={15}
                             className={`shrink-0 ${
                               isActive ? "text-accent" : "opacity-60"
@@ -142,7 +376,7 @@ export function SessionList() {
                             {s.title || formatSessionName(s.id)}
                           </div>
                           <div className="mt-0.5 text-[10px] uppercase tracking-[0.14em] text-muted/70">
-                            {isBusy ? "Live session" : "Saved session"}
+                            {isBusy ? "Live session" : sessionLabel}
                           </div>
                         </div>
                       </button>
@@ -167,6 +401,45 @@ export function SessionList() {
     </div>
   );
 }
+
+const TEMPLATE_OPTIONS: {
+  kind: SessionTemplateKind;
+  label: string;
+  caption: string;
+  iconClassName: string;
+}[] = [
+  {
+    kind: "chat",
+    label: "Chat",
+    caption: "General",
+    iconClassName: "text-sky-400",
+  },
+  {
+    kind: "slides",
+    label: "Slides",
+    caption: "Studio",
+    iconClassName: "text-amber-400",
+  },
+  {
+    kind: "research",
+    label: "Research",
+    caption: "Deep dive",
+    iconClassName: "text-emerald-400",
+  },
+  {
+    kind: "podcast",
+    label: "Podcast",
+    caption: "Studio",
+    iconClassName: "text-fuchsia-400",
+  },
+];
+
+const TEMPLATE_ICONS: Record<SessionTemplateKind, typeof MessageSquare> = {
+  chat: MessageSquare,
+  slides: Presentation,
+  research: Search,
+  podcast: Mic,
+};
 
 function formatSessionName(id: string): string {
   if (id.startsWith("web-")) {

--- a/src/runtime/session-templates.test.ts
+++ b/src/runtime/session-templates.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  buildSessionTemplateStart,
+  clearSessionTemplate,
+  setSessionTemplate,
+} from "./session-templates";
+
+describe("session template helpers", () => {
+  it("builds a topic-scoped slides scaffold command", () => {
+    const start = buildSessionTemplateStart("slides", "Westlake Project");
+    expect(start).toEqual({
+      title: "Westlake Project",
+      text: "/new slides westlake-project",
+      historyTopic: "slides westlake-project",
+    });
+  });
+
+  it("builds starter prompts for research and podcast templates", () => {
+    expect(buildSessionTemplateStart("research", "EV Market")).toMatchObject({
+      title: "EV Market",
+    });
+    expect(buildSessionTemplateStart("research", "EV Market").text).toContain(
+      "deep research",
+    );
+    expect(buildSessionTemplateStart("podcast", "Rust async").text).toContain(
+      "podcast episode",
+    );
+  });
+
+  it("updates template maps immutably", () => {
+    const next = setSessionTemplate({}, "web-1", {
+      kind: "slides",
+      title: "Deck",
+      topic: "slides deck",
+    });
+    expect(next["web-1"]?.kind).toBe("slides");
+    expect(clearSessionTemplate(next, "web-1")).toEqual({});
+  });
+});

--- a/src/runtime/session-templates.ts
+++ b/src/runtime/session-templates.ts
@@ -1,0 +1,134 @@
+import { nextTopicForCommand } from "@/lib/slash-commands";
+
+export type SessionTemplateKind = "chat" | "slides" | "research" | "podcast";
+
+export interface SessionTemplateRecord {
+  kind: SessionTemplateKind;
+  title: string;
+  topic?: string;
+}
+
+export interface SessionTemplateStart {
+  title: string;
+  text: string;
+  historyTopic?: string;
+}
+
+export const SESSION_TEMPLATE_STORAGE_KEY = "octos_session_templates";
+
+export function loadSessionTemplates(): Record<string, SessionTemplateRecord> {
+  if (typeof window === "undefined") return {};
+  try {
+    const parsed = JSON.parse(
+      localStorage.getItem(SESSION_TEMPLATE_STORAGE_KEY) || "{}",
+    ) as unknown;
+    if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
+      return {};
+    }
+    const records: Record<string, SessionTemplateRecord> = {};
+    for (const [sessionId, value] of Object.entries(parsed)) {
+      if (!value || typeof value !== "object" || Array.isArray(value)) {
+        continue;
+      }
+      const record = value as Partial<SessionTemplateRecord>;
+      if (!isSessionTemplateKind(record.kind) || !record.title) continue;
+      records[sessionId] = {
+        kind: record.kind,
+        title: String(record.title),
+        ...(record.topic ? { topic: String(record.topic) } : {}),
+      };
+    }
+    return records;
+  } catch {
+    return {};
+  }
+}
+
+export function persistSessionTemplates(
+  records: Record<string, SessionTemplateRecord>,
+): void {
+  if (typeof window === "undefined") return;
+  localStorage.setItem(SESSION_TEMPLATE_STORAGE_KEY, JSON.stringify(records));
+}
+
+export function setSessionTemplate(
+  records: Record<string, SessionTemplateRecord>,
+  sessionId: string,
+  record: SessionTemplateRecord,
+): Record<string, SessionTemplateRecord> {
+  return { ...records, [sessionId]: record };
+}
+
+export function clearSessionTemplate(
+  records: Record<string, SessionTemplateRecord>,
+  sessionId: string,
+): Record<string, SessionTemplateRecord> {
+  if (!records[sessionId]) return records;
+  const next = { ...records };
+  delete next[sessionId];
+  return next;
+}
+
+export function templateDisplayName(kind: SessionTemplateKind): string {
+  switch (kind) {
+    case "slides":
+      return "Slides Studio";
+    case "research":
+      return "Research";
+    case "podcast":
+      return "Podcast Studio";
+    case "chat":
+      return "General Chat";
+  }
+}
+
+export function buildSessionTemplateStart(
+  kind: Exclude<SessionTemplateKind, "chat">,
+  rawTitle: string,
+): SessionTemplateStart {
+  const title = rawTitle.trim();
+  if (!title) {
+    throw new Error("Template title is required");
+  }
+
+  if (kind === "slides") {
+    const slug = slugifyTemplateTitle(title);
+    const text = `/new slides ${slug}`;
+    return {
+      title,
+      text,
+      historyTopic: nextTopicForCommand(text) ?? undefined,
+    };
+  }
+
+  if (kind === "research") {
+    return {
+      title,
+      text: `Use deep research to investigate ${title}. Run the research workflow directly, keep findings in this session, and produce a concise report with sources.`,
+    };
+  }
+
+  return {
+    title,
+    text: `Create a podcast episode about ${title}. Generate the audio deliverable and include a short episode summary in this session.`,
+  };
+}
+
+function slugifyTemplateTitle(title: string): string {
+  return (
+    title
+      .toLowerCase()
+      .replace(/[^a-z0-9]+/g, "-")
+      .replace(/^-+|-+$/g, "")
+      .slice(0, 80) || "untitled"
+  );
+}
+
+function isSessionTemplateKind(value: unknown): value is SessionTemplateKind {
+  return (
+    value === "chat" ||
+    value === "slides" ||
+    value === "research" ||
+    value === "podcast"
+  );
+}


### PR DESCRIPTION
## Summary
- replace the sidebar New chat action with a template picker for Chat, Slides, Research, and Podcast sessions
- prompt for project/topic names on non-chat templates and send the starter turn through UI Protocol v1
- persist template metadata so sidebar rows render template-specific icons/labels on resume

## Validation
- npm run test:unit -- src/components/session-list-template-selector.test.tsx src/runtime/session-templates.test.ts src/runtime/session-context.test.ts
- npx eslint src/components/session-list.tsx src/components/session-list-template-selector.test.tsx src/runtime/session-templates.ts src/runtime/session-templates.test.ts
- git diff --check
- npm run test:unit
- npm run build (passes with existing CSS/chunk warnings)

Closes #25