### PR TITLE
feat(auth): no-password solo login for the web client

### DIFF
--- a/src/api/auth.ts
+++ b/src/api/auth.ts
@@ -1,4 +1,4 @@
-import { request } from "./client";
+import { publicRequest, request } from "./client";
 import type {
   AuthMeResponse,
   AuthStatusResponse,
@@ -42,7 +42,9 @@ export async function logout(): Promise<void> {
 // to fall through to the create form. `soloCreate` onboards a local profile
 // and logs in atomically.
 export async function soloLogin(): Promise<SoloLoginResult> {
-  return request("/api/auth/solo", { method: "POST" });
+  // publicRequest: a solo 403/404 is a policy denial, not a dead session — do
+  // NOT let the /api/auth/* token reaper clear a signed-in user's tokens.
+  return publicRequest("/api/auth/solo", { method: "POST" });
 }
 
 export async function soloCreate(body: {
@@ -50,7 +52,7 @@ export async function soloCreate(body: {
   username: string;
   email: string;
 }): Promise<SoloCreateResult> {
-  return request("/api/auth/solo/create", {
+  return publicRequest("/api/auth/solo/create", {
     method: "POST",
     body: JSON.stringify(body),
   });

--- a/src/api/auth.ts
+++ b/src/api/auth.ts
@@ -3,6 +3,8 @@ import type {
   AuthMeResponse,
   AuthStatusResponse,
   AuthVerifyResponse,
+  SoloCreateResult,
+  SoloLoginResult,
 } from "./types";
 
 export async function sendCode(email: string): Promise<{ ok: boolean; message?: string }> {
@@ -32,4 +34,24 @@ export async function status(): Promise<AuthStatusResponse> {
 
 export async function logout(): Promise<void> {
   await request("/api/auth/logout", { method: "POST" });
+}
+
+// No-password solo login (Local-mode host opted in via `octos serve --solo`,
+// loopback peer). `soloLogin` re-logs the existing owner — it rejects with an
+// "HTTP 404" error when no solo profile exists yet, which the login page uses
+// to fall through to the create form. `soloCreate` onboards a local profile
+// and logs in atomically.
+export async function soloLogin(): Promise<SoloLoginResult> {
+  return request("/api/auth/solo", { method: "POST" });
+}
+
+export async function soloCreate(body: {
+  name: string;
+  username: string;
+  email: string;
+}): Promise<SoloCreateResult> {
+  return request("/api/auth/solo/create", {
+    method: "POST",
+    body: JSON.stringify(body),
+  });
 }

--- a/src/api/client.test.ts
+++ b/src/api/client.test.ts
@@ -21,7 +21,7 @@ import {
   vi,
 } from "vitest";
 
-import { request, getToken, setToken } from "@/api/client";
+import { publicRequest, request, getToken, setToken } from "@/api/client";
 import { TOKEN_KEY, ADMIN_TOKEN_KEY } from "@/lib/constants";
 
 // ---------------------------------------------------------------------------
@@ -313,6 +313,46 @@ describe("client.request — /api/auth/* prefix matching", () => {
 
     expect(localStorage.getItem(TOKEN_KEY)).toBeNull();
     expect(hrefWrites.length).toBe(1);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// publicRequest — the no-reaper path for solo (policy-gated) endpoints
+// ---------------------------------------------------------------------------
+
+describe("client.publicRequest — solo endpoints never reap tokens", () => {
+  it("403 from /api/auth/solo/create (policy denial) → throws but keeps tokens, no redirect", async () => {
+    // A solo 403 means "not opted in / proxied / non-loopback" — NOT that the
+    // signed-in user's existing token is dead. It must not log them out.
+    mockFetchStatus(403, "forbidden");
+
+    let caught: unknown;
+    try {
+      await publicRequest("/api/auth/solo/create", { method: "POST" });
+    } catch (e) {
+      caught = e;
+    }
+
+    expect(caught).toBeInstanceOf(Error);
+    expect(localStorage.getItem(TOKEN_KEY)).toBe("session-token");
+    expect(localStorage.getItem(ADMIN_TOKEN_KEY)).toBe("admin-token");
+    expect(hrefWrites.length).toBe(0);
+  });
+
+  it("404 from /api/auth/solo (no profile yet) → throws 'HTTP 404', tokens intact", async () => {
+    mockFetchStatus(404);
+
+    let caught: unknown;
+    try {
+      await publicRequest("/api/auth/solo", { method: "POST" });
+    } catch (e) {
+      caught = e;
+    }
+
+    // The login page keys the create-form fallback off this "404" message.
+    expect((caught as Error).message).toContain("404");
+    expect(localStorage.getItem(TOKEN_KEY)).toBe("session-token");
+    expect(hrefWrites.length).toBe(0);
   });
 });
 

--- a/src/api/client.ts
+++ b/src/api/client.ts
@@ -194,3 +194,35 @@ export async function request<T>(
 
   return JSON.parse(text) as T;
 }
+
+/**
+ * Like {@link request} but WITHOUT the `/api/auth/*` 401/403 token reaper, and
+ * without attaching the session token / profile headers. Used for pre-auth,
+ * policy-gated endpoints — specifically the no-password solo login, where a
+ * 403 is a POLICY denial (not opted in, proxied, non-loopback), NOT proof that
+ * an existing session token is dead. Routing those through `request()` would
+ * clear the user's tokens and bounce them to `/login` (see solo-login codex
+ * review). 404 (no solo profile yet) and 403 simply throw, like `request`.
+ */
+export async function publicRequest<T>(
+  path: string,
+  options: RequestInit = {},
+): Promise<T> {
+  const headers: Record<string, string> = {
+    "Content-Type": "application/json",
+    ...(options.headers as Record<string, string>),
+  };
+  const resp = await fetch(`${API_BASE}${path}`, { ...options, headers });
+  if (!resp.ok) {
+    const text = await resp.text();
+    throw new Error(text || `HTTP ${resp.status}`);
+  }
+  if (resp.status === 204) {
+    return undefined as T;
+  }
+  const text = await resp.text();
+  if (!text.trim()) {
+    return undefined as T;
+  }
+  return JSON.parse(text) as T;
+}

--- a/src/api/types.ts
+++ b/src/api/types.ts
@@ -119,7 +119,31 @@ export interface AuthStatusResponse {
   email_login_enabled: boolean;
   admin_token_login_enabled: boolean;
   allow_self_registration: boolean;
+  /** True when the host advertises the no-password solo login path
+   *  (`POST /api/auth/solo*`): a Local-mode deployment opted in via
+   *  `octos serve --solo`. The login page reads this to offer "Continue
+   *  without a password". The server still enforces a loopback,
+   *  non-proxied request at call time — see the backend `api::solo_auth`. */
+  local_solo_enabled?: boolean;
   scoped_profile?: ScopedAuthTarget | null;
+}
+
+/** `POST /api/auth/solo` — re-login for the existing local solo owner. */
+export interface SoloLoginResult {
+  token: string;
+  user: AuthUser;
+}
+
+/** `POST /api/auth/solo/create` — create the local profile AND log in. */
+export interface SoloCreateResult {
+  profile_id: string;
+  user_id: string;
+  name: string;
+  username: string;
+  email: string;
+  created: boolean;
+  runtime_mode: string;
+  token: string;
 }
 
 export interface AuthMeResponse {

--- a/src/auth/auth-context.tsx
+++ b/src/auth/auth-context.tsx
@@ -24,6 +24,12 @@ interface AuthState {
   loading: boolean;
   login: (email: string, code: string) => Promise<void>;
   loginWithToken: (token: string) => Promise<void>;
+  /** No-password solo re-login for the existing local owner. Rejects with an
+   *  "HTTP 404" error when no solo profile exists yet — the caller then shows
+   *  the create form. */
+  soloLogin: () => Promise<void>;
+  /** Onboard a local profile AND log in (no password). */
+  soloCreate: (body: { name: string; username: string; email: string }) => Promise<void>;
   logout: () => Promise<void>;
   /** Re-validate the stored token against `/api/auth/me`. Call this from
    *  any code path that sees an authenticated request rejected (e.g. the
@@ -171,6 +177,49 @@ export function AuthProvider({ children }: { children: ReactNode }) {
     }
   }, [syncMe]);
 
+  // No-password solo login. The server only honours these on a Local-mode
+  // host that opted in (`--solo`) when reached over a non-proxied loopback
+  // connection; otherwise they 403/404, so the SPA can never land a session
+  // it shouldn't. `setToken(_, false)` stores under the session-token slot.
+  const soloLogin = useCallback(async () => {
+    const resp = await authApi.soloLogin();
+    setToken(resp.token);
+    setTokenState(resp.token);
+    setUser(resp.user);
+    // Refine portal/profile from /me; the token already unblocks AuthGuard.
+    try {
+      await syncMe();
+    } catch {
+      // best-effort refine
+    }
+  }, [syncMe]);
+
+  const soloCreate = useCallback(
+    async (body: { name: string; username: string; email: string }) => {
+      const resp = await authApi.soloCreate(body);
+      setToken(resp.token);
+      setTokenState(resp.token);
+      // Establish the principal from the create result so the UI has a user
+      // even if /me fails. The local solo owner is created with the admin
+      // role server-side. (AuthGuard gates on the token, so the app loads
+      // regardless, but this keeps user-dependent chrome populated.)
+      setUser({
+        id: resp.user_id,
+        email: resp.email,
+        name: resp.name,
+        role: "admin",
+        created_at: new Date().toISOString(),
+        last_login_at: null,
+      });
+      try {
+        await syncMe();
+      } catch {
+        // best-effort refine
+      }
+    },
+    [syncMe],
+  );
+
   const logout = useCallback(async () => {
     try {
       await authApi.logout();
@@ -185,7 +234,7 @@ export function AuthProvider({ children }: { children: ReactNode }) {
 
   return (
     <AuthContext.Provider
-      value={{ user, portal, authStatus, token, loading, login, loginWithToken, logout, revalidate }}
+      value={{ user, portal, authStatus, token, loading, login, loginWithToken, soloLogin, soloCreate, logout, revalidate }}
     >
       {children}
     </AuthContext.Provider>

--- a/src/auth/login-page.tsx
+++ b/src/auth/login-page.tsx
@@ -1,11 +1,13 @@
 import { useEffect, useMemo, useState } from "react";
 import { useNavigate, useSearchParams } from "react-router-dom";
 import { useAuth } from "./auth-context";
+import { SoloProfileForm } from "./solo-profile-form";
 import * as authApi from "@/api/auth";
 import type { AuthStatusResponse } from "@/api/types";
 
 export function LoginPage() {
-  const { login, loginWithToken, authStatus: initialAuthStatus } = useAuth();
+  const { login, loginWithToken, soloLogin, authStatus: initialAuthStatus } =
+    useAuth();
   const navigate = useNavigate();
   const [searchParams] = useSearchParams();
   // Validate redirect target — only allow same-origin paths to prevent open redirect
@@ -20,7 +22,7 @@ export function LoginPage() {
   const [email, setEmail] = useState("");
   const [code, setCode] = useState("");
   const [adminToken, setAdminToken] = useState("");
-  const [step, setStep] = useState<"email" | "code">("email");
+  const [step, setStep] = useState<"email" | "code" | "solo">("email");
   const [error, setError] = useState("");
   const [sending, setSending] = useState(false);
 
@@ -40,6 +42,7 @@ export function LoginPage() {
     [authStatus?.admin_token_login_enabled, scopedProfile],
   );
   const emailLoginEnabled = authStatus?.email_login_enabled ?? true;
+  const soloEnabled = authStatus?.local_solo_enabled ?? false;
 
   useEffect(() => {
     if (mode === "token" && !tokenModeEnabled) {
@@ -88,6 +91,26 @@ export function LoginPage() {
     }
   }
 
+  async function handleSoloContinue() {
+    setError("");
+    setSending(true);
+    try {
+      // Re-login the existing local owner. First run (no profile yet) comes
+      // back as an "HTTP 404" error → drop into the create form.
+      await soloLogin();
+      navigate(redirectTo || "/", { replace: true });
+    } catch (e) {
+      const msg = e instanceof Error ? e.message : "";
+      if (msg.includes("404")) {
+        setStep("solo");
+      } else {
+        setError(msg || "Solo login failed");
+      }
+    } finally {
+      setSending(false);
+    }
+  }
+
   return (
     <div className="flex h-screen items-center justify-center bg-surface-dark">
       <div className="w-full max-w-sm rounded-xl bg-surface p-8">
@@ -107,7 +130,29 @@ export function LoginPage() {
               : "Use an allowed or registered email to sign in."}
         </p>
 
+        {soloEnabled && step !== "solo" && (
+          <div className="mb-6">
+            <button
+              data-testid="solo-continue"
+              onClick={handleSoloContinue}
+              disabled={sending}
+              className="w-full rounded-lg bg-accent py-3 font-medium text-surface-dark transition hover:bg-accent-dim disabled:opacity-50"
+            >
+              {sending ? "Continuing..." : "Continue without a password"}
+            </button>
+            <p className="mt-2 text-center text-xs text-muted">
+              Solo mode — local, single-user, stays on this machine.
+            </p>
+            <div className="my-4 flex items-center gap-3 text-xs text-muted">
+              <span className="h-px flex-1 bg-border" />
+              or sign in with email
+              <span className="h-px flex-1 bg-border" />
+            </div>
+          </div>
+        )}
+
         {/* Mode tabs */}
+        {step !== "solo" && (
         <div className="mb-6 flex gap-2">
           <button
             onClick={() => setMode("otp")}
@@ -132,6 +177,7 @@ export function LoginPage() {
             </button>
           )}
         </div>
+        )}
 
         {error && (
           <div data-testid="login-error" className="mb-4 rounded-lg bg-red-900/30 p-3 text-sm text-red-400">
@@ -147,7 +193,22 @@ export function LoginPage() {
           </div>
         )}
 
-        {mode === "otp" ? (
+        {step === "solo" ? (
+          <div className="space-y-4">
+            <SoloProfileForm
+              onDone={() => navigate(redirectTo || "/", { replace: true })}
+            />
+            <button
+              onClick={() => {
+                setStep("email");
+                setError("");
+              }}
+              className="w-full text-sm text-muted hover:text-text-strong"
+            >
+              Back
+            </button>
+          </div>
+        ) : mode === "otp" ? (
           step === "email" ? (
             <div className="space-y-4">
               <input

--- a/src/auth/solo-profile-form.test.tsx
+++ b/src/auth/solo-profile-form.test.tsx
@@ -1,0 +1,114 @@
+import * as React from "react";
+import { act } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { describe, it, expect, vi, afterEach } from "vitest";
+import { MemoryRouter } from "react-router-dom";
+
+(globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT =
+  true;
+
+const soloCreate = vi.fn();
+vi.mock("./auth-context", () => ({ useAuth: () => ({ soloCreate }) }));
+
+import { SoloProfileForm } from "./solo-profile-form";
+
+interface MountedHarness {
+  container: HTMLDivElement;
+  root: Root;
+}
+
+function mount(node: React.ReactElement): MountedHarness {
+  const container = document.createElement("div");
+  document.body.appendChild(container);
+  const root = createRoot(container);
+  act(() => {
+    root.render(node);
+  });
+  return { container, root };
+}
+
+function setInput(container: HTMLElement, testid: string, value: string) {
+  const el = container.querySelector(
+    `[data-testid="${testid}"]`,
+  ) as HTMLInputElement;
+  const setter = Object.getOwnPropertyDescriptor(
+    window.HTMLInputElement.prototype,
+    "value",
+  )!.set!;
+  act(() => {
+    setter.call(el, value);
+    el.dispatchEvent(new Event("input", { bubbles: true }));
+  });
+}
+
+function submitBtn(container: HTMLElement): HTMLButtonElement {
+  return container.querySelector(
+    '[data-testid="solo-submit"]',
+  ) as HTMLButtonElement;
+}
+
+afterEach(() => {
+  for (const node of [...document.body.children]) node.remove();
+  soloCreate.mockReset();
+});
+
+describe("SoloProfileForm", () => {
+  it("keeps submit disabled until name/username/email are valid, then submits trimmed values", async () => {
+    soloCreate.mockResolvedValue(undefined);
+    const onDone = vi.fn();
+    const { container } = mount(
+      <MemoryRouter>
+        <SoloProfileForm onDone={onDone} />
+      </MemoryRouter>,
+    );
+
+    expect(submitBtn(container).disabled).toBe(true);
+
+    setInput(container, "solo-name", "  Ada Lovelace ");
+    setInput(container, "solo-username", " ada ");
+    expect(submitBtn(container).disabled).toBe(true); // email still missing
+
+    setInput(container, "solo-email", " ada@example.com ");
+    expect(submitBtn(container).disabled).toBe(false);
+
+    await act(async () => {
+      submitBtn(container).click();
+    });
+
+    expect(soloCreate).toHaveBeenCalledWith({
+      name: "Ada Lovelace",
+      username: "ada",
+      email: "ada@example.com",
+    });
+    expect(onDone).toHaveBeenCalled();
+  });
+
+  it("keeps submit disabled for an invalid username", () => {
+    const { container } = mount(
+      <MemoryRouter>
+        <SoloProfileForm />
+      </MemoryRouter>,
+    );
+    setInput(container, "solo-name", "Ada");
+    setInput(container, "solo-username", "has space");
+    setInput(container, "solo-email", "ada@example.com");
+    expect(submitBtn(container).disabled).toBe(true);
+  });
+
+  it("surfaces a server rejection", async () => {
+    soloCreate.mockRejectedValue(new Error("username taken"));
+    const { container } = mount(
+      <MemoryRouter>
+        <SoloProfileForm />
+      </MemoryRouter>,
+    );
+    setInput(container, "solo-name", "Ada");
+    setInput(container, "solo-username", "ada");
+    setInput(container, "solo-email", "ada@example.com");
+    await act(async () => {
+      submitBtn(container).click();
+    });
+    const err = container.querySelector('[data-testid="solo-error"]');
+    expect(err?.textContent).toContain("username taken");
+  });
+});

--- a/src/auth/solo-profile-form.tsx
+++ b/src/auth/solo-profile-form.tsx
@@ -1,0 +1,104 @@
+import { useState } from "react";
+import { useNavigate } from "react-router-dom";
+import { useAuth } from "./auth-context";
+
+// Client-side mirror of the backend validators (`validate_local_name`,
+// `normalize_local_username`, `validate_local_email`). UX nicety only — the
+// server stays authoritative and any rejection it returns is shown below.
+const USERNAME_RE = /^[A-Za-z0-9._-]+$/;
+const EMAIL_RE = /^[^\s@]+@[^\s@]+$/;
+
+/**
+ * The solo onboarding form: full name / username / email → `soloCreate`.
+ * On success calls `onDone` if provided, otherwise navigates to `/`.
+ */
+export function SoloProfileForm({ onDone }: { onDone?: () => void }) {
+  const { soloCreate } = useAuth();
+  const navigate = useNavigate();
+  const [name, setName] = useState("");
+  const [username, setUsername] = useState("");
+  const [email, setEmail] = useState("");
+  const [error, setError] = useState("");
+  const [submitting, setSubmitting] = useState(false);
+
+  const nameOk = name.trim().length > 0 && name.trim().length <= 128;
+  const usernameOk =
+    username.trim().length > 0 &&
+    username.trim().length <= 64 &&
+    USERNAME_RE.test(username.trim());
+  const emailOk = EMAIL_RE.test(email.trim());
+  const canSubmit = nameOk && usernameOk && emailOk && !submitting;
+
+  async function handleSubmit() {
+    if (!canSubmit) return;
+    setError("");
+    setSubmitting(true);
+    try {
+      await soloCreate({
+        name: name.trim(),
+        username: username.trim(),
+        email: email.trim(),
+      });
+      if (onDone) onDone();
+      else navigate("/", { replace: true });
+    } catch (e) {
+      setError(e instanceof Error ? e.message : "Could not create profile");
+    } finally {
+      setSubmitting(false);
+    }
+  }
+
+  return (
+    <div className="space-y-4" data-testid="solo-profile-form">
+      <p className="text-sm text-muted">
+        Create a local profile. It stays on this machine — no email code is sent.
+      </p>
+      <input
+        data-testid="solo-name"
+        type="text"
+        placeholder="Full name"
+        value={name}
+        onChange={(e) => setName(e.target.value)}
+        disabled={submitting}
+        autoFocus
+        className="w-full rounded-lg border border-border bg-surface-light px-4 py-3 text-text placeholder-muted outline-none focus:border-accent"
+      />
+      <div>
+        <input
+          data-testid="solo-username"
+          type="text"
+          placeholder="Username"
+          value={username}
+          onChange={(e) => setUsername(e.target.value)}
+          disabled={submitting}
+          className="w-full rounded-lg border border-border bg-surface-light px-4 py-3 font-mono text-text placeholder-muted outline-none focus:border-accent"
+        />
+        <p className="mt-1 text-xs text-muted">
+          Letters, digits, dot, hyphen or underscore.
+        </p>
+      </div>
+      <input
+        data-testid="solo-email"
+        type="email"
+        placeholder="Email"
+        value={email}
+        onChange={(e) => setEmail(e.target.value)}
+        disabled={submitting}
+        className="w-full rounded-lg border border-border bg-surface-light px-4 py-3 text-text placeholder-muted outline-none focus:border-accent"
+      />
+      {error && (
+        <p data-testid="solo-error" className="text-sm text-red-400">
+          {error}
+        </p>
+      )}
+      <button
+        data-testid="solo-submit"
+        onClick={handleSubmit}
+        disabled={!canSubmit}
+        className="w-full rounded-lg bg-accent py-3 font-medium text-surface-dark transition hover:bg-accent-dim disabled:opacity-50"
+      >
+        {submitting ? "Creating…" : "Create profile & continue"}
+      </button>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary

Brings the **no-password solo login** to the user-facing chat SPA — the web-client counterpart to the admin-dashboard solo flow (octos-org/octos#1391), against the same shared backend endpoints.

- Login page shows **"Continue without a password"** when `/api/auth/status` reports `local_solo_enabled`; `soloLogin` re-logs the local owner, falling back to a name/username/email **`SoloProfileForm`** on first run (HTTP 404).
- `soloLogin`/`soloCreate` persist the minted session token; `soloCreate` also seeds a principal from the create result so user-chrome is populated even if the follow-up `/me` refresh fails (AuthGuard already gates on the token).

## Security

No new trust surface — the server enforces the gate (explicit `--solo` opt-in, loopback peer, no proxy headers; see octos-org/octos `api::solo_auth`). The affordance only appears, and only works, on a Local-mode host started with `--solo`. Fleet hosts (Local behind Caddy) never opt in, so `local_solo_enabled` is false there.

Solo endpoints route through a new **`client.publicRequest`** (no `/api/auth/*` token reaper): a solo 403/404 is a *policy* denial, not a dead session, so it must not log a signed-in user out (codex review fix).

## Validation

- `tsc -b` clean; full unit suite **607/607** (incl. new `SoloProfileForm` tests + `publicRequest` reaper-bypass regression tests).
- Reviewed with `codex review`; the P2 above was found and fixed.