### PR TITLE
feat(settings): LLM provider catalog, test connection, gateway params

### DIFF
--- a/src/settings/llm-providers.ts
+++ b/src/settings/llm-providers.ts
@@ -1,0 +1,106 @@
+export interface LlmProvider {
+  id: string;
+  name: string;
+  envKey: string;
+  defaultBaseUrl?: string;
+  models: { id: string; name: string }[];
+}
+
+export const LLM_PROVIDERS: LlmProvider[] = [
+  {
+    id: "openai",
+    name: "OpenAI",
+    envKey: "OPENAI_API_KEY",
+    models: [
+      { id: "gpt-5", name: "GPT-5" },
+      { id: "gpt-5.3-codex", name: "GPT-5.3 Codex" },
+      { id: "gpt-5.1-codex", name: "GPT-5.1 Codex" },
+      { id: "gpt-4o", name: "GPT-4o" },
+      { id: "gpt-4o-mini", name: "GPT-4o Mini" },
+    ],
+  },
+  {
+    id: "anthropic",
+    name: "Anthropic",
+    envKey: "ANTHROPIC_API_KEY",
+    models: [
+      { id: "claude-sonnet-4-20250514", name: "Claude Sonnet 4" },
+      { id: "claude-haiku-4-5", name: "Claude Haiku 4.5" },
+    ],
+  },
+  {
+    id: "deepseek",
+    name: "DeepSeek",
+    envKey: "DEEPSEEK_API_KEY",
+    models: [
+      { id: "deepseek-v3.2", name: "DeepSeek V3.2" },
+      { id: "deepseek-chat", name: "DeepSeek Chat" },
+      { id: "deepseek-r1", name: "DeepSeek R1" },
+    ],
+  },
+  {
+    id: "google",
+    name: "Google Gemini",
+    envKey: "GEMINI_API_KEY",
+    models: [
+      { id: "gemini-3.1-pro-preview", name: "Gemini 3.1 Pro" },
+      { id: "gemini-3-flash-preview", name: "Gemini 3 Flash" },
+    ],
+  },
+  {
+    id: "groq",
+    name: "Groq",
+    envKey: "GROQ_API_KEY",
+    models: [{ id: "llama-3.3-70b-versatile", name: "Llama 3.3 70B" }],
+  },
+  {
+    id: "ollama",
+    name: "Ollama (Local)",
+    envKey: "",
+    defaultBaseUrl: "http://localhost:11434",
+    models: [],
+  },
+  { id: "dashscope", name: "DashScope", envKey: "DASHSCOPE_API_KEY", models: [] },
+  { id: "nvidia", name: "NVIDIA", envKey: "NVIDIA_API_KEY", models: [] },
+  {
+    id: "minimax",
+    name: "MiniMax",
+    envKey: "MINIMAX_API_KEY",
+    models: [
+      { id: "MiniMax-M2.7", name: "MiniMax M2.7" },
+      { id: "MiniMax-M2.5", name: "MiniMax M2.5" },
+    ],
+  },
+  { id: "zhipu", name: "Zhipu (GLM)", envKey: "ZHIPU_API_KEY", models: [] },
+  { id: "moonshot", name: "Moonshot", envKey: "MOONSHOT_API_KEY", models: [] },
+  { id: "perplexity", name: "Perplexity", envKey: "PERPLEXITY_API_KEY", models: [] },
+  {
+    id: "mistral",
+    name: "Mistral",
+    envKey: "MISTRAL_API_KEY",
+    models: [{ id: "mistral-large-2512", name: "Mistral Large" }],
+  },
+  { id: "openrouter", name: "OpenRouter", envKey: "OPENROUTER_API_KEY", models: [] },
+  {
+    id: "vllm",
+    name: "vLLM",
+    envKey: "VLLM_API_KEY",
+    defaultBaseUrl: "http://localhost:8000",
+    models: [],
+  },
+  { id: "__custom_family__", name: "Custom Provider", envKey: "", models: [] },
+];
+
+/** Find provider by ID, falling back to custom */
+export function findProvider(id: string): LlmProvider | undefined {
+  return LLM_PROVIDERS.find((p) => p.id === id);
+}
+
+/** Whether this provider should show a base URL field */
+export function showsBaseUrl(provider: LlmProvider): boolean {
+  return (
+    provider.id === "ollama" ||
+    provider.id === "vllm" ||
+    provider.id === "__custom_family__"
+  );
+}

