### PR TITLE
feat: Octos Hub skill browser

### DIFF
--- a/src/settings/settings-api.ts
+++ b/src/settings/settings-api.ts
@@ -169,6 +169,30 @@ export async function installSkill(source: string): Promise<boolean> {
   }
 }
 
+// ── Hub / Registry ──
+
+export interface HubPackage {
+  name: string;
+  repo: string;
+  description: string | null;
+  author: string | null;
+  license: string | null;
+  version: string | null;
+  provides_tools: boolean;
+  skills: string[];
+  tags: string[];
+  requires: string[];
+}
+
+export async function getSkillRegistry(): Promise<HubPackage[]> {
+  try {
+    const resp = await request<{ packages: HubPackage[] }>("/api/my/profile/skills/registry");
+    return resp.packages ?? [];
+  } catch {
+    return [];
+  }
+}
+
 // ── Admin: Users management ──
 
 export interface AdminUser {

--- a/src/settings/skills-tab.tsx
+++ b/src/settings/skills-tab.tsx
@@ -1,6 +1,6 @@
 import { useState, useEffect, useRef } from "react";
-import { Puzzle, Loader2, Wrench, RefreshCw, Trash2, Plus, Download } from "lucide-react";
-import { getMyProfileSkills, removeSkill, installSkill, type SkillInfo } from "./settings-api";
+import { Puzzle, Loader2, Wrench, RefreshCw, Trash2, Plus, Download, Package, Search, Check, Tag } from "lucide-react";
+import { getMyProfileSkills, removeSkill, installSkill, getSkillRegistry, type SkillInfo, type HubPackage } from "./settings-api";
 
 export function SkillsTab() {
   const [skills, setSkills] = useState<SkillInfo[]>([]);
@@ -16,6 +16,12 @@ export function SkillsTab() {
   // Track which skill is being removed
   const [removingSkill, setRemovingSkill] = useState<string | null>(null);
 
+  // Octos Hub state
+  const [hubPackages, setHubPackages] = useState<HubPackage[]>([]);
+  const [hubLoading, setHubLoading] = useState(true);
+  const [hubSearch, setHubSearch] = useState("");
+  const [installingHub, setInstallingHub] = useState<string | null>(null);
+
   const refreshSkills = async () => {
     setError(null);
     const data = await getMyProfileSkills();
@@ -27,10 +33,12 @@ export function SkillsTab() {
   useEffect(() => {
     mountedRef.current = true;
     let cancelled = false;
-    getMyProfileSkills().then((data) => {
+    Promise.all([getMyProfileSkills(), getSkillRegistry()]).then(([skillData, registryData]) => {
       if (!cancelled) {
-        setSkills(data);
+        setSkills(skillData);
         setLoading(false);
+        setHubPackages(registryData);
+        setHubLoading(false);
       }
     });
     return () => { cancelled = true; mountedRef.current = false; };
@@ -69,6 +77,41 @@ export function SkillsTab() {
       }
     }
   };
+
+  const handleHubInstall = async (pkg: HubPackage) => {
+    setInstallingHub(pkg.name);
+    setError(null);
+    setInstallMessage(null);
+    const ok = await installSkill(pkg.repo);
+    if (mountedRef.current) {
+      setInstallingHub(null);
+      if (ok) {
+        setInstallMessage(`Skill package '${pkg.name}' installed. Restart gateway to load new skills.`);
+        await refreshSkills();
+      } else {
+        setError(`Failed to install skill package '${pkg.name}'.`);
+      }
+    }
+  };
+
+  // Derive which individual skill names from the hub are already installed
+  const installedNames = new Set(skills.map((s) => s.name));
+
+  // Derive installed packages: a hub package is "installed" when ALL its skills are present
+  const isPackageInstalled = (pkg: HubPackage) =>
+    pkg.skills.length > 0 && pkg.skills.every((s) => installedNames.has(s));
+
+  // Filter hub packages by search query
+  const filteredPackages = hubPackages.filter((pkg) => {
+    const q = hubSearch.toLowerCase();
+    if (!q) return true;
+    return (
+      pkg.name.toLowerCase().includes(q) ||
+      (pkg.description ?? "").toLowerCase().includes(q) ||
+      pkg.tags.some((t) => t.toLowerCase().includes(q)) ||
+      pkg.skills.some((s) => s.toLowerCase().includes(q))
+    );
+  });
 
   if (loading) {
     return (
@@ -204,6 +247,156 @@ export function SkillsTab() {
             {installing ? "Installing..." : "Install"}
           </button>
         </div>
+      </div>
+
+      {/* Octos Hub section */}
+      <div className="glass-section rounded-2xl p-6">
+        <div className="flex items-center justify-between mb-5">
+          <div className="flex items-center gap-3">
+            <div className="flex h-10 w-10 items-center justify-center rounded-xl bg-accent/10 text-accent">
+              <Package size={20} />
+            </div>
+            <div>
+              <h3 className="text-sm font-semibold text-text-strong">Octos Hub</h3>
+              <p className="text-xs text-muted">Browse and install skill packages from the registry</p>
+            </div>
+          </div>
+          {!hubLoading && hubPackages.length > 0 && (
+            <span className="text-xs text-muted">
+              {filteredPackages.length} of {hubPackages.length} package{hubPackages.length === 1 ? "" : "s"}
+            </span>
+          )}
+        </div>
+
+        {/* Search */}
+        {!hubLoading && hubPackages.length > 0 && (
+          <div className="relative mb-4">
+            <Search size={14} className="absolute left-3.5 top-1/2 -translate-y-1/2 text-muted/60 pointer-events-none" />
+            <input
+              type="text"
+              value={hubSearch}
+              onChange={(e) => setHubSearch(e.target.value)}
+              placeholder="Search packages, skills, or tags..."
+              className="w-full rounded-xl bg-surface-container pl-9 pr-4 py-2.5 text-sm text-text placeholder-muted/50 outline-none border border-transparent focus:border-accent/30 transition"
+            />
+          </div>
+        )}
+
+        {hubLoading ? (
+          <div className="flex items-center justify-center py-10">
+            <Loader2 size={18} className="animate-spin text-muted" />
+          </div>
+        ) : hubPackages.length === 0 ? (
+          <div className="rounded-xl bg-surface-dark/50 px-6 py-10 text-center">
+            <Package size={32} className="mx-auto mb-3 text-muted/40" />
+            <p className="text-sm text-muted">No packages in registry</p>
+            <p className="mt-1 text-xs text-muted/60">The registry returned no results</p>
+          </div>
+        ) : filteredPackages.length === 0 ? (
+          <div className="rounded-xl bg-surface-dark/50 px-6 py-8 text-center">
+            <Search size={24} className="mx-auto mb-3 text-muted/40" />
+            <p className="text-sm text-muted">No packages match "{hubSearch}"</p>
+          </div>
+        ) : (
+          <div className="grid gap-3 sm:grid-cols-2">
+            {filteredPackages.map((pkg) => {
+              const installed = isPackageInstalled(pkg);
+              const isInstalling = installingHub === pkg.name;
+              return (
+                <div
+                  key={pkg.name}
+                  className="flex flex-col gap-3 rounded-xl bg-surface-container/60 border border-transparent hover:border-border p-4 transition"
+                >
+                  {/* Card header */}
+                  <div className="flex items-start justify-between gap-2">
+                    <div className="min-w-0 flex-1">
+                      <div className="flex items-center gap-2 flex-wrap">
+                        <span className="text-sm font-semibold text-text-strong truncate">
+                          {pkg.name}
+                        </span>
+                        {pkg.version && (
+                          <span className="shrink-0 rounded-md bg-surface-dark/60 px-1.5 py-0.5 text-[10px] font-mono text-muted">
+                            v{pkg.version}
+                          </span>
+                        )}
+                        {installed && (
+                          <span className="shrink-0 flex items-center gap-1 rounded-md bg-accent/15 px-1.5 py-0.5 text-[10px] font-medium text-accent">
+                            <Check size={9} strokeWidth={3} />
+                            Installed
+                          </span>
+                        )}
+                      </div>
+                      <p className="mt-0.5 text-xs text-muted truncate">{pkg.repo}</p>
+                    </div>
+                    {installed ? (
+                      <div className="shrink-0 flex items-center gap-1.5 rounded-lg px-3 py-1.5 text-xs font-medium text-accent bg-accent/10 cursor-default select-none">
+                        <Check size={12} strokeWidth={2.5} />
+                        Installed
+                      </div>
+                    ) : (
+                      <button
+                        onClick={() => handleHubInstall(pkg)}
+                        disabled={isInstalling || installingHub !== null}
+                        className="shrink-0 flex items-center gap-1.5 rounded-lg bg-accent px-3 py-1.5 text-xs font-medium text-white hover:bg-accent-dim disabled:opacity-40 transition"
+                      >
+                        {isInstalling ? (
+                          <Loader2 size={12} className="animate-spin" />
+                        ) : (
+                          <Download size={12} />
+                        )}
+                        {isInstalling ? "Installing…" : "Install"}
+                      </button>
+                    )}
+                  </div>
+
+                  {/* Description */}
+                  {pkg.description && (
+                    <p className="text-xs text-muted leading-relaxed line-clamp-2">
+                      {pkg.description}
+                    </p>
+                  )}
+
+                  {/* Skills list */}
+                  {pkg.skills.length > 0 && (
+                    <div className="flex items-center gap-1.5 flex-wrap">
+                      <Wrench size={11} className="shrink-0 text-muted/60" />
+                      {pkg.skills.map((s) => (
+                        <span
+                          key={s}
+                          className={`rounded-md px-1.5 py-0.5 text-[10px] font-mono transition ${
+                            installedNames.has(s)
+                              ? "bg-accent/15 text-accent"
+                              : "bg-surface-dark/60 text-muted"
+                          }`}
+                        >
+                          {s}
+                        </span>
+                      ))}
+                    </div>
+                  )}
+
+                  {/* Tags */}
+                  {pkg.tags.length > 0 && (
+                    <div className="flex items-center gap-1.5 flex-wrap">
+                      <Tag size={10} className="shrink-0 text-muted/50" />
+                      {pkg.tags.slice(0, 6).map((t) => (
+                        <span
+                          key={t}
+                          className="rounded-md bg-surface-dark/40 px-1.5 py-0.5 text-[10px] text-muted/70"
+                        >
+                          {t}
+                        </span>
+                      ))}
+                      {pkg.tags.length > 6 && (
+                        <span className="text-[10px] text-muted/50">+{pkg.tags.length - 6} more</span>
+                      )}
+                    </div>
+                  )}
+                </div>
+              );
+            })}
+          </div>
+        )}
       </div>
     </div>
   );


### PR DESCRIPTION
## Summary
- Fetch skill packages from the live `/api/my/profile/skills/registry` endpoint (returns `mofa-skills` package with 12 individual skills, tags, requires)
- Add a searchable grid of registry cards below the existing Install Skill section, using the `Package` icon and glass-morphism styling consistent with the rest of the tab
- One-click install per card (calls `installSkill(pkg.repo)`); cards whose every individual skill is already installed show an "Installed ✓" badge and a disabled state instead
- Individual skills within a card are highlighted in accent color when already installed, making partial-install status visible at a glance
- Tags are shown inline (capped at 6 + overflow count) for discoverability
- Skills list and registry are fetched in parallel at mount time; hub section has its own loading spinner independent of the installed-skills list

## Test plan
- [ ] Hub cards render with correct name, description, skills list, and tags
- [ ] Search input filters packages by name, description, skill name, and tag
- [ ] Install button on a card triggers install via `installSkill(repo)` and refreshes the installed list
- [ ] After install, card shows "Installed ✓" badge and button switches to disabled installed state
- [ ] Empty search result state shows a "No packages match" message
- [ ] Registry returning zero packages shows the empty state illustration