### PR TITLE
feat(home): thinking indicator, stop button, smooth scroll, file attachments

### DIFF
--- a/src/home/conversation-view.tsx
+++ b/src/home/conversation-view.tsx
@@ -8,6 +8,14 @@
  * Auto-returns to standby after configurable idle seconds (from settings).
  *
  * Shows suggestion cards when the conversation is empty.
+ *
+ * Features:
+ * - Thinking/streaming indicator (bouncing dots)
+ * - Stop/cancel button during streaming
+ * - Smart auto-scroll with user-scroll detection
+ * - Smooth text streaming animation (useSmooth)
+ * - Tool call display (collapsed)
+ * - File attachments (audio, image, download)
  */
 
 import {
@@ -18,11 +26,27 @@ import {
 } from "react";
 import ReactMarkdown from "react-markdown";
 import remarkGfm from "remark-gfm";
-import { ArrowLeft, SendHorizontal } from "lucide-react";
+import {
+  ArrowLeft,
+  ChevronDown,
+  Download,
+  SendHorizontal,
+  Square,
+  Wrench,
+} from "lucide-react";
 import { useSession } from "@/runtime/session-context";
-import { useThreads, type Thread, type ThreadMessage } from "@/store/thread-store";
+import {
+  useThreads,
+  type Thread,
+  type ThreadMessage,
+  type MessageFile,
+  type ThreadToolCall,
+} from "@/store/thread-store";
 import { sendMessage as bridgeSend } from "@/runtime/ui-protocol-send";
+import { getActiveBridge } from "@/runtime/ui-protocol-runtime";
+import { buildAuthenticatedFileUrl } from "@/api/files";
 import { useHomeSettings } from "./home-settings-context";
+import { useSmooth } from "./use-smooth";
 
 interface ConversationViewProps {
   onBack: () => void;
@@ -33,6 +57,124 @@ function formatBubbleTime(ts: number): string {
   const d = new Date(ts);
   const pad = (n: number) => String(n).padStart(2, "0");
   return `${pad(d.getHours())}:${pad(d.getMinutes())}`;
+}
+
+// ── File type detection ────────────────────────────────────────────
+function isAudioFile(file: MessageFile): boolean {
+  return /\.(mp3|wav|ogg|webm|m4a|aac|flac|opus)$/i.test(file.filename);
+}
+
+function isImageFile(file: MessageFile): boolean {
+  return /\.(png|jpg|jpeg|gif|webp|svg|bmp)$/i.test(file.filename);
+}
+
+// ── Thinking indicator (bouncing dots) ────────────────────────────
+function ThinkingBubble() {
+  return (
+    <div className="flex justify-start mb-2">
+      <div className="home-bubble home-bubble-assistant max-w-[80%] rounded-2xl px-5 py-3">
+        <div className="home-thinking-dots flex items-center gap-1.5">
+          <span className="home-thinking-dot" style={{ animationDelay: "0ms" }} />
+          <span className="home-thinking-dot" style={{ animationDelay: "160ms" }} />
+          <span className="home-thinking-dot" style={{ animationDelay: "320ms" }} />
+          <span className="ml-2 text-base text-white/40">Thinking</span>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+// ── File attachment renderers ─────────────────────────────────────
+function FileAttachment({ file }: { file: MessageFile }) {
+  const url = buildAuthenticatedFileUrl(file.path);
+
+  if (isAudioFile(file)) {
+    return (
+      <div className="home-file-attachment mt-2">
+        <audio controls preload="none" className="home-audio-player w-full">
+          <source src={url} />
+        </audio>
+        {file.caption && (
+          <div className="mt-1 text-sm text-white/40">{file.caption}</div>
+        )}
+      </div>
+    );
+  }
+
+  if (isImageFile(file)) {
+    return (
+      <div className="home-file-attachment mt-2">
+        <img
+          src={url}
+          alt={file.caption || file.filename}
+          className="home-image-attachment max-w-full rounded-xl"
+          loading="lazy"
+        />
+        {file.caption && (
+          <div className="mt-1 text-sm text-white/40">{file.caption}</div>
+        )}
+      </div>
+    );
+  }
+
+  // Generic file — download link
+  return (
+    <div className="home-file-attachment mt-2">
+      <a
+        href={url}
+        download={file.filename}
+        target="_blank"
+        rel="noopener noreferrer"
+        className="home-file-download inline-flex items-center gap-2 rounded-xl px-3 py-2 text-sm"
+      >
+        <Download size={16} className="shrink-0" />
+        <span className="truncate">{file.filename}</span>
+      </a>
+    </div>
+  );
+}
+
+// ── Tool calls indicator ──────────────────────────────────────────
+function ToolCallsIndicator({ toolCalls }: { toolCalls: ThreadToolCall[] }) {
+  if (toolCalls.length === 0) return null;
+  return (
+    <div className="home-tool-indicator mt-2 flex items-center gap-2 text-sm text-white/35">
+      <Wrench size={14} />
+      <span>Used {toolCalls.length} tool{toolCalls.length > 1 ? "s" : ""}</span>
+    </div>
+  );
+}
+
+// ── Pending assistant bubble with smooth streaming ────────────────
+function PendingBubble({ pending }: { pending: ThreadMessage }) {
+  const smoothText = useSmooth(
+    pending.text,
+    pending.status === "streaming",
+  );
+
+  if (!smoothText) return null;
+
+  return (
+    <div className="flex justify-start mb-2">
+      <div className="home-bubble home-bubble-assistant max-w-[80%] rounded-2xl px-5 py-3">
+        <div className="home-bubble-text home-bubble-markdown text-white/90">
+          <ReactMarkdown remarkPlugins={[remarkGfm]}>
+            {smoothText}
+          </ReactMarkdown>
+        </div>
+        {pending.files.length > 0 && (
+          <div>
+            {pending.files.map((file, i) => (
+              <FileAttachment key={`${file.path}-${i}`} file={file} />
+            ))}
+          </div>
+        )}
+        {pending.toolCalls.length > 0 && (
+          <ToolCallsIndicator toolCalls={pending.toolCalls} />
+        )}
+      </div>
+    </div>
+  );
 }
 
 export function ConversationView({ onBack, prefill }: ConversationViewProps) {
@@ -46,12 +188,15 @@ export function ConversationView({ onBack, prefill }: ConversationViewProps) {
   const composingRef = useRef(false);
   const prefillAppliedRef = useRef<string | undefined>(undefined);
 
+  // ── Scroll state ────────────────────────────────────────────────
+  const isAtBottomRef = useRef(true);
+  const [showScrollBtn, setShowScrollBtn] = useState(false);
+
   // ── Prefill from card action ────────────────────────────────────
   useEffect(() => {
     if (prefill && prefill !== prefillAppliedRef.current) {
       prefillAppliedRef.current = prefill;
       setText(prefill);
-      // Focus the textarea after prefill so the user can confirm/edit
       requestAnimationFrame(() => {
         textareaRef.current?.focus();
       });
@@ -78,9 +223,6 @@ export function ConversationView({ onBack, prefill }: ConversationViewProps) {
   }, [threads, resetIdle]);
 
   // ── Fix #4: setSending(false) when thread state changes ─────────
-  // Instead of clearing `sending` immediately after fire-and-forget
-  // `bridgeSend`, we watch for the thread store to reflect the new
-  // assistant activity (pendingAssistant appearing or responses growing).
   const prevThreadSnapshotRef = useRef<{
     pendingCount: number;
     responseCount: number;
@@ -107,10 +249,32 @@ export function ConversationView({ onBack, prefill }: ConversationViewProps) {
     prevThreadSnapshotRef.current = { pendingCount, responseCount };
   }, [threads, sending]);
 
-  // ── Auto-scroll ─────────────────────────────────────────────────
+  // ── Scroll detection ────────────────────────────────────────────
+  const handleScroll = useCallback(() => {
+    const el = scrollRef.current;
+    if (!el) return;
+    const threshold = 50;
+    const atBottom = el.scrollHeight - el.scrollTop - el.clientHeight < threshold;
+    isAtBottomRef.current = atBottom;
+    setShowScrollBtn(!atBottom);
+  }, []);
+
+  const scrollToBottom = useCallback(() => {
+    const el = scrollRef.current;
+    if (el) {
+      el.scrollTo({ top: el.scrollHeight, behavior: "smooth" });
+      isAtBottomRef.current = true;
+      setShowScrollBtn(false);
+    }
+  }, []);
+
+  // ── Smart auto-scroll ──────────────────────────────────────────
   useEffect(() => {
     const el = scrollRef.current;
-    if (el) el.scrollTop = el.scrollHeight;
+    if (!el) return;
+    if (isAtBottomRef.current) {
+      el.scrollTo({ top: el.scrollHeight, behavior: "smooth" });
+    }
   }, [threads]);
 
   // ── Send ────────────────────────────────────────────────────────
@@ -120,8 +284,6 @@ export function ConversationView({ onBack, prefill }: ConversationViewProps) {
     setSending(true);
     resetIdle();
 
-    // Snapshot current thread state BEFORE sending so the effect can
-    // detect when the store changes in response.
     prevThreadSnapshotRef.current = {
       pendingCount: threads.filter(
         (t: Thread) => t.pendingAssistant !== null,
@@ -145,15 +307,14 @@ export function ConversationView({ onBack, prefill }: ConversationViewProps) {
     });
 
     setText("");
-    // NOTE: setSending(false) is NOT called here — the useEffect above
-    // clears it when the thread store reflects the new activity.
-  }, [text, sending, threads, currentSessionId, historyTopic, refreshSessions, markSessionActive, resetIdle]);
+    // Scroll to bottom on send
+    requestAnimationFrame(() => scrollToBottom());
+  }, [text, sending, threads, currentSessionId, historyTopic, refreshSessions, markSessionActive, resetIdle, scrollToBottom]);
 
   // Fill input with a suggestion and send immediately
   const handleSuggestion = useCallback(
     (suggestion: string) => {
       setText(suggestion);
-      // We need to send directly since setState is async
       setSending(true);
       resetIdle();
 
@@ -174,6 +335,23 @@ export function ConversationView({ onBack, prefill }: ConversationViewProps) {
     },
     [currentSessionId, historyTopic, refreshSessions, markSessionActive, resetIdle],
   );
+
+  // ── Cancel / Stop ──────────────────────────────────────────────
+  const handleCancel = useCallback(() => {
+    const bridge = getActiveBridge(currentSessionId, historyTopic);
+    if (bridge) {
+      const pendingThread = threads.find(
+        (t: Thread) =>
+          t.pendingAssistant !== null &&
+          t.pendingAssistant.status === "streaming",
+      );
+      if (pendingThread) {
+        void bridge.interruptTurn(pendingThread.id, "user cancelled").catch(() => {
+          // best-effort: swallow transport errors.
+        });
+      }
+    }
+  }, [currentSessionId, historyTopic, threads]);
 
   const handleKeyDown = useCallback(
     (e: React.KeyboardEvent) => {
@@ -203,6 +381,13 @@ export function ConversationView({ onBack, prefill }: ConversationViewProps) {
       t.pendingAssistant.status === "streaming",
   );
 
+  // Pending assistant with no text yet → show thinking dots
+  const isPending = threads.some(
+    (t: Thread) =>
+      t.pendingAssistant !== null &&
+      !t.pendingAssistant.text,
+  );
+
   const isEmpty = threads.length === 0;
 
   return (
@@ -217,20 +402,15 @@ export function ConversationView({ onBack, prefill }: ConversationViewProps) {
           <ArrowLeft size={24} className="text-white/70" />
         </button>
         <div className="flex-1" />
-        {isStreaming && (
-          <div className="flex items-center gap-2">
-            <div className="h-2 w-2 animate-pulse rounded-full bg-blue-400" />
-            <span className="text-sm text-white/50">Thinking</span>
-          </div>
-        )}
       </div>
 
       {/* Messages */}
       <div
         ref={scrollRef}
-        className="home-messages flex-1 overflow-y-auto px-4 pb-4"
+        className="home-messages relative flex-1 overflow-y-auto px-4 pb-4"
         onTouchStart={resetIdle}
         onMouseMove={resetIdle}
+        onScroll={handleScroll}
       >
         {isEmpty && (
           <div className="flex h-full flex-col items-center justify-center gap-8">
@@ -279,6 +459,18 @@ export function ConversationView({ onBack, prefill }: ConversationViewProps) {
                       {msg.text}
                     </ReactMarkdown>
                   </div>
+                  {/* File attachments */}
+                  {msg.files.length > 0 && (
+                    <div>
+                      {msg.files.map((file, i) => (
+                        <FileAttachment key={`${file.path}-${i}`} file={file} />
+                      ))}
+                    </div>
+                  )}
+                  {/* Tool calls indicator */}
+                  {msg.toolCalls.length > 0 && (
+                    <ToolCallsIndicator toolCalls={msg.toolCalls} />
+                  )}
                   <div className="mt-1 text-xs text-white/30 tabular-nums">
                     {formatBubbleTime(msg.timestamp)}
                   </div>
@@ -286,21 +478,28 @@ export function ConversationView({ onBack, prefill }: ConversationViewProps) {
               </div>
             ))}
 
-            {/* Pending streaming — also markdown */}
-            {thread.pendingAssistant &&
-              thread.pendingAssistant.text && (
-                <div className="flex justify-start mb-2">
-                  <div className="home-bubble home-bubble-assistant max-w-[80%] rounded-2xl px-5 py-3">
-                    <div className="home-bubble-text home-bubble-markdown text-white/90">
-                      <ReactMarkdown remarkPlugins={[remarkGfm]}>
-                        {thread.pendingAssistant.text}
-                      </ReactMarkdown>
-                    </div>
-                  </div>
-                </div>
-              )}
+            {/* Pending streaming with smooth animation */}
+            {thread.pendingAssistant && thread.pendingAssistant.text && (
+              <PendingBubble pending={thread.pendingAssistant} />
+            )}
+
+            {/* Thinking indicator — pending with no text yet */}
+            {thread.pendingAssistant && !thread.pendingAssistant.text && (
+              <ThinkingBubble />
+            )}
           </div>
         ))}
+
+        {/* Scroll-to-bottom button */}
+        {showScrollBtn && (
+          <button
+            onClick={scrollToBottom}
+            className="home-scroll-bottom"
+            aria-label="Scroll to bottom"
+          >
+            <ChevronDown size={22} />
+          </button>
+        )}
       </div>
 
       {/* Input */}
@@ -325,14 +524,24 @@ export function ConversationView({ onBack, prefill }: ConversationViewProps) {
             className="home-composer-input flex-1 resize-none bg-transparent px-3 py-3 outline-none"
             autoFocus
           />
-          <button
-            onClick={() => void handleSend()}
-            disabled={text.trim().length === 0 || sending}
-            className="home-send-button flex shrink-0 items-center justify-center rounded-xl disabled:opacity-30"
-            aria-label={strings.send}
-          >
-            <SendHorizontal size={22} className="text-white" />
-          </button>
+          {isStreaming || isPending ? (
+            <button
+              onClick={handleCancel}
+              className="home-stop-button flex shrink-0 items-center justify-center rounded-xl"
+              aria-label="Stop"
+            >
+              <Square size={18} className="text-white" />
+            </button>
+          ) : (
+            <button
+              onClick={() => void handleSend()}
+              disabled={text.trim().length === 0 || sending}
+              className="home-send-button flex shrink-0 items-center justify-center rounded-xl disabled:opacity-30"
+              aria-label={strings.send}
+            >
+              <SendHorizontal size={22} className="text-white" />
+            </button>
+          )}
         </div>
       </div>
     </div>

--- a/src/home/use-smooth.ts
+++ b/src/home/use-smooth.ts
@@ -1,0 +1,50 @@
+/**
+ * Smooth text streaming animation hook.
+ *
+ * When `isStreaming` is true, the returned string gradually catches up to
+ * `targetText` using requestAnimationFrame, giving a typewriter effect.
+ * Speed adapts: the more characters remaining, the faster per-char rate.
+ * When streaming stops, the full text is returned immediately.
+ */
+import { useEffect, useRef, useState } from "react";
+
+export function useSmooth(targetText: string, isStreaming: boolean): string {
+  const [displayText, setDisplayText] = useState(targetText);
+  const rafRef = useRef<number>(0);
+  const posRef = useRef(0);
+
+  useEffect(() => {
+    // When not streaming, show full text immediately.
+    if (!isStreaming) {
+      cancelAnimationFrame(rafRef.current);
+      posRef.current = targetText.length;
+      setDisplayText(targetText);
+      return;
+    }
+
+    // If target shrunk (new message), reset position.
+    if (posRef.current > targetText.length) {
+      posRef.current = 0;
+    }
+
+    function tick() {
+      const remaining = targetText.length - posRef.current;
+      if (remaining <= 0) {
+        // Caught up — wait for more tokens.
+        rafRef.current = requestAnimationFrame(tick);
+        return;
+      }
+
+      // Adaptive speed: more remaining chars → bigger step.
+      const step = Math.max(1, Math.ceil(remaining / 8));
+      posRef.current = Math.min(posRef.current + step, targetText.length);
+      setDisplayText(targetText.slice(0, posRef.current));
+      rafRef.current = requestAnimationFrame(tick);
+    }
+
+    rafRef.current = requestAnimationFrame(tick);
+    return () => cancelAnimationFrame(rafRef.current);
+  }, [targetText, isStreaming]);
+
+  return displayText;
+}

--- a/src/index.css
+++ b/src/index.css
@@ -1001,6 +1001,118 @@ button, a, input, textarea {
   transform: scale(0.95);
 }
 
+/* ── Stop / Cancel button ────────────────────────── */
+.home-stop-button {
+  width: 52px;
+  height: 52px;
+  min-width: 44px;
+  min-height: 44px;
+  background: #dc2626;
+  border: none;
+  cursor: pointer;
+  border-radius: 12px;
+  transition: background 0.2s ease, transform 0.1s ease;
+}
+
+.home-stop-button:hover {
+  background: #b91c1c;
+}
+
+.home-stop-button:active {
+  transform: scale(0.95);
+}
+
+/* ── Thinking indicator (bouncing dots) ──────────── */
+@keyframes homeThinkingBounce {
+  0%, 80%, 100% {
+    transform: translateY(0) scale(0.7);
+    opacity: 0.35;
+  }
+  40% {
+    transform: translateY(-6px) scale(1);
+    opacity: 1;
+  }
+}
+
+.home-thinking-dot {
+  display: inline-block;
+  width: 10px;
+  height: 10px;
+  border-radius: 50%;
+  background: rgba(255, 255, 255, 0.5);
+  animation: homeThinkingBounce 1.4s ease-in-out infinite;
+}
+
+/* ── Scroll-to-bottom button ─────────────────────── */
+.home-scroll-bottom {
+  position: sticky;
+  bottom: 8px;
+  left: 50%;
+  transform: translateX(-50%);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 44px;
+  height: 44px;
+  min-width: 44px;
+  min-height: 44px;
+  border-radius: 50%;
+  background: rgba(255, 255, 255, 0.1);
+  backdrop-filter: blur(12px);
+  -webkit-backdrop-filter: blur(12px);
+  border: 1px solid rgba(255, 255, 255, 0.12);
+  color: rgba(255, 255, 255, 0.7);
+  cursor: pointer;
+  z-index: 10;
+  transition: background 0.2s ease, transform 0.15s ease;
+  margin-left: auto;
+  margin-right: auto;
+}
+
+.home-scroll-bottom:hover {
+  background: rgba(255, 255, 255, 0.18);
+  transform: translateX(-50%) scale(1.05);
+}
+
+.home-scroll-bottom:active {
+  transform: translateX(-50%) scale(0.95);
+}
+
+/* ── File attachments ────────────────────────────── */
+.home-file-attachment {
+  max-width: 100%;
+}
+
+.home-audio-player {
+  max-width: 100%;
+  height: 44px;
+  border-radius: 10px;
+  filter: invert(1) hue-rotate(180deg);
+  opacity: 0.85;
+}
+
+.home-image-attachment {
+  max-height: 300px;
+  object-fit: contain;
+}
+
+.home-file-download {
+  background: rgba(255, 255, 255, 0.06);
+  border: 1px solid rgba(255, 255, 255, 0.1);
+  color: rgba(255, 255, 255, 0.6);
+  transition: background 0.2s ease, color 0.2s ease;
+}
+
+.home-file-download:hover {
+  background: rgba(255, 255, 255, 0.1);
+  color: rgba(255, 255, 255, 0.85);
+}
+
+/* ── Tool call indicator ─────────────────────────── */
+.home-tool-indicator {
+  padding: 2px 0;
+}
+
 /* ── Home bubble markdown (AI responses) ─────────── */
 /* Inherits .home-bubble-text sizing (1.25rem) and applies prose-like
    styling for readable markdown on the deep-dark home background. */


### PR DESCRIPTION
## Summary
- Thinking indicator: animated bouncing dots in assistant bubble
- Stop/cancel button: red square replaces send during streaming, calls bridge.interruptTurn()
- Smart auto-scroll: tracks user scroll position, only auto-scrolls at bottom, shows scroll-to-bottom button
- Smooth streaming animation: useSmooth hook with rAF-driven text reveal
- Tool call display: "Used N tools" indicator with wrench icon
- File attachments: audio player, image preview, download links in assistant messages

## Test plan
- [ ] Deploy to macmini2, open /home, send a message
- [ ] Verify thinking dots appear while waiting for response
- [ ] Verify stop button appears during streaming, cancels on click
- [ ] Scroll up during response, verify auto-scroll pauses + button appears
- [ ] Verify text streams smoothly (not jumping)
- [ ] Send "activate tools group:media" then request a file, verify attachment renders