### PR TITLE
feat: expand media panel CMS controls

### DIFF
--- a/src/components/content-browser.test.tsx
+++ b/src/components/content-browser.test.tsx
@@ -1,0 +1,254 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import * as React from "react";
+import { act } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import type { ContentEntry } from "@/api/content";
+import type { FileEntry } from "@/store/file-store";
+
+(globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT =
+  true;
+
+const fileStoreMock = vi.hoisted(() => ({
+  files: [] as FileEntry[],
+  removeFile: vi.fn(),
+  renameFile: vi.fn(),
+}));
+
+const contentApiMock = vi.hoisted(() => ({
+  downloadContent: vi.fn(async () => {}),
+}));
+
+vi.mock("@/store/file-store", () => ({
+  useAllFiles: () => fileStoreMock.files,
+  removeFile: fileStoreMock.removeFile,
+  renameFile: fileStoreMock.renameFile,
+}));
+
+vi.mock("@/api/content", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@/api/content")>();
+  return {
+    ...actual,
+    downloadContent: contentApiMock.downloadContent,
+  };
+});
+
+vi.mock("@/api/files", () => ({
+  buildAuthenticatedFileUrl: (path: string) => `/auth-file/${encodeURIComponent(path)}`,
+}));
+
+import { ContentBrowser } from "./content-browser";
+
+interface MountedHarness {
+  container: HTMLDivElement;
+  root: Root;
+  openViewer: ReturnType<typeof vi.fn>;
+  unmount: () => void;
+}
+
+function makeFile(overrides: Partial<FileEntry>): FileEntry {
+  return {
+    id: "file-default",
+    sessionId: "web-current",
+    filename: "report.md",
+    filePath: "/workspace/report.md",
+    size: 2048,
+    status: "ready",
+    timestamp: Date.now(),
+    caption: "",
+    ...overrides,
+  };
+}
+
+function mountBrowser(): MountedHarness {
+  const container = document.createElement("div");
+  document.body.appendChild(container);
+  const root = createRoot(container);
+  const openViewer = vi.fn();
+
+  act(() => {
+    root.render(
+      <ContentBrowser
+        open
+        onClose={() => {}}
+        isMaximized={false}
+        onToggleMaximize={() => {}}
+        onOpenViewer={openViewer}
+        sessionId="web-current"
+        sessionTitle="Current Sprint"
+        sessionLabels={{ "web-research": "Research Archive" }}
+      />,
+    );
+  });
+
+  return {
+    container,
+    root,
+    openViewer,
+    unmount: () => {
+      act(() => root.unmount());
+      container.remove();
+    },
+  };
+}
+
+function setInputValue(input: HTMLInputElement, value: string) {
+  act(() => {
+    const setter = Object.getOwnPropertyDescriptor(
+      window.HTMLInputElement.prototype,
+      "value",
+    )?.set;
+    setter?.call(input, value);
+    input.dispatchEvent(new InputEvent("input", { bubbles: true }));
+  });
+}
+
+function setSelectValue(select: HTMLSelectElement, value: string) {
+  act(() => {
+    const setter = Object.getOwnPropertyDescriptor(
+      window.HTMLSelectElement.prototype,
+      "value",
+    )?.set;
+    setter?.call(select, value);
+    select.dispatchEvent(new Event("change", { bubbles: true }));
+  });
+}
+
+function clickButton(container: HTMLElement, label: string) {
+  const button = [...container.querySelectorAll("button")].find(
+    (candidate) =>
+      candidate.textContent?.trim() === label ||
+      candidate.getAttribute("aria-label") === label ||
+      candidate.getAttribute("title") === label,
+  ) as HTMLButtonElement | undefined;
+  expect(button).toBeTruthy();
+  act(() => button!.click());
+}
+
+beforeEach(() => {
+  fileStoreMock.files = [
+    makeFile({
+      id: "file-report",
+      filename: "weekly-report.md",
+      filePath: "/profiles/ada/data/users/web-current/workspace/weekly-report.md",
+      timestamp: Date.now(),
+      caption: "summary",
+    }),
+    makeFile({
+      id: "file-audio",
+      sessionId: "web-research",
+      filename: "briefing.mp3",
+      filePath: "/profiles/ada/data/users/web-research/skill-output/briefing.mp3",
+      timestamp: Date.now() - 24 * 60 * 60 * 1000,
+      caption: "voice brief",
+    }),
+    makeFile({
+      id: "file-image",
+      filename: "slide-01.png",
+      filePath: "/profiles/ada/data/users/web-current/slides/slide-01.png",
+      timestamp: Date.now(),
+      caption: "cover",
+    }),
+  ];
+  fileStoreMock.removeFile.mockReset();
+  fileStoreMock.renameFile.mockReset();
+  contentApiMock.downloadContent.mockClear();
+});
+
+afterEach(() => {
+  for (const node of [...document.body.children]) node.remove();
+});
+
+describe("ContentBrowser CMS controls", () => {
+  it("renders a profile-wide timeline and filters by type, date, and search", () => {
+    const harness = mountBrowser();
+    try {
+      expect(harness.container.textContent).toContain("weekly-report.md");
+      expect(harness.container.textContent).toContain("briefing.mp3");
+      expect(harness.container.textContent).toContain("Research Archive");
+      expect(harness.container.textContent).toContain("Today");
+      expect(harness.container.textContent).toContain("Yesterday");
+
+      const selects = harness.container.querySelectorAll("select");
+      setSelectValue(selects[0] as HTMLSelectElement, "audio");
+      expect(harness.container.textContent).toContain("briefing.mp3");
+      expect(harness.container.textContent).not.toContain("weekly-report.md");
+
+      setSelectValue(selects[0] as HTMLSelectElement, "all");
+      setSelectValue(selects[1] as HTMLSelectElement, "today");
+      expect(harness.container.textContent).toContain("weekly-report.md");
+      expect(harness.container.textContent).not.toContain("briefing.mp3");
+
+      const search = harness.container.querySelector("input") as HTMLInputElement;
+      setInputValue(search, "slide");
+      expect(harness.container.textContent).toContain("slide-01.png");
+      expect(harness.container.textContent).not.toContain("weekly-report.md");
+    } finally {
+      harness.unmount();
+    }
+  });
+
+  it("renames, downloads, and deletes selected files", () => {
+    const harness = mountBrowser();
+    try {
+      clickButton(harness.container, "Rename weekly-report.md");
+      const renameInput = [...harness.container.querySelectorAll("input")].find(
+        (input) => input.value === "weekly-report.md",
+      ) as HTMLInputElement | undefined;
+      expect(renameInput).toBeTruthy();
+      setInputValue(renameInput!, "weekly-final.md");
+      clickButton(harness.container, "Save rename");
+      expect(fileStoreMock.renameFile).toHaveBeenCalledWith(
+        "file-report",
+        "weekly-final.md",
+      );
+
+      clickButton(harness.container, "Select visible");
+      expect(harness.container.textContent).toContain("3 selected");
+
+      const batchDownload = [...harness.container.querySelectorAll("button")].find(
+        (button) => button.textContent?.trim() === "Download",
+      ) as HTMLButtonElement | undefined;
+      expect(batchDownload).toBeTruthy();
+      act(() => batchDownload!.click());
+      expect(contentApiMock.downloadContent).toHaveBeenCalledTimes(3);
+
+      const batchDelete = [...harness.container.querySelectorAll("button")].find(
+        (button) => button.textContent?.trim() === "Delete",
+      ) as HTMLButtonElement | undefined;
+      expect(batchDelete).toBeTruthy();
+      act(() => batchDelete!.click());
+      expect(fileStoreMock.removeFile).toHaveBeenCalledWith("file-report");
+      expect(fileStoreMock.removeFile).toHaveBeenCalledWith("file-audio");
+      expect(fileStoreMock.removeFile).toHaveBeenCalledWith("file-image");
+    } finally {
+      harness.unmount();
+    }
+  });
+
+  it("switches grid/list modes and opens media with the expected viewer behavior", () => {
+    const harness = mountBrowser();
+    try {
+      clickButton(harness.container, "Grid");
+      expect(harness.container.querySelectorAll("[data-testid='content-file-card']").length)
+        .toBe(3);
+
+      const imageCard = [...harness.container.querySelectorAll("[data-testid='content-file-card']")]
+        .find((card) => card.textContent?.includes("slide-01.png")) as HTMLElement;
+      act(() => imageCard.click());
+      expect(harness.openViewer).toHaveBeenCalledWith(
+        expect.objectContaining({ filename: "slide-01.png" }),
+        expect.arrayContaining([
+          expect.objectContaining({ filename: "slide-01.png" }) as ContentEntry,
+        ]),
+      );
+
+      clickButton(harness.container, "List");
+      const audioRow = [...harness.container.querySelectorAll("[data-testid='content-file-row']")]
+        .find((row) => row.textContent?.includes("briefing.mp3")) as HTMLElement;
+      act(() => audioRow.click());
+      expect(harness.container.textContent).toContain("1.25x");
+    } finally {
+      harness.unmount();
+    }
+  });
+});

