### PR TITLE
fix: correct skills install API endpoint and request field

### DIFF
--- a/src/settings/settings-api.ts
+++ b/src/settings/settings-api.ts
@@ -157,13 +157,20 @@ export async function removeSkill(name: string): Promise<boolean> {
   }
 }
 
+export interface InstallSkillResponse {
+  ok: boolean;
+  installed: string[];
+  skipped: string[];
+  deps_installed: string[];
+}
+
 export async function installSkill(source: string): Promise<boolean> {
   try {
-    await request<void>("/api/my/profile/skills/install", {
+    const resp = await request<InstallSkillResponse>("/api/my/profile/skills", {
       method: "POST",
-      body: JSON.stringify({ source }),
+      body: JSON.stringify({ repo: source }),
     });
-    return true;
+    return resp.ok;
   } catch {
     return false;
   }


### PR DESCRIPTION
## Summary

- The Skills tab \"Install Skill\" form was calling `POST /api/my/profile/skills/install` — this path only has a `DELETE` handler (used for removing a skill by name), so every install attempt returned 405 Method Not Allowed
- The correct install endpoint is `POST /api/my/profile/skills` with body field `repo` (not `source`)  
- The function now also propagates the server's `ok` boolean instead of unconditionally returning `true`

**Verified against live server:**
```
curl -X POST -H 'Authorization: Bearer mofamofa' \
  -d '{"repo":"mofa-org/mofa-skills"}' \
  http://127.0.0.1:50080/api/my/profile/skills
# → {"ok":true,"installed":[...],"skipped":[...],"deps_installed":[...]}
```

## Test plan

- [ ] Open Settings → Skills tab, enter `mofa-org/mofa-skills` in the Install Skill form, submit
- [ ] Verify no 405 error in the network tab; response should be 200 with `ok: true`
- [ ] Verify installed skills list refreshes and shows the newly installed skills
- [ ] Verify removing a skill still works (uses the DELETE path, unchanged)