### PR TITLE
feat: Email send tool + Brave Search

### DIFF
--- a/src/settings/tools-tab.tsx
+++ b/src/settings/tools-tab.tsx
@@ -8,8 +8,13 @@ import {
   Search,
   Zap,
   Timer,
+  Mail,
+  Send,
+  ToggleLeft,
+  ToggleRight,
 } from "lucide-react";
 import { updateMyProfile, type Profile } from "./settings-api";
+import { request } from "@/api/client";
 
 interface ToolsTabProps {
   profile: Profile;
@@ -55,6 +60,13 @@ const SEARCH_ENGINES: SearchEngine[] = [
     placeholder: "Enter You.com API key",
     docsUrl: "https://you.com/search-api",
   },
+  {
+    key: "BRAVE_API_KEY",
+    name: "Brave Search",
+    description: "Privacy-focused web search via Brave",
+    placeholder: "Enter Brave Search API key",
+    docsUrl: "https://brave.com/search/api/",
+  },
 ];
 
 /* ── Deep crawl config ── */
@@ -71,12 +83,27 @@ interface GatewaySettings {
   browser_timeout_secs: string;
 }
 
+/* ── Email tool config ── */
+
+type EmailProvider = "feishu" | "smtp";
+
+interface EmailToolConfig {
+  enabled: boolean;
+  provider: EmailProvider;
+  smtp_host: string;
+  smtp_port: string;
+  smtp_username: string;
+  smtp_password: string;
+  smtp_from: string;
+}
+
 /* ── Form state ── */
 
 interface ToolsFormState {
   env_vars: Record<string, string>;
   crawl: CrawlConfig;
   gateway: GatewaySettings;
+  emailTool: EmailToolConfig;
 }
 
 function profileToForm(profile: Profile): ToolsFormState {
@@ -87,6 +114,7 @@ function profileToForm(profile: Profile): ToolsFormState {
       TAVILY_API_KEY: envVars.TAVILY_API_KEY ?? "",
       PERPLEXITY_API_KEY: envVars.PERPLEXITY_API_KEY ?? "",
       YDC_API_KEY: envVars.YDC_API_KEY ?? "",
+      BRAVE_API_KEY: envVars.BRAVE_API_KEY ?? "",
       CRAWL_MAX_DEPTH: envVars.CRAWL_MAX_DEPTH ?? "",
       CRAWL_MAX_PAGES: envVars.CRAWL_MAX_PAGES ?? "",
       CRAWL_TIMEOUT_SECS: envVars.CRAWL_TIMEOUT_SECS ?? "",
@@ -101,6 +129,15 @@ function profileToForm(profile: Profile): ToolsFormState {
         profile.config.gateway.browser_timeout_secs != null
           ? String(profile.config.gateway.browser_timeout_secs)
           : "",
+    },
+    emailTool: {
+      enabled: envVars.EMAIL_TOOL_ENABLED === "true",
+      provider: (envVars.EMAIL_TOOL_PROVIDER as EmailProvider) || "smtp",
+      smtp_host: envVars.SMTP_HOST ?? "",
+      smtp_port: envVars.SMTP_PORT ?? "",
+      smtp_username: envVars.SMTP_USERNAME ?? "",
+      smtp_password: envVars.SMTP_PASSWORD ?? "",
+      smtp_from: envVars.SMTP_FROM ?? "",
     },
   };
 }
