### PR TITLE
feat(settings): users and sub-accounts management

### DIFF
--- a/src/settings/settings-api.ts
+++ b/src/settings/settings-api.ts
@@ -168,3 +168,88 @@ export async function installSkill(source: string): Promise<boolean> {
     return false;
   }
 }
+
+// ── Admin: Users management ──
+
+export interface AdminUser {
+  id: string;
+  email: string;
+  name: string;
+  role: string;
+  created_at: string;
+  last_login: string | null;
+}
+
+export async function getAdminUsers(): Promise<AdminUser[]> {
+  try {
+    const resp = await request<AdminUser[] | { users: AdminUser[] }>("/api/admin/users");
+    return Array.isArray(resp) ? resp : (resp.users ?? []);
+  } catch {
+    return [];
+  }
+}
+
+export async function createAdminUser(body: {
+  email: string;
+  name: string;
+  user_id?: string;
+  note?: string;
+}): Promise<AdminUser | null> {
+  try {
+    return await request<AdminUser>("/api/admin/users", {
+      method: "POST",
+      body: JSON.stringify(body),
+    });
+  } catch {
+    return null;
+  }
+}
+
+export async function deleteAdminUser(id: string): Promise<boolean> {
+  try {
+    await request<void>(`/api/admin/users/${encodeURIComponent(id)}`, {
+      method: "DELETE",
+    });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+// ── Admin: Allowed Emails ──
+
+export interface AllowedEmail {
+  email: string;
+}
+
+export async function getAllowedEmails(): Promise<AllowedEmail[]> {
+  try {
+    const resp = await request<AllowedEmail[] | { emails: AllowedEmail[] }>("/api/admin/allowed-emails");
+    return Array.isArray(resp) ? resp : (resp.emails ?? []);
+  } catch {
+    return [];
+  }
+}
+
+export async function addAllowedEmail(email: string): Promise<boolean> {
+  try {
+    await request<void>("/api/admin/allowed-emails", {
+      method: "POST",
+      body: JSON.stringify({ email }),
+    });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+export async function removeAllowedEmail(email: string): Promise<boolean> {
+  try {
+    await request<void>(`/api/admin/allowed-emails/${encodeURIComponent(email)}`, {
+      method: "DELETE",
+    });
+    return true;
+  } catch {
+    return false;
+  }
+}

--- a/src/settings/settings-page.tsx
+++ b/src/settings/settings-page.tsx
@@ -10,6 +10,7 @@ import {
   Cpu,
   Puzzle,
   Radio,
+  Users,
   Loader2,
 } from "lucide-react";
 import { getMyProfile, type Profile } from "./settings-api";
@@ -17,14 +18,23 @@ import { ProfileTab } from "./profile-tab";
 import { LlmTab } from "./llm-tab";
 import { SkillsTab } from "./skills-tab";
 import { ChannelsTab } from "./channels-tab";
+import { UsersTab } from "./users-tab";
 
-type TabId = "profile" | "llm" | "skills" | "channels";
+type TabId = "profile" | "llm" | "skills" | "channels" | "users";
 
-const TABS: { id: TabId; label: string; icon: typeof User }[] = [
+interface TabDef {
+  id: TabId;
+  label: string;
+  icon: typeof User;
+  adminOnly?: boolean;
+}
+
+const TABS: TabDef[] = [
   { id: "profile", label: "Profile", icon: User },
   { id: "llm", label: "LLM", icon: Cpu },
   { id: "skills", label: "Skills", icon: Puzzle },
   { id: "channels", label: "Channels", icon: Radio },
+  { id: "users", label: "Users", icon: Users, adminOnly: true },
 ];
 
 export function AdminSettingsPage() {
@@ -112,7 +122,7 @@ export function AdminSettingsPage() {
           {/* Tab rail */}
           <aside className="w-56 shrink-0 border-r border-border/50 px-3 py-4 overflow-y-auto">
             <div className="space-y-1">
-              {TABS.map(({ id, label, icon: Icon }) => (
+              {TABS.filter((t) => !t.adminOnly || portal?.can_access_admin_portal).map(({ id, label, icon: Icon }) => (
                 <button
                   key={id}
                   onClick={() => setActiveTab(id)}
@@ -142,6 +152,7 @@ export function AdminSettingsPage() {
                   )}
                   {activeTab === "skills" && <SkillsTab />}
                   {activeTab === "channels" && <ChannelsTab profile={profile} onProfileUpdated={setProfile} />}
+                  {activeTab === "users" && portal?.can_access_admin_portal && <UsersTab />}
                 </>
               ) : (
                 <div className="flex flex-col items-center justify-center py-20">

--- a/src/settings/users-tab.tsx
+++ b/src/settings/users-tab.tsx
@@ -1,0 +1,418 @@
+import { useState, useEffect, useCallback } from "react";
+import {
+  Users,
+  UserPlus,
+  Trash2,
+  Mail,
+  Shield,
+  Plus,
+  X,
+  Loader2,
+} from "lucide-react";
+import {
+  getAdminUsers,
+  createAdminUser,
+  deleteAdminUser,
+  getAllowedEmails,
+  addAllowedEmail,
+  removeAllowedEmail,
+  type AdminUser,
+  type AllowedEmail,
+} from "./settings-api";
+
+// ── Create Sub-Account form ──
+
+function CreateSubAccountForm({ onCreated }: { onCreated: () => void }) {
+  const [open, setOpen] = useState(false);
+  const [userId, setUserId] = useState("");
+  const [email, setEmail] = useState("");
+  const [displayName, setDisplayName] = useState("");
+  const [note, setNote] = useState("");
+  const [saving, setSaving] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const reset = () => {
+    setUserId("");
+    setEmail("");
+    setDisplayName("");
+    setNote("");
+    setError(null);
+  };
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    if (!email.trim() || !displayName.trim()) return;
+    setSaving(true);
+    setError(null);
+    const result = await createAdminUser({
+      email: email.trim(),
+      name: displayName.trim(),
+      ...(userId.trim() ? { user_id: userId.trim() } : {}),
+      ...(note.trim() ? { note: note.trim() } : {}),
+    });
+    setSaving(false);
+    if (result) {
+      reset();
+      setOpen(false);
+      onCreated();
+    } else {
+      setError("Failed to create sub-account. The server may have rejected the request.");
+    }
+  };
+
+  if (!open) {
+    return (
+      <button
+        onClick={() => setOpen(true)}
+        className="flex items-center gap-2 rounded-xl bg-accent px-4 py-2.5 text-sm font-medium text-white hover:bg-accent-dim transition"
+      >
+        <UserPlus size={14} />
+        Create Sub-Account
+      </button>
+    );
+  }
+
+  return (
+    <form onSubmit={handleSubmit} className="rounded-xl bg-surface-container/60 p-5 space-y-4 border border-border/30">
+      <div className="flex items-center justify-between">
+        <h4 className="text-sm font-semibold text-text-strong">New Sub-Account</h4>
+        <button
+          type="button"
+          onClick={() => { setOpen(false); reset(); }}
+          className="rounded-lg p-1.5 text-muted hover:bg-surface-dark/50 hover:text-text-strong transition"
+        >
+          <X size={14} />
+        </button>
+      </div>
+
+      <div>
+        <label className="mb-1.5 block text-xs font-medium text-muted">User ID</label>
+        <input
+          type="text"
+          value={userId}
+          onChange={(e) => setUserId(e.target.value)}
+          placeholder="Leave blank for auto-assignment"
+          className="w-full rounded-xl bg-surface-dark/50 px-4 py-2.5 text-sm text-text placeholder-muted/50 outline-none border border-transparent focus:border-accent/30 transition"
+        />
+      </div>
+
+      <div>
+        <label className="mb-1.5 block text-xs font-medium text-muted">
+          Email <span className="text-red-400">*</span>
+        </label>
+        <input
+          type="email"
+          value={email}
+          onChange={(e) => setEmail(e.target.value)}
+          placeholder="user@example.com"
+          required
+          className="w-full rounded-xl bg-surface-dark/50 px-4 py-2.5 text-sm text-text placeholder-muted/50 outline-none border border-transparent focus:border-accent/30 transition"
+        />
+        <p className="mt-1 text-[11px] text-muted/60">For web client login</p>
+      </div>
+
+      <div>
+        <label className="mb-1.5 block text-xs font-medium text-muted">
+          Display Name <span className="text-red-400">*</span>
+        </label>
+        <input
+          type="text"
+          value={displayName}
+          onChange={(e) => setDisplayName(e.target.value)}
+          placeholder="Display name"
+          required
+          className="w-full rounded-xl bg-surface-dark/50 px-4 py-2.5 text-sm text-text placeholder-muted/50 outline-none border border-transparent focus:border-accent/30 transition"
+        />
+      </div>
+
+      <div>
+        <label className="mb-1.5 block text-xs font-medium text-muted">Note</label>
+        <input
+          type="text"
+          value={note}
+          onChange={(e) => setNote(e.target.value)}
+          placeholder="Optional note"
+          className="w-full rounded-xl bg-surface-dark/50 px-4 py-2.5 text-sm text-text placeholder-muted/50 outline-none border border-transparent focus:border-accent/30 transition"
+        />
+      </div>
+
+      {error && <p className="text-xs text-red-400">{error}</p>}
+
+      <div className="flex items-center gap-3 pt-1">
+        <button
+          type="submit"
+          disabled={saving || !email.trim() || !displayName.trim()}
+          className="flex items-center gap-2 rounded-xl bg-accent px-5 py-2.5 text-sm font-medium text-white hover:bg-accent-dim disabled:opacity-30 transition"
+        >
+          {saving ? <Loader2 size={14} className="animate-spin" /> : <Plus size={14} />}
+          Create
+        </button>
+        <button
+          type="button"
+          onClick={() => { setOpen(false); reset(); }}
+          className="rounded-xl px-4 py-2.5 text-sm font-medium text-muted hover:text-text-strong hover:bg-surface-dark/50 transition"
+        >
+          Cancel
+        </button>
+      </div>
+    </form>
+  );
+}
+
+// ── Allowed Emails section ──
+
+function AllowedEmailsSection() {
+  const [emails, setEmails] = useState<AllowedEmail[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [newEmail, setNewEmail] = useState("");
+  const [adding, setAdding] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const refresh = useCallback(async () => {
+    const data = await getAllowedEmails();
+    setEmails(data);
+    setLoading(false);
+  }, []);
+
+  useEffect(() => {
+    let cancelled = false;
+    getAllowedEmails().then((data) => {
+      if (!cancelled) {
+        setEmails(data);
+        setLoading(false);
+      }
+    });
+    return () => { cancelled = true; };
+  }, []);
+
+  const handleAdd = async (e: React.FormEvent) => {
+    e.preventDefault();
+    if (!newEmail.trim()) return;
+    setAdding(true);
+    setError(null);
+    const ok = await addAllowedEmail(newEmail.trim());
+    setAdding(false);
+    if (ok) {
+      setNewEmail("");
+      await refresh();
+    } else {
+      setError("Failed to add email to the allowlist.");
+    }
+  };
+
+  const handleRemove = async (email: string) => {
+    const confirmed = window.confirm(`Remove '${email}' from the allowlist?`);
+    if (!confirmed) return;
+    const ok = await removeAllowedEmail(email);
+    if (ok) {
+      await refresh();
+    }
+  };
+
+  return (
+    <div className="glass-section rounded-2xl p-6">
+      <div className="flex items-center gap-3 mb-4">
+        <div className="flex h-10 w-10 items-center justify-center rounded-xl bg-accent/10 text-accent">
+          <Shield size={20} />
+        </div>
+        <div>
+          <h3 className="text-sm font-semibold text-text-strong">Allowed Emails</h3>
+          <p className="text-xs text-muted">
+            These addresses can complete OTP signup later. Registration happens on first successful login.
+          </p>
+        </div>
+      </div>
+
+      {/* Add email form */}
+      <form onSubmit={handleAdd} className="flex items-center gap-2 mb-4">
+        <input
+          type="email"
+          value={newEmail}
+          onChange={(e) => setNewEmail(e.target.value)}
+          placeholder="user@example.com"
+          className="flex-1 rounded-xl bg-surface-container px-4 py-2.5 text-sm text-text placeholder-muted/50 outline-none border border-transparent focus:border-accent/30 transition"
+        />
+        <button
+          type="submit"
+          disabled={adding || !newEmail.trim()}
+          className="flex items-center gap-1.5 rounded-xl bg-accent px-4 py-2.5 text-sm font-medium text-white hover:bg-accent-dim disabled:opacity-30 transition"
+        >
+          {adding ? <Loader2 size={14} className="animate-spin" /> : <Plus size={14} />}
+          Add
+        </button>
+      </form>
+
+      {error && <p className="mb-3 text-xs text-red-400">{error}</p>}
+
+      {loading ? (
+        <div className="flex justify-center py-6">
+          <Loader2 size={18} className="animate-spin text-muted" />
+        </div>
+      ) : emails.length === 0 ? (
+        <div className="rounded-xl bg-surface-dark/50 px-6 py-8 text-center">
+          <Mail size={28} className="mx-auto mb-2 text-muted/40" />
+          <p className="text-sm text-muted">No allowlisted emails yet</p>
+        </div>
+      ) : (
+        <div className="space-y-1.5">
+          {emails.map((entry) => (
+            <div
+              key={entry.email}
+              className="flex items-center justify-between rounded-xl bg-surface-container/60 px-4 py-3 border border-transparent hover:border-border transition"
+            >
+              <div className="flex items-center gap-3 min-w-0">
+                <Mail size={14} className="shrink-0 text-muted" />
+                <span className="text-sm text-text truncate">{entry.email}</span>
+              </div>
+              <button
+                onClick={() => handleRemove(entry.email)}
+                className="shrink-0 rounded-lg p-1.5 text-muted hover:bg-red-500/10 hover:text-red-400 transition"
+                title={`Remove ${entry.email}`}
+              >
+                <Trash2 size={14} />
+              </button>
+            </div>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}
+
+// ── Users Tab (main export) ──
+
+export function UsersTab() {
+  const [users, setUsers] = useState<AdminUser[]>([]);
+  const [loading, setLoading] = useState(true);
+
+  const refresh = useCallback(async () => {
+    const data = await getAdminUsers();
+    setUsers(data);
+    setLoading(false);
+  }, []);
+
+  useEffect(() => {
+    let cancelled = false;
+    getAdminUsers().then((data) => {
+      if (!cancelled) {
+        setUsers(data);
+        setLoading(false);
+      }
+    });
+    return () => { cancelled = true; };
+  }, []);
+
+  const handleDelete = async (user: AdminUser) => {
+    const confirmed = window.confirm(
+      `Delete account '${user.email}'? This will also delete the profile and stop its gateway.`,
+    );
+    if (!confirmed) return;
+    const ok = await deleteAdminUser(user.id);
+    if (ok) {
+      await refresh();
+    }
+  };
+
+  const formatDate = (iso: string | null) => {
+    if (!iso) return "\u2014";
+    return new Date(iso).toLocaleDateString(undefined, {
+      year: "numeric",
+      month: "short",
+      day: "numeric",
+    });
+  };
+
+  return (
+    <div className="space-y-6">
+      {/* Users list */}
+      <div className="glass-section rounded-2xl p-6">
+        <div className="flex items-center justify-between mb-6">
+          <div className="flex items-center gap-3">
+            <div className="flex h-10 w-10 items-center justify-center rounded-xl bg-accent/10 text-accent">
+              <Users size={20} />
+            </div>
+            <div>
+              <h3 className="text-sm font-semibold text-text-strong">Users</h3>
+              <p className="text-xs text-muted">
+                {users.length > 0
+                  ? `${users.length} registered account${users.length === 1 ? "" : "s"}`
+                  : "Manage registered accounts"}
+              </p>
+            </div>
+          </div>
+        </div>
+
+        {/* Create sub-account */}
+        <div className="mb-5">
+          <CreateSubAccountForm onCreated={refresh} />
+        </div>
+
+        {loading ? (
+          <div className="flex justify-center py-10">
+            <Loader2 size={20} className="animate-spin text-muted" />
+          </div>
+        ) : users.length === 0 ? (
+          <div className="rounded-xl bg-surface-dark/50 px-6 py-10 text-center">
+            <Users size={32} className="mx-auto mb-3 text-muted/40" />
+            <p className="text-sm text-muted">No registered accounts yet</p>
+          </div>
+        ) : (
+          <div className="space-y-2">
+            {/* Table header */}
+            <div className="hidden sm:grid grid-cols-[minmax(0,1fr)_minmax(0,1.2fr)_80px_90px_90px_40px] gap-3 px-4 py-2">
+              <span className="text-[11px] font-medium text-muted uppercase tracking-wider">Name</span>
+              <span className="text-[11px] font-medium text-muted uppercase tracking-wider">Email</span>
+              <span className="text-[11px] font-medium text-muted uppercase tracking-wider">Role</span>
+              <span className="text-[11px] font-medium text-muted uppercase tracking-wider">Created</span>
+              <span className="text-[11px] font-medium text-muted uppercase tracking-wider">Last Login</span>
+              <span />
+            </div>
+
+            {/* User rows */}
+            {users.map((u) => (
+              <div
+                key={u.id}
+                className="sm:grid sm:grid-cols-[minmax(0,1fr)_minmax(0,1.2fr)_80px_90px_90px_40px] sm:items-center gap-3 rounded-xl bg-surface-container/60 px-4 py-3 border border-transparent hover:border-border transition"
+              >
+                {/* Name + ID (stacked on mobile) */}
+                <div className="min-w-0">
+                  <p className="text-sm font-medium text-text-strong truncate">{u.name || u.id}</p>
+                  <p className="text-[11px] text-muted/60 font-mono truncate">{u.id}</p>
+                </div>
+                {/* Email */}
+                <p className="text-sm text-text truncate">{u.email}</p>
+                {/* Role badge */}
+                <div>
+                  <span className={`inline-block rounded-md px-2 py-0.5 text-[10px] font-medium uppercase tracking-wider ${
+                    u.role === "admin"
+                      ? "bg-accent/15 text-accent"
+                      : "bg-surface-dark/60 text-muted"
+                  }`}>
+                    {u.role}
+                  </span>
+                </div>
+                {/* Created */}
+                <p className="text-xs text-muted">{formatDate(u.created_at)}</p>
+                {/* Last Login */}
+                <p className="text-xs text-muted">{formatDate(u.last_login)}</p>
+                {/* Delete */}
+                <div className="flex justify-end">
+                  <button
+                    onClick={() => handleDelete(u)}
+                    className="rounded-lg p-1.5 text-muted hover:bg-red-500/10 hover:text-red-400 transition"
+                    title={`Delete ${u.email}`}
+                  >
+                    <Trash2 size={14} />
+                  </button>
+                </div>
+              </div>
+            ))}
+          </div>
+        )}
+      </div>
+
+      {/* Allowed emails */}
+      <AllowedEmailsSection />
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- Add admin-only **Users** tab to the settings page, gated by `portal.can_access_admin_portal`
- **User list**: table with ID, email, name, role, created date, last login; delete with confirmation dialog
- **Create Sub-Account**: inline form with user ID (optional auto-assign), email, display name, and note fields
- **Allowed Emails**: allowlist management for OTP signup with add/remove; explanatory text about deferred registration

## API surface (added to `settings-api.ts`)
- `GET/POST/DELETE /api/admin/users` — user CRUD
- `GET/POST/DELETE /api/admin/allowed-emails` — email allowlist CRUD

## Test plan
- [ ] Verify the Users tab appears only when `can_access_admin_portal` is true
- [ ] Verify the Users tab is hidden for non-admin portals
- [ ] Create a sub-account and confirm it appears in the list
- [ ] Delete a user and confirm the confirmation dialog text
- [ ] Add/remove emails from the allowlist
- [ ] Verify empty states render correctly for both sections
- [ ] TypeScript check (`tsc -b`) and production build pass cleanly
- [ ] ESLint passes on all changed files