### PR TITLE
Fix LLM tab locator timeouts in settings smoke tests

### DIFF
--- a/tests/settings-tabs.spec.ts
+++ b/tests/settings-tabs.spec.ts
@@ -80,10 +80,12 @@ test.describe("Settings page — tab smoke tests", () => {
     await goToSettings(page);
     await clickTab(page, "LLM");
 
+    // Wait for the LLM tab content to fully render (profile-dependent)
+    const llmHeading = page.getByRole("heading", { name: "LLM Configuration" });
+    await llmHeading.waitFor({ state: "visible", timeout: TIMEOUT });
+
     // "LLM Configuration" heading
-    await expect(
-      page.locator("h3", { hasText: "LLM Configuration" }),
-    ).toBeVisible({ timeout: TIMEOUT });
+    await expect(llmHeading).toBeVisible();
 
     // Provider dropdown (select element with "Select a provider..." option)
     await expect(
@@ -92,7 +94,7 @@ test.describe("Settings page — tab smoke tests", () => {
 
     // "Fallback Models" heading
     await expect(
-      page.locator("h3", { hasText: "Fallback Models" }),
+      page.getByRole("heading", { name: "Fallback Models" }),
     ).toBeVisible({ timeout: TIMEOUT });
   });
 
@@ -182,14 +184,14 @@ test.describe("Settings page — tab smoke tests", () => {
     await expect(
       page.locator("h3", { hasText: "Profile Information" }),
     ).toBeHidden({ timeout: TIMEOUT });
-    await expect(
-      page.locator("h3", { hasText: "LLM Configuration" }),
-    ).toBeVisible({ timeout: TIMEOUT });
+    const llmHeading = page.getByRole("heading", { name: "LLM Configuration" });
+    await llmHeading.waitFor({ state: "visible", timeout: TIMEOUT });
+    await expect(llmHeading).toBeVisible();
 
     // Switch to Skills — LLM heading should disappear, Skills heading should appear
     await clickTab(page, "Skills");
     await expect(
-      page.locator("h3", { hasText: "LLM Configuration" }),
+      page.getByRole("heading", { name: "LLM Configuration" }),
     ).toBeHidden({ timeout: TIMEOUT });
     await expect(
       page.locator("h3", { hasText: "Installed Skills" }),


### PR DESCRIPTION
## Summary
- Replace `locator('h3', { hasText: 'LLM Configuration' })` with `getByRole('heading', { name: 'LLM Configuration' })` plus explicit `waitFor` in 2 tests
- The LLM tab content only renders after profile data loads (conditional on `profile` being non-null in settings-page.tsx:162), causing the old locator to timeout at 10s
- Also updates the Fallback Models heading check to use `getByRole` for consistency

## Test plan
- [ ] Run `npx playwright test tests/settings-tabs.spec.ts` against a live server to verify both previously-failing tests now pass
- [ ] `npx tsc -b` passes cleanly (verified locally)