@@ -126,6 +163,27 @@ function formToPayload(form: ToolsFormState, profile: Profile) {
     CRAWL_TIMEOUT_SECS: form.crawl.timeout_secs,
   };
   for (const [key, val] of Object.entries(crawlMap)) {
+    const trimmed = val.trim();
+    if (trimmed) {
+      mergedEnv[key] = trimmed;
+    } else {
+      delete mergedEnv[key];
+    }
+  }
+
+  // Email tool settings
+  const et = form.emailTool;
+  mergedEnv.EMAIL_TOOL_ENABLED = et.enabled ? "true" : "false";
+  mergedEnv.EMAIL_TOOL_PROVIDER = et.provider;
+
+  const smtpMap: Record<string, string> = {
+    SMTP_HOST: et.smtp_host,
+    SMTP_PORT: et.smtp_port,
+    SMTP_USERNAME: et.smtp_username,
+    SMTP_PASSWORD: et.smtp_password,
+    SMTP_FROM: et.smtp_from,
+  };
+  for (const [key, val] of Object.entries(smtpMap)) {
     const trimmed = val.trim();
     if (trimmed) {
       mergedEnv[key] = trimmed;
@@ -229,6 +287,215 @@ function SearchEngineCard({
   );
 }
 
+/* ── Email Tool section ── */
+
+function EmailToolSection({
+  config,
+  onChange,
+}: {
+  config: EmailToolConfig;
+  onChange: (next: EmailToolConfig) => void;
+}) {
+  const [testResult, setTestResult] = useState<TestResult>({ status: "idle" });
+  const [testEmail, setTestEmail] = useState("");
+
+  const smtpConfigured =
+    !!config.smtp_host.trim() &&
+    !!config.smtp_port.trim() &&
+    !!config.smtp_username.trim() &&
+    !!config.smtp_password.trim() &&
+    !!config.smtp_from.trim();
+
+  const set = (patch: Partial<EmailToolConfig>) => onChange({ ...config, ...patch });
+
+  const handleTestEmail = async () => {
+    setTestResult({ status: "testing" });
+    try {
+      const resp = await request<{ ok: boolean; message?: string }>("/api/my/test-email", {
+        method: "POST",
+        body: JSON.stringify({ to: testEmail || "self" }),
+      });
+      if (resp && resp.ok) {
+        setTestResult({ status: "success", message: resp.message || "Test email sent successfully" });
+      } else {
+        setTestResult({ status: "error", message: (resp as { message?: string })?.message || "Failed to send test email" });
+      }
+    } catch {
+      setTestResult({ status: "error", message: "Test email endpoint not available" });
+    }
+  };
+
+  return (
+    <div className="space-y-4">
+      {/* Enable toggle */}
+      <div className="flex items-center justify-between rounded-xl bg-surface-container/60 p-4 border border-transparent hover:border-border transition">
+        <div className="flex items-center gap-2.5">
+          <div className="flex h-8 w-8 shrink-0 items-center justify-center rounded-lg bg-surface-dark/60">
+            <Mail size={14} className="text-muted" />
+          </div>
+          <div>
+            <h4 className="text-sm font-medium text-text-strong">Email Sending</h4>
+            <p className="text-xs text-muted">Allow agents to send emails via this tool</p>
+          </div>
+        </div>
+        <button
+          type="button"
+          onClick={() => set({ enabled: !config.enabled })}
+          className="shrink-0 flex items-center gap-1.5 text-sm font-medium transition"
+          aria-label={config.enabled ? "Disable email tool" : "Enable email tool"}
+        >
+          {config.enabled ? (
+            <ToggleRight size={28} className="text-accent" />
+          ) : (
+            <ToggleLeft size={28} className="text-muted/50" />
+          )}
+        </button>
+      </div>
+
+      {config.enabled && (
+        <>
+          {/* Provider selector */}
+          <div className="rounded-xl bg-surface-container/60 p-4 border border-transparent">
+            <label className="mb-2 block text-xs font-medium text-muted">Provider</label>
+            <div className="flex gap-2">
+              {(["feishu", "smtp"] as EmailProvider[]).map((p) => (
+                <button
+                  key={p}
+                  type="button"
+                  onClick={() => set({ provider: p })}
+                  className={`flex-1 rounded-xl px-4 py-2.5 text-sm font-medium border transition ${
+                    config.provider === p
+                      ? "bg-accent/10 text-accent border-accent/30"
+                      : "bg-surface-dark/50 text-muted border-border hover:border-accent/20"
+                  }`}
+                >
+                  {p === "feishu" ? "Feishu" : "SMTP"}
+                </button>
+              ))}
+            </div>
+          </div>
+
+          {/* SMTP fields */}
+          {config.provider === "smtp" && (
+            <div className="rounded-xl bg-surface-container/60 p-4 border border-transparent space-y-3">
+              <div className="flex items-center justify-between mb-1">
+                <p className="text-xs font-medium text-muted">SMTP Configuration</p>
+                {smtpConfigured && (
+                  <span className="flex items-center gap-1 text-[10px] font-medium text-green-400">
+                    <Check size={10} />
+                    SMTP is configured
+                  </span>
+                )}
+              </div>
+
+              <div className="grid grid-cols-3 gap-3">
+                <div className="col-span-2">
+                  <label className="mb-1.5 block text-xs text-muted">Host</label>
+                  <input
+                    type="text"
+                    value={config.smtp_host}
+                    onChange={(e) => set({ smtp_host: e.target.value })}
+                    placeholder="smtp.example.com"
+                    className="w-full rounded-xl bg-surface-dark/50 px-4 py-2.5 text-sm text-text placeholder-muted/50 outline-none border border-transparent focus:border-accent/30 transition font-mono"
+                  />
+                </div>
+                <div>
+                  <label className="mb-1.5 block text-xs text-muted">Port</label>
+                  <input
+                    type="number"
+                    value={config.smtp_port}
+                    onChange={(e) => set({ smtp_port: e.target.value })}
+                    placeholder="587"
+                    min={1}
+                    max={65535}
+                    className="w-full rounded-xl bg-surface-dark/50 px-4 py-2.5 text-sm text-text placeholder-muted/50 outline-none border border-transparent focus:border-accent/30 transition font-mono"
+                  />
+                </div>
+              </div>
+
+              <div className="grid grid-cols-2 gap-3">
+                <div>
+                  <label className="mb-1.5 block text-xs text-muted">Username</label>
+                  <input
+                    type="text"
+                    value={config.smtp_username}
+                    onChange={(e) => set({ smtp_username: e.target.value })}
+                    placeholder="user@example.com"
+                    className="w-full rounded-xl bg-surface-dark/50 px-4 py-2.5 text-sm text-text placeholder-muted/50 outline-none border border-transparent focus:border-accent/30 transition font-mono"
+                  />
+                </div>
+                <div>
+                  <label className="mb-1.5 block text-xs text-muted">Password</label>
+                  <input
+                    type="password"
+                    value={config.smtp_password}
+                    onChange={(e) => set({ smtp_password: e.target.value })}
+                    placeholder="App password"
+                    className="w-full rounded-xl bg-surface-dark/50 px-4 py-2.5 text-sm text-text placeholder-muted/50 outline-none border border-transparent focus:border-accent/30 transition font-mono"
+                  />
+                </div>
+              </div>
+
+              <div>
+                <label className="mb-1.5 block text-xs text-muted">From Address</label>
+                <input
+                  type="email"
+                  value={config.smtp_from}
+                  onChange={(e) => set({ smtp_from: e.target.value })}
+                  placeholder="noreply@example.com"
+                  className="w-full rounded-xl bg-surface-dark/50 px-4 py-2.5 text-sm text-text placeholder-muted/50 outline-none border border-transparent focus:border-accent/30 transition font-mono"
+                />
+              </div>
+
+              {/* Test send */}
+              <div className="pt-1 border-t border-border/50">
+                <p className="mb-2 text-xs text-muted">Send Test Email</p>
+                <div className="flex gap-2">
+                  <input
+                    type="email"
+                    value={testEmail}
+                    onChange={(e) => setTestEmail(e.target.value)}
+                    placeholder="recipient@example.com (optional)"
+                    className="flex-1 rounded-xl bg-surface-dark/50 px-4 py-2.5 text-sm text-text placeholder-muted/50 outline-none border border-transparent focus:border-accent/30 transition font-mono"
+                  />
+                  <button
+                    type="button"
+                    onClick={handleTestEmail}
+                    disabled={!smtpConfigured || testResult.status === "testing"}
+                    className="shrink-0 flex items-center gap-1.5 rounded-xl px-3 py-2.5 text-xs font-medium border transition disabled:opacity-30
+                      bg-surface-dark/50 text-muted border-border hover:text-accent hover:border-accent/30"
+                  >
+                    {testResult.status === "testing" ? (
+                      <Loader2 size={12} className="animate-spin" />
+                    ) : (
+                      <Send size={12} />
+                    )}
+                    Send Test
+                  </button>
+                </div>
+                {testResult.status === "success" && (
+                  <p className="mt-2 text-xs text-green-400">{testResult.message}</p>
+                )}
+                {testResult.status === "error" && (
+                  <p className="mt-2 text-xs text-red-400">{testResult.message}</p>
+                )}
+              </div>
+            </div>
+          )}
+
+          {config.provider === "feishu" && (
+            <div className="rounded-xl bg-surface-container/60 p-4 border border-transparent">
+              <p className="text-xs text-muted">
+                Feishu email is configured via your Feishu workspace. Ensure the Feishu channel is set up in the Channels tab.
+              </p>
+            </div>
+          )}
+        </>
+      )}
+    </div>
+  );
+}
+
 export function ToolsTab({ profile, onProfileUpdated }: ToolsTabProps) {
   const [form, setForm] = useState<ToolsFormState>(() => profileToForm(profile));
   const [original, setOriginal] = useState<ToolsFormState>(() => profileToForm(profile));
@@ -325,6 +592,24 @@ export function ToolsTab({ profile, onProfileUpdated }: ToolsTabProps) {
             />
           ))}
         </div>
+      </div>
+
+      {/* Email Tool */}
+      <div className="glass-section rounded-2xl p-6">
+        <div className="flex items-center gap-3 mb-6">
+          <div className="flex h-10 w-10 items-center justify-center rounded-xl bg-accent/10 text-accent">
+            <Mail size={20} />
+          </div>
+          <div>
+            <h3 className="text-sm font-semibold text-text-strong">Email Tool</h3>
+            <p className="text-xs text-muted">Allow agents to send emails on your behalf</p>
+          </div>
+        </div>
+
+        <EmailToolSection
+          config={form.emailTool}
+          onChange={(emailTool) => setForm((f) => ({ ...f, emailTool }))}
+        />
       </div>
 
       {/* Deep Crawl Config */}


### PR DESCRIPTION
## Summary
- Add **Brave Search** card to the Web Search APIs section (`BRAVE_API_KEY` env var), matching the existing Serper/Tavily/Perplexity/You.com pattern (masked input + Test button)
- Add **Email Tool** section with: enable/disable toggle, Feishu vs SMTP provider selector, full SMTP field set (host, port, username, password, from address), a "SMTP is configured ✓" status badge, and a "Send Test Email" button that calls `POST /api/my/test-email`
- All config persists via `env_vars`: `EMAIL_TOOL_ENABLED`, `EMAIL_TOOL_PROVIDER`, `SMTP_HOST`, `SMTP_PORT`, `SMTP_USERNAME`, `SMTP_PASSWORD`, `SMTP_FROM`

## Test plan
- [ ] Brave Search card renders in Web Search APIs section with masked input and Test button
- [ ] Email Tool section toggle shows/hides provider and SMTP fields
- [ ] Provider selector switches between Feishu (info text) and SMTP (full fields)
- [ ] SMTP configured indicator appears when all 5 SMTP fields are filled
- [ ] Send Test button is disabled until SMTP fields are filled; shows spinner during request
- [ ] Save Changes persists all new env vars via PUT /api/my/profile
- [ ] TypeScript build passes (npx tsc -b)