### PR TITLE
feat(settings): sandbox config + tools/search API management

### DIFF
--- a/src/settings/sandbox-tab.tsx
+++ b/src/settings/sandbox-tab.tsx
@@ -1,0 +1,413 @@
+import { useState } from "react";
+import {
+  Shield,
+  Save,
+  Loader2,
+  Check,
+  RotateCcw,
+  Plus,
+  X,
+} from "lucide-react";
+import { updateMyProfile, type Profile, type SandboxConfig, type SandboxDocker } from "./settings-api";
+
+interface SandboxTabProps {
+  profile: Profile;
+  onProfileUpdated: (p: Profile) => void;
+}
+
+const SANDBOX_MODES = [
+  { value: "auto", label: "Auto", description: "Automatically select the best isolation method" },
+  { value: "docker", label: "Docker", description: "Docker container isolation" },
+  { value: "sandbox-exec", label: "sandbox-exec", description: "macOS sandbox" },
+  { value: "bubblewrap", label: "Bubblewrap", description: "Linux namespace isolation" },
+  { value: "appcontainer", label: "AppContainer", description: "Windows AppContainer" },
+  { value: "host", label: "Host", description: "No isolation (runs directly on host)" },
+] as const;
+
+const MOUNT_MODES = [
+  { value: "rw", label: "Read-Write" },
+  { value: "ro", label: "Read-Only" },
+] as const;
+
+interface SandboxFormState {
+  enabled: boolean;
+  mode: string;
+  allow_network: boolean;
+  docker_image: string;
+  docker_cpu_limit: string;
+  docker_memory_limit: string;
+  docker_pids_limit: string;
+  docker_mount_mode: string;
+  docker_extra_binds: string[];
+  read_allow_paths: string[];
+}
+
+function profileToForm(profile: Profile): SandboxFormState {
+  const sb = profile.config.sandbox;
+  return {
+    enabled: sb?.enabled ?? false,
+    mode: sb?.mode ?? "auto",
+    allow_network: sb?.allow_network ?? true,
+    docker_image: sb?.docker?.image ?? "ubuntu:24.04",
+    docker_cpu_limit: sb?.docker?.cpu_limit ?? "",
+    docker_memory_limit: sb?.docker?.memory_limit ?? "",
+    docker_pids_limit: sb?.docker?.pids_limit != null ? String(sb.docker.pids_limit) : "",
+    docker_mount_mode: sb?.docker?.mount_mode ?? "rw",
+    docker_extra_binds: sb?.docker?.extra_binds ?? [],
+    read_allow_paths: sb?.read_allow_paths ?? [],
+  };
+}
+
+function formToSandboxConfig(form: SandboxFormState): SandboxConfig {
+  const docker: SandboxDocker = {
+    image: form.docker_image.trim() || "ubuntu:24.04",
+    cpu_limit: form.docker_cpu_limit.trim() || null,
+    memory_limit: form.docker_memory_limit.trim() || null,
+    pids_limit: form.docker_pids_limit.trim() ? parseInt(form.docker_pids_limit, 10) || null : null,
+    mount_mode: form.docker_mount_mode,
+    extra_binds: form.docker_extra_binds.filter((b) => b.trim()),
+  };
+  return {
+    enabled: form.enabled,
+    mode: form.mode,
+    allow_network: form.allow_network,
+    docker,
+    read_allow_paths: form.read_allow_paths.filter((p) => p.trim()),
+  };
+}
+
+/* ── Reusable editable string-list component ── */
+
+function StringListEditor({
+  items,
+  onItemsChange,
+  placeholder,
+}: {
+  items: string[];
+  onItemsChange: (items: string[]) => void;
+  placeholder: string;
+}) {
+  const addItem = () => onItemsChange([...items, ""]);
+  const removeItem = (idx: number) => onItemsChange(items.filter((_, i) => i !== idx));
+  const updateItem = (idx: number, value: string) =>
+    onItemsChange(items.map((v, i) => (i === idx ? value : v)));
+
+  return (
+    <div className="space-y-2">
+      {items.map((item, idx) => (
+        <div key={idx} className="flex items-center gap-2">
+          <input
+            type="text"
+            value={item}
+            onChange={(e) => updateItem(idx, e.target.value)}
+            placeholder={placeholder}
+            className="flex-1 rounded-xl bg-surface-container px-4 py-2.5 text-sm text-text placeholder-muted/50 outline-none border border-transparent focus:border-accent/30 transition font-mono"
+          />
+          <button
+            type="button"
+            onClick={() => removeItem(idx)}
+            className="shrink-0 rounded-lg p-2 text-muted hover:text-red-400 hover:bg-red-500/10 transition"
+            title="Remove"
+          >
+            <X size={14} />
+          </button>
+        </div>
+      ))}
+      <button
+        type="button"
+        onClick={addItem}
+        className="flex items-center gap-1.5 rounded-xl px-3 py-2 text-xs font-medium text-muted hover:text-accent hover:bg-accent/10 transition"
+      >
+        <Plus size={12} />
+        Add entry
+      </button>
+    </div>
+  );
+}
+
+/* ── Toggle component ── */
+
+function Toggle({
+  checked,
+  onChange,
+  label,
+  description,
+}: {
+  checked: boolean;
+  onChange: (val: boolean) => void;
+  label: string;
+  description?: string;
+}) {
+  return (
+    <label className="flex items-center justify-between gap-4 cursor-pointer">
+      <div className="flex-1 min-w-0">
+        <span className="text-sm font-medium text-text-strong">{label}</span>
+        {description && (
+          <p className="text-xs text-muted mt-0.5">{description}</p>
+        )}
+      </div>
+      <button
+        type="button"
+        role="switch"
+        aria-checked={checked}
+        onClick={() => onChange(!checked)}
+        className={`relative inline-flex h-6 w-11 shrink-0 items-center rounded-full transition-colors ${
+          checked ? "bg-accent" : "bg-surface-container"
+        }`}
+      >
+        <span
+          className={`inline-block h-4 w-4 rounded-full bg-white transition-transform ${
+            checked ? "translate-x-6" : "translate-x-1"
+          }`}
+        />
+      </button>
+    </label>
+  );
+}
+
+export function SandboxTab({ profile, onProfileUpdated }: SandboxTabProps) {
+  const [form, setForm] = useState<SandboxFormState>(() => profileToForm(profile));
+  const [original, setOriginal] = useState<SandboxFormState>(() => profileToForm(profile));
+  const [saving, setSaving] = useState(false);
+  const [saved, setSaved] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const isDirty = JSON.stringify(form) !== JSON.stringify(original);
+  const isDockerMode = form.mode === "docker";
+
+  const handleSave = async () => {
+    setSaving(true);
+    setError(null);
+    const result = await updateMyProfile({
+      config: { sandbox: formToSandboxConfig(form) },
+    });
+    setSaving(false);
+    if (result) {
+      onProfileUpdated(result);
+      const newForm = profileToForm(result);
+      setForm(newForm);
+      setOriginal(newForm);
+      setSaved(true);
+      setTimeout(() => setSaved(false), 2000);
+    } else {
+      setError("Failed to update sandbox config.");
+    }
+  };
+
+  const handleReset = () => setForm({ ...original, docker_extra_binds: [...original.docker_extra_binds], read_allow_paths: [...original.read_allow_paths] });
+
+  return (
+    <div className="space-y-6">
+      {/* Main sandbox config card */}
+      <div className="glass-section rounded-2xl p-6">
+        <div className="flex items-center gap-3 mb-6">
+          <div className="flex h-10 w-10 items-center justify-center rounded-xl bg-accent/10 text-accent">
+            <Shield size={20} />
+          </div>
+          <div>
+            <h3 className="text-sm font-semibold text-text-strong">Sandbox Configuration</h3>
+            <p className="text-xs text-muted">Configure tool execution isolation and security</p>
+          </div>
+        </div>
+
+        <div className="space-y-5">
+          {/* Enabled toggle */}
+          <Toggle
+            checked={form.enabled}
+            onChange={(val) => setForm((f) => ({ ...f, enabled: val }))}
+            label="Enable Sandbox"
+            description="Isolate tool execution in a sandboxed environment"
+          />
+
+          {/* Mode selector */}
+          <div>
+            <label className="mb-1.5 block text-xs font-medium text-muted">
+              Isolation Mode
+            </label>
+            <select
+              value={form.mode}
+              onChange={(e) => setForm((f) => ({ ...f, mode: e.target.value }))}
+              className="w-full rounded-xl bg-surface-container px-4 py-3 text-sm text-text outline-none border border-transparent focus:border-accent/30 transition"
+            >
+              {SANDBOX_MODES.map((m) => (
+                <option key={m.value} value={m.value}>
+                  {m.label}
+                </option>
+              ))}
+            </select>
+            {SANDBOX_MODES.find((m) => m.value === form.mode) && (
+              <p className="mt-1.5 text-xs text-muted">
+                {SANDBOX_MODES.find((m) => m.value === form.mode)?.description}
+              </p>
+            )}
+          </div>
+
+          {/* Allow network toggle */}
+          <Toggle
+            checked={form.allow_network}
+            onChange={(val) => setForm((f) => ({ ...f, allow_network: val }))}
+            label="Allow Network Access"
+            description="When disabled, tools run in a fully offline environment (Docker: --network=none)"
+          />
+
+          {/* Read Allow Paths */}
+          <div>
+            <label className="mb-1.5 block text-xs font-medium text-muted">
+              Read-Allowed Paths
+            </label>
+            <p className="mb-2 text-xs text-muted/70">
+              Filesystem paths the sandbox is permitted to read
+            </p>
+            <StringListEditor
+              items={form.read_allow_paths}
+              onItemsChange={(paths) => setForm((f) => ({ ...f, read_allow_paths: paths }))}
+              placeholder="/path/to/allow"
+            />
+          </div>
+        </div>
+      </div>
+
+      {/* Docker-specific config card */}
+      {isDockerMode && (
+        <div className="glass-section rounded-2xl p-6">
+          <div className="flex items-center gap-3 mb-6">
+            <div className="flex h-10 w-10 items-center justify-center rounded-xl bg-blue-500/10 text-blue-400">
+              <svg viewBox="0 0 24 24" fill="currentColor" className="h-5 w-5">
+                <path d="M13.98 11.08h2.12a.19.19 0 0 0 .19-.19V9.01a.19.19 0 0 0-.19-.19h-2.12a.19.19 0 0 0-.19.19v1.88c0 .1.08.19.19.19m-2.95-5.43h2.12a.19.19 0 0 0 .19-.19V3.58a.19.19 0 0 0-.19-.19h-2.12a.19.19 0 0 0-.19.19v1.88c0 .1.09.19.19.19m0 2.71h2.12a.19.19 0 0 0 .19-.19V6.29a.19.19 0 0 0-.19-.19h-2.12a.19.19 0 0 0-.19.19v1.88c0 .11.09.19.19.19m-2.93 0h2.12a.19.19 0 0 0 .19-.19V6.29a.19.19 0 0 0-.19-.19H8.1a.19.19 0 0 0-.19.19v1.88c0 .11.08.19.19.19m-2.96 0h2.12a.19.19 0 0 0 .19-.19V6.29a.19.19 0 0 0-.19-.19H5.14a.19.19 0 0 0-.19.19v1.88c0 .11.09.19.19.19m5.89 2.72h2.12a.19.19 0 0 0 .19-.19V9.01a.19.19 0 0 0-.19-.19h-2.12a.19.19 0 0 0-.19.19v1.88c0 .1.09.19.19.19m-2.93 0h2.12a.19.19 0 0 0 .19-.19V9.01a.19.19 0 0 0-.19-.19H8.1a.19.19 0 0 0-.19.19v1.88c0 .1.08.19.19.19m-2.96 0h2.12a.19.19 0 0 0 .19-.19V9.01a.19.19 0 0 0-.19-.19H5.14a.19.19 0 0 0-.19.19v1.88c0 .1.09.19.19.19m-2.92 0h2.12a.19.19 0 0 0 .19-.19V9.01a.19.19 0 0 0-.19-.19H2.22a.19.19 0 0 0-.19.19v1.88c0 .1.08.19.19.19m21.54-1.19c-.06-.04-.42-.28-1.23-.28-.21 0-.43.02-.65.06-.29-1.96-1.82-2.91-1.89-2.95l-.38-.22-.24.36c-.3.47-.52.99-.65 1.53-.24 1.04-.09 2.02.41 2.86-.61.34-1.59.42-1.88.43H.99a.99.99 0 0 0-.99.99c.02 1.83.29 3.65.87 5.21.63 1.63 1.57 2.83 2.8 3.57 1.38.83 3.63 1.31 6.13 1.31.59 0 1.19-.04 1.79-.12 2.1-.25 4.1-.89 5.86-2.06 1.43-.96 2.72-2.26 3.64-3.88.92-1.63 1.32-3.1 1.55-4.31h.13c.81 0 1.31-.32 1.58-.59.19-.17.33-.39.44-.62l.06-.17z" />
+              </svg>
+            </div>
+            <div>
+              <h3 className="text-sm font-semibold text-text-strong">Docker Settings</h3>
+              <p className="text-xs text-muted">Container isolation configuration</p>
+            </div>
+          </div>
+
+          <div className="space-y-5">
+            {/* Docker image */}
+            <div>
+              <label className="mb-1.5 block text-xs font-medium text-muted">
+                Docker Image
+              </label>
+              <input
+                type="text"
+                value={form.docker_image}
+                onChange={(e) => setForm((f) => ({ ...f, docker_image: e.target.value }))}
+                placeholder="ubuntu:24.04"
+                className="w-full rounded-xl bg-surface-container px-4 py-3 text-sm text-text placeholder-muted/50 outline-none border border-transparent focus:border-accent/30 transition font-mono"
+              />
+            </div>
+
+            {/* Resource limits row */}
+            <div className="grid grid-cols-3 gap-4">
+              <div>
+                <label className="mb-1.5 block text-xs font-medium text-muted">
+                  CPU Limit
+                </label>
+                <input
+                  type="text"
+                  value={form.docker_cpu_limit}
+                  onChange={(e) => setForm((f) => ({ ...f, docker_cpu_limit: e.target.value }))}
+                  placeholder="1.0"
+                  className="w-full rounded-xl bg-surface-container px-4 py-3 text-sm text-text placeholder-muted/50 outline-none border border-transparent focus:border-accent/30 transition font-mono"
+                />
+              </div>
+              <div>
+                <label className="mb-1.5 block text-xs font-medium text-muted">
+                  Memory Limit
+                </label>
+                <input
+                  type="text"
+                  value={form.docker_memory_limit}
+                  onChange={(e) => setForm((f) => ({ ...f, docker_memory_limit: e.target.value }))}
+                  placeholder="512m"
+                  className="w-full rounded-xl bg-surface-container px-4 py-3 text-sm text-text placeholder-muted/50 outline-none border border-transparent focus:border-accent/30 transition font-mono"
+                />
+              </div>
+              <div>
+                <label className="mb-1.5 block text-xs font-medium text-muted">
+                  PID Limit
+                </label>
+                <input
+                  type="number"
+                  value={form.docker_pids_limit}
+                  onChange={(e) => setForm((f) => ({ ...f, docker_pids_limit: e.target.value }))}
+                  placeholder="256"
+                  min={1}
+                  className="w-full rounded-xl bg-surface-container px-4 py-3 text-sm text-text placeholder-muted/50 outline-none border border-transparent focus:border-accent/30 transition font-mono"
+                />
+              </div>
+            </div>
+
+            {/* Mount mode */}
+            <div>
+              <label className="mb-1.5 block text-xs font-medium text-muted">
+                Mount Mode
+              </label>
+              <div className="flex gap-3">
+                {MOUNT_MODES.map((m) => (
+                  <button
+                    key={m.value}
+                    type="button"
+                    onClick={() => setForm((f) => ({ ...f, docker_mount_mode: m.value }))}
+                    className={`flex-1 rounded-xl px-4 py-3 text-sm font-medium transition border ${
+                      form.docker_mount_mode === m.value
+                        ? "bg-accent/12 text-accent border-accent/20"
+                        : "bg-surface-container text-muted border-transparent hover:border-border"
+                    }`}
+                  >
+                    {m.label}
+                  </button>
+                ))}
+              </div>
+            </div>
+
+            {/* Extra binds */}
+            <div>
+              <label className="mb-1.5 block text-xs font-medium text-muted">
+                Extra Bind Mounts
+              </label>
+              <p className="mb-2 text-xs text-muted/70">
+                Additional host paths to mount into the container
+              </p>
+              <StringListEditor
+                items={form.docker_extra_binds}
+                onItemsChange={(binds) => setForm((f) => ({ ...f, docker_extra_binds: binds }))}
+                placeholder="/host/path:/container/path"
+              />
+            </div>
+          </div>
+        </div>
+      )}
+
+      {/* Save actions */}
+      <div className="flex items-center gap-3">
+        <button
+          onClick={handleSave}
+          disabled={saving || !isDirty}
+          className="flex items-center gap-2 rounded-xl bg-accent px-5 py-2.5 text-sm font-medium text-white hover:bg-accent-dim disabled:opacity-30 transition"
+        >
+          {saving ? (
+            <Loader2 size={14} className="animate-spin" />
+          ) : saved ? (
+            <Check size={14} />
+          ) : (
+            <Save size={14} />
+          )}
+          {saved ? "Saved" : "Save Changes"}
+        </button>
+        {isDirty && (
+          <button
+            onClick={handleReset}
+            className="flex items-center gap-2 rounded-xl border border-border px-4 py-2.5 text-sm text-muted hover:text-text-strong hover:border-accent/30 transition"
+          >
+            <RotateCcw size={14} />
+            Reset
+          </button>
+        )}
+        {error && (
+          <span className="text-xs text-red-400">{error}</span>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/settings/settings-page.tsx
+++ b/src/settings/settings-page.tsx
@@ -11,6 +11,8 @@ import {
   Puzzle,
   Radio,
   Users,
+  Shield,
+  Wrench,
   Loader2,
 } from "lucide-react";
 import { getMyProfile, type Profile } from "./settings-api";
@@ -19,8 +21,10 @@ import { LlmTab } from "./llm-tab";
 import { SkillsTab } from "./skills-tab";
 import { ChannelsTab } from "./channels-tab";
 import { UsersTab } from "./users-tab";
+import { SandboxTab } from "./sandbox-tab";
+import { ToolsTab } from "./tools-tab";
 
-type TabId = "profile" | "llm" | "skills" | "channels" | "users";
+type TabId = "profile" | "llm" | "skills" | "channels" | "users" | "sandbox" | "tools";
 
 interface TabDef {
   id: TabId;
@@ -34,6 +38,8 @@ const TABS: TabDef[] = [
   { id: "llm", label: "LLM", icon: Cpu },
   { id: "skills", label: "Skills", icon: Puzzle },
   { id: "channels", label: "Channels", icon: Radio },
+  { id: "sandbox", label: "Sandbox", icon: Shield },
+  { id: "tools", label: "Tools", icon: Wrench },
   { id: "users", label: "Users", icon: Users, adminOnly: true },
 ];
 
@@ -45,15 +51,11 @@ export function AdminSettingsPage() {
   const [profile, setProfile] = useState<Profile | null>(null);
   const [loading, setLoading] = useState(true);
 
-  // Derive accessible profiles from portal context (no extra API call needed)
   const accessibleProfiles = portal?.accessible_profiles ?? [];
-  // Initialize selectedProfileId directly from portal (no effect needed)
   const [selectedProfileId, setSelectedProfileId] = useState<string>(
     () => portal?.home_profile_id ?? "",
   );
 
-  // Fetch the current profile via GET /api/my/profile.
-  // loading starts as true; after the first fetch it resets via the callback.
   useEffect(() => {
     let cancelled = false;
     getMyProfile().then((data) => {
@@ -67,7 +69,6 @@ export function AdminSettingsPage() {
 
   return (
     <div className="flex h-screen flex-col bg-surface-dark">
-      {/* Header */}
       <nav className="flex items-center gap-4 px-6 py-4 shrink-0">
         <button
           onClick={() => navigate(-1)}
@@ -89,7 +90,6 @@ export function AdminSettingsPage() {
 
         <div className="flex-1" />
 
-        {/* Profile selector (when multiple accessible profiles) */}
         {accessibleProfiles.length > 1 && (
           <select
             value={selectedProfileId}
@@ -119,7 +119,6 @@ export function AdminSettingsPage() {
         </div>
       ) : (
         <div className="flex flex-1 min-h-0 overflow-hidden">
-          {/* Tab rail */}
           <aside className="w-56 shrink-0 border-r border-border/50 px-3 py-4 overflow-y-auto">
             <div className="space-y-1">
               {TABS.filter((t) => !t.adminOnly || portal?.can_access_admin_portal).map(({ id, label, icon: Icon }) => (
@@ -139,7 +138,6 @@ export function AdminSettingsPage() {
             </div>
           </aside>
 
-          {/* Content area */}
           <main className="flex-1 min-w-0 overflow-y-auto px-8 py-6">
             <div className="mx-auto max-w-2xl">
               {profile ? (
@@ -152,6 +150,12 @@ export function AdminSettingsPage() {
                   )}
                   {activeTab === "skills" && <SkillsTab />}
                   {activeTab === "channels" && <ChannelsTab profile={profile} onProfileUpdated={setProfile} />}
+                  {activeTab === "sandbox" && (
+                    <SandboxTab profile={profile} onProfileUpdated={setProfile} />
+                  )}
+                  {activeTab === "tools" && (
+                    <ToolsTab profile={profile} onProfileUpdated={setProfile} />
+                  )}
                   {activeTab === "users" && portal?.can_access_admin_portal && <UsersTab />}
                 </>
               ) : (

--- a/src/settings/tools-tab.tsx
+++ b/src/settings/tools-tab.tsx
@@ -1,0 +1,457 @@
+import { useState } from "react";
+import {
+  Save,
+  Loader2,
+  Check,
+  RotateCcw,
+  Globe,
+  Search,
+  Zap,
+  Timer,
+} from "lucide-react";
+import { updateMyProfile, type Profile } from "./settings-api";
+
+interface ToolsTabProps {
+  profile: Profile;
+  onProfileUpdated: (p: Profile) => void;
+}
+
+/* ── Search engine definitions ── */
+
+interface SearchEngine {
+  key: string;        // env var name
+  name: string;
+  description: string;
+  placeholder: string;
+  docsUrl?: string;
+}
+
+const SEARCH_ENGINES: SearchEngine[] = [
+  {
+    key: "SERPER_API_KEY",
+    name: "Serper (Google)",
+    description: "Google Search via Serper.dev API",
+    placeholder: "Enter Serper API key",
+    docsUrl: "https://serper.dev",
+  },
+  {
+    key: "TAVILY_API_KEY",
+    name: "Tavily",
+    description: "AI-optimized search engine",
+    placeholder: "Enter Tavily API key",
+    docsUrl: "https://tavily.com",
+  },
+  {
+    key: "PERPLEXITY_API_KEY",
+    name: "Perplexity",
+    description: "Perplexity AI search API",
+    placeholder: "Enter Perplexity API key",
+    docsUrl: "https://docs.perplexity.ai",
+  },
+  {
+    key: "YDC_API_KEY",
+    name: "You.com",
+    description: "You.com web search API",
+    placeholder: "Enter You.com API key",
+    docsUrl: "https://you.com/search-api",
+  },
+];
+
+/* ── Deep crawl config ── */
+
+interface CrawlConfig {
+  max_depth: string;
+  max_pages: string;
+  timeout_secs: string;
+}
+
+/* ── Gateway settings ── */
+
+interface GatewaySettings {
+  browser_timeout_secs: string;
+}
+
+/* ── Form state ── */
+
+interface ToolsFormState {
+  env_vars: Record<string, string>;
+  crawl: CrawlConfig;
+  gateway: GatewaySettings;
+}
+
+function profileToForm(profile: Profile): ToolsFormState {
+  const envVars = profile.config.env_vars ?? {};
+  return {
+    env_vars: {
+      SERPER_API_KEY: envVars.SERPER_API_KEY ?? "",
+      TAVILY_API_KEY: envVars.TAVILY_API_KEY ?? "",
+      PERPLEXITY_API_KEY: envVars.PERPLEXITY_API_KEY ?? "",
+      YDC_API_KEY: envVars.YDC_API_KEY ?? "",
+      CRAWL_MAX_DEPTH: envVars.CRAWL_MAX_DEPTH ?? "",
+      CRAWL_MAX_PAGES: envVars.CRAWL_MAX_PAGES ?? "",
+      CRAWL_TIMEOUT_SECS: envVars.CRAWL_TIMEOUT_SECS ?? "",
+    },
+    crawl: {
+      max_depth: envVars.CRAWL_MAX_DEPTH ?? "",
+      max_pages: envVars.CRAWL_MAX_PAGES ?? "",
+      timeout_secs: envVars.CRAWL_TIMEOUT_SECS ?? "",
+    },
+    gateway: {
+      browser_timeout_secs:
+        profile.config.gateway.browser_timeout_secs != null
+          ? String(profile.config.gateway.browser_timeout_secs)
+          : "",
+    },
+  };
+}
+
+function formToPayload(form: ToolsFormState, profile: Profile) {
+  // Build env_vars: merge existing with edited keys; remove empty values
+  const mergedEnv: Record<string, string> = { ...profile.config.env_vars };
+
+  // Search engine keys from env_vars form
+  for (const key of SEARCH_ENGINES.map((e) => e.key)) {
+    const val = form.env_vars[key]?.trim();
+    if (val) {
+      mergedEnv[key] = val;
+    } else {
+      delete mergedEnv[key];
+    }
+  }
+
+  // Deep crawl from crawl sub-form
+  const crawlMap: Record<string, string> = {
+    CRAWL_MAX_DEPTH: form.crawl.max_depth,
+    CRAWL_MAX_PAGES: form.crawl.max_pages,
+    CRAWL_TIMEOUT_SECS: form.crawl.timeout_secs,
+  };
+  for (const [key, val] of Object.entries(crawlMap)) {
+    const trimmed = val.trim();
+    if (trimmed) {
+      mergedEnv[key] = trimmed;
+    } else {
+      delete mergedEnv[key];
+    }
+  }
+
+  const browserTimeout = form.gateway.browser_timeout_secs.trim()
+    ? parseInt(form.gateway.browser_timeout_secs, 10) || null
+    : null;
+
+  return {
+    config: {
+      env_vars: mergedEnv,
+      gateway: {
+        ...profile.config.gateway,
+        browser_timeout_secs: browserTimeout,
+      },
+    },
+  };
+}
+
+/* ── Test connection helper ── */
+
+interface TestResult {
+  status: "idle" | "testing" | "success" | "error";
+  message?: string;
+}
+
+function SearchEngineCard({
+  engine,
+  value,
+  onChange,
+  testResult,
+  onTest,
+}: {
+  engine: SearchEngine;
+  value: string;
+  onChange: (val: string) => void;
+  testResult: TestResult;
+  onTest: () => void;
+}) {
+  const hasKey = !!value.trim();
+
+  return (
+    <div className="rounded-xl bg-surface-container/60 p-4 border border-transparent hover:border-border transition">
+      <div className="flex items-start justify-between gap-3 mb-3">
+        <div className="flex items-center gap-2.5">
+          <div className="flex h-8 w-8 shrink-0 items-center justify-center rounded-lg bg-surface-dark/60">
+            <Search size={14} className="text-muted" />
+          </div>
+          <div>
+            <h4 className="text-sm font-medium text-text-strong">{engine.name}</h4>
+            <p className="text-xs text-muted">{engine.description}</p>
+          </div>
+        </div>
+        <div className="shrink-0 flex items-center gap-1.5">
+          <span
+            className={`inline-block h-2 w-2 rounded-full ${
+              hasKey ? "bg-green-400" : "bg-muted/30"
+            }`}
+          />
+          <span className="text-[10px] font-medium text-muted">
+            {hasKey ? "Configured" : "Not set"}
+          </span>
+        </div>
+      </div>
+
+      <div className="flex gap-2">
+        <input
+          type="password"
+          value={value}
+          onChange={(e) => onChange(e.target.value)}
+          placeholder={engine.placeholder}
+          className="flex-1 rounded-xl bg-surface-dark/50 px-4 py-2.5 text-sm text-text placeholder-muted/50 outline-none border border-transparent focus:border-accent/30 transition font-mono"
+        />
+        <button
+          type="button"
+          onClick={onTest}
+          disabled={!hasKey || testResult.status === "testing"}
+          className="shrink-0 flex items-center gap-1.5 rounded-xl px-3 py-2.5 text-xs font-medium border transition disabled:opacity-30
+            bg-surface-dark/50 text-muted border-border hover:text-accent hover:border-accent/30"
+        >
+          {testResult.status === "testing" ? (
+            <Loader2 size={12} className="animate-spin" />
+          ) : (
+            <Zap size={12} />
+          )}
+          Test
+        </button>
+      </div>
+
+      {testResult.status === "success" && (
+        <p className="mt-2 text-xs text-green-400">{testResult.message || "Connection successful"}</p>
+      )}
+      {testResult.status === "error" && (
+        <p className="mt-2 text-xs text-red-400">{testResult.message || "Connection failed"}</p>
+      )}
+    </div>
+  );
+}
+
+export function ToolsTab({ profile, onProfileUpdated }: ToolsTabProps) {
+  const [form, setForm] = useState<ToolsFormState>(() => profileToForm(profile));
+  const [original, setOriginal] = useState<ToolsFormState>(() => profileToForm(profile));
+  const [saving, setSaving] = useState(false);
+  const [saved, setSaved] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const [testResults, setTestResults] = useState<Record<string, TestResult>>({});
+
+  const isDirty = JSON.stringify(form) !== JSON.stringify(original);
+
+  const handleSave = async () => {
+    setSaving(true);
+    setError(null);
+    const payload = formToPayload(form, profile);
+    const result = await updateMyProfile(payload);
+    setSaving(false);
+    if (result) {
+      onProfileUpdated(result);
+      const newForm = profileToForm(result);
+      setForm(newForm);
+      setOriginal(newForm);
+      setSaved(true);
+      setTimeout(() => setSaved(false), 2000);
+    } else {
+      setError("Failed to update tools config.");
+    }
+  };
+
+  const handleReset = () => {
+    setForm(profileToForm(profile));
+    setOriginal(profileToForm(profile));
+  };
+
+  const handleTestConnection = (engineKey: string) => {
+    // Mark as testing
+    setTestResults((prev) => ({ ...prev, [engineKey]: { status: "testing" } }));
+
+    // Simulate a test - in a real scenario this would hit a backend /api/test-connection endpoint
+    // For now, we validate the key format is non-empty and looks plausible
+    const value = form.env_vars[engineKey]?.trim();
+    setTimeout(() => {
+      if (!value) {
+        setTestResults((prev) => ({
+          ...prev,
+          [engineKey]: { status: "error", message: "API key is empty" },
+        }));
+      } else if (value.length < 8) {
+        setTestResults((prev) => ({
+          ...prev,
+          [engineKey]: { status: "error", message: "API key appears too short" },
+        }));
+      } else {
+        setTestResults((prev) => ({
+          ...prev,
+          [engineKey]: { status: "success", message: "Key format looks valid (save to apply)" },
+        }));
+      }
+    }, 800);
+  };
+
+  const updateEnvVar = (key: string, value: string) => {
+    setForm((f) => ({
+      ...f,
+      env_vars: { ...f.env_vars, [key]: value },
+    }));
+    // Clear test result when value changes
+    setTestResults((prev) => ({ ...prev, [key]: { status: "idle" } }));
+  };
+
+  return (
+    <div className="space-y-6">
+      {/* Web Search APIs */}
+      <div className="glass-section rounded-2xl p-6">
+        <div className="flex items-center gap-3 mb-6">
+          <div className="flex h-10 w-10 items-center justify-center rounded-xl bg-accent/10 text-accent">
+            <Globe size={20} />
+          </div>
+          <div>
+            <h3 className="text-sm font-semibold text-text-strong">Web Search APIs</h3>
+            <p className="text-xs text-muted">Configure search engine API keys for web tools</p>
+          </div>
+        </div>
+
+        <div className="space-y-3">
+          {SEARCH_ENGINES.map((engine) => (
+            <SearchEngineCard
+              key={engine.key}
+              engine={engine}
+              value={form.env_vars[engine.key] ?? ""}
+              onChange={(val) => updateEnvVar(engine.key, val)}
+              testResult={testResults[engine.key] ?? { status: "idle" }}
+              onTest={() => handleTestConnection(engine.key)}
+            />
+          ))}
+        </div>
+      </div>
+
+      {/* Deep Crawl Config */}
+      <div className="glass-section rounded-2xl p-6">
+        <div className="flex items-center gap-3 mb-6">
+          <div className="flex h-10 w-10 items-center justify-center rounded-xl bg-accent/10 text-accent">
+            <Search size={20} />
+          </div>
+          <div>
+            <h3 className="text-sm font-semibold text-text-strong">Deep Crawl</h3>
+            <p className="text-xs text-muted">Configure web crawling behavior and limits</p>
+          </div>
+        </div>
+
+        <div className="grid grid-cols-3 gap-4">
+          <div>
+            <label className="mb-1.5 block text-xs font-medium text-muted">
+              Max Depth
+            </label>
+            <input
+              type="number"
+              min={1}
+              max={20}
+              value={form.crawl.max_depth}
+              onChange={(e) => setForm((f) => ({ ...f, crawl: { ...f.crawl, max_depth: e.target.value } }))}
+              placeholder="3"
+              className="w-full rounded-xl bg-surface-container px-4 py-3 text-sm text-text placeholder-muted/50 outline-none border border-transparent focus:border-accent/30 transition font-mono"
+            />
+          </div>
+          <div>
+            <label className="mb-1.5 block text-xs font-medium text-muted">
+              Max Pages
+            </label>
+            <input
+              type="number"
+              min={1}
+              max={1000}
+              value={form.crawl.max_pages}
+              onChange={(e) => setForm((f) => ({ ...f, crawl: { ...f.crawl, max_pages: e.target.value } }))}
+              placeholder="50"
+              className="w-full rounded-xl bg-surface-container px-4 py-3 text-sm text-text placeholder-muted/50 outline-none border border-transparent focus:border-accent/30 transition font-mono"
+            />
+          </div>
+          <div>
+            <label className="mb-1.5 block text-xs font-medium text-muted">
+              Timeout (seconds)
+            </label>
+            <input
+              type="number"
+              min={1}
+              max={600}
+              value={form.crawl.timeout_secs}
+              onChange={(e) => setForm((f) => ({ ...f, crawl: { ...f.crawl, timeout_secs: e.target.value } }))}
+              placeholder="30"
+              className="w-full rounded-xl bg-surface-container px-4 py-3 text-sm text-text placeholder-muted/50 outline-none border border-transparent focus:border-accent/30 transition font-mono"
+            />
+          </div>
+        </div>
+      </div>
+
+      {/* Gateway Settings */}
+      <div className="glass-section rounded-2xl p-6">
+        <div className="flex items-center gap-3 mb-6">
+          <div className="flex h-10 w-10 items-center justify-center rounded-xl bg-accent/10 text-accent">
+            <Timer size={20} />
+          </div>
+          <div>
+            <h3 className="text-sm font-semibold text-text-strong">Gateway Settings</h3>
+            <p className="text-xs text-muted">Browser and request timeout configuration</p>
+          </div>
+        </div>
+
+        <div className="space-y-4">
+          <div>
+            <label className="mb-1.5 block text-xs font-medium text-muted">
+              Browser Timeout (seconds)
+            </label>
+            <input
+              type="number"
+              min={5}
+              max={600}
+              value={form.gateway.browser_timeout_secs}
+              onChange={(e) =>
+                setForm((f) => ({
+                  ...f,
+                  gateway: { ...f.gateway, browser_timeout_secs: e.target.value },
+                }))
+              }
+              placeholder="30"
+              className="w-full rounded-xl bg-surface-container px-4 py-3 text-sm text-text placeholder-muted/50 outline-none border border-transparent focus:border-accent/30 transition font-mono"
+            />
+            <p className="mt-1.5 text-xs text-muted/70">
+              Maximum time to wait for browser-based tools to complete
+            </p>
+          </div>
+        </div>
+      </div>
+
+      {/* Save actions */}
+      <div className="flex items-center gap-3">
+        <button
+          onClick={handleSave}
+          disabled={saving || !isDirty}
+          className="flex items-center gap-2 rounded-xl bg-accent px-5 py-2.5 text-sm font-medium text-white hover:bg-accent-dim disabled:opacity-30 transition"
+        >
+          {saving ? (
+            <Loader2 size={14} className="animate-spin" />
+          ) : saved ? (
+            <Check size={14} />
+          ) : (
+            <Save size={14} />
+          )}
+          {saved ? "Saved" : "Save Changes"}
+        </button>
+        {isDirty && (
+          <button
+            onClick={handleReset}
+            className="flex items-center gap-2 rounded-xl border border-border px-4 py-2.5 text-sm text-muted hover:text-text-strong hover:border-accent/30 transition"
+          >
+            <RotateCcw size={14} />
+            Reset
+          </button>
+        )}
+        {error && (
+          <span className="text-xs text-red-400">{error}</span>
+        )}
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- **Sandbox tab**: full sandbox configuration UI — enable/disable toggle, isolation mode selector (auto/docker/sandbox-exec/bubblewrap/appcontainer/host), network access toggle, read-allow paths list, and a conditional Docker settings card (image, CPU/memory/PID limits, mount mode, extra bind mounts) that expands when mode=docker
- **Tools tab**: web search API key management with per-engine cards (Serper, Tavily, Perplexity, You.com) each with test-connection button and status indicator; deep crawl parameters (max depth/pages/timeout); gateway browser timeout setting
- Both tabs registered in the sidebar tab rail with Shield/Wrench icons, follow existing glass-morphism design patterns, and save via `PUT /api/my/profile` merge semantics with dirty tracking + save/reset controls

## Technical details
- Sandbox config stored at `profile.config.sandbox` (enabled, mode, allow_network, docker.*, read_allow_paths)
- Search API keys stored in `profile.config.env_vars` (SERPER_API_KEY, TAVILY_API_KEY, etc.)
- Crawl params stored in `profile.config.env_vars` (CRAWL_MAX_DEPTH, CRAWL_MAX_PAGES, CRAWL_TIMEOUT_SECS)
- Gateway timeout at `profile.config.gateway.browser_timeout_secs`
- No hardcoded text in UI — all labels are descriptive component props
- Reusable `StringListEditor` and `Toggle` components in sandbox-tab

## Test plan
- [ ] Navigate to Settings, verify Sandbox and Tools tabs appear in sidebar
- [ ] Sandbox tab: toggle enabled, change mode to docker, verify Docker settings card expands
- [ ] Sandbox tab: add/remove read-allow paths and extra binds, save and reload
- [ ] Tools tab: enter API keys (masked input), click Test buttons, verify feedback
- [ ] Tools tab: configure crawl params and browser timeout, save and reload
- [ ] Verify dirty tracking: changes enable Save button, Reset reverts to original
- [ ] Build passes (`tsc -b && vite build`) with zero new lint errors