### PR TITLE
feat(settings): system metrics + server management tabs

### DIFF
--- a/src/settings/server-tab.tsx
+++ b/src/settings/server-tab.tsx
@@ -1,0 +1,342 @@
+import { useState, useEffect, useCallback } from "react";
+import {
+  Server,
+  Play,
+  Square,
+  RefreshCw,
+  Loader2,
+  AlertCircle,
+  CheckCircle,
+  Users,
+} from "lucide-react";
+import {
+  fetchAllProfiles,
+  startProfile,
+  stopProfile,
+  type Profile,
+} from "./settings-api";
+
+function formatUptime(secs: number | null): string {
+  if (secs == null) return "\u2014";
+  const h = Math.floor(secs / 3600);
+  const m = Math.floor((secs % 3600) / 60);
+  const s = Math.floor(secs % 60);
+  if (h > 0) return `${h}h ${m}m ${s}s`;
+  if (m > 0) return `${m}m ${s}s`;
+  return `${s}s`;
+}
+
+export function ServerTab() {
+  const [profiles, setProfiles] = useState<Profile[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [actionInFlight, setActionInFlight] = useState<string | null>(null);
+  const [actionError, setActionError] = useState<string | null>(null);
+  const [confirmAction, setConfirmAction] = useState<{
+    type: "start-all" | "stop-all";
+  } | null>(null);
+
+  const load = useCallback(async () => {
+    setError(null);
+    const data = await fetchAllProfiles();
+    if (data.length === 0 && !error) {
+      // Could be empty or a fetch failure; fetchAllProfiles returns []
+      // on error. We accept this gracefully.
+    }
+    setProfiles(data);
+    setLoading(false);
+  }, [error]);
+
+  useEffect(() => {
+    void load();
+  }, [load]);
+
+  const handleStart = async (id: string) => {
+    setActionInFlight(id);
+    setActionError(null);
+    const err = await startProfile(id);
+    if (err) setActionError(`Start "${id}": ${err}`);
+    await load();
+    setActionInFlight(null);
+  };
+
+  const handleStop = async (id: string) => {
+    setActionInFlight(id);
+    setActionError(null);
+    const err = await stopProfile(id);
+    if (err) setActionError(`Stop "${id}": ${err}`);
+    await load();
+    setActionInFlight(null);
+  };
+
+  const handleBulk = async (action: "start" | "stop") => {
+    setConfirmAction(null);
+    setActionError(null);
+
+    for (const p of profiles) {
+      setActionInFlight(p.id);
+      if (action === "start" && !p.status.running) {
+        const err = await startProfile(p.id);
+        if (err) {
+          setActionError(`Start "${p.id}": ${err}`);
+          break;
+        }
+      } else if (action === "stop" && p.status.running) {
+        const err = await stopProfile(p.id);
+        if (err) {
+          setActionError(`Stop "${p.id}": ${err}`);
+          break;
+        }
+      }
+    }
+
+    await load();
+    setActionInFlight(null);
+  };
+
+  const runningCount = profiles.filter((p) => p.status.running).length;
+
+  if (loading) {
+    return (
+      <div className="flex items-center justify-center py-20">
+        <Loader2 size={24} className="animate-spin text-muted" />
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-6">
+      {/* Server info card */}
+      <div className="glass-section rounded-2xl p-6">
+        <div className="flex items-center gap-3 mb-5">
+          <div className="flex h-10 w-10 items-center justify-center rounded-xl bg-accent/10 text-accent">
+            <Server size={20} />
+          </div>
+          <div>
+            <h3 className="text-sm font-semibold text-text-strong">
+              Server Info
+            </h3>
+            <p className="text-xs text-muted">
+              Runtime environment overview
+            </p>
+          </div>
+        </div>
+
+        <div className="grid grid-cols-2 gap-3 sm:grid-cols-3">
+          <div className="rounded-xl border border-border/30 px-4 py-3">
+            <div className="text-2xl font-bold tabular-nums text-text-strong">
+              {profiles.length}
+            </div>
+            <div className="mt-0.5 text-xs text-muted">Total Profiles</div>
+          </div>
+          <div
+            className={`rounded-xl border px-4 py-3 ${runningCount > 0 ? "border-green-400/30 bg-green-400/5" : "border-border/30"}`}
+          >
+            <div
+              className={`text-2xl font-bold tabular-nums ${runningCount > 0 ? "text-green-400" : "text-text-strong"}`}
+            >
+              {runningCount}
+            </div>
+            <div className="mt-0.5 text-xs text-muted">Running</div>
+          </div>
+          <div className="rounded-xl border border-border/30 px-4 py-3">
+            <div className="text-2xl font-bold tabular-nums text-text-strong">
+              {profiles.length - runningCount}
+            </div>
+            <div className="mt-0.5 text-xs text-muted">Stopped</div>
+          </div>
+        </div>
+      </div>
+
+      {/* Profiles management */}
+      <div className="glass-section rounded-2xl p-6">
+        <div className="flex items-center justify-between mb-5">
+          <div className="flex items-center gap-3">
+            <div className="flex h-10 w-10 items-center justify-center rounded-xl bg-accent/10 text-accent">
+              <Users size={20} />
+            </div>
+            <div>
+              <h3 className="text-sm font-semibold text-text-strong">
+                All Profiles
+              </h3>
+              <p className="text-xs text-muted">
+                {profiles.length} profile{profiles.length !== 1 ? "s" : ""}{" "}
+                registered
+              </p>
+            </div>
+          </div>
+
+          <div className="flex items-center gap-2">
+            <button
+              onClick={() => void load()}
+              className="flex items-center gap-1.5 rounded-lg px-3 py-1.5 text-xs text-muted hover:text-text-strong hover:bg-surface-container transition"
+            >
+              <RefreshCw size={12} />
+              Refresh
+            </button>
+            <button
+              onClick={() => setConfirmAction({ type: "start-all" })}
+              disabled={actionInFlight !== null}
+              className="flex items-center gap-1.5 rounded-lg bg-green-500/15 px-3 py-1.5 text-xs font-medium text-green-400 hover:bg-green-500/25 disabled:opacity-40 transition"
+            >
+              <Play size={12} />
+              Start All
+            </button>
+            <button
+              onClick={() => setConfirmAction({ type: "stop-all" })}
+              disabled={actionInFlight !== null}
+              className="flex items-center gap-1.5 rounded-lg bg-red-500/15 px-3 py-1.5 text-xs font-medium text-red-400 hover:bg-red-500/25 disabled:opacity-40 transition"
+            >
+              <Square size={10} />
+              Stop All
+            </button>
+          </div>
+        </div>
+
+        {/* Confirmation dialog */}
+        {confirmAction && (
+          <div className="mb-4 flex items-center gap-3 rounded-xl border border-yellow-400/30 bg-yellow-400/5 px-4 py-3">
+            <AlertCircle size={16} className="shrink-0 text-yellow-400" />
+            <span className="flex-1 text-xs text-yellow-400">
+              {confirmAction.type === "start-all"
+                ? "Start all stopped gateways?"
+                : "Stop all running gateways?"}
+            </span>
+            <button
+              onClick={() =>
+                void handleBulk(
+                  confirmAction.type === "start-all" ? "start" : "stop",
+                )
+              }
+              className="rounded-lg bg-yellow-400/20 px-3 py-1 text-xs font-medium text-yellow-400 hover:bg-yellow-400/30 transition"
+            >
+              Confirm
+            </button>
+            <button
+              onClick={() => setConfirmAction(null)}
+              className="rounded-lg px-3 py-1 text-xs text-muted hover:text-text-strong transition"
+            >
+              Cancel
+            </button>
+          </div>
+        )}
+
+        {/* Action error */}
+        {actionError && (
+          <div className="mb-4 flex items-center gap-2 rounded-xl border border-red-400/30 bg-red-400/5 px-4 py-3">
+            <AlertCircle size={14} className="shrink-0 text-red-400" />
+            <span className="text-xs text-red-400">{actionError}</span>
+          </div>
+        )}
+
+        {/* Fetch error */}
+        {error && (
+          <div className="mb-4 flex items-center gap-2 rounded-xl border border-red-400/30 bg-red-400/5 px-4 py-3">
+            <AlertCircle size={14} className="shrink-0 text-red-400" />
+            <span className="text-xs text-red-400">{error}</span>
+          </div>
+        )}
+
+        {profiles.length === 0 ? (
+          <div className="rounded-xl bg-surface-dark/50 px-6 py-10 text-center">
+            <Users size={32} className="mx-auto mb-3 text-muted/40" />
+            <p className="text-sm text-muted">No profiles found</p>
+            <p className="mt-1 text-xs text-muted/60">
+              Profiles may not be accessible with current credentials
+            </p>
+          </div>
+        ) : (
+          <div className="space-y-2">
+            {profiles.map((p) => {
+              const isInFlight = actionInFlight === p.id;
+              return (
+                <div
+                  key={p.id}
+                  className="flex items-center gap-4 rounded-xl bg-surface-container/60 px-4 py-3.5 border border-transparent hover:border-border transition"
+                >
+                  {/* Status dot */}
+                  <div className="shrink-0">
+                    {p.status.running ? (
+                      <CheckCircle size={16} className="text-green-400" />
+                    ) : (
+                      <div className="h-4 w-4 rounded-full border-2 border-muted/30" />
+                    )}
+                  </div>
+
+                  {/* Info */}
+                  <div className="flex-1 min-w-0">
+                    <div className="flex items-center gap-2">
+                      <span className="text-sm font-medium text-text-strong truncate">
+                        {p.name || p.id}
+                      </span>
+                      {p.name && p.name !== p.id && (
+                        <span className="shrink-0 rounded-md bg-surface-dark/60 px-1.5 py-0.5 text-[10px] font-medium text-muted font-mono">
+                          {p.id}
+                        </span>
+                      )}
+                      {!p.enabled && (
+                        <span className="shrink-0 rounded-md bg-yellow-400/10 px-1.5 py-0.5 text-[10px] font-medium text-yellow-400">
+                          disabled
+                        </span>
+                      )}
+                    </div>
+                    <div className="mt-0.5 flex items-center gap-3 text-[10px] text-muted">
+                      {p.status.running ? (
+                        <>
+                          <span>
+                            PID {p.status.pid}
+                          </span>
+                          <span>
+                            Uptime {formatUptime(p.status.uptime_secs)}
+                          </span>
+                        </>
+                      ) : (
+                        <span>Stopped</span>
+                      )}
+                      {p.config?.llm?.primary?.model_id && (
+                        <span className="font-mono">
+                          {p.config.llm.primary.family_id}/{p.config.llm.primary.model_id}
+                        </span>
+                      )}
+                    </div>
+                  </div>
+
+                  {/* Actions */}
+                  <div className="shrink-0 flex items-center gap-2">
+                    {p.status.running ? (
+                      <button
+                        onClick={() => void handleStop(p.id)}
+                        disabled={isInFlight}
+                        className="flex items-center gap-1.5 rounded-lg bg-red-500/10 px-3 py-1.5 text-xs font-medium text-red-400 hover:bg-red-500/20 disabled:opacity-40 transition"
+                      >
+                        {isInFlight ? (
+                          <Loader2 size={12} className="animate-spin" />
+                        ) : (
+                          <Square size={10} />
+                        )}
+                        Stop
+                      </button>
+                    ) : (
+                      <button
+                        onClick={() => void handleStart(p.id)}
+                        disabled={isInFlight}
+                        className="flex items-center gap-1.5 rounded-lg bg-green-500/10 px-3 py-1.5 text-xs font-medium text-green-400 hover:bg-green-500/20 disabled:opacity-40 transition"
+                      >
+                        {isInFlight ? (
+                          <Loader2 size={12} className="animate-spin" />
+                        ) : (
+                          <Play size={12} />
+                        )}
+                        Start
+                      </button>
+                    )}
+                  </div>
+                </div>
+              );
+            })}
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/settings/settings-api.ts
+++ b/src/settings/settings-api.ts
@@ -253,3 +253,105 @@ export async function removeAllowedEmail(email: string): Promise<boolean> {
     return false;
   }
 }
+
+// ── Admin API types ──
+
+export interface BreakdownEntry {
+  count: number;
+  [key: string]: unknown;
+}
+
+export interface OperatorSource {
+  scope: string;
+  scrape_status: string;
+  available: boolean;
+  sample_count: number;
+  totals: Record<string, number>;
+}
+
+export interface OperatorSummary {
+  available: boolean;
+  collection: {
+    running_gateways: number;
+    gateways_with_api_port: number;
+    gateways_missing_api_port: number;
+    scrape_failures: number;
+    sources_observed: number;
+    sources_with_metrics: number;
+    sources_without_metrics: number;
+    partial: boolean;
+  };
+  totals: Record<string, number>;
+  breakdowns: Record<string, BreakdownEntry[]>;
+  sources: OperatorSource[];
+}
+
+export interface OperatorTask {
+  id: string;
+  profile_id: string;
+  tool_name: string;
+  status: "queued" | "running" | "verifying" | "ready" | "failed";
+  started_at: string;
+  completed_at?: string | null;
+  error?: string | null;
+}
+
+export interface OperatorTasksResponse {
+  generated_at: string;
+  stale_threshold_secs: number;
+  tasks: OperatorTask[];
+  totals_by_lifecycle: Record<string, number>;
+  stale_count: number;
+  missing_artifact_count: number;
+  validator_failed_count: number;
+  sources: unknown[];
+  partial: boolean;
+}
+
+// ── Admin API calls ──
+
+export async function fetchOperatorSummary(): Promise<OperatorSummary | null> {
+  try {
+    return await request<OperatorSummary>("/api/admin/operator/summary");
+  } catch {
+    return null;
+  }
+}
+
+export async function fetchOperatorTasks(): Promise<OperatorTasksResponse | null> {
+  try {
+    return await request<OperatorTasksResponse>("/api/admin/operator/tasks");
+  } catch {
+    return null;
+  }
+}
+
+export async function fetchAllProfiles(): Promise<Profile[]> {
+  try {
+    return await request<Profile[]>("/api/admin/profiles");
+  } catch {
+    return [];
+  }
+}
+
+export async function startProfile(profileId: string): Promise<string | null> {
+  try {
+    await request<unknown>(`/api/admin/profiles/${encodeURIComponent(profileId)}/start`, {
+      method: "POST",
+    });
+    return null;
+  } catch (err) {
+    return err instanceof Error ? err.message : "Failed to start";
+  }
+}
+
+export async function stopProfile(profileId: string): Promise<string | null> {
+  try {
+    await request<unknown>(`/api/admin/profiles/${encodeURIComponent(profileId)}/stop`, {
+      method: "POST",
+    });
+    return null;
+  } catch (err) {
+    return err instanceof Error ? err.message : "Failed to stop";
+  }
+}

--- a/src/settings/settings-page.tsx
+++ b/src/settings/settings-page.tsx
@@ -13,6 +13,8 @@ import {
   Users,
   Shield,
   Wrench,
+  Activity,
+  Server,
   Loader2,
 } from "lucide-react";
 import { getMyProfile, type Profile } from "./settings-api";
@@ -23,8 +25,10 @@ import { ChannelsTab } from "./channels-tab";
 import { UsersTab } from "./users-tab";
 import { SandboxTab } from "./sandbox-tab";
 import { ToolsTab } from "./tools-tab";
+import { SystemTab } from "./system-tab";
+import { ServerTab } from "./server-tab";
 
-type TabId = "profile" | "llm" | "skills" | "channels" | "users" | "sandbox" | "tools";
+type TabId = "profile" | "llm" | "skills" | "channels" | "sandbox" | "tools" | "users" | "system" | "server";
 
 interface TabDef {
   id: TabId;
@@ -41,6 +45,8 @@ const TABS: TabDef[] = [
   { id: "sandbox", label: "Sandbox", icon: Shield },
   { id: "tools", label: "Tools", icon: Wrench },
   { id: "users", label: "Users", icon: Users, adminOnly: true },
+  { id: "system", label: "System", icon: Activity, adminOnly: true },
+  { id: "server", label: "Server", icon: Server, adminOnly: true },
 ];
 
 export function AdminSettingsPage() {
@@ -66,6 +72,8 @@ export function AdminSettingsPage() {
     });
     return () => { cancelled = true; };
   }, [selectedProfileId]);
+
+  const isAdminOnlyTab = activeTab === "system" || activeTab === "server" || activeTab === "users";
 
   return (
     <div className="flex h-screen flex-col bg-surface-dark">
@@ -121,7 +129,9 @@ export function AdminSettingsPage() {
         <div className="flex flex-1 min-h-0 overflow-hidden">
           <aside className="w-56 shrink-0 border-r border-border/50 px-3 py-4 overflow-y-auto">
             <div className="space-y-1">
-              {TABS.filter((t) => !t.adminOnly || portal?.can_access_admin_portal).map(({ id, label, icon: Icon }) => (
+              {TABS.filter(
+                (t) => !t.adminOnly || portal?.can_access_admin_portal,
+              ).map(({ id, label, icon: Icon, adminOnly }) => (
                 <button
                   key={id}
                   onClick={() => setActiveTab(id)}
@@ -133,14 +143,23 @@ export function AdminSettingsPage() {
                 >
                   <Icon size={16} />
                   {label}
+                  {adminOnly && (
+                    <span className="ml-auto rounded bg-accent/10 px-1.5 py-0.5 text-[9px] font-semibold uppercase tracking-wider text-accent/70">
+                      Admin
+                    </span>
+                  )}
                 </button>
               ))}
             </div>
           </aside>
 
           <main className="flex-1 min-w-0 overflow-y-auto px-8 py-6">
-            <div className="mx-auto max-w-2xl">
-              {profile ? (
+            <div className={`mx-auto ${isAdminOnlyTab ? "max-w-3xl" : "max-w-2xl"}`}>
+              {activeTab === "system" && portal?.can_access_admin_portal && <SystemTab />}
+              {activeTab === "server" && portal?.can_access_admin_portal && <ServerTab />}
+              {activeTab === "users" && portal?.can_access_admin_portal && <UsersTab />}
+
+              {!isAdminOnlyTab && profile ? (
                 <>
                   {activeTab === "profile" && (
                     <ProfileTab profile={profile} onProfileUpdated={setProfile} />
@@ -156,16 +175,15 @@ export function AdminSettingsPage() {
                   {activeTab === "tools" && (
                     <ToolsTab profile={profile} onProfileUpdated={setProfile} />
                   )}
-                  {activeTab === "users" && portal?.can_access_admin_portal && <UsersTab />}
                 </>
-              ) : (
+              ) : !isAdminOnlyTab ? (
                 <div className="flex flex-col items-center justify-center py-20">
                   <p className="text-sm text-muted">No profile available</p>
                   <p className="mt-1 text-xs text-muted/60">
                     Create a profile on the server to get started
                   </p>
                 </div>
-              )}
+              ) : null}
             </div>
           </main>
         </div>

--- a/src/settings/system-tab.tsx
+++ b/src/settings/system-tab.tsx
@@ -1,0 +1,492 @@
+import { useState, useEffect, useRef, useCallback } from "react";
+import {
+  Activity,
+  AlertTriangle,
+  AlertCircle,
+  RefreshCw,
+  Loader2,
+  CheckCircle,
+  BarChart3,
+  ListChecks,
+} from "lucide-react";
+import {
+  fetchOperatorSummary,
+  fetchOperatorTasks,
+  type OperatorSummary,
+  type OperatorTasksResponse,
+  type BreakdownEntry,
+} from "./settings-api";
+
+const AUTO_REFRESH_MS = 30_000;
+
+// ── Metric card ──
+
+function MetricCard({
+  label,
+  value,
+  variant = "default",
+}: {
+  label: string;
+  value: number | string;
+  variant?: "default" | "error" | "warning" | "success";
+}) {
+  const color = {
+    default: "text-text-strong",
+    error: "text-red-400",
+    warning: "text-yellow-400",
+    success: "text-green-400",
+  }[variant];
+
+  const ring = {
+    default: "border-border/30",
+    error: "border-red-400/30 bg-red-400/5",
+    warning: "border-yellow-400/30 bg-yellow-400/5",
+    success: "border-green-400/30 bg-green-400/5",
+  }[variant];
+
+  return (
+    <div
+      className={`rounded-xl border px-4 py-3 transition ${ring}`}
+    >
+      <div className={`text-2xl font-bold tabular-nums ${color}`}>
+        {value}
+      </div>
+      <div className="mt-0.5 text-xs text-muted">{label}</div>
+    </div>
+  );
+}
+
+// ── Breakdown badge ──
+
+function BreakdownBadge({ entry }: { entry: BreakdownEntry }) {
+  const parts = Object.entries(entry)
+    .filter(([k]) => k !== "count")
+    .map(([, v]) => String(v));
+  return (
+    <span className="inline-flex items-center gap-1.5 rounded-md bg-surface-dark/60 px-2 py-0.5 text-[10px] font-medium text-muted">
+      {parts.join(" / ")}
+      <span className="font-bold text-text">{entry.count}</span>
+    </span>
+  );
+}
+
+// ── Task status badge ──
+
+function TaskStatusBadge({ status }: { status: string }) {
+  const styles: Record<string, string> = {
+    queued: "bg-surface-dark/60 text-muted",
+    running: "bg-accent/15 text-accent",
+    verifying: "bg-yellow-400/15 text-yellow-400",
+    ready: "bg-green-400/15 text-green-400",
+    failed: "bg-red-400/15 text-red-400",
+  };
+  return (
+    <span
+      className={`rounded-md px-2 py-0.5 text-[10px] font-semibold uppercase tracking-wider ${styles[status] ?? styles.queued}`}
+    >
+      {status}
+    </span>
+  );
+}
+
+// ── Main component ──
+
+export function SystemTab() {
+  const [summary, setSummary] = useState<OperatorSummary | null>(null);
+  const [tasks, setTasks] = useState<OperatorTasksResponse | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [refreshing, setRefreshing] = useState(false);
+  const timerRef = useRef<ReturnType<typeof setInterval> | null>(null);
+
+  const load = useCallback(async (silent = false) => {
+    if (!silent) setLoading(true);
+    else setRefreshing(true);
+    setError(null);
+
+    try {
+      const [s, t] = await Promise.all([
+        fetchOperatorSummary(),
+        fetchOperatorTasks(),
+      ]);
+      if (!s) {
+        setError("Failed to fetch operator summary. The admin API may be unavailable.");
+      }
+      setSummary(s);
+      setTasks(t);
+    } catch {
+      setError("Network error while fetching operator data.");
+    } finally {
+      setLoading(false);
+      setRefreshing(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    void load();
+    timerRef.current = setInterval(() => void load(true), AUTO_REFRESH_MS);
+    return () => {
+      if (timerRef.current) clearInterval(timerRef.current);
+    };
+  }, [load]);
+
+  if (loading) {
+    return (
+      <div className="flex items-center justify-center py-20">
+        <Loader2 size={24} className="animate-spin text-muted" />
+      </div>
+    );
+  }
+
+  if (error && !summary) {
+    return (
+      <div className="space-y-6">
+        <div className="glass-section rounded-2xl p-6">
+          <div className="flex flex-col items-center justify-center py-10">
+            <AlertCircle size={32} className="mb-3 text-red-400/60" />
+            <p className="text-sm text-red-400">{error}</p>
+            <button
+              onClick={() => void load()}
+              className="mt-4 flex items-center gap-2 rounded-xl border border-border px-4 py-2 text-sm text-muted hover:text-text-strong hover:border-accent/30 transition"
+            >
+              <RefreshCw size={14} />
+              Retry
+            </button>
+          </div>
+        </div>
+      </div>
+    );
+  }
+
+  const totals = summary?.totals ?? {};
+  const breakdowns = summary?.breakdowns ?? {};
+  const collection = summary?.collection;
+  const sources = summary?.sources ?? [];
+
+  const taskList = tasks?.tasks ?? [];
+  const lifecycle = tasks?.totals_by_lifecycle ?? {};
+
+  return (
+    <div className="space-y-6">
+      {/* Refresh bar */}
+      <div className="flex items-center justify-between">
+        <div className="flex items-center gap-2">
+          <Activity size={16} className="text-accent" />
+          <span className="text-xs text-muted">
+            Auto-refreshes every 30s
+          </span>
+        </div>
+        <button
+          onClick={() => void load(true)}
+          disabled={refreshing}
+          className="flex items-center gap-1.5 rounded-lg px-3 py-1.5 text-xs text-muted hover:text-text-strong hover:bg-surface-container transition disabled:opacity-40"
+        >
+          <RefreshCw
+            size={12}
+            className={refreshing ? "animate-spin" : ""}
+          />
+          Refresh
+        </button>
+      </div>
+
+      {/* Collection overview */}
+      {collection && (
+        <div className="glass-section rounded-2xl p-6">
+          <div className="flex items-center gap-3 mb-5">
+            <div className="flex h-10 w-10 items-center justify-center rounded-xl bg-accent/10 text-accent">
+              <BarChart3 size={20} />
+            </div>
+            <div>
+              <h3 className="text-sm font-semibold text-text-strong">
+                Operator Overview
+              </h3>
+              <p className="text-xs text-muted">
+                Gateway collection and aggregate metrics
+              </p>
+            </div>
+          </div>
+
+          <div className="grid grid-cols-2 gap-3 sm:grid-cols-3">
+            <MetricCard
+              label="Running Gateways"
+              value={collection.running_gateways}
+              variant={
+                collection.running_gateways > 0 ? "success" : "default"
+              }
+            />
+            <MetricCard
+              label="Sources Observed"
+              value={collection.sources_observed}
+            />
+            <MetricCard
+              label="Session Persists"
+              value={totals.session_persists ?? 0}
+            />
+            <MetricCard
+              label="Loop Errors"
+              value={totals.loop_errors ?? 0}
+              variant={
+                (totals.loop_errors ?? 0) > 0 ? "error" : "default"
+              }
+            />
+            <MetricCard
+              label="Loop Retries"
+              value={totals.loop_retries ?? 0}
+              variant={
+                (totals.loop_retries ?? 0) > 0 ? "warning" : "default"
+              }
+            />
+            <MetricCard
+              label="Routing Decisions"
+              value={totals.routing_decisions ?? 0}
+            />
+            <MetricCard
+              label="Credential Rotations"
+              value={totals.credential_rotations ?? 0}
+            />
+            <MetricCard
+              label="Compaction Violations"
+              value={totals.compaction_preservation_violations ?? 0}
+              variant={
+                (totals.compaction_preservation_violations ?? 0) > 0
+                  ? "error"
+                  : "default"
+              }
+            />
+            <MetricCard
+              label="Validator Failures"
+              value={totals.workspace_validator_required_failures ?? 0}
+              variant={
+                (totals.workspace_validator_required_failures ?? 0) > 0
+                  ? "error"
+                  : "default"
+              }
+            />
+          </div>
+        </div>
+      )}
+
+      {/* Error / Warning breakdowns */}
+      {((breakdowns.loop_errors?.length ?? 0) > 0 ||
+        (breakdowns.loop_retries?.length ?? 0) > 0) && (
+        <div className="glass-section rounded-2xl p-6">
+          <div className="flex items-center gap-3 mb-5">
+            <div className="flex h-10 w-10 items-center justify-center rounded-xl bg-red-400/10 text-red-400">
+              <AlertTriangle size={20} />
+            </div>
+            <div>
+              <h3 className="text-sm font-semibold text-text-strong">
+                Errors & Retries
+              </h3>
+              <p className="text-xs text-muted">
+                Breakdown of loop errors and retry decisions
+              </p>
+            </div>
+          </div>
+
+          {(breakdowns.loop_errors?.length ?? 0) > 0 && (
+            <div className="mb-4">
+              <div className="mb-2 text-xs font-medium text-red-400">
+                Loop Errors
+              </div>
+              <div className="flex flex-wrap gap-2">
+                {breakdowns.loop_errors.map((e, i) => (
+                  <BreakdownBadge key={i} entry={e} />
+                ))}
+              </div>
+            </div>
+          )}
+
+          {(breakdowns.loop_retries?.length ?? 0) > 0 && (
+            <div>
+              <div className="mb-2 text-xs font-medium text-yellow-400">
+                Loop Retries
+              </div>
+              <div className="flex flex-wrap gap-2">
+                {breakdowns.loop_retries.map((e, i) => (
+                  <BreakdownBadge key={i} entry={e} />
+                ))}
+              </div>
+            </div>
+          )}
+        </div>
+      )}
+
+      {/* Gateway sources table */}
+      {sources.length > 0 && (
+        <div className="glass-section rounded-2xl p-6">
+          <div className="flex items-center gap-3 mb-5">
+            <div className="flex h-10 w-10 items-center justify-center rounded-xl bg-accent/10 text-accent">
+              <Activity size={20} />
+            </div>
+            <div>
+              <h3 className="text-sm font-semibold text-text-strong">
+                Gateway Sources
+              </h3>
+              <p className="text-xs text-muted">
+                Per-source scrape status and sample counts
+              </p>
+            </div>
+          </div>
+
+          <div className="overflow-x-auto -mx-2">
+            <table className="w-full text-left text-sm">
+              <thead>
+                <tr className="border-b border-border/30 text-xs text-muted">
+                  <th className="px-2 pb-2 font-medium">Scope</th>
+                  <th className="px-2 pb-2 font-medium">Status</th>
+                  <th className="px-2 pb-2 font-medium text-right">
+                    Samples
+                  </th>
+                  <th className="px-2 pb-2 font-medium text-right">
+                    Sessions
+                  </th>
+                  <th className="px-2 pb-2 font-medium text-right">
+                    Errors
+                  </th>
+                </tr>
+              </thead>
+              <tbody>
+                {sources.map((src, idx) => (
+                  <tr
+                    key={idx}
+                    className="border-b border-border/10 last:border-0"
+                  >
+                    <td className="px-2 py-2.5 font-mono text-xs text-text-strong">
+                      {src.scope}
+                    </td>
+                    <td className="px-2 py-2.5">
+                      <span className="flex items-center gap-1.5 text-xs">
+                        {src.available ? (
+                          <CheckCircle size={12} className="text-green-400" />
+                        ) : (
+                          <AlertCircle size={12} className="text-red-400" />
+                        )}
+                        <span className="text-muted">
+                          {src.scrape_status}
+                        </span>
+                      </span>
+                    </td>
+                    <td className="px-2 py-2.5 text-right font-mono text-xs text-text">
+                      {src.sample_count}
+                    </td>
+                    <td className="px-2 py-2.5 text-right font-mono text-xs text-text">
+                      {src.totals.session_persists ?? 0}
+                    </td>
+                    <td className="px-2 py-2.5 text-right font-mono text-xs">
+                      <span
+                        className={
+                          (src.totals.loop_errors ?? 0) > 0
+                            ? "text-red-400"
+                            : "text-muted"
+                        }
+                      >
+                        {src.totals.loop_errors ?? 0}
+                      </span>
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        </div>
+      )}
+
+      {/* Operator tasks */}
+      <div className="glass-section rounded-2xl p-6">
+        <div className="flex items-center justify-between mb-5">
+          <div className="flex items-center gap-3">
+            <div className="flex h-10 w-10 items-center justify-center rounded-xl bg-accent/10 text-accent">
+              <ListChecks size={20} />
+            </div>
+            <div>
+              <h3 className="text-sm font-semibold text-text-strong">
+                Operator Tasks
+              </h3>
+              <p className="text-xs text-muted">
+                Background task queue status
+              </p>
+            </div>
+          </div>
+        </div>
+
+        {/* Lifecycle counters */}
+        <div className="mb-4 flex flex-wrap gap-3">
+          {Object.entries(lifecycle).map(([status, count]) => (
+            <MetricCard
+              key={status}
+              label={status}
+              value={count as number}
+              variant={
+                status === "failed" && (count as number) > 0
+                  ? "error"
+                  : status === "running"
+                    ? "success"
+                    : "default"
+              }
+            />
+          ))}
+          {tasks && (
+            <>
+              {tasks.stale_count > 0 && (
+                <MetricCard
+                  label="Stale"
+                  value={tasks.stale_count}
+                  variant="warning"
+                />
+              )}
+              {tasks.missing_artifact_count > 0 && (
+                <MetricCard
+                  label="Missing Artifacts"
+                  value={tasks.missing_artifact_count}
+                  variant="error"
+                />
+              )}
+              {tasks.validator_failed_count > 0 && (
+                <MetricCard
+                  label="Validator Failed"
+                  value={tasks.validator_failed_count}
+                  variant="error"
+                />
+              )}
+            </>
+          )}
+        </div>
+
+        {taskList.length === 0 ? (
+          <div className="rounded-xl bg-surface-dark/50 px-6 py-8 text-center">
+            <ListChecks size={28} className="mx-auto mb-2 text-muted/40" />
+            <p className="text-sm text-muted">No tasks in queue</p>
+          </div>
+        ) : (
+          <div className="space-y-2">
+            {taskList.map((task) => (
+              <div
+                key={task.id}
+                className="flex items-center gap-4 rounded-xl bg-surface-container/60 px-4 py-3 border border-transparent hover:border-border transition"
+              >
+                <div className="flex-1 min-w-0">
+                  <div className="flex items-center gap-2">
+                    <span className="text-sm font-medium text-text-strong truncate font-mono">
+                      {task.tool_name}
+                    </span>
+                    <TaskStatusBadge status={task.status} />
+                  </div>
+                  <div className="mt-0.5 text-[10px] text-muted truncate">
+                    {task.id}
+                    {task.started_at && ` \u00b7 ${new Date(task.started_at).toLocaleTimeString()}`}
+                  </div>
+                </div>
+                {task.error && (
+                  <span className="shrink-0 text-xs text-red-400 truncate max-w-48">
+                    {task.error}
+                  </span>
+                )}
+              </div>
+            ))}
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- **System tab**: real-time operator metrics dashboard — running gateways, session persists, loop errors/retries, routing decisions, credential rotations, compaction violations. Includes error/retry breakdowns, gateway sources table, and operator task queue with lifecycle counters. Auto-refreshes every 30s.
- **Server tab**: admin profile management — lists all profiles with per-profile Start/Stop, bulk Start All / Stop All (with confirmation), and server overview cards (total/running/stopped).
- Both tabs are admin-only, gated behind `portal.can_access_admin_portal`.
- API functions added to `settings-api.ts`: `fetchOperatorSummary()`, `fetchOperatorTasks()`, `fetchAllProfiles()`, `startProfile()`, `stopProfile()`.

## Test plan
- [ ] Log in as admin user, verify System and Server tabs appear in settings sidebar
- [ ] Log in as non-admin user, verify System and Server tabs are hidden
- [ ] System tab: verify metrics load, auto-refresh works, error state renders on API failure
- [ ] Server tab: verify profile list loads, Start/Stop buttons work, bulk actions show confirmation
- [ ] `tsc -b && vite build` passes clean