--- a/src/components/content-browser.tsx
+++ b/src/components/content-browser.tsx
@@ -1,24 +1,33 @@
-import { useMemo, useState } from "react";
+import { useMemo, useState, type ReactNode } from "react";
 import {
-  ChevronDown,
-  ChevronRight,
+  Check,
+  Clock3,
   Download,
+  Edit3,
   File,
   FileText,
-  FolderClosed,
-  FolderOpen,
   Image as ImageIcon,
+  LayoutGrid,
+  List,
   Maximize2,
   Minimize2,
   Music,
   Presentation,
+  Search,
+  Trash2,
   Video,
   X,
 } from "lucide-react";
 
 import type { ContentEntry } from "@/api/content";
 import { downloadContent } from "@/api/content";
-import { useFileStore, type FileEntry } from "@/store/file-store";
+import { buildAuthenticatedFileUrl } from "@/api/files";
+import {
+  removeFile,
+  renameFile,
+  useAllFiles,
+  type FileEntry,
+} from "@/store/file-store";
 import { AudioPlayer } from "@/components/viewers/audio-player";
 import { SessionTitleEditor } from "@/components/session-title-editor";
 
@@ -30,32 +39,74 @@ interface ContentBrowserProps {
   onOpenViewer: (entry: ContentEntry, allEntries: ContentEntry[]) => void;
   sessionId: string;
   sessionTitle: string;
+  sessionLabels?: Record<string, string>;
   onRenameTitle?: (title: string) => void;
 }
+
+type CategoryFilter = ContentEntry["category"] | "all";
+type DateFilter = "all" | "today" | "yesterday" | "7d" | "30d";
+type ViewMode = "timeline" | "grid" | "list";
+
+const CATEGORY_OPTIONS: { value: CategoryFilter; label: string }[] = [
+  { value: "all", label: "All types" },
+  { value: "report", label: "Reports" },
+  { value: "audio", label: "Audio" },
+  { value: "slides", label: "Slides" },
+  { value: "image", label: "Images" },
+  { value: "video", label: "Video" },
+  { value: "other", label: "Documents" },
+];
+
+const DATE_OPTIONS: { value: DateFilter; label: string }[] = [
+  { value: "all", label: "Any date" },
+  { value: "today", label: "Today" },
+  { value: "yesterday", label: "Yesterday" },
+  { value: "7d", label: "Last 7 days" },
+  { value: "30d", label: "Last 30 days" },
+];
 
 function inferCategory(filename: string): ContentEntry["category"] {
   if (/\.(mp3|wav|ogg|m4a|opus|flac|aac)$/i.test(filename)) return "audio";
   if (/\.(mp4|webm|mov|avi|mkv)$/i.test(filename)) return "video";
   if (/\.(png|jpg|jpeg|gif|webp|svg|bmp)$/i.test(filename)) return "image";
   if (/\.(ppt|pptx|key)$/i.test(filename)) return "slides";
-  if (/\.(md|markdown|txt|js|ts|tsx|jsx|json)$/i.test(filename)) return "report";
+  if (/\.(md|markdown|txt|js|ts|tsx|jsx|json|pdf|doc|docx)$/i.test(filename)) {
+    return "report";
+  }
   return "other";
 }
 
-function fileIcon(entry: ContentEntry) {
+function renderFileIcon(entry: ContentEntry, size: number) {
   switch (entry.category) {
     case "audio":
-      return Music;
+      return <Music size={size} />;
     case "video":
-      return Video;
+      return <Video size={size} />;
     case "image":
-      return ImageIcon;
+      return <ImageIcon size={size} />;
     case "slides":
-      return Presentation;
+      return <Presentation size={size} />;
     case "report":
-      return FileText;
+      return <FileText size={size} />;
     default:
-      return File;
+      return <File size={size} />;
+  }
+}
+
+function categoryTone(category: ContentEntry["category"]): string {
+  switch (category) {
+    case "audio":
+      return "bg-purple-500/15 text-purple-300";
+    case "video":
+      return "bg-red-500/15 text-red-300";
+    case "image":
+      return "bg-emerald-500/15 text-emerald-300";
+    case "slides":
+      return "bg-amber-500/15 text-amber-300";
+    case "report":
+      return "bg-sky-500/15 text-sky-300";
+    default:
+      return "bg-surface-light text-muted";
   }
 }
 
@@ -76,29 +127,44 @@ function formatTime(value: string): string {
   });
 }
 
