### PR TITLE
feat(home): settings panel, night mode, burn-in protection, suggestions

### DIFF
--- a/src/home/constants.ts
+++ b/src/home/constants.ts
@@ -3,54 +3,183 @@
  *
  * No string is hardcoded in JSX. If i18n is ever wired in, swap
  * these exports for a `t()` call.
+ *
+ * HOME_I18N provides per-language string tables; the active language
+ * is selected via the settings context (`lang` field).
  */
 
-export const HOME_STRINGS = {
-  weekdays: [
-    "Sunday",
-    "Monday",
-    "Tuesday",
-    "Wednesday",
-    "Thursday",
-    "Friday",
-    "Saturday",
-  ] as const,
-  months: [
-    "January",
-    "February",
-    "March",
-    "April",
-    "May",
-    "June",
-    "July",
-    "August",
-    "September",
-    "October",
-    "November",
-    "December",
-  ] as const,
+export interface HomeStrings {
+  weekdays: readonly string[];
+  months: readonly string[];
 
   // Quick-action card labels
-  cardChat: "Chat",
-  cardNews: "News",
-  cardMusic: "Music",
-  cardHome: "Home",
+  cardChat: string;
+  cardNews: string;
+  cardMusic: string;
+  cardHome: string;
 
   // Quick-action card prefills (empty string = no prefill)
-  cardChatPrefill: "",
-  cardNewsPrefill: "What's the latest news today?",
-  cardMusicPrefill: "Play some music for me",
-  cardHomePrefill: "What's the status of my home devices?",
+  cardChatPrefill: string;
+  cardNewsPrefill: string;
+  cardMusicPrefill: string;
+  cardHomePrefill: string;
 
   // Misc
-  backToStandby: "Back",
-  send: "Send",
-  inputPlaceholder: "Say something...",
-  weatherUnavailable: "Weather unavailable",
-  locationUnavailable: "Location unavailable",
+  backToStandby: string;
+  send: string;
+  inputPlaceholder: string;
+  weatherUnavailable: string;
+  locationUnavailable: string;
 
   // Idle return
-  idleReturnSeconds: 30,
+  idleReturnSeconds: number;
+
+  // Settings panel
+  settingsTitle: string;
+  settingsCity: string;
+  settingsCityPlaceholder: string;
+  settingsTempUnit: string;
+  settingsClockFormat: string;
+  settingsIdleSeconds: string;
+  settingsNightMode: string;
+  settingsNightAuto: string;
+  settingsNightOn: string;
+  settingsNightOff: string;
+  settingsLanguage: string;
+  settingsClose: string;
+
+  // Suggestion prompts
+  suggestions: readonly string[];
+}
+
+export const HOME_I18N: Record<string, HomeStrings> = {
+  en: {
+    weekdays: [
+      "Sunday",
+      "Monday",
+      "Tuesday",
+      "Wednesday",
+      "Thursday",
+      "Friday",
+      "Saturday",
+    ],
+    months: [
+      "January",
+      "February",
+      "March",
+      "April",
+      "May",
+      "June",
+      "July",
+      "August",
+      "September",
+      "October",
+      "November",
+      "December",
+    ],
+
+    cardChat: "Chat",
+    cardNews: "News",
+    cardMusic: "Music",
+    cardHome: "Home",
+
+    cardChatPrefill: "",
+    cardNewsPrefill: "What's the latest news today?",
+    cardMusicPrefill: "Play some music for me",
+    cardHomePrefill: "What's the status of my home devices?",
+
+    backToStandby: "Back",
+    send: "Send",
+    inputPlaceholder: "Say something...",
+    weatherUnavailable: "Weather unavailable",
+    locationUnavailable: "Location unavailable",
+
+    idleReturnSeconds: 30,
+
+    settingsTitle: "Settings",
+    settingsCity: "Default City",
+    settingsCityPlaceholder: "e.g. San Francisco",
+    settingsTempUnit: "Temperature",
+    settingsClockFormat: "Clock Format",
+    settingsIdleSeconds: "Idle Return (seconds)",
+    settingsNightMode: "Night Mode",
+    settingsNightAuto: "Auto",
+    settingsNightOn: "On",
+    settingsNightOff: "Off",
+    settingsLanguage: "Language",
+    settingsClose: "Close",
+
+    suggestions: [
+      "What's the weather like today?",
+      "Tell me today's top news",
+      "Set a timer for 5 minutes",
+      "What can you help me with?",
+    ],
+  },
+
+  zh: {
+    weekdays: [
+      "\u661F\u671F\u65E5",
+      "\u661F\u671F\u4E00",
+      "\u661F\u671F\u4E8C",
+      "\u661F\u671F\u4E09",
+      "\u661F\u671F\u56DB",
+      "\u661F\u671F\u4E94",
+      "\u661F\u671F\u516D",
+    ],
+    months: [
+      "\u4E00\u6708",
+      "\u4E8C\u6708",
+      "\u4E09\u6708",
+      "\u56DB\u6708",
+      "\u4E94\u6708",
+      "\u516D\u6708",
+      "\u4E03\u6708",
+      "\u516B\u6708",
+      "\u4E5D\u6708",
+      "\u5341\u6708",
+      "\u5341\u4E00\u6708",
+      "\u5341\u4E8C\u6708",
+    ],
+
+    cardChat: "\u804A\u5929",
+    cardNews: "\u65B0\u95FB",
+    cardMusic: "\u97F3\u4E50",
+    cardHome: "\u9996\u9875",
+
+    cardChatPrefill: "",
+    cardNewsPrefill: "\u4ECA\u5929\u6709\u4EC0\u4E48\u65B0\u95FB\uFF1F",
+    cardMusicPrefill: "\u7ED9\u6211\u64AD\u653E\u97F3\u4E50",
+    cardHomePrefill: "\u6211\u7684\u5BB6\u5C45\u8BBE\u5907\u72B6\u6001\u5982\u4F55\uFF1F",
+
+    backToStandby: "\u8FD4\u56DE",
+    send: "\u53D1\u9001",
+    inputPlaceholder: "\u8BF4\u70B9\u4EC0\u4E48...",
+    weatherUnavailable: "\u5929\u6C14\u4FE1\u606F\u4E0D\u53EF\u7528",
+    locationUnavailable: "\u4F4D\u7F6E\u4FE1\u606F\u4E0D\u53EF\u7528",
+
+    idleReturnSeconds: 30,
+
+    settingsTitle: "\u8BBE\u7F6E",
+    settingsCity: "\u9ED8\u8BA4\u57CE\u5E02",
+    settingsCityPlaceholder: "\u4F8B\u5982 \u5317\u4EAC",
+    settingsTempUnit: "\u6E29\u5EA6\u5355\u4F4D",
+    settingsClockFormat: "\u65F6\u949F\u683C\u5F0F",
+    settingsIdleSeconds: "\u7A7A\u95F2\u8FD4\u56DE (\u79D2)",
+    settingsNightMode: "\u591C\u95F4\u6A21\u5F0F",
+    settingsNightAuto: "\u81EA\u52A8",
+    settingsNightOn: "\u5F00\u542F",
+    settingsNightOff: "\u5173\u95ED",
+    settingsLanguage: "\u8BED\u8A00",
+    settingsClose: "\u5173\u95ED",
+
+    suggestions: [
+      "\u4ECA\u5929\u5929\u6C14\u600E\u4E48\u6837\uFF1F",
+      "\u7ED9\u6211\u8BB2\u8BB2\u4ECA\u5929\u7684\u65B0\u95FB",
+      "\u8BBE\u4E2A5\u5206\u949F\u5012\u8BA1\u65F6",
+      "\u4F60\u80FD\u5E2E\u6211\u505A\u4EC0\u4E48\uFF1F",
+    ],
+  },
 } as const;
 
 /** Fallback location used when both geolocation and IP-based lookup fail. */
@@ -59,6 +188,8 @@ export const DEFAULT_LOCATION = {
   lon: -122.4194,
   city: "San Francisco",
 } as const;
+
+export const HOME_STRINGS = HOME_I18N.en;
 
 // Open-Meteo WMO weather code → emoji + label
 // https://open-meteo.com/en/docs  §WMO Weather interpretation codes

--- a/src/home/conversation-view.tsx
+++ b/src/home/conversation-view.tsx
@@ -5,8 +5,9 @@
  * Reuses OctosRuntimeProvider + ThreadStore for message state, and
  * `bridgeSend` for the WS send path.
  *
- * Auto-returns to standby after `IDLE_RETURN_SECONDS` of inactivity
- * (no user input, no streaming).
+ * Auto-returns to standby after configurable idle seconds (from settings).
+ *
+ * Shows suggestion cards when the conversation is empty.
  */
 
 import {
@@ -21,15 +22,12 @@ import { ArrowLeft, SendHorizontal } from "lucide-react";
 import { useSession } from "@/runtime/session-context";
 import { useThreads, type Thread, type ThreadMessage } from "@/store/thread-store";
 import { sendMessage as bridgeSend } from "@/runtime/ui-protocol-send";
-import { HOME_STRINGS } from "./constants";
+import { useHomeSettings } from "./home-settings-context";
 
 interface ConversationViewProps {
   onBack: () => void;
   prefill?: string;
 }
-
-/** Idle-return timer duration in ms. */
-const IDLE_MS = HOME_STRINGS.idleReturnSeconds * 1000;
 
 function formatBubbleTime(ts: number): string {
   const d = new Date(ts);
@@ -60,11 +58,14 @@ export function ConversationView({ onBack, prefill }: ConversationViewProps) {
     }
   }, [prefill]);
 
+  const { strings, idleSeconds } = useHomeSettings();
+  const idleMs = idleSeconds * 1000;
+
   // ── Idle return ─────────────────────────────────────────────────
   const resetIdle = useCallback(() => {
     clearTimeout(idleTimerRef.current);
-    idleTimerRef.current = setTimeout(onBack, IDLE_MS);
-  }, [onBack]);
+    idleTimerRef.current = setTimeout(onBack, idleMs);
+  }, [onBack, idleMs]);
 
   useEffect(() => {
     resetIdle();
@@ -148,6 +149,32 @@ export function ConversationView({ onBack, prefill }: ConversationViewProps) {
     // clears it when the thread store reflects the new activity.
   }, [text, sending, threads, currentSessionId, historyTopic, refreshSessions, markSessionActive, resetIdle]);
 
+  // Fill input with a suggestion and send immediately
+  const handleSuggestion = useCallback(
+    (suggestion: string) => {
+      setText(suggestion);
+      // We need to send directly since setState is async
+      setSending(true);
+      resetIdle();
+
+      bridgeSend({
+        sessionId: currentSessionId,
+        historyTopic,
+        text: suggestion,
+        requestText: suggestion,
+        media: [],
+        onSessionActive: (firstMsg) => markSessionActive(firstMsg),
+        onComplete: () => {
+          void refreshSessions();
+        },
+      });
+
+      setText("");
+      setSending(false);
+    },
+    [currentSessionId, historyTopic, refreshSessions, markSessionActive, resetIdle],
+  );
+
   const handleKeyDown = useCallback(
     (e: React.KeyboardEvent) => {
       if (composingRef.current || e.nativeEvent.isComposing || e.keyCode === 229) return;
@@ -176,6 +203,8 @@ export function ConversationView({ onBack, prefill }: ConversationViewProps) {
       t.pendingAssistant.status === "streaming",
   );
 
+  const isEmpty = threads.length === 0;
+
   return (
     <div className="home-conversation flex h-full w-full flex-col">
       {/* Header */}
@@ -183,7 +212,7 @@ export function ConversationView({ onBack, prefill }: ConversationViewProps) {
         <button
           onClick={onBack}
           className="home-back-button flex items-center justify-center rounded-xl"
-          aria-label={HOME_STRINGS.backToStandby}
+          aria-label={strings.backToStandby}
         >
           <ArrowLeft size={24} className="text-white/70" />
         </button>
@@ -203,11 +232,24 @@ export function ConversationView({ onBack, prefill }: ConversationViewProps) {
         onTouchStart={resetIdle}
         onMouseMove={resetIdle}
       >
-        {threads.length === 0 && (
-          <div className="flex h-full items-center justify-center">
+        {isEmpty && (
+          <div className="flex h-full flex-col items-center justify-center gap-8">
             <span className="text-xl text-white/30">
-              {HOME_STRINGS.inputPlaceholder}
+              {strings.inputPlaceholder}
             </span>
+
+            {/* Suggestion cards */}
+            <div className="home-suggestions grid w-full max-w-lg grid-cols-1 gap-3 sm:grid-cols-2">
+              {strings.suggestions.map((suggestion) => (
+                <button
+                  key={suggestion}
+                  onClick={() => handleSuggestion(suggestion)}
+                  className="home-suggestion-card rounded-2xl px-4 py-3 text-left text-base text-white/70 transition-all hover:text-white/90"
+                >
+                  {suggestion}
+                </button>
+              ))}
+            </div>
           </div>
         )}
         {threads.map((thread: Thread) => (
@@ -278,7 +320,7 @@ export function ConversationView({ onBack, prefill }: ConversationViewProps) {
             onCompositionEnd={() => {
               composingRef.current = false;
             }}
-            placeholder={HOME_STRINGS.inputPlaceholder}
+            placeholder={strings.inputPlaceholder}
             rows={1}
             className="home-composer-input flex-1 resize-none bg-transparent px-3 py-3 outline-none"
             autoFocus
@@ -287,7 +329,7 @@ export function ConversationView({ onBack, prefill }: ConversationViewProps) {
             onClick={() => void handleSend()}
             disabled={text.trim().length === 0 || sending}
             className="home-send-button flex shrink-0 items-center justify-center rounded-xl disabled:opacity-30"
-            aria-label={HOME_STRINGS.send}
+            aria-label={strings.send}
           >
             <SendHorizontal size={22} className="text-white" />
           </button>

--- a/src/home/home-assistant-page.tsx
+++ b/src/home/home-assistant-page.tsx
@@ -1,9 +1,9 @@
 /**
- * Home Assistant full-screen page — `/home` route.
+ * Home Assistant full-screen page -- `/home` route.
  *
  * Two modes:
- *   1. **Standby** — large clock, weather, quick-action cards.
- *   2. **Conversation** — large-font chat bubbles with auto-idle return.
+ *   1. **Standby** -- large clock, weather, quick-action cards.
+ *   2. **Conversation** -- large-font chat bubbles with auto-idle return.
  *
  * The page is always full-screen (no sidebar, no top nav). It wraps
  * OctosRuntimeProvider so the conversation view can read from
@@ -17,6 +17,10 @@
  * either resumes that session or creates a fresh one titled
  * "Home Assistant", then switches the SessionContext to it so the WS
  * bridge connects to the right session.
+ *
+ * Night mode: dims display and hides non-essential UI between 22:00
+ * and 06:00 (auto), or always/never based on user setting. Touch/mouse
+ * activity temporarily restores normal brightness for 5 seconds.
  */
 
 import { useMemo, useCallback, useEffect, useRef, useState } from "react";
@@ -25,11 +29,65 @@ import { useSession } from "@/runtime/session-context";
 import { useWakeLock } from "./use-wake-lock";
 import { StandbyView } from "./standby-view";
 import { ConversationView } from "./conversation-view";
+import {
+  HomeSettingsProvider,
+  useHomeSettings,
+} from "./home-settings-context";
+import { useClock } from "./use-clock";
 
 type Mode = "standby" | "conversation";
 
 const HOME_SESSION_KEY = "octos_home_session_id";
 const HOME_SESSION_TITLE = "Home Assistant";
+
+/** Duration in ms to temporarily suppress night mode on interaction. */
+const NIGHT_SUPPRESS_MS = 5000;
+
+/**
+ * Night-mode logic hook.
+ * Returns `true` when the display should be in night mode.
+ */
+function useNightMode(): boolean {
+  const { nightMode } = useHomeSettings();
+  const clock = useClock();
+  const [suppressed, setSuppressed] = useState(false);
+  const suppressTimerRef = useRef<ReturnType<typeof setTimeout> | undefined>(
+    undefined,
+  );
+
+  // Determine raw night state
+  const rawNight = useMemo(() => {
+    if (nightMode === "on") return true;
+    if (nightMode === "off") return false;
+    // auto: 22:00 - 06:00
+    const h = clock.date.getHours();
+    return h >= 22 || h < 6;
+  }, [nightMode, clock.date]);
+
+  // Suppress on user activity
+  useEffect(() => {
+    if (!rawNight) return;
+
+    const handler = () => {
+      setSuppressed(true);
+      clearTimeout(suppressTimerRef.current);
+      suppressTimerRef.current = setTimeout(
+        () => setSuppressed(false),
+        NIGHT_SUPPRESS_MS,
+      );
+    };
+
+    window.addEventListener("mousemove", handler);
+    window.addEventListener("touchstart", handler);
+    return () => {
+      window.removeEventListener("mousemove", handler);
+      window.removeEventListener("touchstart", handler);
+      clearTimeout(suppressTimerRef.current);
+    };
+  }, [rawNight]);
+
+  return rawNight && !suppressed;
+}
 
 /**
  * Inner shell that lives inside OctosRuntimeProvider so it can access
@@ -41,6 +99,7 @@ function HomeAssistantShell() {
   const [mode, setMode] = useState<Mode>("standby");
   const [prefill, setPrefill] = useState<string | undefined>(undefined);
   const initRef = useRef(false);
+  const nightActive = useNightMode();
 
   // Resolve the target home session id synchronously during render
   // (no setState in an effect). `createSession` is safe to call during
@@ -76,7 +135,7 @@ function HomeAssistantShell() {
   }, []);
 
   return (
-    <>
+    <div className={nightActive ? "home-night-mode" : ""}>
       {/* Standby layer */}
       <div
         className={`home-layer absolute inset-0 transition-opacity duration-500 ease-in-out ${
@@ -85,7 +144,7 @@ function HomeAssistantShell() {
             : "opacity-0 pointer-events-none z-0"
         }`}
       >
-        <StandbyView onActivate={activate} />
+        <StandbyView onActivate={activate} nightActive={nightActive} />
       </div>
 
       {/* Conversation layer */}
@@ -98,7 +157,7 @@ function HomeAssistantShell() {
       >
         <ConversationView onBack={deactivate} prefill={prefill} />
       </div>
-    </>
+    </div>
   );
 }
 
@@ -107,9 +166,11 @@ export function HomeAssistantPage() {
 
   return (
     <div className="home-root relative h-screen w-screen overflow-hidden">
-      <OctosRuntimeProvider>
-        <HomeAssistantShell />
-      </OctosRuntimeProvider>
+      <HomeSettingsProvider>
+        <OctosRuntimeProvider>
+          <HomeAssistantShell />
+        </OctosRuntimeProvider>
+      </HomeSettingsProvider>
     </div>
   );
 }

--- a/src/home/home-settings-context.tsx
+++ b/src/home/home-settings-context.tsx
@@ -1,0 +1,121 @@
+/**
+ * Home Settings Context — centralised settings state for the Home UI.
+ *
+ * Reads initial values from localStorage (keys prefixed `octos_home_`),
+ * exposes typed getters and an `update` function that persists changes
+ * back to localStorage.
+ *
+ * Wrap the Home page root with `<HomeSettingsProvider>` and consume via
+ * `useHomeSettings()`.
+ */
+
+import {
+  createContext,
+  useCallback,
+  useContext,
+  useMemo,
+  useState,
+  type ReactNode,
+} from "react";
+import { HOME_I18N, type HomeStrings } from "./constants";
+
+// ── Types ───────────────────────────────────────────────────────
+
+export type TempUnit = "C" | "F";
+export type ClockFormat = "12h" | "24h";
+export type NightMode = "auto" | "on" | "off";
+export type Lang = "en" | "zh";
+
+export interface HomeSettings {
+  city: string;
+  tempUnit: TempUnit;
+  clockFormat: ClockFormat;
+  idleSeconds: number;
+  nightMode: NightMode;
+  lang: Lang;
+}
+
+export interface HomeSettingsContextValue extends HomeSettings {
+  /** Localised string table for the active language. */
+  strings: HomeStrings;
+  /** Partially update settings (only changed keys). */
+  update: (patch: Partial<HomeSettings>) => void;
+}
+
+// ── Storage helpers ─────────────────────────────────────────────
+
+const KEYS = {
+  city: "octos_home_city",
+  tempUnit: "octos_home_temp_unit",
+  clockFormat: "octos_home_clock_format",
+  idleSeconds: "octos_home_idle_seconds",
+  nightMode: "octos_home_night_mode",
+  lang: "octos_home_lang",
+} as const;
+
+function readLS(): HomeSettings {
+  return {
+    city: localStorage.getItem(KEYS.city) ?? "",
+    tempUnit: (localStorage.getItem(KEYS.tempUnit) as TempUnit) || "C",
+    clockFormat:
+      (localStorage.getItem(KEYS.clockFormat) as ClockFormat) || "24h",
+    idleSeconds: clampIdle(
+      Number(localStorage.getItem(KEYS.idleSeconds)) || 30,
+    ),
+    nightMode:
+      (localStorage.getItem(KEYS.nightMode) as NightMode) || "auto",
+    lang: (localStorage.getItem(KEYS.lang) as Lang) || "en",
+  };
+}
+
+function writeLS(s: HomeSettings) {
+  localStorage.setItem(KEYS.city, s.city);
+  localStorage.setItem(KEYS.tempUnit, s.tempUnit);
+  localStorage.setItem(KEYS.clockFormat, s.clockFormat);
+  localStorage.setItem(KEYS.idleSeconds, String(s.idleSeconds));
+  localStorage.setItem(KEYS.nightMode, s.nightMode);
+  localStorage.setItem(KEYS.lang, s.lang);
+}
+
+function clampIdle(n: number): number {
+  return Math.max(10, Math.min(300, Math.round(n)));
+}
+
+// ── Context ─────────────────────────────────────────────────────
+
+const Ctx = createContext<HomeSettingsContextValue | null>(null);
+
+export function HomeSettingsProvider({ children }: { children: ReactNode }) {
+  const [settings, setSettings] = useState<HomeSettings>(readLS);
+
+  const update = useCallback((patch: Partial<HomeSettings>) => {
+    setSettings((prev) => {
+      const next = { ...prev, ...patch };
+      if (patch.idleSeconds !== undefined) {
+        next.idleSeconds = clampIdle(patch.idleSeconds);
+      }
+      writeLS(next);
+      return next;
+    });
+  }, []);
+
+  const strings = useMemo(
+    () => HOME_I18N[settings.lang] ?? HOME_I18N.en,
+    [settings.lang],
+  );
+
+  const value = useMemo<HomeSettingsContextValue>(
+    () => ({ ...settings, strings, update }),
+    [settings, strings, update],
+  );
+
+  return <Ctx value={value}>{children}</Ctx>;
+}
+
+export function useHomeSettings(): HomeSettingsContextValue {
+  const ctx = useContext(Ctx);
+  if (!ctx) {
+    throw new Error("useHomeSettings must be used inside HomeSettingsProvider");
+  }
+  return ctx;
+}

--- a/src/home/home-settings.tsx
+++ b/src/home/home-settings.tsx
@@ -1,0 +1,234 @@
+/**
+ * Home Settings — slide-in panel from the right.
+ *
+ * Provides controls for city, temperature unit, clock format, idle
+ * timeout, night mode, and language. All values are persisted to
+ * localStorage via the HomeSettingsContext.
+ */
+
+import { useCallback, useEffect, useRef, useState } from "react";
+import { Settings, X } from "lucide-react";
+import {
+  useHomeSettings,
+  type ClockFormat,
+  type Lang,
+  type NightMode,
+  type TempUnit,
+} from "./home-settings-context";
+
+// ── Gear button (placed in standby view) ───────────────────────
+
+export function SettingsGearButton({
+  onClick,
+}: {
+  onClick: () => void;
+}) {
+  return (
+    <button
+      onClick={(e) => {
+        e.stopPropagation();
+        onClick();
+      }}
+      className="home-settings-gear absolute right-4 top-4 z-30 flex items-center justify-center rounded-xl"
+      aria-label="Settings"
+    >
+      <Settings size={22} className="text-white/40 hover:text-white/80 transition-colors" />
+    </button>
+  );
+}
+
+// ── Panel ───────────────────────────────────────────────────────
+
+interface HomeSettingsPanelProps {
+  open: boolean;
+  onClose: () => void;
+}
+
+export function HomeSettingsPanel({ open, onClose }: HomeSettingsPanelProps) {
+  const s = useHomeSettings();
+  const panelRef = useRef<HTMLDivElement>(null);
+  // Reset draft each time the panel opens so it picks up the latest value.
+  const [cityDraft, setCityDraft] = useState(s.city);
+  const [prevOpen, setPrevOpen] = useState(open);
+  if (open && !prevOpen) {
+    setCityDraft(s.city);
+  }
+  if (open !== prevOpen) {
+    setPrevOpen(open);
+  }
+
+  // Close on Escape
+  useEffect(() => {
+    if (!open) return;
+    const handler = (e: KeyboardEvent) => {
+      if (e.key === "Escape") onClose();
+    };
+    window.addEventListener("keydown", handler);
+    return () => window.removeEventListener("keydown", handler);
+  }, [open, onClose]);
+
+  // Commit city on blur / Enter
+  const commitCity = useCallback(() => {
+    const trimmed = cityDraft.trim();
+    if (trimmed !== s.city) {
+      s.update({ city: trimmed });
+    }
+  }, [cityDraft, s]);
+
+  const t = s.strings;
+
+  return (
+    <>
+      {/* Backdrop */}
+      <div
+        className={`fixed inset-0 z-40 transition-opacity duration-300 ${
+          open
+            ? "opacity-100 pointer-events-auto"
+            : "opacity-0 pointer-events-none"
+        }`}
+        style={{ background: "rgba(0,0,0,0.5)" }}
+        onClick={onClose}
+      />
+
+      {/* Panel */}
+      <div
+        ref={panelRef}
+        className={`home-settings-panel fixed right-0 top-0 bottom-0 z-50 flex w-80 max-w-[85vw] flex-col transition-transform duration-300 ease-out ${
+          open ? "translate-x-0" : "translate-x-full"
+        }`}
+      >
+        {/* Header */}
+        <div className="flex items-center justify-between px-5 py-4">
+          <h2 className="text-lg font-semibold text-white">{t.settingsTitle}</h2>
+          <button
+            onClick={onClose}
+            className="flex items-center justify-center rounded-lg p-1.5 hover:bg-white/10 transition-colors"
+            aria-label={t.settingsClose}
+          >
+            <X size={20} className="text-white/60" />
+          </button>
+        </div>
+
+        {/* Scrollable body */}
+        <div className="flex-1 overflow-y-auto px-5 pb-8 space-y-6">
+          {/* City */}
+          <SettingsField label={t.settingsCity}>
+            <input
+              type="text"
+              value={cityDraft}
+              onChange={(e) => setCityDraft(e.target.value)}
+              onBlur={commitCity}
+              onKeyDown={(e) => {
+                if (e.key === "Enter") commitCity();
+              }}
+              placeholder={t.settingsCityPlaceholder}
+              className="home-settings-input"
+            />
+          </SettingsField>
+
+          {/* Temperature unit */}
+          <SettingsField label={t.settingsTempUnit}>
+            <SegmentedPicker
+              options={["C", "F"] as TempUnit[]}
+              value={s.tempUnit}
+              onChange={(v) => s.update({ tempUnit: v })}
+            />
+          </SettingsField>
+
+          {/* Clock format */}
+          <SettingsField label={t.settingsClockFormat}>
+            <SegmentedPicker
+              options={["12h", "24h"] as ClockFormat[]}
+              value={s.clockFormat}
+              onChange={(v) => s.update({ clockFormat: v })}
+            />
+          </SettingsField>
+
+          {/* Idle seconds */}
+          <SettingsField label={t.settingsIdleSeconds}>
+            <input
+              type="number"
+              min={10}
+              max={300}
+              step={5}
+              value={s.idleSeconds}
+              onChange={(e) =>
+                s.update({ idleSeconds: Number(e.target.value) })
+              }
+              className="home-settings-input w-24 text-center"
+            />
+          </SettingsField>
+
+          {/* Night mode */}
+          <SettingsField label={t.settingsNightMode}>
+            <SegmentedPicker
+              options={["auto", "on", "off"] as NightMode[]}
+              labels={[t.settingsNightAuto, t.settingsNightOn, t.settingsNightOff]}
+              value={s.nightMode}
+              onChange={(v) => s.update({ nightMode: v })}
+            />
+          </SettingsField>
+
+          {/* Language */}
+          <SettingsField label={t.settingsLanguage}>
+            <SegmentedPicker
+              options={["en", "zh"] as Lang[]}
+              labels={["EN", "\u4E2D\u6587"]}
+              value={s.lang}
+              onChange={(v) => s.update({ lang: v })}
+            />
+          </SettingsField>
+        </div>
+      </div>
+    </>
+  );
+}
+
+// ── Small helpers ───────────────────────────────────────────────
+
+function SettingsField({
+  label,
+  children,
+}: {
+  label: string;
+  children: React.ReactNode;
+}) {
+  return (
+    <div className="space-y-2">
+      <label className="block text-sm font-medium text-white/50">
+        {label}
+      </label>
+      {children}
+    </div>
+  );
+}
+
+function SegmentedPicker<T extends string>({
+  options,
+  labels,
+  value,
+  onChange,
+}: {
+  options: T[];
+  labels?: string[];
+  value: T;
+  onChange: (v: T) => void;
+}) {
+  return (
+    <div className="home-settings-segmented flex rounded-lg overflow-hidden">
+      {options.map((opt, i) => (
+        <button
+          key={opt}
+          onClick={() => onChange(opt)}
+          className={`flex-1 px-3 py-2 text-sm font-medium transition-colors ${
+            value === opt
+              ? "bg-blue-500/30 text-blue-300 border-blue-500/40"
+              : "bg-white/5 text-white/50 hover:bg-white/10 hover:text-white/70"
+          }`}
+        >
+          {labels?.[i] ?? opt}
+        </button>
+      ))}
+    </div>
+  );
+}

--- a/src/home/standby-view.tsx
+++ b/src/home/standby-view.tsx
@@ -3,98 +3,169 @@
  *
  * Designed for small touch-screen displays (800x480 / 1280x800) at
  * arm's-length (>1m). High-contrast text on a deep-dark background.
+ *
+ * Enhanced with:
+ * - Settings gear button (top-right)
+ * - Burn-in protection (periodic micro-shift + idle dim)
+ * - Night mode support (hides cards/weather, dims display)
+ * - i18n via settings context
  */
 
-import { useCallback } from "react";
+import { useCallback, useState } from "react";
 import { MessageSquare, Newspaper, Music, Home } from "lucide-react";
 import { useClock } from "./use-clock";
 import { useWeather } from "./use-weather";
-import { HOME_STRINGS } from "./constants";
+import { useHomeSettings } from "./home-settings-context";
+import { useBurnInProtection } from "./use-burn-in-protection";
+import { SettingsGearButton, HomeSettingsPanel } from "./home-settings";
 
 interface StandbyViewProps {
-  onActivate: (prefill?: string) => void;
+  onActivate: () => void;
+  nightActive: boolean;
 }
 
-const QUICK_ACTIONS = [
-  { id: "chat", icon: MessageSquare, label: HOME_STRINGS.cardChat, color: "text-blue-400", prefill: HOME_STRINGS.cardChatPrefill },
-  { id: "news", icon: Newspaper, label: HOME_STRINGS.cardNews, color: "text-amber-400", prefill: HOME_STRINGS.cardNewsPrefill },
-  { id: "music", icon: Music, label: HOME_STRINGS.cardMusic, color: "text-emerald-400", prefill: HOME_STRINGS.cardMusicPrefill },
-  { id: "home", icon: Home, label: HOME_STRINGS.cardHome, color: "text-purple-400", prefill: HOME_STRINGS.cardHomePrefill },
-] as const;
-
-export function StandbyView({ onActivate }: StandbyViewProps) {
+export function StandbyView({ onActivate, nightActive }: StandbyViewProps) {
   const clock = useClock();
   const weather = useWeather();
+  const { strings, tempUnit, clockFormat } = useHomeSettings();
+  const burnIn = useBurnInProtection();
+  const [settingsOpen, setSettingsOpen] = useState(false);
 
-  const dateStr = `${HOME_STRINGS.weekdays[clock.date.getDay()]}, ${HOME_STRINGS.months[clock.date.getMonth()]} ${clock.date.getDate()}`;
+  const dateStr = `${strings.weekdays[clock.date.getDay()]}, ${strings.months[clock.date.getMonth()]} ${clock.date.getDate()}`;
+
+  // Format hours according to clock format setting
+  const displayHours = (() => {
+    const h = clock.date.getHours();
+    if (clockFormat === "12h") {
+      const h12 = h % 12 || 12;
+      return String(h12).padStart(2, "0");
+    }
+    return clock.hours;
+  })();
+
+  const ampm = clockFormat === "12h"
+    ? clock.date.getHours() >= 12 ? "PM" : "AM"
+    : null;
+
+  // Format temperature according to unit setting
+  const displayTemp = (() => {
+    if (tempUnit === "F") {
+      return Math.round(weather.temperature * 9 / 5 + 32);
+    }
+    return weather.temperature;
+  })();
+
+  const QUICK_ACTIONS = [
+    { id: "chat", icon: MessageSquare, label: strings.cardChat, color: "text-blue-400" },
+    { id: "news", icon: Newspaper, label: strings.cardNews, color: "text-amber-400" },
+    { id: "music", icon: Music, label: strings.cardMusic, color: "text-emerald-400" },
+    { id: "home", icon: Home, label: strings.cardHome, color: "text-purple-400" },
+  ] as const;
 
   const handleClick = useCallback(() => {
-    onActivate();
-  }, [onActivate]);
+    if (!settingsOpen) onActivate();
+  }, [onActivate, settingsOpen]);
 
   return (
     <div
-      className="home-standby flex h-full w-full flex-col items-center justify-center select-none cursor-pointer"
+      className={`home-standby flex h-full w-full flex-col items-center justify-center select-none cursor-pointer ${
+        burnIn.dimmed ? "home-dimmed" : ""
+      }`}
       onClick={handleClick}
       role="button"
       tabIndex={0}
       onKeyDown={(e) => {
         if (e.key === "Enter" || e.key === " ") onActivate();
       }}
+      onMouseMove={() => burnIn.onActivity()}
+      onTouchStart={() => burnIn.onActivity()}
     >
-      {/* Weather strip */}
-      <div className="home-weather-strip mb-4 flex items-center gap-3">
-        {weather.loading ? (
-          <div className="h-6 w-24 animate-pulse rounded-full bg-white/10" />
-        ) : weather.error ? (
-          <span className="text-lg text-white/40">
-            {HOME_STRINGS.weatherUnavailable}
-          </span>
-        ) : (
-          <>
-            <span className="text-3xl leading-none">{weather.emoji}</span>
-            <span className="text-2xl font-medium tabular-nums text-white/90">
-              {weather.temperature}&deg;C
+      {/* Settings gear */}
+      <SettingsGearButton onClick={() => setSettingsOpen(true)} />
+
+      {/* Weather strip — hidden in night mode */}
+      {!nightActive && (
+        <div className="home-weather-strip mb-4 flex items-center gap-3">
+          {weather.loading ? (
+            <div className="h-6 w-24 animate-pulse rounded-full bg-white/10" />
+          ) : weather.error ? (
+            <span className="text-lg text-white/40">
+              {strings.weatherUnavailable}
             </span>
-            <span className="text-lg text-white/50">{weather.label}</span>
-            {weather.city && (
-              <span className="text-lg text-white/40">&middot; {weather.city}</span>
-            )}
-          </>
+          ) : (
+            <>
+              <span className="text-3xl leading-none">{weather.emoji}</span>
+              <span className="text-2xl font-medium tabular-nums text-white/90">
+                {displayTemp}&deg;{tempUnit}
+              </span>
+              <span className="text-lg text-white/50">{weather.label}</span>
+              {weather.city && (
+                <span className="text-lg text-white/40">&middot; {weather.city}</span>
+              )}
+            </>
+          )}
+        </div>
+      )}
+
+      {/* Clock — shifted by burn-in protection */}
+      <div
+        className={`home-clock tabular-nums ${nightActive ? "home-clock-night" : "text-white"}`}
+        aria-live="polite"
+        style={{
+          transform: `translate(${burnIn.offset.x}px, ${burnIn.offset.y}px)`,
+          transition: "transform 2s ease-in-out",
+        }}
+      >
+        <span>{displayHours}</span>
+        <span className="home-clock-colon">:</span>
+        <span>{clock.minutes}</span>
+        {ampm && (
+          <span className="home-clock-ampm ml-3 text-[0.3em] font-normal text-white/40">
+            {ampm}
+          </span>
         )}
       </div>
 
-      {/* Clock */}
-      <div className="home-clock tabular-nums text-white" aria-live="polite">
-        <span>{clock.hours}</span>
-        <span className="home-clock-colon">:</span>
-        <span>{clock.minutes}</span>
+      {/* Date — shifted with clock */}
+      <div
+        className="home-date mt-2 text-white/50"
+        style={{
+          transform: `translate(${burnIn.offset.x}px, ${burnIn.offset.y}px)`,
+          transition: "transform 2s ease-in-out",
+        }}
+      >
+        {dateStr}
       </div>
 
-      {/* Date */}
-      <div className="home-date mt-2 text-white/50">{dateStr}</div>
+      {/* Quick actions — hidden in night mode */}
+      {!nightActive && (
+        <div className="home-quick-actions mt-10 flex gap-4">
+          {QUICK_ACTIONS.map(({ id, icon: Icon, label, color }) => (
+            <button
+              key={id}
+              onClick={(e) => {
+                e.stopPropagation();
+                onActivate();
+              }}
+              className="home-quick-card group flex flex-col items-center justify-center gap-2"
+              aria-label={label}
+            >
+              <div className="home-quick-card-icon flex items-center justify-center rounded-2xl">
+                <Icon size={28} className={`${color} transition-transform group-hover:scale-110`} />
+              </div>
+              <span className="text-sm font-medium text-white/60 group-hover:text-white/90 transition-colors">
+                {label}
+              </span>
+            </button>
+          ))}
+        </div>
+      )}
 
-      {/* Quick actions */}
-      <div className="home-quick-actions mt-10 flex gap-4">
-        {QUICK_ACTIONS.map(({ id, icon: Icon, label, color, prefill }) => (
-          <button
-            key={id}
-            onClick={(e) => {
-              e.stopPropagation();
-              onActivate(prefill || undefined);
-            }}
-            className="home-quick-card group flex flex-col items-center justify-center gap-2"
-            aria-label={label}
-          >
-            <div className="home-quick-card-icon flex items-center justify-center rounded-2xl">
-              <Icon size={28} className={`${color} transition-transform group-hover:scale-110`} />
-            </div>
-            <span className="text-sm font-medium text-white/60 group-hover:text-white/90 transition-colors">
-              {label}
-            </span>
-          </button>
-        ))}
-      </div>
+      {/* Settings panel */}
+      <HomeSettingsPanel
+        open={settingsOpen}
+        onClose={() => setSettingsOpen(false)}
+      />
     </div>
   );
 }

--- a/src/home/use-burn-in-protection.ts
+++ b/src/home/use-burn-in-protection.ts
@@ -1,0 +1,83 @@
+/**
+ * Burn-in protection hook.
+ *
+ * 1. Every 3 minutes, micro-shifts the clock position by a random
+ *    offset within +/-30px (CSS transform).
+ * 2. After 5 minutes of no user interaction, dims the display to
+ *    brightness 0.5 (applies a CSS filter on the root element).
+ *
+ * Returns:
+ * - `offset` — { x, y } to feed into `transform: translate(...)`.
+ * - `dimmed` — whether the low-brightness mode is active.
+ * - `onActivity` — call on any user interaction (touch, mouse, key).
+ */
+
+import { useState, useEffect, useCallback, useRef } from "react";
+
+export interface BurnInState {
+  offset: { x: number; y: number };
+  dimmed: boolean;
+  onActivity: () => void;
+}
+
+const SHIFT_INTERVAL = 3 * 60 * 1000; // 3 min
+const DIM_TIMEOUT = 5 * 60 * 1000; // 5 min
+const MAX_OFFSET = 30; // px
+
+function randomOffset(): { x: number; y: number } {
+  return {
+    x: Math.round((Math.random() - 0.5) * 2 * MAX_OFFSET),
+    y: Math.round((Math.random() - 0.5) * 2 * MAX_OFFSET),
+  };
+}
+
+export function useBurnInProtection(): BurnInState {
+  const [offset, setOffset] = useState({ x: 0, y: 0 });
+  const [dimmed, setDimmed] = useState(false);
+  const dimTimerRef = useRef<ReturnType<typeof setTimeout> | undefined>(
+    undefined,
+  );
+  const lastActivityRef = useRef(0);
+
+  // Reset dim timer
+  const resetDim = useCallback(() => {
+    lastActivityRef.current = Date.now();
+    setDimmed(false);
+    clearTimeout(dimTimerRef.current);
+    dimTimerRef.current = setTimeout(() => setDimmed(true), DIM_TIMEOUT);
+  }, []);
+
+  // Public callback for user interaction events
+  const onActivity = useCallback(() => {
+    resetDim();
+  }, [resetDim]);
+
+  // Periodic clock shift
+  useEffect(() => {
+    const id = setInterval(() => {
+      setOffset(randomOffset());
+    }, SHIFT_INTERVAL);
+    return () => clearInterval(id);
+  }, []);
+
+  // Initial dim timer
+  useEffect(() => {
+    dimTimerRef.current = setTimeout(() => setDimmed(true), DIM_TIMEOUT);
+    return () => clearTimeout(dimTimerRef.current);
+  }, []);
+
+  // Global interaction listeners for dim reset
+  useEffect(() => {
+    const handler = () => onActivity();
+    window.addEventListener("mousemove", handler);
+    window.addEventListener("touchstart", handler);
+    window.addEventListener("keydown", handler);
+    return () => {
+      window.removeEventListener("mousemove", handler);
+      window.removeEventListener("touchstart", handler);
+      window.removeEventListener("keydown", handler);
+    };
+  }, [onActivity]);
+
+  return { offset, dimmed, onActivity };
+}

--- a/src/home/use-weather.ts
+++ b/src/home/use-weather.ts
@@ -1,10 +1,11 @@
 /**
- * Weather hook — fetches current weather from Open-Meteo.
+ * Weather hook -- fetches current weather from Open-Meteo.
  *
  * Location resolution waterfall:
- *   1. Browser Geolocation API
- *   2. IP-based geolocation (ipapi.co)
- *   3. Hardcoded default (San Francisco)
+ *   1. City name from settings (geocoded via Open-Meteo Geocoding API)
+ *   2. Browser Geolocation API
+ *   3. IP-based geolocation (ipapi.co)
+ *   4. Hardcoded default (San Francisco)
  *
  * Refreshes every 15 minutes. Never shows "unavailable" — the
  * default-city fallback guarantees a result.
@@ -12,6 +13,7 @@
 
 import { useState, useEffect, useRef } from "react";
 import { WMO_WEATHER, DEFAULT_LOCATION } from "./constants";
+import { useHomeSettings } from "./home-settings-context";
 
 export interface WeatherState {
   temperature: number;
@@ -31,6 +33,23 @@ interface ResolvedLocation {
   city: string | null;
 }
 
+async function geocodeCity(
+  city: string,
+): Promise<{ lat: number; lon: number } | null> {
+  try {
+    const url = `https://geocoding-api.open-meteo.com/v1/search?name=${encodeURIComponent(city)}&count=1`;
+    const res = await fetch(url);
+    if (!res.ok) return null;
+    const data = (await res.json()) as {
+      results?: { latitude: number; longitude: number }[];
+    };
+    if (!data.results?.length) return null;
+    return { lat: data.results[0].latitude, lon: data.results[0].longitude };
+  } catch {
+    return null;
+  }
+}
+
 async function fetchWeather(
   lat: number,
   lon: number,
@@ -47,7 +66,6 @@ async function fetchWeather(
   };
 }
 
-/** Attempt IP-based geolocation via ipapi.co. */
 async function fetchIpLocation(): Promise<ResolvedLocation> {
   const res = await fetch("https://ipapi.co/json/");
   if (!res.ok) throw new Error(`IP geolocation HTTP ${res.status}`);
@@ -63,6 +81,7 @@ async function fetchIpLocation(): Promise<ResolvedLocation> {
 }
 
 export function useWeather(): WeatherState {
+  const { city } = useHomeSettings();
   const [state, setState] = useState<WeatherState>({
     temperature: 0,
     weatherCode: 0,
@@ -106,7 +125,15 @@ export function useWeather(): WeatherState {
     }
 
     async function resolveLocation(): Promise<ResolvedLocation> {
-      // 1. Try browser geolocation
+      // 1. City from settings (geocoded)
+      if (city.trim()) {
+        const geo = await geocodeCity(city.trim());
+        if (geo) {
+          return { lat: geo.lat, lon: geo.lon, city: city.trim() };
+        }
+      }
+
+      // 2. Browser geolocation
       try {
         const pos = await new Promise<GeolocationPosition>((resolve, reject) => {
           if (!navigator.geolocation) {
@@ -124,17 +151,17 @@ export function useWeather(): WeatherState {
           city: null,
         };
       } catch {
-        // Geolocation denied or unavailable — try IP fallback
+        // Geolocation denied or unavailable
       }
 
-      // 2. Try IP-based geolocation
+      // 3. IP-based geolocation
       try {
         return await fetchIpLocation();
       } catch {
-        // IP geolocation also failed — use default
+        // IP geolocation also failed
       }
 
-      // 3. Hardcoded default
+      // 4. Hardcoded default
       return {
         lat: DEFAULT_LOCATION.lat,
         lon: DEFAULT_LOCATION.lon,
@@ -159,7 +186,7 @@ export function useWeather(): WeatherState {
       cancelled = true;
       clearInterval(timerRef.current);
     };
-  }, []);
+  }, [city]);
 
   return state;
 }

--- a/src/index.css
+++ b/src/index.css
@@ -1045,3 +1045,95 @@ button, a, input, textarea {
     height: 72px;
   }
 }
+
+/* ── Night mode ─────────────────────────────────────── */
+.home-night-mode {
+  filter: brightness(0.3) sepia(0.2);
+  transition: filter 1s ease-in-out;
+}
+
+.home-clock-night {
+  color: #8b2020;
+}
+
+/* ── Burn-in dimmed state ──────────────────────────── */
+.home-dimmed {
+  filter: brightness(0.5);
+  transition: filter 2s ease-in-out;
+}
+
+/* ── Settings gear button ──────────────────────────── */
+.home-settings-gear {
+  width: 44px;
+  height: 44px;
+  background: transparent;
+  border: none;
+  cursor: pointer;
+  transition: background 0.2s ease;
+  border-radius: 12px;
+}
+
+.home-settings-gear:hover {
+  background: rgba(255, 255, 255, 0.08);
+}
+
+/* ── Settings panel ────────────────────────────────── */
+.home-settings-panel {
+  background: rgba(12, 14, 24, 0.92);
+  backdrop-filter: blur(32px) saturate(140%);
+  -webkit-backdrop-filter: blur(32px) saturate(140%);
+  border-left: 1px solid rgba(255, 255, 255, 0.08);
+}
+
+.home-settings-input {
+  display: block;
+  width: 100%;
+  padding: 0.5rem 0.75rem;
+  font-size: 0.9rem;
+  color: #f0f4f8;
+  background: rgba(255, 255, 255, 0.06);
+  border: 1px solid rgba(255, 255, 255, 0.1);
+  border-radius: 10px;
+  outline: none;
+  transition: border-color 0.2s ease;
+}
+
+.home-settings-input:focus {
+  border-color: rgba(59, 130, 246, 0.5);
+}
+
+.home-settings-input::placeholder {
+  color: rgba(255, 255, 255, 0.25);
+}
+
+.home-settings-segmented {
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  border-radius: 10px;
+  overflow: hidden;
+}
+
+.home-settings-segmented button {
+  border: none;
+  cursor: pointer;
+}
+
+/* ── Suggestion cards ──────────────────────────────── */
+.home-suggestion-card {
+  background: rgba(255, 255, 255, 0.04);
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  cursor: pointer;
+  transition:
+    background 0.2s ease,
+    border-color 0.2s ease,
+    transform 0.15s ease;
+}
+
+.home-suggestion-card:hover {
+  background: rgba(255, 255, 255, 0.08);
+  border-color: rgba(255, 255, 255, 0.14);
+  transform: translateY(-1px);
+}
+
+.home-suggestion-card:active {
+  transform: scale(0.98);
+}


### PR DESCRIPTION
## Summary

- **Settings panel**: Slide-in panel (gear icon, top-right of standby view) with controls for default city, temperature unit (C/F), clock format (12h/24h), idle return seconds (10-300), night mode (auto/on/off), and language (en/zh). All values persisted to `localStorage` with `octos_home_` prefix.
- **Night mode**: Auto-activates 22:00-06:00 (or always/never per setting). Applies `brightness(0.3) + sepia(0.2)` filter, shows dark-red clock only, hides weather strip and quick-action cards. Touch/mouse movement temporarily restores normal brightness for 5 seconds.
- **Burn-in protection**: Clock position micro-shifts every 3 minutes (random +/-30px with smooth CSS transition). After 5 minutes of no user interaction, display dims to 50% brightness. Any input resets the timer.
- **Suggestion cards**: 4 suggested prompts shown in the empty conversation state. Clicking a card sends the message immediately. i18n-aware (en/zh).
- **i18n**: `constants.ts` refactored to `HOME_I18N` with `en` and `zh` string tables. `HomeSettingsContext` provides the active `strings` object to all child components.
- **Weather improvements**: `use-weather` now supports city-based geocoding via Open-Meteo Geocoding API (falls back to browser geolocation). Temperature displayed in user-selected unit.

## New files
- `src/home/home-settings-context.tsx` -- React context + provider for settings state
- `src/home/home-settings.tsx` -- Gear button + slide-in settings panel
- `src/home/use-burn-in-protection.ts` -- Hook for clock shift + idle dim

## Modified files
- `src/home/constants.ts` -- i18n string tables + suggestion prompts
- `src/home/home-assistant-page.tsx` -- Settings provider wrapper + night mode hook
- `src/home/standby-view.tsx` -- Gear button, burn-in shift, night mode, i18n
- `src/home/conversation-view.tsx` -- Suggestion cards, settings-driven idle timer, i18n
- `src/home/use-weather.ts` -- City geocoding support
- `src/index.css` -- Night mode, dimmed, settings panel, suggestion card styles

## Test plan
- [ ] Open `/home` route, verify standby view displays clock, weather, quick-action cards
- [ ] Click gear icon -- settings panel slides in from right with backdrop
- [ ] Change city to a known city, verify weather updates after panel close
- [ ] Toggle temperature unit C/F, verify display updates
- [ ] Toggle clock format 12h/24h, verify AM/PM indicator appears/disappears
- [ ] Adjust idle seconds, verify conversation auto-returns at configured time
- [ ] Set night mode to "on" -- verify dim filter, red clock, hidden cards/weather
- [ ] Set night mode to "auto" -- verify activates between 22:00-06:00
- [ ] Move mouse during night mode -- verify 5-second brightness restore
- [ ] Wait 3+ minutes in standby -- verify clock position micro-shifts
- [ ] Wait 5+ minutes idle -- verify display dims to 50%
- [ ] Click into conversation with empty history -- verify 4 suggestion cards
- [ ] Click a suggestion card -- verify message sends immediately
- [ ] Switch language to zh -- verify all visible text changes to Chinese
- [ ] Refresh page -- verify all settings persist from localStorage