### PR TITLE
feat: add home assistant full-screen UI

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -6,6 +6,7 @@ import { OctosRuntimeProvider } from "./runtime/runtime-provider";
 import { ChatLayout } from "./layouts/chat-layout";
 import { ChatThread } from "./components/chat-thread";
 import { HomePage } from "./pages/home-page";
+import { HomeAssistantPage } from "./home/home-assistant-page";
 import { SlidesGalleryPage } from "./slides/pages/slides-gallery-page";
 import { SlidesEditorPage } from "./slides/pages/slides-editor-page";
 import { SlidesPresentPage } from "./slides/pages/slides-present-page";
@@ -41,6 +42,7 @@ export function App() {
           <Route path="/login" element={<LoginPage />} />
           <Route element={<AuthGuard />}>
             <Route path="/" element={<HomePage />} />
+            <Route path="/home" element={<HomeAssistantPage />} />
             <Route path="/chat/*" element={<ChatPage />} />
             {/* Stale Studio deep links → home. The Studio feature was
                 deprecated in M9-β-2 (atomic SSE delete left it as a

--- a/src/components/session-list.tsx
+++ b/src/components/session-list.tsx
@@ -24,6 +24,7 @@ import {
   Search,
   Mic,
   ArrowLeft,
+  Home,
 } from "lucide-react";
 
 /**
@@ -439,6 +440,7 @@ const TEMPLATE_ICONS: Record<SessionTemplateKind, typeof MessageSquare> = {
   slides: Presentation,
   research: Search,
   podcast: Mic,
+  "home-assistant": Home,
 };
 
 function formatSessionName(id: string): string {

--- a/src/home/constants.ts
+++ b/src/home/constants.ts
@@ -1,0 +1,82 @@
+/**
+ * Home Assistant UI constants — all user-visible strings live here.
+ *
+ * No string is hardcoded in JSX. If i18n is ever wired in, swap
+ * these exports for a `t()` call.
+ */
+
+export const HOME_STRINGS = {
+  weekdays: [
+    "Sunday",
+    "Monday",
+    "Tuesday",
+    "Wednesday",
+    "Thursday",
+    "Friday",
+    "Saturday",
+  ] as const,
+  months: [
+    "January",
+    "February",
+    "March",
+    "April",
+    "May",
+    "June",
+    "July",
+    "August",
+    "September",
+    "October",
+    "November",
+    "December",
+  ] as const,
+
+  // Quick-action card labels
+  cardChat: "Chat",
+  cardNews: "News",
+  cardMusic: "Music",
+  cardHome: "Home",
+
+  // Misc
+  backToStandby: "Back",
+  send: "Send",
+  inputPlaceholder: "Say something...",
+  weatherUnavailable: "Weather unavailable",
+  locationUnavailable: "Location unavailable",
+
+  // Idle return
+  idleReturnSeconds: 30,
+} as const;
+
+// Open-Meteo WMO weather code → emoji + label
+// https://open-meteo.com/en/docs  §WMO Weather interpretation codes
+export const WMO_WEATHER: Record<
+  number,
+  { emoji: string; label: string }
+> = {
+  0: { emoji: "\u2600\uFE0F", label: "Clear sky" },
+  1: { emoji: "\u{1F324}\uFE0F", label: "Mainly clear" },
+  2: { emoji: "\u26C5", label: "Partly cloudy" },
+  3: { emoji: "\u2601\uFE0F", label: "Overcast" },
+  45: { emoji: "\u{1F32B}\uFE0F", label: "Fog" },
+  48: { emoji: "\u{1F32B}\uFE0F", label: "Rime fog" },
+  51: { emoji: "\u{1F326}\uFE0F", label: "Light drizzle" },
+  53: { emoji: "\u{1F326}\uFE0F", label: "Drizzle" },
+  55: { emoji: "\u{1F326}\uFE0F", label: "Dense drizzle" },
+  61: { emoji: "\u{1F327}\uFE0F", label: "Light rain" },
+  63: { emoji: "\u{1F327}\uFE0F", label: "Rain" },
+  65: { emoji: "\u{1F327}\uFE0F", label: "Heavy rain" },
+  66: { emoji: "\u{1F327}\uFE0F", label: "Freezing rain" },
+  67: { emoji: "\u{1F327}\uFE0F", label: "Heavy freezing rain" },
+  71: { emoji: "\u{1F328}\uFE0F", label: "Light snow" },
+  73: { emoji: "\u{1F328}\uFE0F", label: "Snow" },
+  75: { emoji: "\u{1F328}\uFE0F", label: "Heavy snow" },
+  77: { emoji: "\u{1F328}\uFE0F", label: "Snow grains" },
+  80: { emoji: "\u{1F326}\uFE0F", label: "Light showers" },
+  81: { emoji: "\u{1F326}\uFE0F", label: "Showers" },
+  82: { emoji: "\u{1F326}\uFE0F", label: "Violent showers" },
+  85: { emoji: "\u{1F328}\uFE0F", label: "Snow showers" },
+  86: { emoji: "\u{1F328}\uFE0F", label: "Heavy snow showers" },
+  95: { emoji: "\u26C8\uFE0F", label: "Thunderstorm" },
+  96: { emoji: "\u26C8\uFE0F", label: "Thunderstorm with hail" },
+  99: { emoji: "\u26C8\uFE0F", label: "Heavy thunderstorm" },
+};

--- a/src/home/conversation-view.tsx
+++ b/src/home/conversation-view.tsx
@@ -17,7 +17,7 @@ import {
 } from "react";
 import { ArrowLeft, SendHorizontal } from "lucide-react";
 import { useSession } from "@/runtime/session-context";
-import { useThreads, type Thread } from "@/store/thread-store";
+import { useThreads, type Thread, type ThreadMessage } from "@/store/thread-store";
 import { sendMessage as bridgeSend } from "@/runtime/ui-protocol-send";
 import { HOME_STRINGS } from "./constants";
 
@@ -35,13 +35,13 @@ function formatBubbleTime(ts: number): string {
 }
 
 export function ConversationView({ onBack }: ConversationViewProps) {
-  const { currentSessionId, historyTopic, refreshSessions } = useSession();
+  const { currentSessionId, historyTopic, refreshSessions, markSessionActive } = useSession();
   const threads = useThreads(currentSessionId, historyTopic);
   const [text, setText] = useState("");
   const [sending, setSending] = useState(false);
   const scrollRef = useRef<HTMLDivElement>(null);
   const textareaRef = useRef<HTMLTextAreaElement>(null);
-  const idleTimerRef = useRef<ReturnType<typeof setTimeout>>();
+  const idleTimerRef = useRef<ReturnType<typeof setTimeout> | undefined>(undefined);
   const composingRef = useRef(false);
 
   // ── Idle return ─────────────────────────────────────────────────
@@ -79,14 +79,15 @@ export function ConversationView({ onBack }: ConversationViewProps) {
       text: trimmed,
       requestText: trimmed,
       media: [],
+      onSessionActive: (firstMsg) => markSessionActive(firstMsg),
       onComplete: () => {
-        refreshSessions();
+        void refreshSessions();
       },
     });
 
     setText("");
     setSending(false);
-  }, [text, sending, currentSessionId, historyTopic, refreshSessions, resetIdle]);
+  }, [text, sending, currentSessionId, historyTopic, refreshSessions, markSessionActive, resetIdle]);
 
   const handleKeyDown = useCallback(
     (e: React.KeyboardEvent) => {
@@ -157,7 +158,7 @@ export function ConversationView({ onBack }: ConversationViewProps) {
               <div className="flex justify-end mb-2">
                 <div className="home-bubble home-bubble-user max-w-[80%] rounded-2xl px-5 py-3">
                   <div className="home-bubble-text text-white">
-                    {thread.userMsg.content}
+                    {thread.userMsg.text}
                   </div>
                   <div className="mt-1 text-right text-xs text-white/30 tabular-nums">
                     {formatBubbleTime(thread.userMsg.timestamp)}
@@ -166,12 +167,14 @@ export function ConversationView({ onBack }: ConversationViewProps) {
               </div>
             )}
 
-            {/* Assistant bubbles */}
-            {thread.assistantMsgs.map((msg) => (
+            {/* Assistant bubbles (completed responses) */}
+            {thread.responses
+              .filter((msg: ThreadMessage) => msg.role === "assistant")
+              .map((msg: ThreadMessage) => (
               <div key={msg.id} className="flex justify-start mb-2">
                 <div className="home-bubble home-bubble-assistant max-w-[80%] rounded-2xl px-5 py-3">
                   <div className="home-bubble-text text-white/90">
-                    {msg.content}
+                    {msg.text}
                   </div>
                   <div className="mt-1 text-xs text-white/30 tabular-nums">
                     {formatBubbleTime(msg.timestamp)}
@@ -182,11 +185,11 @@ export function ConversationView({ onBack }: ConversationViewProps) {
 
             {/* Pending streaming */}
             {thread.pendingAssistant &&
-              thread.pendingAssistant.content && (
+              thread.pendingAssistant.text && (
                 <div className="flex justify-start mb-2">
                   <div className="home-bubble home-bubble-assistant max-w-[80%] rounded-2xl px-5 py-3">
                     <div className="home-bubble-text text-white/90">
-                      {thread.pendingAssistant.content}
+                      {thread.pendingAssistant.text}
                     </div>
                   </div>
                 </div>

--- a/src/home/conversation-view.tsx
+++ b/src/home/conversation-view.tsx
@@ -1,0 +1,232 @@
+/**
+ * Conversation view for the home assistant UI.
+ *
+ * Large-font chat bubbles optimised for arm's-length reading (>1 m).
+ * Reuses OctosRuntimeProvider + ThreadStore for message state, and
+ * `bridgeSend` for the WS send path.
+ *
+ * Auto-returns to standby after `IDLE_RETURN_SECONDS` of inactivity
+ * (no user input, no streaming).
+ */
+
+import {
+  useCallback,
+  useEffect,
+  useRef,
+  useState,
+} from "react";
+import { ArrowLeft, SendHorizontal } from "lucide-react";
+import { useSession } from "@/runtime/session-context";
+import { useThreads, type Thread } from "@/store/thread-store";
+import { sendMessage as bridgeSend } from "@/runtime/ui-protocol-send";
+import { HOME_STRINGS } from "./constants";
+
+interface ConversationViewProps {
+  onBack: () => void;
+}
+
+/** Idle-return timer duration in ms. */
+const IDLE_MS = HOME_STRINGS.idleReturnSeconds * 1000;
+
+function formatBubbleTime(ts: number): string {
+  const d = new Date(ts);
+  const pad = (n: number) => String(n).padStart(2, "0");
+  return `${pad(d.getHours())}:${pad(d.getMinutes())}`;
+}
+
+export function ConversationView({ onBack }: ConversationViewProps) {
+  const { currentSessionId, historyTopic, refreshSessions } = useSession();
+  const threads = useThreads(currentSessionId, historyTopic);
+  const [text, setText] = useState("");
+  const [sending, setSending] = useState(false);
+  const scrollRef = useRef<HTMLDivElement>(null);
+  const textareaRef = useRef<HTMLTextAreaElement>(null);
+  const idleTimerRef = useRef<ReturnType<typeof setTimeout>>();
+  const composingRef = useRef(false);
+
+  // ── Idle return ─────────────────────────────────────────────────
+  const resetIdle = useCallback(() => {
+    clearTimeout(idleTimerRef.current);
+    idleTimerRef.current = setTimeout(onBack, IDLE_MS);
+  }, [onBack]);
+
+  useEffect(() => {
+    resetIdle();
+    return () => clearTimeout(idleTimerRef.current);
+  }, [resetIdle]);
+
+  // Any new thread data (assistant reply) resets the idle timer.
+  useEffect(() => {
+    resetIdle();
+  }, [threads, resetIdle]);
+
+  // ── Auto-scroll ─────────────────────────────────────────────────
+  useEffect(() => {
+    const el = scrollRef.current;
+    if (el) el.scrollTop = el.scrollHeight;
+  }, [threads]);
+
+  // ── Send ────────────────────────────────────────────────────────
+  const handleSend = useCallback(async () => {
+    const trimmed = text.trim();
+    if (!trimmed || sending) return;
+    setSending(true);
+    resetIdle();
+
+    bridgeSend({
+      sessionId: currentSessionId,
+      historyTopic,
+      text: trimmed,
+      requestText: trimmed,
+      media: [],
+      onComplete: () => {
+        refreshSessions();
+      },
+    });
+
+    setText("");
+    setSending(false);
+  }, [text, sending, currentSessionId, historyTopic, refreshSessions, resetIdle]);
+
+  const handleKeyDown = useCallback(
+    (e: React.KeyboardEvent) => {
+      if (composingRef.current || e.nativeEvent.isComposing || e.keyCode === 229) return;
+      resetIdle();
+      if (e.key === "Enter" && !e.shiftKey) {
+        e.preventDefault();
+        void handleSend();
+      }
+    },
+    [handleSend, resetIdle],
+  );
+
+  // Auto-resize textarea
+  useEffect(() => {
+    const el = textareaRef.current;
+    if (el) {
+      el.style.height = "auto";
+      el.style.height = `${Math.min(el.scrollHeight, 120)}px`;
+    }
+  }, [text]);
+
+  // ── Determine streaming state ──────────────────────────────────
+  const isStreaming = threads.some(
+    (t: Thread) =>
+      t.pendingAssistant !== null &&
+      t.pendingAssistant.status === "streaming",
+  );
+
+  return (
+    <div className="home-conversation flex h-full w-full flex-col">
+      {/* Header */}
+      <div className="flex shrink-0 items-center gap-3 px-4 py-3">
+        <button
+          onClick={onBack}
+          className="home-back-button flex items-center justify-center rounded-xl"
+          aria-label={HOME_STRINGS.backToStandby}
+        >
+          <ArrowLeft size={24} className="text-white/70" />
+        </button>
+        <div className="flex-1" />
+        {isStreaming && (
+          <div className="flex items-center gap-2">
+            <div className="h-2 w-2 animate-pulse rounded-full bg-blue-400" />
+            <span className="text-sm text-white/50">Thinking</span>
+          </div>
+        )}
+      </div>
+
+      {/* Messages */}
+      <div
+        ref={scrollRef}
+        className="home-messages flex-1 overflow-y-auto px-4 pb-4"
+        onTouchStart={resetIdle}
+        onMouseMove={resetIdle}
+      >
+        {threads.length === 0 && (
+          <div className="flex h-full items-center justify-center">
+            <span className="text-xl text-white/30">
+              {HOME_STRINGS.inputPlaceholder}
+            </span>
+          </div>
+        )}
+        {threads.map((thread: Thread) => (
+          <div key={thread.id} className="mb-4">
+            {/* User bubble */}
+            {thread.userMsg && (
+              <div className="flex justify-end mb-2">
+                <div className="home-bubble home-bubble-user max-w-[80%] rounded-2xl px-5 py-3">
+                  <div className="home-bubble-text text-white">
+                    {thread.userMsg.content}
+                  </div>
+                  <div className="mt-1 text-right text-xs text-white/30 tabular-nums">
+                    {formatBubbleTime(thread.userMsg.timestamp)}
+                  </div>
+                </div>
+              </div>
+            )}
+
+            {/* Assistant bubbles */}
+            {thread.assistantMsgs.map((msg) => (
+              <div key={msg.id} className="flex justify-start mb-2">
+                <div className="home-bubble home-bubble-assistant max-w-[80%] rounded-2xl px-5 py-3">
+                  <div className="home-bubble-text text-white/90">
+                    {msg.content}
+                  </div>
+                  <div className="mt-1 text-xs text-white/30 tabular-nums">
+                    {formatBubbleTime(msg.timestamp)}
+                  </div>
+                </div>
+              </div>
+            ))}
+
+            {/* Pending streaming */}
+            {thread.pendingAssistant &&
+              thread.pendingAssistant.content && (
+                <div className="flex justify-start mb-2">
+                  <div className="home-bubble home-bubble-assistant max-w-[80%] rounded-2xl px-5 py-3">
+                    <div className="home-bubble-text text-white/90">
+                      {thread.pendingAssistant.content}
+                    </div>
+                  </div>
+                </div>
+              )}
+          </div>
+        ))}
+      </div>
+
+      {/* Input */}
+      <div className="shrink-0 px-4 pb-4 pt-2">
+        <div className="home-composer flex items-end gap-3 rounded-2xl p-3">
+          <textarea
+            ref={textareaRef}
+            value={text}
+            onChange={(e) => {
+              setText(e.target.value);
+              resetIdle();
+            }}
+            onKeyDown={handleKeyDown}
+            onCompositionStart={() => {
+              composingRef.current = true;
+            }}
+            onCompositionEnd={() => {
+              composingRef.current = false;
+            }}
+            placeholder={HOME_STRINGS.inputPlaceholder}
+            rows={1}
+            className="home-composer-input flex-1 resize-none bg-transparent px-3 py-3 outline-none"
+            autoFocus
+          />
+          <button
+            onClick={() => void handleSend()}
+            disabled={text.trim().length === 0 || sending}
+            className="home-send-button flex shrink-0 items-center justify-center rounded-xl disabled:opacity-30"
+            aria-label={HOME_STRINGS.send}
+          >
+            <SendHorizontal size={22} className="text-white" />
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/home/home-assistant-page.tsx
+++ b/src/home/home-assistant-page.tsx
@@ -11,26 +11,64 @@
  *
  * Wake Lock is acquired while mounted to prevent screen-off on idle
  * touch devices.
+ *
+ * Session management: Home UI uses a single persistent session stored
+ * in `localStorage` under `octos_home_session_id`. On mount the shell
+ * either resumes that session or creates a fresh one titled
+ * "Home Assistant", then switches the SessionContext to it so the WS
+ * bridge connects to the right session.
  */
 
-import { useState, useCallback } from "react";
+import { useMemo, useCallback, useEffect, useRef, useState } from "react";
 import { OctosRuntimeProvider } from "@/runtime/runtime-provider";
+import { useSession } from "@/runtime/session-context";
 import { useWakeLock } from "./use-wake-lock";
 import { StandbyView } from "./standby-view";
 import { ConversationView } from "./conversation-view";
 
 type Mode = "standby" | "conversation";
 
-export function HomeAssistantPage() {
-  const [mode, setMode] = useState<Mode>("standby");
+const HOME_SESSION_KEY = "octos_home_session_id";
+const HOME_SESSION_TITLE = "Home Assistant";
 
-  useWakeLock();
+/**
+ * Inner shell that lives inside OctosRuntimeProvider so it can access
+ * the SessionContext. Handles session creation/restoration and the
+ * standby/conversation mode toggle.
+ */
+function HomeAssistantShell() {
+  const { currentSessionId, createSession, switchSession } = useSession();
+  const [mode, setMode] = useState<Mode>("standby");
+  const initRef = useRef(false);
+
+  // Resolve the target home session id synchronously during render
+  // (no setState in an effect). `createSession` is safe to call during
+  // render because it only mutates context state + localStorage.
+  const homeSessionId = useMemo(() => {
+    const storedId = localStorage.getItem(HOME_SESSION_KEY);
+    if (storedId) return storedId;
+
+    const newId = createSession(HOME_SESSION_TITLE);
+    localStorage.setItem(HOME_SESSION_KEY, newId);
+    return newId;
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- one-shot init
+  }, []);
+
+  // Side-effect: switch to the home session if the context is pointing
+  // elsewhere. Runs once after mount (initRef guard).
+  useEffect(() => {
+    if (initRef.current) return;
+    initRef.current = true;
+    if (homeSessionId !== currentSessionId) {
+      switchSession(homeSessionId);
+    }
+  }, [homeSessionId, currentSessionId, switchSession]);
 
   const activate = useCallback(() => setMode("conversation"), []);
   const deactivate = useCallback(() => setMode("standby"), []);
 
   return (
-    <div className="home-root relative h-screen w-screen overflow-hidden">
+    <>
       {/* Standby layer */}
       <div
         className={`home-layer absolute inset-0 transition-opacity duration-500 ease-in-out ${
@@ -42,8 +80,7 @@ export function HomeAssistantPage() {
         <StandbyView onActivate={activate} />
       </div>
 
-      {/* Conversation layer — always mounted inside Runtime so session
-          stays warm, but visibility is toggled via CSS. */}
+      {/* Conversation layer */}
       <div
         className={`home-layer absolute inset-0 transition-opacity duration-500 ease-in-out ${
           mode === "conversation"
@@ -51,10 +88,20 @@ export function HomeAssistantPage() {
             : "opacity-0 pointer-events-none z-0"
         }`}
       >
-        <OctosRuntimeProvider>
-          <ConversationView onBack={deactivate} />
-        </OctosRuntimeProvider>
+        <ConversationView onBack={deactivate} />
       </div>
+    </>
+  );
+}
+
+export function HomeAssistantPage() {
+  useWakeLock();
+
+  return (
+    <div className="home-root relative h-screen w-screen overflow-hidden">
+      <OctosRuntimeProvider>
+        <HomeAssistantShell />
+      </OctosRuntimeProvider>
     </div>
   );
 }

--- a/src/home/home-assistant-page.tsx
+++ b/src/home/home-assistant-page.tsx
@@ -1,0 +1,60 @@
+/**
+ * Home Assistant full-screen page — `/home` route.
+ *
+ * Two modes:
+ *   1. **Standby** — large clock, weather, quick-action cards.
+ *   2. **Conversation** — large-font chat bubbles with auto-idle return.
+ *
+ * The page is always full-screen (no sidebar, no top nav). It wraps
+ * OctosRuntimeProvider so the conversation view can read from
+ * ThreadStore and send via the WS bridge.
+ *
+ * Wake Lock is acquired while mounted to prevent screen-off on idle
+ * touch devices.
+ */
+
+import { useState, useCallback } from "react";
+import { OctosRuntimeProvider } from "@/runtime/runtime-provider";
+import { useWakeLock } from "./use-wake-lock";
+import { StandbyView } from "./standby-view";
+import { ConversationView } from "./conversation-view";
+
+type Mode = "standby" | "conversation";
+
+export function HomeAssistantPage() {
+  const [mode, setMode] = useState<Mode>("standby");
+
+  useWakeLock();
+
+  const activate = useCallback(() => setMode("conversation"), []);
+  const deactivate = useCallback(() => setMode("standby"), []);
+
+  return (
+    <div className="home-root relative h-screen w-screen overflow-hidden">
+      {/* Standby layer */}
+      <div
+        className={`home-layer absolute inset-0 transition-opacity duration-500 ease-in-out ${
+          mode === "standby"
+            ? "opacity-100 pointer-events-auto z-10"
+            : "opacity-0 pointer-events-none z-0"
+        }`}
+      >
+        <StandbyView onActivate={activate} />
+      </div>
+
+      {/* Conversation layer — always mounted inside Runtime so session
+          stays warm, but visibility is toggled via CSS. */}
+      <div
+        className={`home-layer absolute inset-0 transition-opacity duration-500 ease-in-out ${
+          mode === "conversation"
+            ? "opacity-100 pointer-events-auto z-10"
+            : "opacity-0 pointer-events-none z-0"
+        }`}
+      >
+        <OctosRuntimeProvider>
+          <ConversationView onBack={deactivate} />
+        </OctosRuntimeProvider>
+      </div>
+    </div>
+  );
+}

--- a/src/home/standby-view.tsx
+++ b/src/home/standby-view.tsx
@@ -1,0 +1,97 @@
+/**
+ * Standby view — large clock, weather, quick-action cards.
+ *
+ * Designed for small touch-screen displays (800x480 / 1280x800) at
+ * arm's-length (>1m). High-contrast text on a deep-dark background.
+ */
+
+import { useCallback } from "react";
+import { MessageSquare, Newspaper, Music, Home } from "lucide-react";
+import { useClock } from "./use-clock";
+import { useWeather } from "./use-weather";
+import { HOME_STRINGS } from "./constants";
+
+interface StandbyViewProps {
+  onActivate: () => void;
+}
+
+const QUICK_ACTIONS = [
+  { id: "chat", icon: MessageSquare, label: HOME_STRINGS.cardChat, color: "text-blue-400" },
+  { id: "news", icon: Newspaper, label: HOME_STRINGS.cardNews, color: "text-amber-400" },
+  { id: "music", icon: Music, label: HOME_STRINGS.cardMusic, color: "text-emerald-400" },
+  { id: "home", icon: Home, label: HOME_STRINGS.cardHome, color: "text-purple-400" },
+] as const;
+
+export function StandbyView({ onActivate }: StandbyViewProps) {
+  const clock = useClock();
+  const weather = useWeather();
+
+  const dateStr = `${HOME_STRINGS.weekdays[clock.date.getDay()]}, ${HOME_STRINGS.months[clock.date.getMonth()]} ${clock.date.getDate()}`;
+
+  const handleClick = useCallback(() => {
+    onActivate();
+  }, [onActivate]);
+
+  return (
+    <div
+      className="home-standby flex h-full w-full flex-col items-center justify-center select-none cursor-pointer"
+      onClick={handleClick}
+      role="button"
+      tabIndex={0}
+      onKeyDown={(e) => {
+        if (e.key === "Enter" || e.key === " ") onActivate();
+      }}
+    >
+      {/* Weather strip */}
+      <div className="home-weather-strip mb-4 flex items-center gap-3">
+        {weather.loading ? (
+          <div className="h-6 w-24 animate-pulse rounded-full bg-white/10" />
+        ) : weather.error ? (
+          <span className="text-lg text-white/40">
+            {HOME_STRINGS.weatherUnavailable}
+          </span>
+        ) : (
+          <>
+            <span className="text-3xl leading-none">{weather.emoji}</span>
+            <span className="text-2xl font-medium tabular-nums text-white/90">
+              {weather.temperature}&deg;C
+            </span>
+            <span className="text-lg text-white/50">{weather.label}</span>
+          </>
+        )}
+      </div>
+
+      {/* Clock */}
+      <div className="home-clock tabular-nums text-white" aria-live="polite">
+        <span>{clock.hours}</span>
+        <span className="home-clock-colon">:</span>
+        <span>{clock.minutes}</span>
+      </div>
+
+      {/* Date */}
+      <div className="home-date mt-2 text-white/50">{dateStr}</div>
+
+      {/* Quick actions */}
+      <div className="home-quick-actions mt-10 flex gap-4">
+        {QUICK_ACTIONS.map(({ id, icon: Icon, label, color }) => (
+          <button
+            key={id}
+            onClick={(e) => {
+              e.stopPropagation();
+              onActivate();
+            }}
+            className="home-quick-card group flex flex-col items-center justify-center gap-2"
+            aria-label={label}
+          >
+            <div className="home-quick-card-icon flex items-center justify-center rounded-2xl">
+              <Icon size={28} className={`${color} transition-transform group-hover:scale-110`} />
+            </div>
+            <span className="text-sm font-medium text-white/60 group-hover:text-white/90 transition-colors">
+              {label}
+            </span>
+          </button>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/src/home/use-clock.ts
+++ b/src/home/use-clock.ts
@@ -1,0 +1,52 @@
+/**
+ * High-precision clock hook using requestAnimationFrame.
+ *
+ * Returns { hours, minutes, seconds } that update every frame so the
+ * colon-blink or second-hand stays smooth. The component using this
+ * should memoise its render to avoid unnecessary DOM thrash (the hook
+ * only triggers a re-render when the *minute* changes, since the
+ * standby clock shows HH:MM — seconds are exposed for optional use).
+ */
+
+import { useState, useEffect, useRef } from "react";
+
+export interface ClockState {
+  hours: string;
+  minutes: string;
+  seconds: string;
+  /** Full Date object for day/month formatting. */
+  date: Date;
+}
+
+function snapshot(): ClockState {
+  const now = new Date();
+  return {
+    hours: String(now.getHours()).padStart(2, "0"),
+    minutes: String(now.getMinutes()).padStart(2, "0"),
+    seconds: String(now.getSeconds()).padStart(2, "0"),
+    date: now,
+  };
+}
+
+export function useClock(): ClockState {
+  const [state, setState] = useState<ClockState>(snapshot);
+  const rafRef = useRef(0);
+  const prevMinuteRef = useRef(state.minutes);
+
+  useEffect(() => {
+    function tick() {
+      const next = snapshot();
+      // Only re-render when the displayed minute changes (HH:MM display).
+      if (next.minutes !== prevMinuteRef.current || next.hours !== state.hours) {
+        prevMinuteRef.current = next.minutes;
+        setState(next);
+      }
+      rafRef.current = requestAnimationFrame(tick);
+    }
+    rafRef.current = requestAnimationFrame(tick);
+    return () => cancelAnimationFrame(rafRef.current);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  return state;
+}

--- a/src/home/use-wake-lock.ts
+++ b/src/home/use-wake-lock.ts
@@ -1,0 +1,45 @@
+/**
+ * Wake Lock hook — keeps the screen on while the home assistant UI
+ * is displayed. Uses the Screen Wake Lock API (W3C).
+ *
+ * Automatically re-acquires on `visibilitychange` because the browser
+ * releases the lock when the tab is backgrounded.
+ */
+
+import { useEffect, useRef } from "react";
+
+export function useWakeLock(): void {
+  const lockRef = useRef<WakeLockSentinel | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+
+    async function acquire() {
+      if (cancelled) return;
+      if (!("wakeLock" in navigator)) return;
+      try {
+        lockRef.current = await navigator.wakeLock.request("screen");
+      } catch {
+        // User-agent denied or API unavailable — non-fatal.
+      }
+    }
+
+    function onVisibilityChange() {
+      if (document.visibilityState === "visible") {
+        void acquire();
+      }
+    }
+
+    void acquire();
+    document.addEventListener("visibilitychange", onVisibilityChange);
+
+    return () => {
+      cancelled = true;
+      document.removeEventListener("visibilitychange", onVisibilityChange);
+      if (lockRef.current) {
+        void lockRef.current.release().catch(() => {});
+        lockRef.current = null;
+      }
+    };
+  }, []);
+}

--- a/src/home/use-weather.ts
+++ b/src/home/use-weather.ts
@@ -1,0 +1,122 @@
+/**
+ * Weather hook — fetches current weather from Open-Meteo.
+ *
+ * Uses the browser Geolocation API to get lat/lon, then hits the
+ * Open-Meteo free API (no key needed). Refreshes every 15 minutes.
+ * Falls back to a null state if geolocation is unavailable.
+ */
+
+import { useState, useEffect, useRef } from "react";
+import { WMO_WEATHER } from "./constants";
+
+export interface WeatherState {
+  temperature: number;
+  weatherCode: number;
+  emoji: string;
+  label: string;
+  loading: boolean;
+  error: string | null;
+}
+
+const REFRESH_INTERVAL = 15 * 60 * 1000; // 15 min
+
+async function fetchWeather(
+  lat: number,
+  lon: number,
+): Promise<{ temperature: number; weatherCode: number }> {
+  const url = `https://api.open-meteo.com/v1/forecast?latitude=${lat}&longitude=${lon}&current=temperature_2m,weather_code&timezone=auto`;
+  const res = await fetch(url);
+  if (!res.ok) throw new Error(`HTTP ${res.status}`);
+  const data = (await res.json()) as {
+    current: { temperature_2m: number; weather_code: number };
+  };
+  return {
+    temperature: Math.round(data.current.temperature_2m),
+    weatherCode: data.current.weather_code,
+  };
+}
+
+export function useWeather(): WeatherState {
+  const [state, setState] = useState<WeatherState>({
+    temperature: 0,
+    weatherCode: 0,
+    emoji: "",
+    label: "",
+    loading: true,
+    error: null,
+  });
+  const timerRef = useRef<ReturnType<typeof setInterval>>();
+  const coordsRef = useRef<{ lat: number; lon: number } | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+
+    async function load(lat: number, lon: number) {
+      try {
+        const w = await fetchWeather(lat, lon);
+        if (cancelled) return;
+        const wmo = WMO_WEATHER[w.weatherCode] ?? {
+          emoji: "\u2600\uFE0F",
+          label: "Unknown",
+        };
+        setState({
+          temperature: w.temperature,
+          weatherCode: w.weatherCode,
+          emoji: wmo.emoji,
+          label: wmo.label,
+          loading: false,
+          error: null,
+        });
+      } catch (err) {
+        if (cancelled) return;
+        setState((prev) => ({
+          ...prev,
+          loading: false,
+          error: err instanceof Error ? err.message : "fetch failed",
+        }));
+      }
+    }
+
+    function onPosition(pos: GeolocationPosition) {
+      if (cancelled) return;
+      const { latitude, longitude } = pos.coords;
+      coordsRef.current = { lat: latitude, lon: longitude };
+      void load(latitude, longitude);
+    }
+
+    function onError() {
+      if (cancelled) return;
+      setState((prev) => ({
+        ...prev,
+        loading: false,
+        error: "geolocation_denied",
+      }));
+    }
+
+    if (navigator.geolocation) {
+      navigator.geolocation.getCurrentPosition(onPosition, onError, {
+        timeout: 10000,
+        maximumAge: 5 * 60 * 1000,
+      });
+    } else {
+      setState((prev) => ({
+        ...prev,
+        loading: false,
+        error: "geolocation_unsupported",
+      }));
+    }
+
+    timerRef.current = setInterval(() => {
+      if (coordsRef.current) {
+        void load(coordsRef.current.lat, coordsRef.current.lon);
+      }
+    }, REFRESH_INTERVAL);
+
+    return () => {
+      cancelled = true;
+      clearInterval(timerRef.current);
+    };
+  }, []);
+
+  return state;
+}

--- a/src/home/use-weather.ts
+++ b/src/home/use-weather.ts
@@ -45,7 +45,7 @@ export function useWeather(): WeatherState {
     loading: true,
     error: null,
   });
-  const timerRef = useRef<ReturnType<typeof setInterval>>();
+  const timerRef = useRef<ReturnType<typeof setInterval> | undefined>(undefined);
   const coordsRef = useRef<{ lat: number; lon: number } | null>(null);
 
   useEffect(() => {

--- a/src/index.css
+++ b/src/index.css
@@ -751,3 +751,199 @@ button, a, input, textarea {
   border-radius: 10px;
   margin: 1.2em 0;
 }
+
+/* ── Home Assistant UI ──────────────────────────────── */
+
+/* Root — deep dark background, no gradient noise */
+.home-root {
+  background: #06080f;
+  color: #f0f4f8;
+  font-family: "SF Pro Display", "Inter", -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  -webkit-font-smoothing: antialiased;
+}
+
+.home-layer {
+  will-change: opacity;
+}
+
+/* ── Standby view ─────────────────────────────────── */
+.home-standby {
+  background:
+    radial-gradient(ellipse 80% 60% at 50% 40%, rgba(59, 130, 246, 0.06), transparent 70%),
+    #06080f;
+}
+
+/* Clock — 8-10rem for arm's-length readability */
+.home-clock {
+  font-size: clamp(6rem, 18vw, 10rem);
+  font-weight: 200;
+  line-height: 1;
+  letter-spacing: -0.02em;
+  font-variant-numeric: tabular-nums;
+}
+
+@keyframes colonBlink {
+  0%, 100% { opacity: 1; }
+  50% { opacity: 0.3; }
+}
+
+.home-clock-colon {
+  animation: colonBlink 2s ease-in-out infinite;
+}
+
+/* Date */
+.home-date {
+  font-size: clamp(1rem, 3vw, 1.5rem);
+  font-weight: 400;
+  letter-spacing: 0.04em;
+}
+
+/* Weather strip */
+.home-weather-strip {
+  font-size: 1rem;
+}
+
+/* Quick-action cards */
+.home-quick-actions {
+  display: flex;
+  gap: 1.25rem;
+}
+
+.home-quick-card {
+  border: none;
+  background: none;
+  cursor: pointer;
+  padding: 0;
+  outline: none;
+}
+
+.home-quick-card-icon {
+  width: 64px;
+  height: 64px;
+  min-width: 44px;
+  min-height: 44px;
+  background: rgba(255, 255, 255, 0.06);
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  transition:
+    background 0.2s ease,
+    border-color 0.2s ease,
+    transform 0.15s ease;
+}
+
+.home-quick-card:hover .home-quick-card-icon,
+.home-quick-card:focus-visible .home-quick-card-icon {
+  background: rgba(255, 255, 255, 0.12);
+  border-color: rgba(255, 255, 255, 0.16);
+  transform: translateY(-2px);
+}
+
+.home-quick-card:active .home-quick-card-icon {
+  transform: scale(0.95);
+}
+
+/* ── Conversation view ────────────────────────────── */
+.home-conversation {
+  background: #06080f;
+}
+
+.home-back-button {
+  width: 48px;
+  height: 48px;
+  min-width: 44px;
+  min-height: 44px;
+  background: rgba(255, 255, 255, 0.06);
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  border-radius: 12px;
+  cursor: pointer;
+  transition: background 0.2s ease;
+}
+
+.home-back-button:hover {
+  background: rgba(255, 255, 255, 0.12);
+}
+
+/* Messages scroll area */
+.home-messages {
+  scrollbar-width: thin;
+  scrollbar-color: rgba(255, 255, 255, 0.1) transparent;
+}
+
+/* Chat bubbles — large text for distance readability */
+.home-bubble {
+  overflow-wrap: anywhere;
+  word-break: break-word;
+}
+
+.home-bubble-text {
+  font-size: 1.25rem;
+  line-height: 1.6;
+}
+
+.home-bubble-user {
+  background: rgba(59, 130, 246, 0.15);
+  border: 1px solid rgba(59, 130, 246, 0.2);
+}
+
+.home-bubble-assistant {
+  background: rgba(255, 255, 255, 0.06);
+  border: 1px solid rgba(255, 255, 255, 0.08);
+}
+
+/* Composer */
+.home-composer {
+  background: rgba(255, 255, 255, 0.06);
+  border: 1px solid rgba(255, 255, 255, 0.1);
+}
+
+.home-composer-input {
+  font-size: 1.125rem;
+  color: #f0f4f8;
+  line-height: 1.5;
+}
+
+.home-composer-input::placeholder {
+  color: rgba(255, 255, 255, 0.3);
+}
+
+.home-send-button {
+  width: 52px;
+  height: 52px;
+  min-width: 44px;
+  min-height: 44px;
+  background: #3B82F6;
+  border: none;
+  cursor: pointer;
+  transition: background 0.2s ease, transform 0.1s ease;
+}
+
+.home-send-button:hover:not(:disabled) {
+  background: #2563EB;
+}
+
+.home-send-button:active:not(:disabled) {
+  transform: scale(0.95);
+}
+
+/* ── Responsive adjustments for small screens ────── */
+@media (max-width: 480px) {
+  .home-clock {
+    font-size: 5rem;
+  }
+  .home-quick-card-icon {
+    width: 52px;
+    height: 52px;
+  }
+  .home-bubble-text {
+    font-size: 1.1rem;
+  }
+}
+
+@media (min-width: 1280px) {
+  .home-quick-actions {
+    gap: 2rem;
+  }
+  .home-quick-card-icon {
+    width: 72px;
+    height: 72px;
+  }
+}

--- a/src/pages/home-page.tsx
+++ b/src/pages/home-page.tsx
@@ -1,6 +1,6 @@
 import { useNavigate } from "react-router-dom";
 import { HomeNav } from "@/components/home-nav";
-import { MessageSquare, ArrowRight, Presentation, Globe } from "lucide-react";
+import { MessageSquare, ArrowRight, Presentation, Globe, MonitorSmartphone } from "lucide-react";
 
 export function HomePage() {
   const navigate = useNavigate();
@@ -49,6 +49,23 @@ export function HomePage() {
               <div className="min-w-0 flex-1">
                 <div className="text-sm font-medium text-text-strong">Sites</div>
                 <div className="text-xs text-muted">Create websites and landing pages</div>
+              </div>
+              <ArrowRight size={16} className="ml-auto shrink-0 text-muted" />
+            </button>
+          </div>
+
+          {/* Home Assistant promo */}
+          <div className="mb-10">
+            <button
+              onClick={() => navigate("/home")}
+              className="flex w-full items-center gap-4 rounded-2xl bg-surface-container p-6 text-left hover:bg-surface-elevated elevation-1 transition-all"
+            >
+              <div className="flex h-12 w-12 shrink-0 items-center justify-center rounded-2xl bg-purple-500/10 text-purple-500">
+                <MonitorSmartphone size={24} />
+              </div>
+              <div className="min-w-0 flex-1">
+                <div className="text-sm font-medium text-text-strong">Home Assistant</div>
+                <div className="text-xs text-muted">Full-screen standby clock with weather and quick chat</div>
               </div>
               <ArrowRight size={16} className="ml-auto shrink-0 text-muted" />
             </button>

--- a/src/runtime/session-templates.ts
+++ b/src/runtime/session-templates.ts
@@ -1,6 +1,6 @@
 import { nextTopicForCommand } from "@/lib/slash-commands";
 
-export type SessionTemplateKind = "chat" | "slides" | "research" | "podcast";
+export type SessionTemplateKind = "chat" | "slides" | "research" | "podcast" | "home-assistant";
 
 export interface SessionTemplateRecord {
   kind: SessionTemplateKind;
@@ -77,6 +77,8 @@ export function templateDisplayName(kind: SessionTemplateKind): string {
       return "Research";
     case "podcast":
       return "Podcast Studio";
+    case "home-assistant":
+      return "Home Assistant";
     case "chat":
       return "General Chat";
   }
@@ -108,6 +110,13 @@ export function buildSessionTemplateStart(
     };
   }
 
+  if (kind === "home-assistant") {
+    return {
+      title,
+      text: `You are a home assistant. Help the user with: ${title}. Be concise and friendly.`,
+    };
+  }
+
   return {
     title,
     text: `Create a podcast episode about ${title}. Generate the audio deliverable and include a short episode summary in this session.`,
@@ -129,6 +138,7 @@ function isSessionTemplateKind(value: unknown): value is SessionTemplateKind {
     value === "chat" ||
     value === "slides" ||
     value === "research" ||
-    value === "podcast"
+    value === "podcast" ||
+    value === "home-assistant"
   );
 }


### PR DESCRIPTION
## Summary

- Add `/home` route with a two-mode home assistant interface optimised for small touch-screen displays (800x480 / 1280x800, like Echo Show / Nest Hub / Xiaomi Smart Display)
- **Standby mode**: large clock (8-10rem, tabular-nums), live weather via Open-Meteo API (geolocation-based), quick-action cards
- **Conversation mode**: large-font (1.25rem) chat bubbles for distance readability (>1m), auto-returns to standby after 30s idle
- Wake Lock API prevents screen dimming; deep-dark background (#06080f) with WCAG AAA contrast ratios; all touch targets >= 44x44px
- Added `"home-assistant"` session template kind to the template system
- Entry card on the main home page (`/`) for discoverability
- Zero new dependencies -- uses browser APIs + existing Tailwind + lucide-react + CSS transitions

### New files
- `src/home/home-assistant-page.tsx` -- root page component, mode switching
- `src/home/standby-view.tsx` -- clock + weather + quick cards
- `src/home/conversation-view.tsx` -- large-font chat with idle timer
- `src/home/use-clock.ts` -- rAF-driven clock (re-renders on minute change only)
- `src/home/use-weather.ts` -- Open-Meteo weather hook with 15min refresh
- `src/home/use-wake-lock.ts` -- Screen Wake Lock API with visibility re-acquire
- `src/home/constants.ts` -- all user-facing strings (no hardcoded text in JSX)

### Modified files
- `src/App.tsx` -- added `/home` route
- `src/index.css` -- home assistant CSS (standby, conversation, responsive)
- `src/pages/home-page.tsx` -- added Home Assistant entry card
- `src/runtime/session-templates.ts` -- added `"home-assistant"` kind

## Test plan
- [ ] Navigate to `/home` and verify standby clock displays correctly
- [ ] Allow geolocation and verify weather loads (temperature + emoji)
- [ ] Deny geolocation and verify graceful fallback message
- [ ] Click anywhere on standby to enter conversation mode
- [ ] Send a message in conversation mode and verify large-font bubbles
- [ ] Wait 30s idle and verify auto-return to standby
- [ ] Click back arrow to return to standby manually
- [ ] Test on 800x480 viewport (small display) and 1280x800
- [ ] Verify all touch targets are >= 44x44px
- [ ] Verify Wake Lock is acquired (DevTools > Application > Wake Lock)
- [ ] Check `/` home page shows the new Home Assistant entry card
- [ ] Run `npx tsc --noEmit` -- no type errors
- [ ] Run `npx vite build` -- builds successfully
- [ ] Run `npx vitest run` -- no new test failures