--- a/src/settings/llm-tab.tsx
+++ b/src/settings/llm-tab.tsx
@@ -1,58 +1,191 @@
 import { useState } from "react";
-import { Cpu, Save, Loader2, Check, RotateCcw } from "lucide-react";
+import {
+  Cpu,
+  Save,
+  Loader2,
+  Check,
+  RotateCcw,
+  Plug,
+  Settings2,
+  AlertCircle,
+  CheckCircle2,
+  XCircle,
+} from "lucide-react";
+import { request } from "@/api/client";
 import { updateMyProfile, type Profile } from "./settings-api";
+import {
+  LLM_PROVIDERS,
+  findProvider,
+  showsBaseUrl,
+  type LlmProvider,
+} from "./llm-providers";
+
+/* ─── Props ─── */
 
 interface LlmTabProps {
   profile: Profile;
   onProfileUpdated: (p: Profile) => void;
 }
 
+/* ─── Form State ─── */
+
 interface LlmFormState {
   family_id: string;
   model_id: string;
+  custom_family_id: string;
+  custom_model_id: string;
+  base_url: string;
   system_prompt: string;
-  max_output_tokens: string; // string for input binding, empty = null
+  max_output_tokens: string;
+  max_history: string;
+  max_iterations: string;
+  max_concurrent_sessions: string;
+  browser_timeout_secs: string;
+}
+
+type TestStatus = "idle" | "testing" | "connected" | "failed";
+
+/* ─── Helpers ─── */
+
+function resolveProviderFromProfile(familyId: string): LlmProvider | undefined {
+  return LLM_PROVIDERS.find((p) => p.id === familyId);
 }
 
 function profileToForm(profile: Profile): LlmFormState {
+  const familyId = profile.config.llm.primary.family_id ?? "";
+  const knownProvider = resolveProviderFromProfile(familyId);
+
   return {
-    family_id: profile.config.llm.primary.family_id ?? "",
-    model_id: profile.config.llm.primary.model_id ?? "",
+    family_id: knownProvider ? familyId : familyId ? "__custom_family__" : "",
+    model_id: knownProvider ? (profile.config.llm.primary.model_id ?? "") : "",
+    custom_family_id: knownProvider ? "" : familyId,
+    custom_model_id: knownProvider ? "" : (profile.config.llm.primary.model_id ?? ""),
+    base_url: "",
     system_prompt: profile.config.gateway.system_prompt ?? "",
     max_output_tokens:
       profile.config.gateway.max_output_tokens != null
         ? String(profile.config.gateway.max_output_tokens)
         : "",
+    max_history:
+      profile.config.gateway.max_history != null
+        ? String(profile.config.gateway.max_history)
+        : "",
+    max_iterations:
+      profile.config.gateway.max_iterations != null
+        ? String(profile.config.gateway.max_iterations)
+        : "",
+    max_concurrent_sessions:
+      profile.config.gateway.max_concurrent_sessions != null
+        ? String(profile.config.gateway.max_concurrent_sessions)
+        : "",
+    browser_timeout_secs:
+      profile.config.gateway.browser_timeout_secs != null
+        ? String(profile.config.gateway.browser_timeout_secs)
+        : "",
   };
 }
 