-function decodePath(value: string): string {
-  try {
-    return decodeURIComponent(value);
-  } catch {
-    return value;
-  }
+function dayKey(value: string): string {
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) return "unknown";
+  return date.toISOString().slice(0, 10);
 }
 
-function relativeSessionPath(filePath: string): string {
-  const decoded = decodePath(filePath);
-  for (const root of ["workspace", "skill-output", "slides", "research"]) {
-    const marker = `/${root}/`;
-    const index = decoded.indexOf(marker);
-    if (index >= 0) return decoded.slice(index + 1);
-  }
-  return decoded.split("/").slice(-2).join("/");
+function dayLabel(key: string): string {
+  if (key === "unknown") return "Unknown date";
+  const date = new Date(`${key}T00:00:00`);
+  const today = new Date();
+  const yesterday = new Date();
+  yesterday.setDate(today.getDate() - 1);
+  if (key === today.toISOString().slice(0, 10)) return "Today";
+  if (key === yesterday.toISOString().slice(0, 10)) return "Yesterday";
+  return date.toLocaleDateString(undefined, {
+    month: "short",
+    day: "numeric",
+    year: date.getFullYear() === today.getFullYear() ? undefined : "numeric",
+  });
 }
 
-function groupNameForPath(filePath: string): string {
-  const relativePath = relativeSessionPath(filePath);
-  const slash = relativePath.lastIndexOf("/");
-  if (slash <= 0) return "workspace";
-  return relativePath.slice(0, slash);
+function dateMatches(value: string, filter: DateFilter): boolean {
+  if (filter === "all") return true;
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) return false;
+  const now = new Date();
+  const startOfToday = new Date(now.getFullYear(), now.getMonth(), now.getDate());
+  const startOfTomorrow = new Date(startOfToday);
+  startOfTomorrow.setDate(startOfToday.getDate() + 1);
+  const startOfYesterday = new Date(startOfToday);
+  startOfYesterday.setDate(startOfToday.getDate() - 1);
+
+  if (filter === "today") return date >= startOfToday && date < startOfTomorrow;
+  if (filter === "yesterday") return date >= startOfYesterday && date < startOfToday;
+
+  const windowStart = new Date(startOfToday);
+  windowStart.setDate(startOfToday.getDate() - (filter === "7d" ? 6 : 29));
+  return date >= windowStart;
 }
 
 function toContentEntry(file: FileEntry): ContentEntry {
@@ -116,6 +182,37 @@ function toContentEntry(file: FileEntry): ContentEntry {
   };
 }
 
+function isOpenable(entry: ContentEntry): boolean {
+  return (
+    entry.category === "image" ||
+    entry.category === "video" ||
+    entry.category === "audio" ||
+    /\.(md|markdown|txt|js|ts|tsx|jsx|json)$/i.test(entry.filename)
+  );
+}
+
+function sessionLabelForEntry(
+  entry: ContentEntry,
+  currentSessionId: string,
+  currentSessionTitle: string,
+  sessionLabels: Record<string, string>,
+): string {
+  if (!entry.session_id) return "Unscoped";
+  if (entry.session_id === "_content") return "Profile library";
+  if (entry.session_id === currentSessionId) return currentSessionTitle;
+  return sessionLabels[entry.session_id] || entry.session_id;
+}
+
+function groupByDay(entries: ContentEntry[]): [string, ContentEntry[]][] {
+  const groups = new Map<string, ContentEntry[]>();
+  for (const entry of entries) {
+    const key = dayKey(entry.created_at);
+    if (!groups.has(key)) groups.set(key, []);
+    groups.get(key)!.push(entry);
+  }
+  return [...groups.entries()].sort(([a], [b]) => b.localeCompare(a));
+}
+
 export function ContentBrowser({
   open,
   onClose,
@@ -124,48 +221,134 @@ export function ContentBrowser({
   onOpenViewer,
   sessionId,
   sessionTitle,
+  sessionLabels = {},
   onRenameTitle,
 }: ContentBrowserProps) {
-  const files = useFileStore(sessionId);
+  const files = useAllFiles();
   const [audioEntry, setAudioEntry] = useState<ContentEntry | null>(null);
+  const [viewMode, setViewMode] = useState<ViewMode>("timeline");
+  const [search, setSearch] = useState("");
+  const [category, setCategory] = useState<CategoryFilter>("all");
+  const [dateFilter, setDateFilter] = useState<DateFilter>("all");
+  const [selectedIds, setSelectedIds] = useState<Set<string>>(new Set());
+  const [renamingId, setRenamingId] = useState<string | null>(null);
+  const [renameDraft, setRenameDraft] = useState("");
 
-  const entries = useMemo(() => files.map(toContentEntry), [files]);
+  const entries = useMemo(
+    () =>
+      files
+        .map(toContentEntry)
+        .sort(
+          (a, b) =>
+            new Date(b.created_at).getTime() - new Date(a.created_at).getTime(),
+        ),
+    [files],
+  );
   const imageEntries = useMemo(
     () => entries.filter((entry) => entry.category === "image"),
     [entries],
   );
-  const grouped = useMemo(() => {
-    const groups = new Map<string, ContentEntry[]>();
-    for (const entry of entries) {
-      const groupName = groupNameForPath(entry.path);
-      if (!groups.has(groupName)) groups.set(groupName, []);
-      groups.get(groupName)!.push(entry);
-    }
-
-    return Array.from(groups.entries())
-      .sort(([a], [b]) => a.localeCompare(b))
-      .map(([name, groupEntries]) => [
-        name,
-        [...groupEntries].sort((a, b) => a.filename.localeCompare(b.filename)),
-      ] as const);
-  }, [entries]);
+  const filteredEntries = useMemo(() => {
+    const query = search.trim().toLowerCase();
+    return entries.filter((entry) => {
+      const sessionLabel = sessionLabelForEntry(
+        entry,
+        sessionId,
+        sessionTitle,
+        sessionLabels,
+      );
+      const haystack = [
+        entry.filename,
+        entry.path,
+        entry.caption,
+        entry.tool_name,
+        sessionLabel,
+      ]
+        .filter(Boolean)
+        .join(" ")
+        .toLowerCase();
+      return (
+        (!query || haystack.includes(query)) &&
+        (category === "all" || entry.category === category) &&
+        dateMatches(entry.created_at, dateFilter)
+      );
+    });
+  }, [category, dateFilter, entries, search, sessionId, sessionLabels, sessionTitle]);
+  const selectedEntries = useMemo(
+    () => filteredEntries.filter((entry) => selectedIds.has(entry.id)),
+    [filteredEntries, selectedIds],
+  );
 
   if (!open) return null;
+
+  const openEntry = (entry: ContentEntry) => {
+    if (entry.category === "audio") {
+      setAudioEntry(entry);
+      return;
+    }
+    if (isOpenable(entry)) {
+      onOpenViewer(entry, entry.category === "image" ? imageEntries : [entry]);
+      return;
+    }
+    void downloadContent(entry);
+  };
+
+  const toggleSelected = (id: string) => {
+    setSelectedIds((current) => {
+      const next = new Set(current);
+      if (next.has(id)) next.delete(id);
+      else next.add(id);
+      return next;
+    });
+  };
+
+  const deleteEntries = (ids: string[]) => {
+    for (const id of ids) removeFile(id);
+    setSelectedIds((current) => {
+      const next = new Set(current);
+      for (const id of ids) next.delete(id);
+      return next;
+    });
+    if (audioEntry && ids.includes(audioEntry.id)) {
+      setAudioEntry(null);
+    }
+  };
+
+  const downloadSelected = () => {
+    void Promise.allSettled(selectedEntries.map((entry) => downloadContent(entry)));
+  };
+
+  const startRename = (entry: ContentEntry) => {
+    setRenamingId(entry.id);
+    setRenameDraft(entry.filename);
+  };
+
+  const commitRename = () => {
+    if (!renamingId) return;
+    renameFile(renamingId, renameDraft);
+    setRenamingId(null);
+    setRenameDraft("");
+  };
+
+  const selectVisible = () => {
+    setSelectedIds(new Set(filteredEntries.map((entry) => entry.id)));
+  };
 
   return (
     <div className="glass-panel flex h-full flex-col overflow-hidden rounded-[16px]">
       <div className="px-3 pt-3">
-        <div className="glass-toolbar flex items-start justify-between gap-3 rounded-[14px] px-4 py-4">
+        <div className="glass-toolbar flex flex-wrap items-start justify-between gap-3 rounded-[14px] px-4 py-4">
           <div className="min-w-0 flex-1">
-            <div className="min-w-0 flex-1">
-              <div className="shell-kicker">Session Files</div>
-              <SessionTitleEditor
-                value={sessionTitle}
-                onSave={onRenameTitle}
-                buttonClassName="mt-2 w-full text-left text-[1.24rem] font-semibold tracking-tight text-text-strong transition hover:text-accent"
-                inputClassName="mt-2 w-full rounded-[12px] border border-accent/40 bg-surface-container px-3 py-2.5 text-[1.08rem] font-semibold tracking-tight text-text outline-none"
-                testId="content-session-title"
-              />
+            <div className="shell-kicker">Session Files</div>
+            <SessionTitleEditor
+              value={sessionTitle}
+              onSave={onRenameTitle}
+              buttonClassName="mt-2 w-full text-left text-[1.24rem] font-semibold tracking-tight text-text-strong transition hover:text-accent"
+              inputClassName="mt-2 w-full rounded-[12px] border border-accent/40 bg-surface-container px-3 py-2.5 text-[1.08rem] font-semibold tracking-tight text-text outline-none"
+              testId="content-session-title"
+            />
+            <div className="mt-2 text-xs text-muted">
+              {filteredEntries.length} of {entries.length} files
             </div>
           </div>
           <div className="flex items-center gap-2">
@@ -173,6 +356,7 @@ export function ContentBrowser({
               onClick={onToggleMaximize}
               className="glass-icon-button rounded-[10px] p-2"
               title={isMaximized ? "Restore" : "Maximize"}
+              aria-label={isMaximized ? "Restore files panel" : "Maximize files panel"}
             >
               {isMaximized ? (
                 <Minimize2 className="h-4 w-4" />
@@ -184,11 +368,92 @@ export function ContentBrowser({
               onClick={onClose}
               className="glass-icon-button rounded-[10px] p-2"
               title="Close"
+              aria-label="Close files panel"
             >
               <X className="h-4 w-4" />
             </button>
           </div>
         </div>
+
+        <div className="mt-2 grid gap-2 xl:grid-cols-[minmax(180px,1fr)_auto_auto]">
+          <label className="glass-section flex min-w-0 items-center gap-2 rounded-[12px] px-3 py-2">
+            <Search size={14} className="shrink-0 text-muted" />
+            <input
+              value={search}
+              onChange={(event) => setSearch(event.target.value)}
+              placeholder="Search files, sessions, tools"
+              className="min-w-0 flex-1 bg-transparent text-sm text-text outline-none placeholder:text-muted/70"
+            />
+          </label>
+          <div className="grid grid-cols-2 gap-2">
+            <select
+              value={category}
+              onChange={(event) => setCategory(event.target.value as CategoryFilter)}
+              className="glass-section rounded-[12px] px-3 py-2 text-sm text-text outline-none"
+              aria-label="Filter by type"
+            >
+              {CATEGORY_OPTIONS.map((option) => (
+                <option key={option.value} value={option.value}>
+                  {option.label}
+                </option>
+              ))}
+            </select>
+            <select
+              value={dateFilter}
+              onChange={(event) => setDateFilter(event.target.value as DateFilter)}
+              className="glass-section rounded-[12px] px-3 py-2 text-sm text-text outline-none"
+              aria-label="Filter by date"
+            >
+              {DATE_OPTIONS.map((option) => (
+                <option key={option.value} value={option.value}>
+                  {option.label}
+                </option>
+              ))}
+            </select>
+          </div>
+          <div className="glass-section flex items-center gap-1 rounded-[12px] p-1">
+            <ModeButton active={viewMode === "timeline"} onClick={() => setViewMode("timeline")}>
+              <Clock3 size={14} />
+              <span>Timeline</span>
+            </ModeButton>
+            <ModeButton active={viewMode === "grid"} onClick={() => setViewMode("grid")}>
+              <LayoutGrid size={14} />
+              <span>Grid</span>
+            </ModeButton>
+            <ModeButton active={viewMode === "list"} onClick={() => setViewMode("list")}>
+              <List size={14} />
+              <span>List</span>
+            </ModeButton>
+          </div>
+        </div>
+
+        {selectedEntries.length > 0 && (
+          <div className="glass-section mt-2 flex flex-wrap items-center gap-2 rounded-[12px] px-3 py-2 text-xs text-muted">
+            <span className="font-medium text-text">
+              {selectedEntries.length} selected
+            </span>
+            <button
+              onClick={downloadSelected}
+              className="glass-icon-button rounded-[9px] px-2 py-1.5 hover:text-accent"
+            >
+              <Download size={13} />
+              <span>Download</span>
+            </button>
+            <button
+              onClick={() => deleteEntries(selectedEntries.map((entry) => entry.id))}
+              className="glass-icon-button rounded-[9px] px-2 py-1.5 hover:text-red-300"
+            >
+              <Trash2 size={13} />
+              <span>Delete</span>
+            </button>
+            <button
+              onClick={() => setSelectedIds(new Set())}
+              className="ml-auto rounded-[9px] px-2 py-1.5 text-muted hover:bg-surface-elevated hover:text-text"
+            >
+              Clear
+            </button>
+          </div>
+        )}
       </div>
 
       {audioEntry && (
@@ -198,124 +463,411 @@ export function ContentBrowser({
       <div className="flex-1 overflow-y-auto px-3 pb-3 pt-2">
         {entries.length === 0 ? (
           <div className="shell-empty-state flex h-full items-center justify-center rounded-[12px] px-5 text-center text-sm text-muted">
-            Files generated in this session will appear here.
+            Files generated in your sessions will appear here.
+          </div>
+        ) : filteredEntries.length === 0 ? (
+          <div className="shell-empty-state flex h-full items-center justify-center rounded-[12px] px-5 text-center text-sm text-muted">
+            No files match the current filters.
           </div>
         ) : (
-          <div className="space-y-3">
-            {grouped.map(([groupName, groupEntries]) => (
-              <FileGroup
-                key={groupName}
-                name={groupName}
-                entries={groupEntries}
-                onOpen={(entry) => {
-                  if (entry.category === "audio") {
-                    setAudioEntry(entry);
-                    return;
-                  }
-
-                  onOpenViewer(
-                    entry,
-                    entry.category === "image" ? imageEntries : [entry],
-                  );
-                }}
+          <>
+            <div className="mb-2 flex items-center justify-between gap-3 text-xs text-muted">
+              <button
+                onClick={selectVisible}
+                className="rounded-[9px] px-2 py-1.5 hover:bg-surface-elevated hover:text-text"
+              >
+                Select visible
+              </button>
+              <span>{viewMode === "timeline" ? "Newest first" : "Sorted by recency"}</span>
+            </div>
+            {viewMode === "timeline" ? (
+              <TimelineView
+                entries={filteredEntries}
+                selectedIds={selectedIds}
+                renamingId={renamingId}
+                renameDraft={renameDraft}
+                onRenameDraft={setRenameDraft}
+                onCommitRename={commitRename}
+                onCancelRename={() => setRenamingId(null)}
+                onStartRename={startRename}
+                onToggleSelected={toggleSelected}
+                onOpen={openEntry}
+                onDelete={(entry) => deleteEntries([entry.id])}
+                sessionLabel={(entry) =>
+                  sessionLabelForEntry(entry, sessionId, sessionTitle, sessionLabels)
+                }
               />
-            ))}
-          </div>
+            ) : viewMode === "grid" ? (
+              <GridView
+                entries={filteredEntries}
+                selectedIds={selectedIds}
+                isMaximized={isMaximized}
+                renamingId={renamingId}
+                renameDraft={renameDraft}
+                onRenameDraft={setRenameDraft}
+                onCommitRename={commitRename}
+                onCancelRename={() => setRenamingId(null)}
+                onStartRename={startRename}
+                onToggleSelected={toggleSelected}
+                onOpen={openEntry}
+                onDelete={(entry) => deleteEntries([entry.id])}
+                sessionLabel={(entry) =>
+                  sessionLabelForEntry(entry, sessionId, sessionTitle, sessionLabels)
+                }
+              />
+            ) : (
+              <ListView
+                entries={filteredEntries}
+                selectedIds={selectedIds}
+                renamingId={renamingId}
+                renameDraft={renameDraft}
+                onRenameDraft={setRenameDraft}
+                onCommitRename={commitRename}
+                onCancelRename={() => setRenamingId(null)}
+                onStartRename={startRename}
+                onToggleSelected={toggleSelected}
+                onOpen={openEntry}
+                onDelete={(entry) => deleteEntries([entry.id])}
+                sessionLabel={(entry) =>
+                  sessionLabelForEntry(entry, sessionId, sessionTitle, sessionLabels)
+                }
+              />
+            )}
+          </>
         )}
       </div>
     </div>
   );
 }
 
-function FileGroup({
-  name,
-  entries,
-  onOpen,
+function ModeButton({
+  active,
+  onClick,
+  children,
 }: {
-  name: string;
-  entries: ContentEntry[];
-  onOpen: (entry: ContentEntry) => void;
+  active: boolean;
+  onClick: () => void;
+  children: ReactNode;
 }) {
-  const [open, setOpen] = useState(true);
-
   return (
-    <div className="glass-section rounded-[12px] p-1.5">
-      <button
-        onClick={() => setOpen((value) => !value)}
-        className="flex w-full items-center gap-2 rounded-[12px] px-3 py-2.5 text-left text-xs font-semibold text-text-strong hover:bg-surface-elevated/60"
-      >
-        {open ? (
-          <>
-            <ChevronDown size={14} className="shrink-0 text-muted" />
-            <FolderOpen size={14} className="shrink-0 text-accent/70" />
-          </>
-        ) : (
-          <>
-            <ChevronRight size={14} className="shrink-0 text-muted" />
-            <FolderClosed size={14} className="shrink-0 text-muted" />
-          </>
-        )}
-        <span className="truncate">{name}</span>
-        <span className="ml-auto shrink-0 text-[10px] text-muted/50">
-          {entries.length}
-        </span>
-      </button>
-      {open && (
-        <div className="ml-3 mt-2 space-y-2 border-l border-border/40 pl-3">
-          {entries.map((entry) => {
-            const Icon = fileIcon(entry);
-            const opensViewer =
-              entry.category === "image" ||
-              entry.category === "video" ||
-              entry.category === "audio" ||
-              /\.(md|markdown|txt|js|ts|tsx|jsx|json)$/i.test(entry.filename);
+    <button
+      type="button"
+      onClick={onClick}
+      className={`flex items-center gap-1.5 rounded-[9px] px-2.5 py-1.5 text-xs font-medium ${
+        active ? "bg-accent text-white" : "text-muted hover:bg-surface-elevated hover:text-text"
+      }`}
+    >
+      {children}
+    </button>
+  );
+}
 
-            return (
-              <div
+interface EntryActionProps {
+  entry: ContentEntry;
+  selected: boolean;
+  renaming: boolean;
+  renameDraft: string;
+  onRenameDraft: (value: string) => void;
+  onCommitRename: () => void;
+  onCancelRename: () => void;
+  onStartRename: (entry: ContentEntry) => void;
+  onToggleSelected: (id: string) => void;
+  onOpen: (entry: ContentEntry) => void;
+  onDelete: (entry: ContentEntry) => void;
+  sessionLabel: (entry: ContentEntry) => string;
+}
+
+function EntryActions({
+  entry,
+  selected,
+  onToggleSelected,
+  onStartRename,
+  onDelete,
+}: EntryActionProps) {
+  return (
+    <div className="flex shrink-0 items-center gap-1">
+      <button
+        onClick={(event) => {
+          event.stopPropagation();
+          onToggleSelected(entry.id);
+        }}
+        className={`flex h-7 w-7 items-center justify-center rounded-[9px] border ${
+          selected
+            ? "border-accent bg-accent text-white"
+            : "border-border text-transparent hover:text-muted"
+        }`}
+        title={selected ? "Deselect" : "Select"}
+        aria-label={selected ? `Deselect ${entry.filename}` : `Select ${entry.filename}`}
+      >
+        <Check size={13} />
+      </button>
+      <button
+        onClick={(event) => {
+          event.stopPropagation();
+          void downloadContent(entry);
+        }}
+        className="glass-icon-button rounded-[9px] p-1.5 hover:text-accent"
+        title="Download"
+        aria-label={`Download ${entry.filename}`}
+      >
+        <Download size={13} />
+      </button>
+      <button
+        onClick={(event) => {
+          event.stopPropagation();
+          onStartRename(entry);
+        }}
+        className="glass-icon-button rounded-[9px] p-1.5 hover:text-accent"
+        title="Rename"
+        aria-label={`Rename ${entry.filename}`}
+      >
+        <Edit3 size={13} />
+      </button>
+      <button
+        onClick={(event) => {
+          event.stopPropagation();
+          onDelete(entry);
+        }}
+        className="glass-icon-button rounded-[9px] p-1.5 hover:text-red-300"
+        title="Delete"
+        aria-label={`Delete ${entry.filename}`}
+      >
+        <Trash2 size={13} />
+      </button>
+    </div>
+  );
+}
+
+function RenameField({
+  value,
+  onChange,
+  onCommit,
+  onCancel,
+}: {
+  value: string;
+  onChange: (value: string) => void;
+  onCommit: () => void;
+  onCancel: () => void;
+}) {
+  return (
+    <div className="flex min-w-0 items-center gap-1">
+      <input
+        autoFocus
+        value={value}
+        onChange={(event) => onChange(event.target.value)}
+        onKeyDown={(event) => {
+          if (event.key === "Enter") onCommit();
+          if (event.key === "Escape") onCancel();
+        }}
+        className="min-w-0 flex-1 rounded-[9px] border border-accent/40 bg-surface-container px-2 py-1.5 text-sm text-text outline-none"
+      />
+      <button
+        onClick={onCommit}
+        className="glass-icon-button rounded-[9px] p-1.5 text-emerald-300"
+        title="Save rename"
+      >
+        <Check size={13} />
+      </button>
+      <button
+        onClick={onCancel}
+        className="glass-icon-button rounded-[9px] p-1.5 text-muted"
+        title="Cancel rename"
+      >
+        <X size={13} />
+      </button>
+    </div>
+  );
+}
+
+function EntryMeta({
+  entry,
+  sessionLabel,
+}: {
+  entry: ContentEntry;
+  sessionLabel: (entry: ContentEntry) => string;
+}) {
+  return (
+    <div className="mt-1 flex flex-wrap gap-x-2 gap-y-1 text-[10px] text-muted">
+      <span className={`rounded-md px-1.5 py-0.5 font-semibold uppercase ${categoryTone(entry.category)}`}>
+        {entry.category}
+      </span>
+      <span>{formatSize(entry.size_bytes)}</span>
+      <span>{formatTime(entry.created_at)}</span>
+      <span>{sessionLabel(entry)}</span>
+      {entry.tool_name && <span>{entry.tool_name}</span>}
+    </div>
+  );
+}
+
+function EntryPreview({ entry }: { entry: ContentEntry }) {
+  if (entry.category === "image") {
+    return (
+      <img
+        src={buildAuthenticatedFileUrl(entry.path)}
+        alt={entry.filename}
+        className="h-full w-full object-cover"
+        loading="lazy"
+      />
+    );
+  }
+  return (
+    <div className={`flex h-full w-full items-center justify-center ${categoryTone(entry.category)}`}>
+      {renderFileIcon(entry, 32)}
+    </div>
+  );
+}
+
+function EntryRow(props: EntryActionProps) {
+  return (
+    <div
+      className="glass-file-row flex items-start gap-3 rounded-[12px] px-3 py-3 transition-colors hover:bg-surface-elevated/70"
+      onClick={() => props.onOpen(props.entry)}
+      data-testid="content-file-row"
+    >
+      <div className="glass-pill mt-0.5 flex h-9 w-9 shrink-0 items-center justify-center rounded-[10px] text-muted">
+        {renderFileIcon(props.entry, 15)}
+      </div>
+      <div className="min-w-0 flex-1">
+        {props.renaming ? (
+          <RenameField
+            value={props.renameDraft}
+            onChange={props.onRenameDraft}
+            onCommit={props.onCommitRename}
+            onCancel={props.onCancelRename}
+          />
+        ) : (
+          <div className="truncate text-sm font-medium text-text-strong">
+            {props.entry.filename}
+          </div>
+        )}
+        <EntryMeta entry={props.entry} sessionLabel={props.sessionLabel} />
+        {props.entry.caption && (
+          <div className="mt-1 truncate text-xs text-muted/80">{props.entry.caption}</div>
+        )}
+      </div>
+      <EntryActions {...props} />
+    </div>
+  );
+}
+
+function TimelineView(props: Omit<EntryActionProps, "entry" | "selected" | "renaming"> & {
+  entries: ContentEntry[];
+  selectedIds: Set<string>;
+  renamingId: string | null;
+}) {
+  return (
+    <div className="space-y-3">
+      {groupByDay(props.entries).map(([key, entries]) => (
+        <section key={key} className="space-y-2">
+          <div className="sticky top-0 z-10 glass-toolbar rounded-[10px] px-3 py-2 text-xs font-semibold text-text-strong">
+            {dayLabel(key)}
+          </div>
+          <div className="space-y-2">
+            {entries.map((entry) => (
+              <EntryRow
                 key={entry.id}
-                className="glass-file-row flex items-start gap-2 rounded-[12px] px-3 py-3 transition-colors hover:bg-surface-elevated/70"
-              >
-                <button
-                  onClick={() => {
-                    if (opensViewer) {
-                      onOpen(entry);
-                    } else {
-                      void downloadContent(entry);
-                    }
-                  }}
-                  className="flex min-w-0 flex-1 items-start gap-2 text-left"
-                >
-                  <div className="glass-pill mt-0.5 flex h-8 w-8 shrink-0 items-center justify-center rounded-[10px] text-muted">
-                    <Icon size={14} />
-                  </div>
-                  <div className="min-w-0 flex-1">
-                    <div className="truncate text-sm font-medium text-text-strong">
-                      {entry.filename}
-                    </div>
-                    <div className="mt-1 flex flex-wrap gap-x-2 gap-y-0.5 text-[10px] text-muted">
-                      <span>{formatSize(entry.size_bytes)}</span>
-                      <span>{formatTime(entry.created_at)}</span>
-                      <span className="uppercase tracking-[0.14em] text-muted/60">
-                        {entry.category}
-                      </span>
-                    </div>
-                  </div>
-                </button>
-                <button
-                  onClick={(event) => {
-                    event.stopPropagation();
-                    void downloadContent(entry);
-                  }}
-                  className="glass-icon-button shrink-0 rounded-[10px] p-1.5 hover:text-accent"
-                  title="Download"
-                >
-                  <Download size={14} />
-                </button>
-              </div>
-            );
-          })}
+                {...props}
+                entry={entry}
+                selected={props.selectedIds.has(entry.id)}
+                renaming={props.renamingId === entry.id}
+              />
+            ))}
+          </div>
+        </section>
+      ))}
+    </div>
+  );
+}
+
+function GridView(props: Omit<EntryActionProps, "entry" | "selected" | "renaming"> & {
+  entries: ContentEntry[];
+  selectedIds: Set<string>;
+  isMaximized: boolean;
+  renamingId: string | null;
+}) {
+  return (
+    <div
+      className={`grid gap-3 ${
+        props.isMaximized
+          ? "grid-cols-[repeat(auto-fill,minmax(210px,1fr))]"
+          : "grid-cols-[repeat(auto-fill,minmax(150px,1fr))]"
+      }`}
+    >
+      {props.entries.map((entry) => (
+        <EntryCard
+          key={entry.id}
+          {...props}
+          entry={entry}
+          selected={props.selectedIds.has(entry.id)}
+          renaming={props.renamingId === entry.id}
+        />
+      ))}
+    </div>
+  );
+}
+
+function EntryCard(props: EntryActionProps) {
+  return (
+    <div
+      className="group overflow-hidden rounded-[12px] border border-border bg-surface-container transition-colors hover:bg-surface-elevated"
+      onClick={() => props.onOpen(props.entry)}
+      data-testid="content-file-card"
+    >
+      <div className="relative aspect-[4/3] overflow-hidden bg-surface-dark">
+        <EntryPreview entry={props.entry} />
+        <div className="absolute left-2 top-2">
+          <button
+            onClick={(event) => {
+              event.stopPropagation();
+              props.onToggleSelected(props.entry.id);
+            }}
+            className={`flex h-7 w-7 items-center justify-center rounded-[9px] border ${
+              props.selected
+                ? "border-accent bg-accent text-white"
+                : "border-white/40 bg-black/30 text-transparent group-hover:text-white"
+            }`}
+            aria-label={props.selected ? `Deselect ${props.entry.filename}` : `Select ${props.entry.filename}`}
+          >
+            <Check size={13} />
+          </button>
         </div>
-      )}
+      </div>
+      <div className="space-y-2 p-3">
+        {props.renaming ? (
+          <RenameField
+            value={props.renameDraft}
+            onChange={props.onRenameDraft}
+            onCommit={props.onCommitRename}
+            onCancel={props.onCancelRename}
+          />
+        ) : (
+          <div className="truncate text-sm font-medium text-text-strong">
+            {props.entry.filename}
+          </div>
+        )}
+        <EntryMeta entry={props.entry} sessionLabel={props.sessionLabel} />
+        <EntryActions {...props} />
+      </div>
+    </div>
+  );
+}
+
+function ListView(props: Omit<EntryActionProps, "entry" | "selected" | "renaming"> & {
+  entries: ContentEntry[];
+  selectedIds: Set<string>;
+  renamingId: string | null;
+}) {
+  return (
+    <div className="space-y-2">
+      {props.entries.map((entry) => (
+        <EntryRow
+          key={entry.id}
+          {...props}
+          entry={entry}
+          selected={props.selectedIds.has(entry.id)}
+          renaming={props.renamingId === entry.id}
+        />
+      ))}
     </div>
   );
 }

--- a/src/components/viewers/audio-player.tsx
+++ b/src/components/viewers/audio-player.tsx
@@ -17,6 +17,7 @@ export function AudioPlayer({ entry, onClose }: AudioPlayerProps) {
   const [playing, setPlaying] = useState(false);
   const [currentTime, setCurrentTime] = useState(0);
   const [duration, setDuration] = useState(0);
+  const [playbackRate, setPlaybackRate] = useState(1);
 
   useEffect(() => {
     const audio = audioRef.current;
@@ -49,12 +50,22 @@ export function AudioPlayer({ entry, onClose }: AudioPlayerProps) {
     setPlaying(false);
   };
 
-  const seek = (e: React.MouseEvent<HTMLDivElement>) => {
+  const seekToRatio = (ratio: number) => {
     const audio = audioRef.current;
     if (!audio || !duration) return;
+    audio.currentTime = Math.max(0, Math.min(1, ratio)) * duration;
+  };
+
+  const seek = (e: React.MouseEvent<HTMLDivElement>) => {
     const rect = e.currentTarget.getBoundingClientRect();
-    const ratio = (e.clientX - rect.left) / rect.width;
-    audio.currentTime = ratio * duration;
+    seekToRatio((e.clientX - rect.left) / rect.width);
+  };
+
+  const changeSpeed = (rate: number) => {
+    setPlaybackRate(rate);
+    if (audioRef.current) {
+      audioRef.current.playbackRate = rate;
+    }
   };
 
   const formatTime = (s: number) => {
@@ -64,9 +75,13 @@ export function AudioPlayer({ entry, onClose }: AudioPlayerProps) {
   };
 
   const progress = duration > 0 ? (currentTime / duration) * 100 : 0;
+  const waveform = [
+    26, 42, 58, 36, 70, 48, 62, 30, 74, 54, 46, 66, 38, 82, 56, 44,
+    68, 50, 76, 34, 60, 48, 72, 40, 64, 52, 86, 44, 58, 36, 70, 46,
+  ];
 
   return (
-    <div className="border-t border-border bg-surface-container px-3 py-2.5">
+    <div className="border-t border-border bg-surface-container px-3 py-3">
       <audio ref={audioRef} src={audioUrl(entry)} preload="none" />
 
       <div className="flex items-center gap-3">
@@ -87,31 +102,73 @@ export function AudioPlayer({ entry, onClose }: AudioPlayerProps) {
           )}
         </button>
 
-        {/* Info + progress */}
         <div className="min-w-0 flex-1">
           <p className="truncate text-xs font-medium text-text">
             {entry.filename}
           </p>
-          <div className="mt-1 flex items-center gap-2">
+          <div className="mt-2 flex items-center gap-2">
             <span className="text-[10px] text-muted w-8">
               {formatTime(currentTime)}
             </span>
             <div
-              className="flex-1 h-1.5 rounded-full bg-surface-container cursor-pointer"
+              className="flex h-7 flex-1 cursor-pointer items-end gap-0.5 rounded-md bg-surface-dark/50 px-1.5 py-1"
               onClick={seek}
+              role="slider"
+              aria-label="Seek audio"
+              aria-valuemin={0}
+              aria-valuemax={Math.max(1, duration)}
+              aria-valuenow={currentTime}
             >
-              <div
-                className="h-full rounded-full bg-accent transition-all"
-                style={{ width: `${progress}%` }}
-              />
+              {waveform.map((height, index) => {
+                const filled = (index / Math.max(1, waveform.length - 1)) * 100 <= progress;
+                return (
+                  <span
+                    key={index}
+                    className={`flex-1 rounded-sm ${
+                      filled ? "bg-accent" : "bg-border"
+                    }`}
+                    style={{ height: `${height}%` }}
+                  />
+                );
+              })}
             </div>
             <span className="text-[10px] text-muted w-8 text-right">
               {formatTime(duration)}
             </span>
           </div>
+          <input
+            className="sr-only"
+            type="range"
+            aria-label="Seek audio"
+            min={0}
+            max={Math.max(1, duration)}
+            step={0.1}
+            value={currentTime}
+            onChange={(event) => {
+              const next = Number(event.target.value);
+              if (Number.isFinite(next) && duration > 0) {
+                seekToRatio(next / duration);
+              }
+            }}
+          />
+          <div className="mt-2 flex flex-wrap items-center gap-1.5">
+            {[0.75, 1, 1.25, 1.5, 2].map((rate) => (
+              <button
+                key={rate}
+                type="button"
+                onClick={() => changeSpeed(rate)}
+                className={`rounded-md px-2 py-1 text-[10px] font-semibold ${
+                  playbackRate === rate
+                    ? "bg-accent text-white"
+                    : "bg-surface-light text-muted hover:text-text"
+                }`}
+              >
+                {rate}x
+              </button>
+            ))}
+          </div>
         </div>
 
-        {/* Close */}
         <button
           onClick={onClose}
           className="shrink-0 rounded-lg p-1.5 text-muted hover:bg-surface-container hover:text-text"

--- a/src/layouts/chat-layout.test.tsx
+++ b/src/layouts/chat-layout.test.tsx
@@ -59,6 +59,9 @@ vi.mock("@/components/content-viewer", () => ({
 
 vi.mock("@/store/file-store", () => ({
   useFileStore: () => [],
+  useAllFiles: () => [],
+  removeFile: vi.fn(),
+  renameFile: vi.fn(),
 }));
 
 const bridgeMocks = vi.hoisted(() => ({

--- a/src/layouts/chat-layout.tsx
+++ b/src/layouts/chat-layout.tsx
@@ -1,4 +1,4 @@
-import { type ReactNode, useState, useEffect, useCallback } from "react";
+import { type ReactNode, useState, useEffect, useCallback, useMemo } from "react";
 import { useAuth } from "@/auth/auth-context";
 import { useOctosStatus } from "@/hooks/use-octos-status";
 import { useTheme } from "@/hooks/use-theme";
@@ -23,12 +23,19 @@ import { useFileStore } from "@/store/file-store";
 
 export function ChatLayout({ children }: { children: ReactNode }) {
   const { user, portal, logout } = useAuth();
-  const { currentSessionId, currentSessionTitle, historyTopic, renameSession } =
+  const { sessions, currentSessionId, currentSessionTitle, historyTopic, renameSession } =
     useSession();
   const status = useOctosStatus();
   const { theme, toggleTheme } = useTheme();
   const [mediaPanelOpen, setMediaPanelOpen] = useState(false);
   const sessionFiles = useFileStore(currentSessionId);
+  const sessionLabels = useMemo(
+    () =>
+      Object.fromEntries(
+        sessions.map((session) => [session.id, session.title || session.id]),
+      ),
+    [sessions],
+  );
   const {
     effectiveWidth,
     isMaximized,
@@ -255,6 +262,7 @@ export function ChatLayout({ children }: { children: ReactNode }) {
                 onOpenViewer={openViewer}
                 sessionId={currentSessionId}
                 sessionTitle={currentSessionTitle}
+                sessionLabels={sessionLabels}
                 onRenameTitle={(title) => renameSession(currentSessionId, title)}
               />
             </div>
@@ -273,6 +281,7 @@ export function ChatLayout({ children }: { children: ReactNode }) {
             onOpenViewer={openViewer}
             sessionId={currentSessionId}
             sessionTitle={currentSessionTitle}
+            sessionLabels={sessionLabels}
             onRenameTitle={(title) => renameSession(currentSessionId, title)}
           />
         </div>

--- a/src/store/file-store.ts
+++ b/src/store/file-store.ts
@@ -117,6 +117,12 @@ export function updateFile(id: string, updates: Partial<FileEntry>) {
   }
 }
 
+export function renameFile(id: string, filename: string): void {
+  const trimmed = filename.trim();
+  if (!trimmed) return;
+  updateFile(id, { filename: trimmed });
+}
+
 export function removeFile(id: string): void {
   const idx = allFiles.findIndex((f) => f.id === id);
   if (idx !== -1) {


### PR DESCRIPTION
## Summary
- Rebuild the files panel as a profile-wide media library with timeline, grid, and list modes.
- Add filename/session/tool search, type/date filters, sticky day grouping, session labels, larger image previews, and batch selection actions.
- Add file rename/remove/download controls and richer audio playback with waveform seek + speed controls.
- Cover the CMS panel behavior with unit tests and keep the chat layout file-store mocks aligned.

Refs #23.

## Remaining gap

This intentionally does **not** say `Closes #23`: the web UI now has the requested management surface, but the platform still has no server-side content rename method, and session-history file entries are path-backed rather than content-catalog-id-backed. A physical backend rename/delete proof is still needed before closing the issue under the closure contract.

## Validation
- `npx eslint src/components/content-browser.tsx src/components/content-browser.test.tsx src/components/viewers/audio-player.tsx src/layouts/chat-layout.tsx src/layouts/chat-layout.test.tsx src/store/file-store.ts`
- `npm run test:unit -- src/components/content-browser.test.tsx src/layouts/chat-layout.test.tsx`
- `npm run test:unit` — 40 files / 602 tests
- `npm run build` — passed with existing CSS `file:` utility warnings and existing chunk-size warnings
- `git diff --check`
