### PR TITLE
feat: System metric panels + live logs

### DIFF
--- a/src/settings/system-tab.tsx
+++ b/src/settings/system-tab.tsx
@@ -8,6 +8,15 @@ import {
   CheckCircle,
   BarChart3,
   ListChecks,
+  ChevronDown,
+  ChevronRight,
+  GitBranch,
+  Route,
+  Package,
+  Terminal,
+  Pause,
+  Play,
+  Trash2,
 } from "lucide-react";
 import {
   fetchOperatorSummary,
@@ -16,8 +25,10 @@ import {
   type OperatorTasksResponse,
   type BreakdownEntry,
 } from "./settings-api";
+import { API_BASE, TOKEN_KEY, ADMIN_TOKEN_KEY } from "@/lib/constants";
 
 const AUTO_REFRESH_MS = 30_000;
+const MAX_LOG_LINES = 500;
 
 // ── Metric card ──
 
@@ -86,6 +97,395 @@ function TaskStatusBadge({ status }: { status: string }) {
     >
       {status}
     </span>
+  );
+}
+
+// ── Collapsible section ──
+
+function CollapsibleSection({
+  icon,
+  iconBg,
+  iconColor,
+  title,
+  subtitle,
+  children,
+  defaultOpen = false,
+}: {
+  icon: React.ReactNode;
+  iconBg: string;
+  iconColor: string;
+  title: string;
+  subtitle: string;
+  children: React.ReactNode;
+  defaultOpen?: boolean;
+}) {
+  const [open, setOpen] = useState(defaultOpen);
+  return (
+    <div className="glass-section rounded-2xl overflow-hidden">
+      <button
+        onClick={() => setOpen((v) => !v)}
+        className="flex w-full items-center gap-3 p-6 text-left hover:bg-surface-container/30 transition"
+      >
+        <div
+          className={`flex h-10 w-10 shrink-0 items-center justify-center rounded-xl ${iconBg} ${iconColor}`}
+        >
+          {icon}
+        </div>
+        <div className="flex-1 min-w-0">
+          <h3 className="text-sm font-semibold text-text-strong">{title}</h3>
+          <p className="text-xs text-muted">{subtitle}</p>
+        </div>
+        <span className="text-muted">
+          {open ? <ChevronDown size={16} /> : <ChevronRight size={16} />}
+        </span>
+      </button>
+      {open && <div className="px-6 pb-6">{children}</div>}
+    </div>
+  );
+}
+
+// ── Retry Bucket State panel ──
+
+function RetryBucketPanel({
+  entries,
+}: {
+  entries: BreakdownEntry[];
+}) {
+  if (entries.length === 0) {
+    return (
+      <div className="rounded-xl bg-surface-dark/50 px-4 py-6 text-center">
+        <p className="text-sm text-muted">No retry events recorded</p>
+      </div>
+    );
+  }
+
+  // Group by variant
+  const byVariant: Record<string, BreakdownEntry[]> = {};
+  for (const entry of entries) {
+    const variant = String(entry.variant ?? "unknown");
+    (byVariant[variant] ??= []).push(entry);
+  }
+
+  return (
+    <div className="space-y-4">
+      {Object.entries(byVariant).map(([variant, items]) => (
+        <div key={variant}>
+          <div className="mb-2 text-xs font-medium text-yellow-400 uppercase tracking-wider">
+            {variant}
+          </div>
+          <div className="flex flex-wrap gap-2">
+            {items.map((entry, i) => (
+              <BreakdownBadge key={i} entry={entry} />
+            ))}
+          </div>
+        </div>
+      ))}
+    </div>
+  );
+}
+
+// ── Routing Decisions panel ──
+
+function RoutingDecisionsPanel({
+  entries,
+  cheapTotal,
+  strongTotal,
+}: {
+  entries: BreakdownEntry[];
+  cheapTotal: number;
+  strongTotal: number;
+}) {
+  const grandTotal = cheapTotal + strongTotal;
+  const cheapPct =
+    grandTotal > 0 ? Math.round((cheapTotal / grandTotal) * 100) : 0;
+  const strongPct = grandTotal > 0 ? 100 - cheapPct : 0;
+
+  return (
+    <div className="space-y-4">
+      {/* Summary bar */}
+      {grandTotal > 0 && (
+        <div className="space-y-2">
+          <div className="flex items-center justify-between text-xs text-muted">
+            <span>
+              Cheap{" "}
+              <span className="font-bold text-green-400">{cheapPct}%</span>
+            </span>
+            <span>
+              <span className="font-bold text-accent">{strongPct}%</span>{" "}
+              Strong
+            </span>
+          </div>
+          <div className="h-2 w-full rounded-full bg-surface-dark/60 overflow-hidden">
+            <div
+              className="h-full rounded-full bg-gradient-to-r from-green-400 to-accent transition-all duration-500"
+              style={{ width: `${cheapPct}%` }}
+            />
+          </div>
+          <div className="flex items-center justify-between text-[10px] text-muted">
+            <span>{cheapTotal} cheap calls</span>
+            <span>{strongTotal} strong calls</span>
+          </div>
+        </div>
+      )}
+
+      {entries.length === 0 ? (
+        <div className="rounded-xl bg-surface-dark/50 px-4 py-6 text-center">
+          <p className="text-sm text-muted">No routing decisions recorded</p>
+        </div>
+      ) : (
+        <div className="flex flex-wrap gap-2">
+          {entries.map((entry, i) => (
+            <BreakdownBadge key={i} entry={entry} />
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}
+
+// ── Compaction Events panel ──
+
+function CompactionEventsPanel({
+  violationCount,
+  entries,
+}: {
+  violationCount: number;
+  entries: BreakdownEntry[];
+}) {
+  return (
+    <div className="space-y-4">
+      <div className="grid grid-cols-1 gap-3 sm:grid-cols-2">
+        <MetricCard
+          label="Preservation Violations"
+          value={violationCount}
+          variant={violationCount > 0 ? "error" : "success"}
+        />
+        <MetricCard
+          label="Total Compaction Events"
+          value={entries.reduce((s, e) => s + e.count, 0)}
+          variant="default"
+        />
+      </div>
+
+      {entries.length > 0 && (
+        <div>
+          <div className="mb-2 text-xs font-medium text-muted">
+            Event Breakdown
+          </div>
+          <div className="flex flex-wrap gap-2">
+            {entries.map((entry, i) => (
+              <BreakdownBadge key={i} entry={entry} />
+            ))}
+          </div>
+        </div>
+      )}
+
+      {violationCount === 0 && entries.length === 0 && (
+        <div className="rounded-xl bg-surface-dark/50 px-4 py-6 text-center">
+          <p className="text-sm text-muted">No compaction events recorded</p>
+        </div>
+      )}
+    </div>
+  );
+}
+
+// ── Live Logs panel ──
+
+function stripAnsi(str: string): string {
+  // Strip ANSI escape sequences (colors, bold, dim, etc.)
+  // eslint-disable-next-line no-control-regex
+  return str.replace(/\x1b\[[0-9;]*[a-zA-Z]/g, "");
+}
+
+function getToken(): string | null {
+  return (
+    localStorage.getItem(TOKEN_KEY) || localStorage.getItem(ADMIN_TOKEN_KEY)
+  );
+}
+
+type LogLine = {
+  id: number;
+  text: string;
+  level: "info" | "warn" | "error" | "debug" | "plain";
+};
+
+let logLineId = 0;
+
+function classifyLine(text: string): LogLine["level"] {
+  if (/ WARN /i.test(text) || /\bwarn\b/i.test(text)) return "warn";
+  if (/ ERROR /i.test(text) || /\berror\b/i.test(text)) return "error";
+  if (/ INFO /i.test(text) || /\binfo\b/i.test(text)) return "info";
+  if (/ DEBUG /i.test(text) || /\bdebug\b/i.test(text)) return "debug";
+  return "plain";
+}
+
+const LOG_LEVEL_COLOR: Record<LogLine["level"], string> = {
+  info: "text-blue-400",
+  warn: "text-yellow-400",
+  error: "text-red-400",
+  debug: "text-muted",
+  plain: "text-text/80",
+};
+
+function LiveLogsPanel() {
+  const [lines, setLines] = useState<LogLine[]>([]);
+  const [paused, setPaused] = useState(false);
+  const [connected, setConnected] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const bottomRef = useRef<HTMLDivElement>(null);
+  const pausedRef = useRef(false);
+  const esRef = useRef<EventSource | null>(null);
+  const lineBufferRef = useRef<LogLine[]>([]);
+
+  const addLine = useCallback((text: string) => {
+    const cleaned = stripAnsi(text).trim();
+    if (!cleaned) return;
+    const line: LogLine = {
+      id: ++logLineId,
+      text: cleaned,
+      level: classifyLine(cleaned),
+    };
+    lineBufferRef.current = [...lineBufferRef.current, line].slice(-MAX_LOG_LINES);
+    if (!pausedRef.current) {
+      setLines([...lineBufferRef.current]);
+    }
+  }, []);
+
+  const connect = useCallback(() => {
+    if (esRef.current) {
+      esRef.current.close();
+      esRef.current = null;
+    }
+    setError(null);
+
+    const token = getToken();
+    // EventSource doesn't support custom headers natively —
+    // pass token as query param (same approach as the admin log viewer)
+    const url = `${API_BASE}/api/my/profile/logs${token ? `?token=${encodeURIComponent(token)}` : ""}`;
+
+    let es: EventSource;
+    try {
+      es = new EventSource(url);
+    } catch {
+      setError("Log streaming requires server v0.2+");
+      return;
+    }
+    esRef.current = es;
+
+    es.onopen = () => setConnected(true);
+
+    es.onmessage = (evt) => {
+      addLine(evt.data);
+    };
+
+    es.onerror = () => {
+      setConnected(false);
+      // EventSource auto-reconnects; only surface an error if it never
+      // connected at all
+      if (lineBufferRef.current.length === 0) {
+        setError("Unable to connect to log stream. The endpoint may not be available.");
+      }
+    };
+  }, [addLine]);
+
+  useEffect(() => {
+    connect();
+    return () => {
+      esRef.current?.close();
+      esRef.current = null;
+    };
+  }, [connect]);
+
+  // Auto-scroll to bottom when not paused
+  useEffect(() => {
+    if (!paused && bottomRef.current) {
+      bottomRef.current.scrollIntoView({ behavior: "smooth" });
+    }
+  }, [lines, paused]);
+
+  const handlePauseToggle = () => {
+    const next = !paused;
+    setPaused(next);
+    pausedRef.current = next;
+    if (!next) {
+      // Resume: flush buffered lines into state
+      setLines([...lineBufferRef.current]);
+    }
+  };
+
+  const handleClear = () => {
+    lineBufferRef.current = [];
+    setLines([]);
+  };
+
+  return (
+    <div className="space-y-3">
+      {/* Toolbar */}
+      <div className="flex items-center gap-2">
+        <div className="flex items-center gap-1.5">
+          <span
+            className={`inline-block h-2 w-2 rounded-full transition-colors ${connected ? "bg-green-400" : "bg-muted/40"}`}
+          />
+          <span className="text-xs text-muted">
+            {connected ? "Connected" : "Connecting…"}
+          </span>
+        </div>
+        <div className="flex-1" />
+        <button
+          onClick={handlePauseToggle}
+          className="flex items-center gap-1.5 rounded-lg px-3 py-1.5 text-xs text-muted hover:text-text-strong hover:bg-surface-container transition"
+        >
+          {paused ? <Play size={12} /> : <Pause size={12} />}
+          {paused ? "Resume" : "Pause"}
+        </button>
+        <button
+          onClick={handleClear}
+          className="flex items-center gap-1.5 rounded-lg px-3 py-1.5 text-xs text-muted hover:text-text-strong hover:bg-surface-container transition"
+        >
+          <Trash2 size={12} />
+          Clear
+        </button>
+      </div>
+
+      {/* Log viewport */}
+      <div className="relative h-72 overflow-y-auto rounded-xl bg-zinc-950 border border-border/20 p-3 font-mono text-[11px] leading-relaxed">
+        {error && lines.length === 0 ? (
+          <div className="flex h-full items-center justify-center">
+            <p className="text-yellow-400/80 text-xs text-center px-4">{error}</p>
+          </div>
+        ) : lines.length === 0 ? (
+          <div className="flex h-full items-center justify-center">
+            <div className="flex items-center gap-2 text-muted/50">
+              <Loader2 size={14} className="animate-spin" />
+              <span className="text-xs">Waiting for log events…</span>
+            </div>
+          </div>
+        ) : (
+          <>
+            {lines.map((line) => (
+              <div key={line.id} className={`${LOG_LEVEL_COLOR[line.level]} whitespace-pre-wrap break-all`}>
+                {line.text}
+              </div>
+            ))}
+            <div ref={bottomRef} />
+          </>
+        )}
+
+        {/* Paused overlay */}
+        {paused && lines.length > 0 && (
+          <div className="pointer-events-none sticky bottom-0 left-0 right-0 flex justify-center pb-1">
+            <span className="rounded-full bg-zinc-800/90 px-3 py-1 text-[10px] text-yellow-400 border border-yellow-400/20">
+              Paused — {lineBufferRef.current.length} lines buffered
+            </span>
+          </div>
+        )}
+      </div>
+
+      <div className="text-[10px] text-muted text-right">
+        {lines.length}/{MAX_LOG_LINES} lines · SSE stream at{" "}
+        <code className="font-mono">/api/my/profile/logs</code>
+      </div>
+    </div>
   );
 }
 
@@ -165,6 +565,15 @@ export function SystemTab() {
 
   const taskList = tasks?.tasks ?? [];
   const lifecycle = tasks?.totals_by_lifecycle ?? {};
+
+  // Routing decision counts derived from breakdowns
+  const routingEntries = breakdowns.routing_decisions ?? [];
+  const cheapTotal = routingEntries
+    .filter((e) => String(e.tier ?? e.model_tier ?? e.type ?? "") === "cheap")
+    .reduce((s, e) => s + e.count, 0);
+  const strongTotal = routingEntries
+    .filter((e) => String(e.tier ?? e.model_tier ?? e.type ?? "") === "strong")
+    .reduce((s, e) => s + e.count, 0);
 
   return (
     <div className="space-y-6">
@@ -311,6 +720,49 @@ export function SystemTab() {
           )}
         </div>
       )}
+
+      {/* ── NEW: Retry Bucket State ── */}
+      <CollapsibleSection
+        icon={<GitBranch size={20} />}
+        iconBg="bg-yellow-400/10"
+        iconColor="text-yellow-400"
+        title="Retry Bucket State"
+        subtitle="Per-variant retry counters from loop retry events"
+        defaultOpen={(breakdowns.loop_retries?.length ?? 0) > 0}
+      >
+        <RetryBucketPanel entries={breakdowns.loop_retries ?? []} />
+      </CollapsibleSection>
+
+      {/* ── NEW: Routing Decisions ── */}
+      <CollapsibleSection
+        icon={<Route size={20} />}
+        iconBg="bg-accent/10"
+        iconColor="text-accent"
+        title="Routing Decisions"
+        subtitle="Cheap vs strong LLM call share from routing decisions"
+        defaultOpen={(totals.routing_decisions ?? 0) > 0}
+      >
+        <RoutingDecisionsPanel
+          entries={routingEntries}
+          cheapTotal={cheapTotal}
+          strongTotal={strongTotal}
+        />
+      </CollapsibleSection>
+
+      {/* ── NEW: Compaction Events ── */}
+      <CollapsibleSection
+        icon={<Package size={20} />}
+        iconBg="bg-purple-400/10"
+        iconColor="text-purple-400"
+        title="Compaction Events"
+        subtitle="Context compaction activity and preservation violations"
+        defaultOpen={(totals.compaction_preservation_violations ?? 0) > 0}
+      >
+        <CompactionEventsPanel
+          violationCount={totals.compaction_preservation_violations ?? 0}
+          entries={breakdowns.compaction_preservation_violations ?? []}
+        />
+      </CollapsibleSection>
 
       {/* Gateway sources table */}
       {sources.length > 0 && (
@@ -487,6 +939,18 @@ export function SystemTab() {
           </div>
         )}
       </div>
+
+      {/* ── NEW: Live Logs ── */}
+      <CollapsibleSection
+        icon={<Terminal size={20} />}
+        iconBg="bg-zinc-400/10"
+        iconColor="text-zinc-300"
+        title="Live Logs"
+        subtitle="Real-time gateway log stream via SSE"
+        defaultOpen={false}
+      >
+        <LiveLogsPanel />
+      </CollapsibleSection>
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- Add three collapsible metric breakdown panels below Operator Overview: **Retry Bucket State** (groups `breakdowns.loop_retries` by variant), **Routing Decisions** (cheap vs strong share bar + breakdown badges from `breakdowns.routing_decisions`), and **Compaction Events** (preservation violation counter + event breakdown from `totals.compaction_preservation_violations` and `breakdowns.compaction_preservation_violations`)
- Add **Live Logs** collapsible panel: connects to the existing SSE endpoint `/api/my/profile/logs`, strips ANSI escape sequences, auto-scrolls, supports Pause/Resume and Clear, keeps a 500-line FIFO buffer

## Notes
- Endpoint research confirmed `/api/my/profile/logs` returns SSE (`data: ...` lines), not WebSocket. `/api/admin/logs` and `/api/admin/logs/stream` return 404. The Live Logs panel connects to the SSE endpoint directly; token is passed as a query param since `EventSource` does not support custom headers.
- All three metric panels are collapsible (default open only when data is present) to avoid visual noise when metrics are zero.
- `npx tsc -b` passes with zero errors.

## Test plan
- [ ] New metric panels appear below Operator Overview in Settings > System
- [ ] Retry Bucket State shows loop_retries grouped by variant (badge: decision/variant count)
- [ ] Routing Decisions shows cheap/strong bar and total breakdown badges
- [ ] Compaction Events shows preservation violation counter (red when >0, green when 0)
- [ ] Panels default-open only when relevant data is non-zero
- [ ] Live Logs panel connects and streams log lines on expand
- [ ] ANSI color codes are stripped from log output
- [ ] Pause/Resume toggles auto-scroll and buffers incoming lines while paused
- [ ] Clear wipes the buffer and display
- [ ] Buffer caps at 500 lines (oldest evicted)