### PR TITLE
fix(home): weather fallback, card actions, markdown, send bug

### DIFF
--- a/src/home/constants.ts
+++ b/src/home/constants.ts
@@ -36,6 +36,12 @@ export const HOME_STRINGS = {
   cardMusic: "Music",
   cardHome: "Home",
 
+  // Quick-action card prefills (empty string = no prefill)
+  cardChatPrefill: "",
+  cardNewsPrefill: "What's the latest news today?",
+  cardMusicPrefill: "Play some music for me",
+  cardHomePrefill: "What's the status of my home devices?",
+
   // Misc
   backToStandby: "Back",
   send: "Send",
@@ -45,6 +51,13 @@ export const HOME_STRINGS = {
 
   // Idle return
   idleReturnSeconds: 30,
+} as const;
+
+/** Fallback location used when both geolocation and IP-based lookup fail. */
+export const DEFAULT_LOCATION = {
+  lat: 37.7749,
+  lon: -122.4194,
+  city: "San Francisco",
 } as const;
 
 // Open-Meteo WMO weather code → emoji + label

--- a/src/home/conversation-view.tsx
+++ b/src/home/conversation-view.tsx
@@ -15,6 +15,8 @@ import {
   useRef,
   useState,
 } from "react";
+import ReactMarkdown from "react-markdown";
+import remarkGfm from "remark-gfm";
 import { ArrowLeft, SendHorizontal } from "lucide-react";
 import { useSession } from "@/runtime/session-context";
 import { useThreads, type Thread, type ThreadMessage } from "@/store/thread-store";
@@ -23,6 +25,7 @@ import { HOME_STRINGS } from "./constants";
 
 interface ConversationViewProps {
   onBack: () => void;
+  prefill?: string;
 }
 
 /** Idle-return timer duration in ms. */
@@ -34,7 +37,7 @@ function formatBubbleTime(ts: number): string {
   return `${pad(d.getHours())}:${pad(d.getMinutes())}`;
 }
 
-export function ConversationView({ onBack }: ConversationViewProps) {
+export function ConversationView({ onBack, prefill }: ConversationViewProps) {
   const { currentSessionId, historyTopic, refreshSessions, markSessionActive } = useSession();
   const threads = useThreads(currentSessionId, historyTopic);
   const [text, setText] = useState("");
@@ -43,6 +46,19 @@ export function ConversationView({ onBack }: ConversationViewProps) {
   const textareaRef = useRef<HTMLTextAreaElement>(null);
   const idleTimerRef = useRef<ReturnType<typeof setTimeout> | undefined>(undefined);
   const composingRef = useRef(false);
+  const prefillAppliedRef = useRef<string | undefined>(undefined);
+
+  // ── Prefill from card action ────────────────────────────────────
+  useEffect(() => {
+    if (prefill && prefill !== prefillAppliedRef.current) {
+      prefillAppliedRef.current = prefill;
+      setText(prefill);
+      // Focus the textarea after prefill so the user can confirm/edit
+      requestAnimationFrame(() => {
+        textareaRef.current?.focus();
+      });
+    }
+  }, [prefill]);
 
   // ── Idle return ─────────────────────────────────────────────────
   const resetIdle = useCallback(() => {
@@ -60,6 +76,36 @@ export function ConversationView({ onBack }: ConversationViewProps) {
     resetIdle();
   }, [threads, resetIdle]);
 
+  // ── Fix #4: setSending(false) when thread state changes ─────────
+  // Instead of clearing `sending` immediately after fire-and-forget
+  // `bridgeSend`, we watch for the thread store to reflect the new
+  // assistant activity (pendingAssistant appearing or responses growing).
+  const prevThreadSnapshotRef = useRef<{
+    pendingCount: number;
+    responseCount: number;
+  }>({ pendingCount: 0, responseCount: 0 });
+
+  useEffect(() => {
+    if (!sending) return;
+
+    const pendingCount = threads.filter(
+      (t: Thread) => t.pendingAssistant !== null,
+    ).length;
+    const responseCount = threads.reduce(
+      (sum: number, t: Thread) => sum + t.responses.length,
+      0,
+    );
+
+    const prev = prevThreadSnapshotRef.current;
+    if (
+      pendingCount > prev.pendingCount ||
+      responseCount > prev.responseCount
+    ) {
+      setSending(false);
+    }
+    prevThreadSnapshotRef.current = { pendingCount, responseCount };
+  }, [threads, sending]);
+
   // ── Auto-scroll ─────────────────────────────────────────────────
   useEffect(() => {
     const el = scrollRef.current;
@@ -72,6 +118,18 @@ export function ConversationView({ onBack }: ConversationViewProps) {
     if (!trimmed || sending) return;
     setSending(true);
     resetIdle();
+
+    // Snapshot current thread state BEFORE sending so the effect can
+    // detect when the store changes in response.
+    prevThreadSnapshotRef.current = {
+      pendingCount: threads.filter(
+        (t: Thread) => t.pendingAssistant !== null,
+      ).length,
+      responseCount: threads.reduce(
+        (sum: number, t: Thread) => sum + t.responses.length,
+        0,
+      ),
+    };
 
     bridgeSend({
       sessionId: currentSessionId,
@@ -86,8 +144,9 @@ export function ConversationView({ onBack }: ConversationViewProps) {
     });
 
     setText("");
-    setSending(false);
-  }, [text, sending, currentSessionId, historyTopic, refreshSessions, markSessionActive, resetIdle]);
+    // NOTE: setSending(false) is NOT called here — the useEffect above
+    // clears it when the thread store reflects the new activity.
+  }, [text, sending, threads, currentSessionId, historyTopic, refreshSessions, markSessionActive, resetIdle]);
 
   const handleKeyDown = useCallback(
     (e: React.KeyboardEvent) => {
@@ -153,7 +212,7 @@ export function ConversationView({ onBack }: ConversationViewProps) {
         )}
         {threads.map((thread: Thread) => (
           <div key={thread.id} className="mb-4">
-            {/* User bubble */}
+            {/* User bubble — plain text */}
             {thread.userMsg && (
               <div className="flex justify-end mb-2">
                 <div className="home-bubble home-bubble-user max-w-[80%] rounded-2xl px-5 py-3">
@@ -167,14 +226,16 @@ export function ConversationView({ onBack }: ConversationViewProps) {
               </div>
             )}
 
-            {/* Assistant bubbles (completed responses) */}
+            {/* Assistant bubbles — markdown rendered */}
             {thread.responses
               .filter((msg: ThreadMessage) => msg.role === "assistant")
               .map((msg: ThreadMessage) => (
               <div key={msg.id} className="flex justify-start mb-2">
                 <div className="home-bubble home-bubble-assistant max-w-[80%] rounded-2xl px-5 py-3">
-                  <div className="home-bubble-text text-white/90">
-                    {msg.text}
+                  <div className="home-bubble-text home-bubble-markdown text-white/90">
+                    <ReactMarkdown remarkPlugins={[remarkGfm]}>
+                      {msg.text}
+                    </ReactMarkdown>
                   </div>
                   <div className="mt-1 text-xs text-white/30 tabular-nums">
                     {formatBubbleTime(msg.timestamp)}
@@ -183,13 +244,15 @@ export function ConversationView({ onBack }: ConversationViewProps) {
               </div>
             ))}
 
-            {/* Pending streaming */}
+            {/* Pending streaming — also markdown */}
             {thread.pendingAssistant &&
               thread.pendingAssistant.text && (
                 <div className="flex justify-start mb-2">
                   <div className="home-bubble home-bubble-assistant max-w-[80%] rounded-2xl px-5 py-3">
-                    <div className="home-bubble-text text-white/90">
-                      {thread.pendingAssistant.text}
+                    <div className="home-bubble-text home-bubble-markdown text-white/90">
+                      <ReactMarkdown remarkPlugins={[remarkGfm]}>
+                        {thread.pendingAssistant.text}
+                      </ReactMarkdown>
                     </div>
                   </div>
                 </div>

--- a/src/home/home-assistant-page.tsx
+++ b/src/home/home-assistant-page.tsx
@@ -39,6 +39,7 @@ const HOME_SESSION_TITLE = "Home Assistant";
 function HomeAssistantShell() {
   const { currentSessionId, createSession, switchSession } = useSession();
   const [mode, setMode] = useState<Mode>("standby");
+  const [prefill, setPrefill] = useState<string | undefined>(undefined);
   const initRef = useRef(false);
 
   // Resolve the target home session id synchronously during render
@@ -64,8 +65,15 @@ function HomeAssistantShell() {
     }
   }, [homeSessionId, currentSessionId, switchSession]);
 
-  const activate = useCallback(() => setMode("conversation"), []);
-  const deactivate = useCallback(() => setMode("standby"), []);
+  const activate = useCallback((cardPrefill?: string) => {
+    setPrefill(cardPrefill);
+    setMode("conversation");
+  }, []);
+
+  const deactivate = useCallback(() => {
+    setPrefill(undefined);
+    setMode("standby");
+  }, []);
 
   return (
     <>
@@ -88,7 +96,7 @@ function HomeAssistantShell() {
             : "opacity-0 pointer-events-none z-0"
         }`}
       >
-        <ConversationView onBack={deactivate} />
+        <ConversationView onBack={deactivate} prefill={prefill} />
       </div>
     </>
   );

--- a/src/home/standby-view.tsx
+++ b/src/home/standby-view.tsx
@@ -12,14 +12,14 @@ import { useWeather } from "./use-weather";
 import { HOME_STRINGS } from "./constants";
 
 interface StandbyViewProps {
-  onActivate: () => void;
+  onActivate: (prefill?: string) => void;
 }
 
 const QUICK_ACTIONS = [
-  { id: "chat", icon: MessageSquare, label: HOME_STRINGS.cardChat, color: "text-blue-400" },
-  { id: "news", icon: Newspaper, label: HOME_STRINGS.cardNews, color: "text-amber-400" },
-  { id: "music", icon: Music, label: HOME_STRINGS.cardMusic, color: "text-emerald-400" },
-  { id: "home", icon: Home, label: HOME_STRINGS.cardHome, color: "text-purple-400" },
+  { id: "chat", icon: MessageSquare, label: HOME_STRINGS.cardChat, color: "text-blue-400", prefill: HOME_STRINGS.cardChatPrefill },
+  { id: "news", icon: Newspaper, label: HOME_STRINGS.cardNews, color: "text-amber-400", prefill: HOME_STRINGS.cardNewsPrefill },
+  { id: "music", icon: Music, label: HOME_STRINGS.cardMusic, color: "text-emerald-400", prefill: HOME_STRINGS.cardMusicPrefill },
+  { id: "home", icon: Home, label: HOME_STRINGS.cardHome, color: "text-purple-400", prefill: HOME_STRINGS.cardHomePrefill },
 ] as const;
 
 export function StandbyView({ onActivate }: StandbyViewProps) {
@@ -57,6 +57,9 @@ export function StandbyView({ onActivate }: StandbyViewProps) {
               {weather.temperature}&deg;C
             </span>
             <span className="text-lg text-white/50">{weather.label}</span>
+            {weather.city && (
+              <span className="text-lg text-white/40">&middot; {weather.city}</span>
+            )}
           </>
         )}
       </div>
@@ -73,12 +76,12 @@ export function StandbyView({ onActivate }: StandbyViewProps) {
 
       {/* Quick actions */}
       <div className="home-quick-actions mt-10 flex gap-4">
-        {QUICK_ACTIONS.map(({ id, icon: Icon, label, color }) => (
+        {QUICK_ACTIONS.map(({ id, icon: Icon, label, color, prefill }) => (
           <button
             key={id}
             onClick={(e) => {
               e.stopPropagation();
-              onActivate();
+              onActivate(prefill || undefined);
             }}
             className="home-quick-card group flex flex-col items-center justify-center gap-2"
             aria-label={label}

--- a/src/home/use-weather.ts
+++ b/src/home/use-weather.ts
@@ -1,24 +1,35 @@
 /**
  * Weather hook — fetches current weather from Open-Meteo.
  *
- * Uses the browser Geolocation API to get lat/lon, then hits the
- * Open-Meteo free API (no key needed). Refreshes every 15 minutes.
- * Falls back to a null state if geolocation is unavailable.
+ * Location resolution waterfall:
+ *   1. Browser Geolocation API
+ *   2. IP-based geolocation (ipapi.co)
+ *   3. Hardcoded default (San Francisco)
+ *
+ * Refreshes every 15 minutes. Never shows "unavailable" — the
+ * default-city fallback guarantees a result.
  */
 
 import { useState, useEffect, useRef } from "react";
-import { WMO_WEATHER } from "./constants";
+import { WMO_WEATHER, DEFAULT_LOCATION } from "./constants";
 
 export interface WeatherState {
   temperature: number;
   weatherCode: number;
   emoji: string;
   label: string;
+  city: string | null;
   loading: boolean;
   error: string | null;
 }
 
 const REFRESH_INTERVAL = 15 * 60 * 1000; // 15 min
+
+interface ResolvedLocation {
+  lat: number;
+  lon: number;
+  city: string | null;
+}
 
 async function fetchWeather(
   lat: number,
@@ -36,24 +47,40 @@ async function fetchWeather(
   };
 }
 
+/** Attempt IP-based geolocation via ipapi.co. */
+async function fetchIpLocation(): Promise<ResolvedLocation> {
+  const res = await fetch("https://ipapi.co/json/");
+  if (!res.ok) throw new Error(`IP geolocation HTTP ${res.status}`);
+  const data = (await res.json()) as {
+    latitude: number;
+    longitude: number;
+    city?: string;
+  };
+  if (typeof data.latitude !== "number" || typeof data.longitude !== "number") {
+    throw new Error("IP geolocation returned invalid coordinates");
+  }
+  return { lat: data.latitude, lon: data.longitude, city: data.city ?? null };
+}
+
 export function useWeather(): WeatherState {
   const [state, setState] = useState<WeatherState>({
     temperature: 0,
     weatherCode: 0,
     emoji: "",
     label: "",
+    city: null,
     loading: true,
     error: null,
   });
   const timerRef = useRef<ReturnType<typeof setInterval> | undefined>(undefined);
-  const coordsRef = useRef<{ lat: number; lon: number } | null>(null);
+  const locationRef = useRef<ResolvedLocation | null>(null);
 
   useEffect(() => {
     let cancelled = false;
 
-    async function load(lat: number, lon: number) {
+    async function load(loc: ResolvedLocation) {
       try {
-        const w = await fetchWeather(lat, lon);
+        const w = await fetchWeather(loc.lat, loc.lon);
         if (cancelled) return;
         const wmo = WMO_WEATHER[w.weatherCode] ?? {
           emoji: "\u2600\uFE0F",
@@ -64,6 +91,7 @@ export function useWeather(): WeatherState {
           weatherCode: w.weatherCode,
           emoji: wmo.emoji,
           label: wmo.label,
+          city: loc.city,
           loading: false,
           error: null,
         });
@@ -77,38 +105,53 @@ export function useWeather(): WeatherState {
       }
     }
 
-    function onPosition(pos: GeolocationPosition) {
-      if (cancelled) return;
-      const { latitude, longitude } = pos.coords;
-      coordsRef.current = { lat: latitude, lon: longitude };
-      void load(latitude, longitude);
+    async function resolveLocation(): Promise<ResolvedLocation> {
+      // 1. Try browser geolocation
+      try {
+        const pos = await new Promise<GeolocationPosition>((resolve, reject) => {
+          if (!navigator.geolocation) {
+            reject(new Error("geolocation_unsupported"));
+            return;
+          }
+          navigator.geolocation.getCurrentPosition(resolve, reject, {
+            timeout: 10000,
+            maximumAge: 5 * 60 * 1000,
+          });
+        });
+        return {
+          lat: pos.coords.latitude,
+          lon: pos.coords.longitude,
+          city: null,
+        };
+      } catch {
+        // Geolocation denied or unavailable — try IP fallback
+      }
+
+      // 2. Try IP-based geolocation
+      try {
+        return await fetchIpLocation();
+      } catch {
+        // IP geolocation also failed — use default
+      }
+
+      // 3. Hardcoded default
+      return {
+        lat: DEFAULT_LOCATION.lat,
+        lon: DEFAULT_LOCATION.lon,
+        city: DEFAULT_LOCATION.city,
+      };
     }
 
-    function onError() {
+    void (async () => {
+      const loc = await resolveLocation();
       if (cancelled) return;
-      setState((prev) => ({
-        ...prev,
-        loading: false,
-        error: "geolocation_denied",
-      }));
-    }
-
-    if (navigator.geolocation) {
-      navigator.geolocation.getCurrentPosition(onPosition, onError, {
-        timeout: 10000,
-        maximumAge: 5 * 60 * 1000,
-      });
-    } else {
-      setState((prev) => ({
-        ...prev,
-        loading: false,
-        error: "geolocation_unsupported",
-      }));
-    }
+      locationRef.current = loc;
+      await load(loc);
+    })();
 
     timerRef.current = setInterval(() => {
-      if (coordsRef.current) {
-        void load(coordsRef.current.lat, coordsRef.current.lon);
+      if (locationRef.current) {
+        void load(locationRef.current);
       }
     }, REFRESH_INTERVAL);
 

--- a/src/index.css
+++ b/src/index.css
@@ -924,6 +924,104 @@ button, a, input, textarea {
   transform: scale(0.95);
 }
 
+/* ── Home bubble markdown (AI responses) ─────────── */
+/* Inherits .home-bubble-text sizing (1.25rem) and applies prose-like
+   styling for readable markdown on the deep-dark home background. */
+.home-bubble-markdown {
+  line-height: 1.65;
+}
+.home-bubble-markdown p {
+  margin: 0 0 0.6em;
+}
+.home-bubble-markdown p:last-child {
+  margin-bottom: 0;
+}
+.home-bubble-markdown a {
+  color: #7fc4ff;
+  text-decoration: underline;
+  text-underline-offset: 2px;
+  text-decoration-color: rgba(127, 196, 255, 0.35);
+}
+.home-bubble-markdown a:hover {
+  text-decoration-color: #7fc4ff;
+}
+.home-bubble-markdown strong {
+  color: #f0f4f8;
+  font-weight: 600;
+}
+.home-bubble-markdown code:not(pre code) {
+  background: rgba(255, 140, 86, 0.14);
+  color: #ffb38c;
+  padding: 0.12em 0.35em;
+  border-radius: 5px;
+  font-size: 0.88em;
+  font-family: ui-monospace, "SF Mono", Menlo, Consolas, monospace;
+}
+.home-bubble-markdown pre {
+  background: rgba(0, 0, 0, 0.3);
+  border-radius: 10px;
+  padding: 0.75em 1em;
+  margin: 0.6em 0;
+  overflow-x: auto;
+  font-size: 0.85em;
+  line-height: 1.5;
+  color: #d0ddef;
+}
+.home-bubble-markdown ul,
+.home-bubble-markdown ol {
+  margin: 0.4em 0;
+  padding-left: 1.4em;
+}
+.home-bubble-markdown li {
+  margin: 0.25em 0;
+}
+.home-bubble-markdown li::marker {
+  color: rgba(255, 255, 255, 0.4);
+}
+.home-bubble-markdown blockquote {
+  border-left: 3px solid rgba(255, 255, 255, 0.2);
+  padding: 0.4em 0.8em;
+  margin: 0.5em 0;
+  color: rgba(255, 255, 255, 0.65);
+  font-style: italic;
+}
+.home-bubble-markdown h1,
+.home-bubble-markdown h2,
+.home-bubble-markdown h3,
+.home-bubble-markdown h4 {
+  color: #f0f4f8;
+  margin: 0.8em 0 0.3em;
+  font-weight: 600;
+}
+.home-bubble-markdown h1 { font-size: 1.3em; }
+.home-bubble-markdown h2 { font-size: 1.15em; }
+.home-bubble-markdown h3 { font-size: 1.05em; }
+.home-bubble-markdown table {
+  width: 100%;
+  border-collapse: separate;
+  border-spacing: 0;
+  border-radius: 8px;
+  overflow: hidden;
+  margin: 0.5em 0;
+  font-size: 0.9em;
+}
+.home-bubble-markdown th,
+.home-bubble-markdown td {
+  padding: 0.4em 0.6em;
+  border-bottom: 1px solid rgba(255, 255, 255, 0.08);
+  text-align: left;
+}
+.home-bubble-markdown th {
+  color: #f0f4f8;
+  font-weight: 600;
+  background: rgba(255, 255, 255, 0.06);
+}
+.home-bubble-markdown hr {
+  border: 0;
+  border-top: 1px solid rgba(255, 255, 255, 0.1);
+  margin: 1em 0;
+}
+
 /* ── Responsive adjustments for small screens ────── */
 @media (max-width: 480px) {
   .home-clock {


### PR DESCRIPTION
## Summary
- **Weather fallback**: When browser geolocation is denied, falls back to IP-based lookup (`ipapi.co`), then to a hardcoded default (San Francisco). City name is displayed in the weather strip when available.
- **Card differentiation**: Each quick-action card (Chat/News/Music/Home) passes a unique prefill string to the conversation view. The text is filled into the input box and focused — not auto-sent — so the user can confirm or edit before sending.
- **Markdown rendering**: AI response bubbles now render markdown via `react-markdown` + `remark-gfm` (already in deps). Added `.home-bubble-markdown` CSS for readable links, inline code, code blocks, lists, blockquotes, and tables on the dark home background.
- **setSending timing**: Removed the immediate `setSending(false)` after the fire-and-forget `bridgeSend()`. Now uses a `useEffect` that watches `threads` for `pendingAssistant` appearance or `responses` length increase before clearing the sending lock.

## Changed files
| File | What changed |
|---|---|
| `src/home/constants.ts` | Added `DEFAULT_LOCATION`, card prefill strings |
| `src/home/use-weather.ts` | Promise-based location waterfall (geo → IP → default), `city` in state |
| `src/home/standby-view.tsx` | `onActivate(prefill?)` signature, city display in weather strip |
| `src/home/home-assistant-page.tsx` | Prefill state, passes it to ConversationView |
| `src/home/conversation-view.tsx` | Prefill effect, ReactMarkdown for AI bubbles, useEffect-based setSending |
| `src/index.css` | `.home-bubble-markdown` prose styles |

## Test plan
- [ ] Deny geolocation permission — verify weather falls back to IP city or "San Francisco"
- [ ] Click each quick-action card — verify correct prefill text appears in input (not sent)
- [ ] Send a message that triggers markdown in the AI response — verify links, code, lists render
- [ ] Send a message — verify send button stays disabled until the assistant response appears in thread store
- [ ] `npx tsc -b` passes with zero errors
- [ ] `npm run build` succeeds