### PR TITLE
fix: align settings save payloads with server API types

### DIFF
--- a/src/settings/profile-tab.tsx
+++ b/src/settings/profile-tab.tsx
@@ -33,8 +33,6 @@ const LABELS = {
   profileId: "Profile ID",
   displayName: "Display Name",
   displayNamePlaceholder: "Enter display name",
-  loginEmail: "Login Email",
-  loginEmailPlaceholder: "Enter email for OTP login",
   autoStart: "Auto-start Gateway",
   autoStartDesc: "Automatically start gateway when server starts",
   adminMode: "Admin Mode",
@@ -123,7 +121,6 @@ interface EnvVarRow {
 export function ProfileTab({ profile, onProfileUpdated, onNavigateBack }: ProfileTabProps) {
   // Profile name + editable fields
   const [name, setName] = useState(profile.name);
-  const [email, setEmail] = useState(profile.config.email ?? "");
   const [autoStart, setAutoStart] = useState(profile.enabled);
   const [adminMode, setAdminMode] = useState(profile.config.admin_mode);
   const [saving, setSaving] = useState(false);
@@ -168,7 +165,6 @@ export function ProfileTab({ profile, onProfileUpdated, onNavigateBack }: Profil
       name: name.trim(),
       enabled: autoStart,
       config: {
-        email: email.trim() || null,
         admin_mode: adminMode,
       },
     });
@@ -340,20 +336,6 @@ export function ProfileTab({ profile, onProfileUpdated, onNavigateBack }: Profil
             />
           </div>
 
-          {/* Login Email (editable) */}
-          <div>
-            <label className="mb-1.5 block text-xs font-medium text-muted">
-              {LABELS.loginEmail}
-            </label>
-            <input
-              type="email"
-              value={email}
-              onChange={(e) => setEmail(e.target.value)}
-              placeholder={LABELS.loginEmailPlaceholder}
-              className="w-full rounded-xl bg-surface-container px-4 py-3 text-sm text-text placeholder-muted/50 outline-none border border-transparent focus:border-accent/30 transition"
-            />
-          </div>
-
           {/* Auto-start Gateway (toggle) */}
           <div className="flex items-center justify-between rounded-xl bg-surface-container/60 px-4 py-3">
             <div>
@@ -427,7 +409,6 @@ export function ProfileTab({ profile, onProfileUpdated, onNavigateBack }: Profil
               saving ||
               !name.trim() ||
               (name.trim() === profile.name &&
-                email.trim() === (profile.config.email ?? "") &&
                 autoStart === profile.enabled &&
                 adminMode === profile.config.admin_mode)
             }


### PR DESCRIPTION
## Summary
- Remove Login Email input from Profile tab — `config.email` is an `EmailSettings` struct on the server, not a plain string. Sending a string caused HTTP 400: `invalid type: string "...", expected struct EmailSettings`
- Remove associated state variable (`email`), LABELS entries, and dirty-check reference
- Audited all other settings tabs (LLM, Channels, Tools, Sandbox) — their save payloads already match server-expected types

## Test plan
- [ ] Profile tab saves without 400 error (name, autoStart, adminMode all persist)
- [ ] LLM tab saves primary/fallbacks/adaptive_routing correctly
- [ ] Channels tab add/remove/toggle persists
- [ ] Tools tab saves env_vars and gateway settings
- [ ] Sandbox tab saves sandbox config struct