### PR TITLE
feat(home): widget cards, hourly forecast, greeting, prefill fix

### DIFF
--- a/src/home/constants.ts
+++ b/src/home/constants.ts
@@ -24,6 +24,12 @@ export interface HomeStrings {
   cardMusicPrefill: string;
   cardHomePrefill: string;
 
+  // Greetings (time-of-day)
+  greetingMorning: string;
+  greetingAfternoon: string;
+  greetingEvening: string;
+  greetingNight: string;
+
   // Misc
   backToStandby: string;
   send: string;
@@ -88,6 +94,11 @@ export const HOME_I18N: Record<string, HomeStrings> = {
     cardMusicPrefill: "Play some music for me",
     cardHomePrefill: "What's the status of my home devices?",
 
+    greetingMorning: "Good morning",
+    greetingAfternoon: "Good afternoon",
+    greetingEvening: "Good evening",
+    greetingNight: "Good night",
+
     backToStandby: "Back",
     send: "Send",
     inputPlaceholder: "Say something...",
@@ -151,6 +162,11 @@ export const HOME_I18N: Record<string, HomeStrings> = {
     cardNewsPrefill: "\u4ECA\u5929\u6709\u4EC0\u4E48\u65B0\u95FB\uFF1F",
     cardMusicPrefill: "\u7ED9\u6211\u64AD\u653E\u97F3\u4E50",
     cardHomePrefill: "\u6211\u7684\u5BB6\u5C45\u8BBE\u5907\u72B6\u6001\u5982\u4F55\uFF1F",
+
+    greetingMorning: "\u65E9\u4E0A\u597D",
+    greetingAfternoon: "\u4E0B\u5348\u597D",
+    greetingEvening: "\u665A\u4E0A\u597D",
+    greetingNight: "\u665A\u5B89",
 
     backToStandby: "\u8FD4\u56DE",
     send: "\u53D1\u9001",

--- a/src/home/standby-view.tsx
+++ b/src/home/standby-view.tsx
@@ -1,17 +1,20 @@
 /**
- * Standby view — large clock, weather, quick-action cards.
+ * Standby view — large clock, weather widget, quick-action cards.
  *
  * Designed for small touch-screen displays (800x480 / 1280x800) at
  * arm's-length (>1m). High-contrast text on a deep-dark background.
  *
  * Enhanced with:
  * - Settings gear button (top-right)
+ * - Greeting text (top-left, time-of-day aware)
+ * - Weather widget card with 6-hour forecast strip
+ * - Glassmorphism widget cards
  * - Burn-in protection (periodic micro-shift + idle dim)
  * - Night mode support (hides cards/weather, dims display)
  * - i18n via settings context
  */
 
-import { useCallback, useState } from "react";
+import { useCallback, useMemo, useState } from "react";
 import { MessageSquare, Newspaper, Music, Home } from "lucide-react";
 import { useClock } from "./use-clock";
 import { useWeather } from "./use-weather";
@@ -33,6 +36,15 @@ export function StandbyView({ onActivate, nightActive }: StandbyViewProps) {
 
   const dateStr = `${strings.weekdays[clock.date.getDay()]}, ${strings.months[clock.date.getMonth()]} ${clock.date.getDate()}`;
 
+  // Greeting based on time of day
+  const greeting = useMemo(() => {
+    const h = clock.date.getHours();
+    if (h >= 5 && h < 12) return strings.greetingMorning;
+    if (h >= 12 && h < 17) return strings.greetingAfternoon;
+    if (h >= 17 && h < 21) return strings.greetingEvening;
+    return strings.greetingNight;
+  }, [clock.date, strings]);
+
   // Format hours according to clock format setting
   const displayHours = (() => {
     const h = clock.date.getHours();
@@ -48,18 +60,20 @@ export function StandbyView({ onActivate, nightActive }: StandbyViewProps) {
     : null;
 
   // Format temperature according to unit setting
-  const displayTemp = (() => {
+  const formatTemp = useCallback((tempC: number) => {
     if (tempUnit === "F") {
-      return Math.round(weather.temperature * 9 / 5 + 32);
+      return Math.round(tempC * 9 / 5 + 32);
     }
-    return weather.temperature;
-  })();
+    return tempC;
+  }, [tempUnit]);
+
+  const displayTemp = formatTemp(weather.temperature);
 
   const QUICK_ACTIONS = [
-    { id: "chat", icon: MessageSquare, label: strings.cardChat, color: "text-blue-400" },
-    { id: "news", icon: Newspaper, label: strings.cardNews, color: "text-amber-400" },
-    { id: "music", icon: Music, label: strings.cardMusic, color: "text-emerald-400" },
-    { id: "home", icon: Home, label: strings.cardHome, color: "text-purple-400" },
+    { id: "chat", icon: MessageSquare, label: strings.cardChat, color: "text-blue-400", prefill: strings.cardChatPrefill },
+    { id: "news", icon: Newspaper, label: strings.cardNews, color: "text-amber-400", prefill: strings.cardNewsPrefill },
+    { id: "music", icon: Music, label: strings.cardMusic, color: "text-emerald-400", prefill: strings.cardMusicPrefill },
+    { id: "home", icon: Home, label: strings.cardHome, color: "text-purple-400", prefill: strings.cardHomePrefill },
   ] as const;
 
   const handleClick = useCallback(() => {
@@ -80,32 +94,16 @@ export function StandbyView({ onActivate, nightActive }: StandbyViewProps) {
       onMouseMove={() => burnIn.onActivity()}
       onTouchStart={() => burnIn.onActivity()}
     >
-      {/* Settings gear */}
-      <SettingsGearButton onClick={() => setSettingsOpen(true)} />
-
-      {/* Weather strip — hidden in night mode */}
-      {!nightActive && (
-        <div className="home-weather-strip mb-4 flex items-center gap-3">
-          {weather.loading ? (
-            <div className="h-6 w-24 animate-pulse rounded-full bg-white/10" />
-          ) : weather.error ? (
-            <span className="text-lg text-white/40">
-              {strings.weatherUnavailable}
-            </span>
-          ) : (
-            <>
-              <span className="text-3xl leading-none">{weather.emoji}</span>
-              <span className="text-2xl font-medium tabular-nums text-white/90">
-                {displayTemp}&deg;{tempUnit}
-              </span>
-              <span className="text-lg text-white/50">{weather.label}</span>
-              {weather.city && (
-                <span className="text-lg text-white/40">&middot; {weather.city}</span>
-              )}
-            </>
-          )}
-        </div>
-      )}
+      {/* Top bar: greeting (left) + settings gear (right) */}
+      <div className="home-top-bar absolute top-0 left-0 right-0 flex items-center justify-between px-6 pt-5 z-20">
+        {!nightActive && (
+          <span className="home-greeting text-2xl font-light text-white/40">
+            {greeting}
+          </span>
+        )}
+        {nightActive && <span />}
+        <SettingsGearButton onClick={() => setSettingsOpen(true)} />
+      </div>
 
       {/* Clock — shifted by burn-in protection */}
       <div
@@ -137,9 +135,61 @@ export function StandbyView({ onActivate, nightActive }: StandbyViewProps) {
         {dateStr}
       </div>
 
+      {/* Weather widget card — hidden in night mode */}
+      {!nightActive && (
+        <div className="home-widget home-weather-widget mt-8 mx-4 px-6 py-4">
+          {weather.loading ? (
+            <div className="flex items-center gap-3">
+              <div className="h-10 w-20 animate-pulse rounded-xl bg-white/10" />
+              <div className="h-6 w-40 animate-pulse rounded-lg bg-white/10" />
+            </div>
+          ) : weather.error ? (
+            <span className="text-lg text-white/40">
+              {strings.weatherUnavailable}
+            </span>
+          ) : (
+            <div className="home-weather-layout flex items-center gap-6">
+              {/* Current conditions — left side */}
+              <div className="home-weather-current flex items-center gap-3 shrink-0">
+                <span className="text-4xl leading-none">{weather.emoji}</span>
+                <div className="flex flex-col">
+                  <span className="text-3xl font-semibold tabular-nums text-white/95 leading-tight">
+                    {displayTemp}&deg;{tempUnit}
+                  </span>
+                  <span className="text-sm text-white/50 leading-tight mt-0.5">
+                    {weather.label}
+                    {weather.city && <span> &middot; {weather.city}</span>}
+                  </span>
+                </div>
+              </div>
+
+              {/* Divider */}
+              {weather.hourly.length > 0 && (
+                <div className="home-weather-divider w-px h-12 bg-white/10 shrink-0" />
+              )}
+
+              {/* Hourly forecast strip — right side */}
+              {weather.hourly.length > 0 && (
+                <div className="home-forecast-strip flex gap-4 overflow-x-auto">
+                  {weather.hourly.map((item, i) => (
+                    <div key={i} className="home-forecast-item flex flex-col items-center gap-1 shrink-0">
+                      <span className="text-xs text-white/40 tabular-nums">{item.hour}</span>
+                      <span className="text-lg leading-none">{item.emoji}</span>
+                      <span className="text-sm font-medium tabular-nums text-white/70">
+                        {formatTemp(item.temp)}&deg;
+                      </span>
+                    </div>
+                  ))}
+                </div>
+              )}
+            </div>
+          )}
+        </div>
+      )}
+
       {/* Quick actions — hidden in night mode */}
       {!nightActive && (
-        <div className="home-quick-actions mt-10 flex gap-4">
+        <div className="home-quick-actions mt-8">
           {QUICK_ACTIONS.map(({ id, icon: Icon, label, color, prefill }) => (
             <button
               key={id}

--- a/src/home/use-weather.ts
+++ b/src/home/use-weather.ts
@@ -15,12 +15,19 @@ import { useState, useEffect, useRef } from "react";
 import { WMO_WEATHER, DEFAULT_LOCATION } from "./constants";
 import { useHomeSettings } from "./home-settings-context";
 
+export interface HourlyForecastItem {
+  hour: string;
+  temp: number;
+  emoji: string;
+}
+
 export interface WeatherState {
   temperature: number;
   weatherCode: number;
   emoji: string;
   label: string;
   city: string | null;
+  hourly: HourlyForecastItem[];
   loading: boolean;
   error: string | null;
 }
@@ -53,16 +60,49 @@ async function geocodeCity(
 async function fetchWeather(
   lat: number,
   lon: number,
-): Promise<{ temperature: number; weatherCode: number }> {
-  const url = `https://api.open-meteo.com/v1/forecast?latitude=${lat}&longitude=${lon}&current=temperature_2m,weather_code&timezone=auto`;
+): Promise<{
+  temperature: number;
+  weatherCode: number;
+  hourly: HourlyForecastItem[];
+}> {
+  const url = `https://api.open-meteo.com/v1/forecast?latitude=${lat}&longitude=${lon}&current=temperature_2m,weather_code&hourly=temperature_2m,weather_code&forecast_hours=6&timezone=auto`;
   const res = await fetch(url);
   if (!res.ok) throw new Error(`HTTP ${res.status}`);
   const data = (await res.json()) as {
     current: { temperature_2m: number; weather_code: number };
+    hourly?: {
+      time?: string[];
+      temperature_2m?: number[];
+      weather_code?: number[];
+    };
   };
+
+  const hourly: HourlyForecastItem[] = [];
+  if (data.hourly?.time && data.hourly.temperature_2m && data.hourly.weather_code) {
+    const len = Math.min(
+      data.hourly.time.length,
+      data.hourly.temperature_2m.length,
+      data.hourly.weather_code.length,
+      6,
+    );
+    for (let i = 0; i < len; i++) {
+      const dt = new Date(data.hourly.time[i]);
+      const wmo = WMO_WEATHER[data.hourly.weather_code[i]] ?? {
+        emoji: "\u2600\uFE0F",
+        label: "Unknown",
+      };
+      hourly.push({
+        hour: String(dt.getHours()).padStart(2, "0") + ":00",
+        temp: Math.round(data.hourly.temperature_2m[i]),
+        emoji: wmo.emoji,
+      });
+    }
+  }
+
   return {
     temperature: Math.round(data.current.temperature_2m),
     weatherCode: data.current.weather_code,
+    hourly,
   };
 }
 
@@ -88,6 +128,7 @@ export function useWeather(): WeatherState {
     emoji: "",
     label: "",
     city: null,
+    hourly: [],
     loading: true,
     error: null,
   });
@@ -111,6 +152,7 @@ export function useWeather(): WeatherState {
           emoji: wmo.emoji,
           label: wmo.label,
           city: loc.city,
+          hourly: w.hourly,
           loading: false,
           error: null,
         });

--- a/src/index.css
+++ b/src/index.css
@@ -773,6 +773,21 @@ button, a, input, textarea {
     #06080f;
 }
 
+/* ── Top bar (greeting + settings) ───────────────── */
+.home-top-bar {
+  pointer-events: none;
+}
+.home-top-bar > * {
+  pointer-events: auto;
+}
+
+/* Greeting text */
+.home-greeting {
+  font-size: clamp(1.1rem, 2.5vw, 1.5rem);
+  font-weight: 300;
+  letter-spacing: 0.02em;
+}
+
 /* Clock — 8-10rem for arm's-length readability */
 .home-clock {
   font-size: clamp(6rem, 18vw, 10rem);
@@ -798,28 +813,91 @@ button, a, input, textarea {
   letter-spacing: 0.04em;
 }
 
-/* Weather strip */
-.home-weather-strip {
-  font-size: 1rem;
+/* ── Widget card base (glassmorphism) ────────────── */
+.home-widget {
+  background: rgba(255, 255, 255, 0.05);
+  backdrop-filter: blur(20px);
+  -webkit-backdrop-filter: blur(20px);
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  border-radius: 20px;
+  transition:
+    background 0.2s ease,
+    border-color 0.2s ease,
+    transform 0.15s ease;
 }
 
-/* Quick-action cards */
+.home-widget:hover {
+  background: rgba(255, 255, 255, 0.07);
+  border-color: rgba(255, 255, 255, 0.12);
+}
+
+/* ── Weather widget ──────────────────────────────── */
+.home-weather-widget {
+  max-width: 640px;
+  width: 100%;
+}
+
+.home-weather-layout {
+  flex-wrap: nowrap;
+}
+
+.home-weather-current {
+  min-width: 0;
+}
+
+.home-forecast-strip {
+  min-width: 0;
+  scrollbar-width: none;
+}
+
+.home-forecast-strip::-webkit-scrollbar {
+  display: none;
+}
+
+.home-forecast-item {
+  min-width: 44px;
+}
+
+/* ── Quick-action cards ──────────────────────────── */
 .home-quick-actions {
-  display: flex;
-  gap: 1.25rem;
+  display: grid;
+  grid-template-columns: repeat(2, 1fr);
+  gap: 1rem;
+  max-width: 320px;
+  width: 100%;
+  padding: 0 1rem;
 }
 
 .home-quick-card {
   border: none;
-  background: none;
+  background: rgba(255, 255, 255, 0.05);
+  backdrop-filter: blur(20px);
+  -webkit-backdrop-filter: blur(20px);
+  border-radius: 20px;
+  border: 1px solid rgba(255, 255, 255, 0.08);
   cursor: pointer;
-  padding: 0;
+  padding: 1.25rem 0.75rem;
   outline: none;
+  transition:
+    background 0.2s ease,
+    border-color 0.2s ease,
+    transform 0.15s ease;
+}
+
+.home-quick-card:hover,
+.home-quick-card:focus-visible {
+  background: rgba(255, 255, 255, 0.09);
+  border-color: rgba(255, 255, 255, 0.16);
+  transform: translateY(-2px);
+}
+
+.home-quick-card:active {
+  transform: scale(0.97);
 }
 
 .home-quick-card-icon {
-  width: 64px;
-  height: 64px;
+  width: 56px;
+  height: 56px;
   min-width: 44px;
   min-height: 44px;
   background: rgba(255, 255, 255, 0.06);
@@ -834,7 +912,6 @@ button, a, input, textarea {
 .home-quick-card:focus-visible .home-quick-card-icon {
   background: rgba(255, 255, 255, 0.12);
   border-color: rgba(255, 255, 255, 0.16);
-  transform: translateY(-2px);
 }
 
 .home-quick-card:active .home-quick-card-icon {
@@ -1027,22 +1104,48 @@ button, a, input, textarea {
   .home-clock {
     font-size: 5rem;
   }
+  .home-quick-actions {
+    max-width: 260px;
+    gap: 0.75rem;
+  }
+  .home-quick-card {
+    padding: 1rem 0.5rem;
+  }
   .home-quick-card-icon {
-    width: 52px;
-    height: 52px;
+    width: 48px;
+    height: 48px;
+  }
+  .home-weather-widget {
+    padding-left: 1rem;
+    padding-right: 1rem;
+  }
+  .home-weather-layout {
+    flex-direction: column;
+    gap: 0.75rem;
+  }
+  .home-weather-divider {
+    width: 100%;
+    height: 1px;
   }
   .home-bubble-text {
     font-size: 1.1rem;
+  }
+  .home-greeting {
+    font-size: 1rem;
   }
 }
 
 @media (min-width: 1280px) {
   .home-quick-actions {
-    gap: 2rem;
+    max-width: 400px;
+    gap: 1.25rem;
   }
   .home-quick-card-icon {
-    width: 72px;
-    height: 72px;
+    width: 64px;
+    height: 64px;
+  }
+  .home-weather-widget {
+    max-width: 720px;
   }
 }
 


### PR DESCRIPTION
## Summary
- Redesigned standby view with glassmorphism widget cards
- Weather widget: current conditions + 6-hour hourly forecast strip from Open-Meteo
- Time-of-day greeting (morning/afternoon/evening/night, en/zh)
- Fixed quick-action prefill bug: card prefill strings now properly wired from i18n constants
- 2x2 grid layout for quick action cards (was horizontal flex row)
- Touch-friendly: 44px+ targets, generous spacing

## Test plan
- [ ] Deploy to macmini2, open /home in browser
- [ ] Verify weather widget shows current temp + 6-hour forecast
- [ ] Verify greeting changes based on time of day
- [ ] Verify quick action cards prefill correctly
- [ ] Verify night mode hides weather + cards
- [ ] Run Playwright test suite