+function optionalInt(value: string): number | null {
+  const trimmed = value.trim();
+  if (!trimmed) return null;
+  const n = parseInt(trimmed, 10);
+  return Number.isNaN(n) ? null : n;
+}
+
+/* ─── Shared UI atoms ─── */
+
+const inputClass =
+  "w-full rounded-xl bg-surface-container px-4 py-3 text-sm text-text placeholder-muted/50 outline-none border border-transparent focus:border-accent/30 transition";
+const selectClass =
+  "w-full rounded-xl bg-surface-container px-4 py-3 text-sm text-text outline-none border border-transparent focus:border-accent/30 transition appearance-none cursor-pointer";
+const labelClass = "mb-1.5 block text-xs font-medium text-muted";
+
+/* ─── Component ─── */
+
 export function LlmTab({ profile, onProfileUpdated }: LlmTabProps) {
   const [form, setForm] = useState<LlmFormState>(() => profileToForm(profile));
-  const [original, setOriginal] = useState<LlmFormState>(() => profileToForm(profile));
+  const [original, setOriginal] = useState<LlmFormState>(() =>
+    profileToForm(profile),
+  );
   const [saving, setSaving] = useState(false);
   const [saved, setSaved] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  const [testStatus, setTestStatus] = useState<TestStatus>("idle");
 
   const isDirty = JSON.stringify(form) !== JSON.stringify(original);
+  const isCustom = form.family_id === "__custom_family__";
+  const selectedProvider = isCustom ? undefined : findProvider(form.family_id);
+  const providerModels = selectedProvider?.models ?? [];
+  const needsBaseUrl = selectedProvider
+    ? showsBaseUrl(selectedProvider)
+    : isCustom;
 
+  /* ── Derived effective IDs (what we send to API) ── */
+  const effectiveFamilyId = isCustom
+    ? form.custom_family_id
+    : form.family_id;
+  const effectiveModelId = isCustom
+    ? form.custom_model_id
+    : form.model_id === "__custom__"
+      ? form.custom_model_id
+      : form.model_id;
+
+  /* ── Provider change ── */
+  const handleProviderChange = (newFamilyId: string) => {
+    const provider = findProvider(newFamilyId);
+    setForm((f) => ({
+      ...f,
+      family_id: newFamilyId,
+      model_id: provider?.models[0]?.id ?? "",
+      custom_family_id: "",
+      custom_model_id: "",
+      base_url: provider?.defaultBaseUrl ?? "",
+    }));
+    setTestStatus("idle");
+  };
+
+  /* ── Test Connection ── */
+  const handleTestConnection = async () => {
+    if (!effectiveFamilyId) return;
+    setTestStatus("testing");
+    try {
+      const envKey = selectedProvider?.envKey || "";
+      await request<{ ok: boolean }>("/api/my/test-provider", {
+        method: "POST",
+        body: JSON.stringify({
+          provider: effectiveFamilyId,
+          api_key_env: envKey || undefined,
+        }),
+      });
+      setTestStatus("connected");
+    } catch {
+      setTestStatus("failed");
+    }
+    setTimeout(() => setTestStatus("idle"), 4000);
+  };
+
+  /* ── Save ── */
   const handleSave = async () => {
     setSaving(true);
     setError(null);
 
-    const maxTokens = form.max_output_tokens.trim()
-      ? parseInt(form.max_output_tokens, 10) || null
-      : null;
-
     const result = await updateMyProfile({
       config: {
         llm: {
-          primary: { family_id: form.family_id, model_id: form.model_id },
+          primary: {
+            family_id: effectiveFamilyId,
+            model_id: effectiveModelId,
+          },
           fallbacks: profile.config.llm.fallbacks,
         },
         gateway: {
           ...profile.config.gateway,
           system_prompt: form.system_prompt.trim() || null,
-          max_output_tokens: maxTokens,
+          max_output_tokens: optionalInt(form.max_output_tokens),
+          max_history: optionalInt(form.max_history),
+          max_iterations: optionalInt(form.max_iterations),
+          max_concurrent_sessions: optionalInt(form.max_concurrent_sessions),
+          browser_timeout_secs: optionalInt(form.browser_timeout_secs),
         },
       },
     });
@@ -72,111 +205,336 @@ export function LlmTab({ profile, onProfileUpdated }: LlmTabProps) {
 
   const handleReset = () => {
     setForm({ ...original });
+    setTestStatus("idle");
   };
 
   return (
     <div className="space-y-6">
+      {/* ── Model Selection ── */}
       <div className="glass-section rounded-2xl p-6">
         <div className="flex items-center gap-3 mb-6">
           <div className="flex h-10 w-10 items-center justify-center rounded-xl bg-accent/10 text-accent">
             <Cpu size={20} />
           </div>
           <div>
-            <h3 className="text-sm font-semibold text-text-strong">LLM Configuration</h3>
-            <p className="text-xs text-muted">Configure the language model for this profile</p>
+            <h3 className="text-sm font-semibold text-text-strong">
+              LLM Configuration
+            </h3>
+            <p className="text-xs text-muted">
+              Select a provider and model for this profile
+            </p>
           </div>
         </div>
 
         <div className="space-y-5">
-          {/* Provider / Family ID */}
+          {/* Provider Family */}
           <div>
-            <label className="mb-1.5 block text-xs font-medium text-muted">
-              Provider (family_id)
-            </label>
-            <input
-              type="text"
+            <label className={labelClass}>Provider</label>
+            <select
               value={form.family_id}
-              onChange={(e) => setForm((f) => ({ ...f, family_id: e.target.value }))}
-              placeholder="e.g. openai, anthropic, deepseek"
-              className="w-full rounded-xl bg-surface-container px-4 py-3 text-sm text-text placeholder-muted/50 outline-none border border-transparent focus:border-accent/30 transition"
-            />
+              onChange={(e) => handleProviderChange(e.target.value)}
+              className={selectClass}
+            >
+              <option value="">Select a provider...</option>
+              {LLM_PROVIDERS.map((p) => (
+                <option key={p.id} value={p.id}>
+                  {p.name}
+                </option>
+              ))}
+            </select>
           </div>
 
-          {/* Model ID */}
+          {/* Custom provider ID (only when Custom selected) */}
+          {isCustom && (
+            <div>
+              <label className={labelClass}>Custom Provider ID</label>
+              <input
+                type="text"
+                value={form.custom_family_id}
+                onChange={(e) =>
+                  setForm((f) => ({ ...f, custom_family_id: e.target.value }))
+                }
+                placeholder="e.g. my-provider"
+                className={inputClass}
+              />
+            </div>
+          )}
+
+          {/* Model selector (when provider has models) */}
+          {!isCustom && providerModels.length > 0 && (
+            <div>
+              <label className={labelClass}>Model</label>
+              <select
+                value={form.model_id}
+                onChange={(e) =>
+                  setForm((f) => ({ ...f, model_id: e.target.value }))
+                }
+                className={selectClass}
+              >
+                {providerModels.map((m) => (
+                  <option key={m.id} value={m.id}>
+                    {m.name}
+                  </option>
+                ))}
+                <option value="__custom__">Custom model...</option>
+              </select>
+            </div>
+          )}
+
+          {/* Custom model input (custom provider, empty model list, or "Custom model..." chosen) */}
+          {(isCustom ||
+            (selectedProvider && providerModels.length === 0) ||
+            form.model_id === "__custom__") && (
+            <div>
+              <label className={labelClass}>
+                {isCustom || providerModels.length === 0
+                  ? "Model ID"
+                  : "Custom Model ID"}
+              </label>
+              <input
+                type="text"
+                value={form.custom_model_id}
+                onChange={(e) =>
+                  setForm((f) => ({ ...f, custom_model_id: e.target.value }))
+                }
+                placeholder="e.g. my-model-v2"
+                className={inputClass}
+              />
+            </div>
+          )}
+
+          {/* Env key hint */}
+          {selectedProvider?.envKey && (
+            <div className="flex items-start gap-2 rounded-xl bg-surface-dark/50 px-4 py-3">
+              <AlertCircle
+                size={14}
+                className="mt-0.5 shrink-0 text-amber-400"
+              />
+              <span className="text-xs text-muted">
+                Requires{" "}
+                <code className="rounded bg-surface-container px-1.5 py-0.5 font-mono text-[11px] text-text">
+                  {selectedProvider.envKey}
+                </code>{" "}
+                in Environment Variables
+              </span>
+            </div>
+          )}
+
+          {/* Base URL (ollama / vllm / custom) */}
+          {needsBaseUrl && (
+            <div>
+              <label className={labelClass}>Base URL</label>
+              <input
+                type="text"
+                value={form.base_url}
+                onChange={(e) =>
+                  setForm((f) => ({ ...f, base_url: e.target.value }))
+                }
+                placeholder={
+                  selectedProvider?.defaultBaseUrl ?? "https://api.example.com"
+                }
+                className={inputClass}
+              />
+            </div>
+          )}
+
+          {/* Test Connection */}
+          {form.family_id && (
+            <div className="flex items-center gap-3">
+              <button
+                onClick={handleTestConnection}
+                disabled={testStatus === "testing" || !effectiveFamilyId}
+                className="flex items-center gap-2 rounded-xl border border-border px-4 py-2.5 text-sm font-medium text-muted hover:text-text-strong hover:border-accent/30 disabled:opacity-30 transition"
+              >
+                {testStatus === "testing" ? (
+                  <Loader2 size={14} className="animate-spin" />
+                ) : (
+                  <Plug size={14} />
+                )}
+                {testStatus === "testing" ? "Testing..." : "Test Connection"}
+              </button>
+              {testStatus === "connected" && (
+                <span className="flex items-center gap-1.5 text-xs font-medium text-green-400">
+                  <CheckCircle2 size={14} />
+                  Connected
+                </span>
+              )}
+              {testStatus === "failed" && (
+                <span className="flex items-center gap-1.5 text-xs font-medium text-red-400">
+                  <XCircle size={14} />
+                  Connection failed
+                </span>
+              )}
+            </div>
+          )}
+        </div>
+      </div>
+
+      {/* ── Prompt & Output ── */}
+      <div className="glass-section rounded-2xl p-6">
+        <div className="flex items-center gap-3 mb-6">
+          <div className="flex h-10 w-10 items-center justify-center rounded-xl bg-accent/10 text-accent">
+            <Settings2 size={20} />
+          </div>
           <div>
-            <label className="mb-1.5 block text-xs font-medium text-muted">
-              Model
-            </label>
-            <input
-              type="text"
-              value={form.model_id}
-              onChange={(e) => setForm((f) => ({ ...f, model_id: e.target.value }))}
-              placeholder="e.g. gpt-5.5, claude-sonnet-4-20250514"
-              className="w-full rounded-xl bg-surface-container px-4 py-3 text-sm text-text placeholder-muted/50 outline-none border border-transparent focus:border-accent/30 transition"
+            <h3 className="text-sm font-semibold text-text-strong">
+              Prompt & Output
+            </h3>
+            <p className="text-xs text-muted">
+              System prompt and output token limit
+            </p>
+          </div>
+        </div>
+
+        <div className="space-y-5">
+          {/* System prompt */}
+          <div>
+            <label className={labelClass}>System Prompt</label>
+            <textarea
+              value={form.system_prompt}
+              onChange={(e) =>
+                setForm((f) => ({ ...f, system_prompt: e.target.value }))
+              }
+              placeholder="Optional system prompt override..."
+              rows={4}
+              className="w-full resize-y rounded-xl bg-surface-container px-4 py-3 text-sm text-text placeholder-muted/50 outline-none border border-transparent focus:border-accent/30 transition"
             />
           </div>
 
           {/* Max Output Tokens */}
           <div>
-            <label className="mb-1.5 block text-xs font-medium text-muted">
-              Max Output Tokens
-            </label>
+            <label className={labelClass}>Max Output Tokens</label>
             <input
               type="number"
               min={256}
               max={128000}
               step={256}
               value={form.max_output_tokens}
-              onChange={(e) => setForm((f) => ({ ...f, max_output_tokens: e.target.value }))}
+              onChange={(e) =>
+                setForm((f) => ({ ...f, max_output_tokens: e.target.value }))
+              }
               placeholder="Leave empty for default"
-              className="w-full rounded-xl bg-surface-container px-4 py-3 text-sm text-text placeholder-muted/50 outline-none border border-transparent focus:border-accent/30 transition"
+              className={inputClass}
             />
           </div>
+        </div>
+      </div>
 
-          {/* System prompt */}
+      {/* ── Gateway Advanced ── */}
+      <div className="glass-section rounded-2xl p-6">
+        <div className="flex items-center gap-3 mb-6">
+          <div className="flex h-10 w-10 items-center justify-center rounded-xl bg-accent/10 text-accent">
+            <Settings2 size={20} />
+          </div>
           <div>
-            <label className="mb-1.5 block text-xs font-medium text-muted">
-              System Prompt
-            </label>
-            <textarea
-              value={form.system_prompt}
-              onChange={(e) => setForm((f) => ({ ...f, system_prompt: e.target.value }))}
-              placeholder="Optional system prompt override..."
-              rows={4}
-              className="w-full resize-y rounded-xl bg-surface-container px-4 py-3 text-sm text-text placeholder-muted/50 outline-none border border-transparent focus:border-accent/30 transition"
-            />
+            <h3 className="text-sm font-semibold text-text-strong">
+              Gateway Parameters
+            </h3>
+            <p className="text-xs text-muted">
+              Advanced session and iteration limits
+            </p>
           </div>
         </div>
 
-        {/* Actions */}
-        <div className="mt-6 flex items-center gap-3">
-          <button
-            onClick={handleSave}
-            disabled={saving || !isDirty}
-            className="flex items-center gap-2 rounded-xl bg-accent px-5 py-2.5 text-sm font-medium text-white hover:bg-accent-dim disabled:opacity-30 transition"
-          >
-            {saving ? (
-              <Loader2 size={14} className="animate-spin" />
-            ) : saved ? (
-              <Check size={14} />
-            ) : (
-              <Save size={14} />
-            )}
-            {saved ? "Saved" : "Save Changes"}
-          </button>
-          {isDirty && (
-            <button
-              onClick={handleReset}
-              className="flex items-center gap-2 rounded-xl border border-border px-4 py-2.5 text-sm text-muted hover:text-text-strong hover:border-accent/30 transition"
-            >
-              <RotateCcw size={14} />
-              Reset
-            </button>
-          )}
-          {error && (
-            <span className="text-xs text-red-400">{error}</span>
-          )}
+        <div className="grid grid-cols-2 gap-4">
+          {/* Max History */}
+          <div>
+            <label className={labelClass}>Max History</label>
+            <input
+              type="number"
+              min={1}
+              max={200}
+              value={form.max_history}
+              onChange={(e) =>
+                setForm((f) => ({ ...f, max_history: e.target.value }))
+              }
+              placeholder="Default"
+              className={inputClass}
+            />
+          </div>
+
+          {/* Max Iterations */}
+          <div>
+            <label className={labelClass}>Max Iterations</label>
+            <input
+              type="number"
+              min={1}
+              max={100}
+              value={form.max_iterations}
+              onChange={(e) =>
+                setForm((f) => ({ ...f, max_iterations: e.target.value }))
+              }
+              placeholder="Default"
+              className={inputClass}
+            />
+          </div>
+
+          {/* Max Concurrent Sessions */}
+          <div>
+            <label className={labelClass}>Max Concurrent Sessions</label>
+            <input
+              type="number"
+              min={1}
+              max={50}
+              value={form.max_concurrent_sessions}
+              onChange={(e) =>
+                setForm((f) => ({
+                  ...f,
+                  max_concurrent_sessions: e.target.value,
+                }))
+              }
+              placeholder="Default"
+              className={inputClass}
+            />
+          </div>
+
+          {/* Browser Timeout */}
+          <div>
+            <label className={labelClass}>Browser Timeout (seconds)</label>
+            <input
+              type="number"
+              min={5}
+              max={600}
+              value={form.browser_timeout_secs}
+              onChange={(e) =>
+                setForm((f) => ({
+                  ...f,
+                  browser_timeout_secs: e.target.value,
+                }))
+              }
+              placeholder="Default"
+              className={inputClass}
+            />
+          </div>
         </div>
+      </div>
+
+      {/* ── Actions ── */}
+      <div className="flex items-center gap-3">
+        <button
+          onClick={handleSave}
+          disabled={saving || !isDirty}
+          className="flex items-center gap-2 rounded-xl bg-accent px-5 py-2.5 text-sm font-medium text-white hover:bg-accent-dim disabled:opacity-30 transition"
+        >
+          {saving ? (
+            <Loader2 size={14} className="animate-spin" />
+          ) : saved ? (
+            <Check size={14} />
+          ) : (
+            <Save size={14} />
+          )}
+          {saved ? "Saved" : "Save Changes"}
+        </button>
+        {isDirty && (
+          <button
+            onClick={handleReset}
+            className="flex items-center gap-2 rounded-xl border border-border px-4 py-2.5 text-sm text-muted hover:text-text-strong hover:border-accent/30 transition"
+          >
+            <RotateCcw size={14} />
+            Reset
+          </button>
+        )}
+        {error && <span className="text-xs text-red-400">{error}</span>}
       </div>
     </div>
   );


### PR DESCRIPTION
## Summary
- Replace free-text family_id/model_id inputs with a **provider dropdown** (16 providers) and **model dropdown** that auto-populates per provider, with custom model fallback for providers with empty or user-extended model lists
- Add **env key hint** (e.g. "Requires OPENAI_API_KEY in Environment Variables") shown contextually per provider
- Add **Base URL** field shown only for Ollama / vLLM / Custom providers
- Add **Test Connection** button (`POST /api/my/test-provider`) with idle/testing/connected/failed state feedback
- Add **Gateway Parameters** section: max_history, max_iterations, max_concurrent_sessions, browser_timeout_secs (all saved via `PUT /api/my/profile`)
- Extract provider catalog to `src/settings/llm-providers.ts` for reuse

## Test plan
- [ ] Select each provider from dropdown, verify model list populates correctly
- [ ] Select "Custom Provider", verify custom family_id and model_id inputs appear
- [ ] Select Ollama/vLLM, verify Base URL field appears with correct default placeholder
- [ ] Select OpenAI, verify env key hint shows "OPENAI_API_KEY"
- [ ] Click "Test Connection", verify loading spinner and success/failure feedback
- [ ] Fill gateway params, save, reload page, verify values persist
- [ ] `tsc -b` passes, `vite build` succeeds, `eslint` clean