### PR TITLE
feat(home): voice orb with Web Speech API and state animations

### DIFF
--- a/src/home/constants.ts
+++ b/src/home/constants.ts
@@ -54,6 +54,11 @@ export interface HomeStrings {
   settingsLanguage: string;
   settingsClose: string;
 
+  // Voice
+  voiceListening: string;
+  voiceNotSupported: string;
+  voiceError: string;
+
   // Suggestion prompts
   suggestions: readonly string[];
 }
@@ -119,6 +124,10 @@ export const HOME_I18N: Record<string, HomeStrings> = {
     settingsNightOff: "Off",
     settingsLanguage: "Language",
     settingsClose: "Close",
+
+    voiceListening: "Listening...",
+    voiceNotSupported: "Voice not supported",
+    voiceError: "Voice error",
 
     suggestions: [
       "What's the weather like today?",
@@ -188,6 +197,10 @@ export const HOME_I18N: Record<string, HomeStrings> = {
     settingsNightOff: "\u5173\u95ED",
     settingsLanguage: "\u8BED\u8A00",
     settingsClose: "\u5173\u95ED",
+
+    voiceListening: "\u6B63\u5728\u542C...",
+    voiceNotSupported: "\u8BED\u97F3\u4E0D\u652F\u6301",
+    voiceError: "\u8BED\u97F3\u9519\u8BEF",
 
     suggestions: [
       "\u4ECA\u5929\u5929\u6C14\u600E\u4E48\u6837\uFF1F",

--- a/src/home/standby-view.tsx
+++ b/src/home/standby-view.tsx
@@ -21,6 +21,8 @@ import { useWeather } from "./use-weather";
 import { useHomeSettings } from "./home-settings-context";
 import { useBurnInProtection } from "./use-burn-in-protection";
 import { SettingsGearButton, HomeSettingsPanel } from "./home-settings";
+import { VoiceOrb } from "./voice-orb";
+import { useVoiceInput } from "./use-voice-input";
 
 interface StandbyViewProps {
   onActivate: (prefill?: string) => void;
@@ -33,6 +35,24 @@ export function StandbyView({ onActivate, nightActive }: StandbyViewProps) {
   const { strings, tempUnit, clockFormat } = useHomeSettings();
   const burnIn = useBurnInProtection();
   const [settingsOpen, setSettingsOpen] = useState(false);
+
+  const voice = useVoiceInput({
+    onResult: (text) => onActivate(text),
+    lang: strings === (undefined as never) ? "en-US" : undefined,
+  });
+
+  const handleOrbClick = useCallback(() => {
+    if (!voice.isSupported) {
+      // Fallback: just activate conversation mode (keyboard input)
+      onActivate();
+      return;
+    }
+    if (voice.orbState === "listening") {
+      voice.stop();
+    } else if (voice.orbState === "idle") {
+      voice.start();
+    }
+  }, [voice, onActivate]);
 
   const dateStr = `${strings.weekdays[clock.date.getDay()]}, ${strings.months[clock.date.getMonth()]} ${clock.date.getDate()}`;
 
@@ -134,6 +154,24 @@ export function StandbyView({ onActivate, nightActive }: StandbyViewProps) {
       >
         {dateStr}
       </div>
+
+      {/* Voice Orb — hidden in night mode */}
+      {!nightActive && (
+        <div
+          className="mt-6"
+          style={{
+            transform: `translate(${burnIn.offset.x}px, ${burnIn.offset.y}px)`,
+            transition: "transform 2s ease-in-out",
+          }}
+        >
+          <VoiceOrb state={voice.orbState} onClick={handleOrbClick} />
+          {voice.orbState === "listening" && voice.transcript && (
+            <p className="mt-2 text-center text-sm text-white/40 max-w-[200px] truncate">
+              {voice.transcript}
+            </p>
+          )}
+        </div>
+      )}
 
       {/* Weather widget card — hidden in night mode */}
       {!nightActive && (

--- a/src/home/use-voice-input.ts
+++ b/src/home/use-voice-input.ts
@@ -1,0 +1,181 @@
+/**
+ * useVoiceInput — Web Speech API hook for voice recognition.
+ *
+ * Wraps `SpeechRecognition` / `webkitSpeechRecognition` with graceful
+ * degradation for unsupported browsers (Firefox, older mobile).
+ *
+ * State machine: idle → listening → processing → idle
+ * The `speaking` state is set externally (when TTS / AI response plays).
+ */
+
+import { useCallback, useEffect, useRef, useState } from "react";
+import type { OrbState } from "./voice-orb";
+
+/* ── Extend Window for webkitSpeechRecognition ────────── */
+interface SpeechRecognitionEvent extends Event {
+  readonly resultIndex: number;
+  readonly results: SpeechRecognitionResultList;
+}
+
+interface SpeechRecognitionErrorEvent extends Event {
+  readonly error: string;
+  readonly message: string;
+}
+
+type SpeechRecognitionInstance = {
+  continuous: boolean;
+  interimResults: boolean;
+  lang: string;
+  start(): void;
+  stop(): void;
+  abort(): void;
+  onresult: ((event: SpeechRecognitionEvent) => void) | null;
+  onerror: ((event: SpeechRecognitionErrorEvent) => void) | null;
+  onend: (() => void) | null;
+  onspeechend: (() => void) | null;
+};
+
+type SpeechRecognitionCtor = new () => SpeechRecognitionInstance;
+
+function getSpeechRecognition(): SpeechRecognitionCtor | null {
+  const w = window as unknown as Record<string, unknown>;
+  return (
+    (w.SpeechRecognition as SpeechRecognitionCtor | undefined) ??
+    (w.webkitSpeechRecognition as SpeechRecognitionCtor | undefined) ??
+    null
+  );
+}
+
+/* ── Public interface ─────────────────────────────────── */
+export interface VoiceInputState {
+  orbState: OrbState;
+  isSupported: boolean;
+  start: () => void;
+  stop: () => void;
+  transcript: string;
+  /** Externally set the orb to `speaking` state. */
+  setSpeaking: (speaking: boolean) => void;
+}
+
+export interface VoiceInputOptions {
+  onResult: (text: string) => void;
+  onSpeakingDone?: () => void;
+  lang?: string;
+}
+
+/** Silence timeout — auto-stop after 10 s of no speech. */
+const SILENCE_TIMEOUT = 10_000;
+
+export function useVoiceInput(options: VoiceInputOptions): VoiceInputState {
+  const { onResult, lang = "en-US" } = options;
+  const [orbState, setOrbState] = useState<OrbState>("idle");
+  const [transcript, setTranscript] = useState("");
+  const [isSupported] = useState(() => getSpeechRecognition() !== null);
+
+  const recognitionRef = useRef<SpeechRecognitionInstance | null>(null);
+  const silenceTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const optionsRef = useRef(options);
+  optionsRef.current = options;
+
+  /* ── Cleanup on unmount ──────────────────────────────── */
+  useEffect(() => {
+    return () => {
+      recognitionRef.current?.abort();
+      recognitionRef.current = null;
+      if (silenceTimerRef.current) clearTimeout(silenceTimerRef.current);
+    };
+  }, []);
+
+  /* ── Start listening ─────────────────────────────────── */
+  const start = useCallback(() => {
+    const Ctor = getSpeechRecognition();
+    if (!Ctor) return;
+
+    // Abort any existing session
+    recognitionRef.current?.abort();
+    if (silenceTimerRef.current) clearTimeout(silenceTimerRef.current);
+
+    const rec = new Ctor();
+    rec.continuous = false;
+    rec.interimResults = true;
+    rec.lang = lang;
+    recognitionRef.current = rec;
+
+    setOrbState("listening");
+    setTranscript("");
+
+    // Start silence timer
+    silenceTimerRef.current = setTimeout(() => {
+      rec.stop();
+    }, SILENCE_TIMEOUT);
+
+    rec.onresult = (event: SpeechRecognitionEvent) => {
+      // Reset silence timer on any result
+      if (silenceTimerRef.current) clearTimeout(silenceTimerRef.current);
+      silenceTimerRef.current = setTimeout(() => {
+        rec.stop();
+      }, SILENCE_TIMEOUT);
+
+      let finalText = "";
+      let interimText = "";
+      for (let i = event.resultIndex; i < event.results.length; i++) {
+        const result = event.results[i];
+        if (result.isFinal) {
+          finalText += result[0].transcript;
+        } else {
+          interimText += result[0].transcript;
+        }
+      }
+
+      // Show interim text as transcript for visual feedback
+      setTranscript(finalText || interimText);
+
+      if (finalText) {
+        setOrbState("processing");
+        if (silenceTimerRef.current) clearTimeout(silenceTimerRef.current);
+        optionsRef.current.onResult(finalText.trim());
+      }
+    };
+
+    rec.onspeechend = () => {
+      // Speech ended — transition to processing while waiting for final result
+      if (orbState === "listening") {
+        setOrbState("processing");
+      }
+    };
+
+    rec.onerror = (_event: SpeechRecognitionErrorEvent) => {
+      if (silenceTimerRef.current) clearTimeout(silenceTimerRef.current);
+      recognitionRef.current = null;
+      setOrbState("idle");
+    };
+
+    rec.onend = () => {
+      if (silenceTimerRef.current) clearTimeout(silenceTimerRef.current);
+      recognitionRef.current = null;
+      // Only reset to idle if we're still in listening/processing
+      // (don't override 'speaking' set externally)
+      setOrbState((prev) => (prev === "speaking" ? prev : "idle"));
+    };
+
+    try {
+      rec.start();
+    } catch {
+      setOrbState("idle");
+      recognitionRef.current = null;
+    }
+  }, [lang, orbState]);
+
+  /* ── Stop listening ──────────────────────────────────── */
+  const stop = useCallback(() => {
+    if (silenceTimerRef.current) clearTimeout(silenceTimerRef.current);
+    recognitionRef.current?.stop();
+  }, []);
+
+  /* ── External speaking control ───────────────────────── */
+  const setSpeaking = useCallback((speaking: boolean) => {
+    setOrbState(speaking ? "speaking" : "idle");
+  }, []);
+
+  return { orbState, isSupported, start, stop, transcript, setSpeaking };
+}

--- a/src/home/voice-orb.tsx
+++ b/src/home/voice-orb.tsx
@@ -1,0 +1,59 @@
+/**
+ * Voice Orb — a circular glassmorphism button that serves as the primary
+ * voice-interaction entry point on the standby view.
+ *
+ * States drive visual appearance via CSS `data-state` attribute:
+ * - idle:       soft breathing glow
+ * - listening:  green glow, faster pulse
+ * - processing: purple spinning indicator
+ * - speaking:   amber pulsing glow
+ *
+ * Pure CSS animations — Canvas version deferred to PR 4.
+ */
+
+import { Mic } from "lucide-react";
+
+export type OrbState = "idle" | "listening" | "processing" | "speaking";
+
+export interface VoiceOrbProps {
+  state: OrbState;
+  onClick: () => void;
+  disabled?: boolean;
+}
+
+export function VoiceOrb({ state, onClick, disabled }: VoiceOrbProps) {
+  return (
+    <button
+      className="home-voice-orb"
+      data-state={state}
+      onClick={(e) => {
+        e.stopPropagation();
+        if (!disabled) onClick();
+      }}
+      disabled={disabled}
+      aria-label={
+        state === "idle"
+          ? "Tap to speak"
+          : state === "listening"
+            ? "Listening..."
+            : state === "processing"
+              ? "Processing..."
+              : "Speaking..."
+      }
+      type="button"
+    >
+      <Mic
+        size={32}
+        className={`home-voice-orb-icon ${
+          state === "listening"
+            ? "text-emerald-400"
+            : state === "processing"
+              ? "text-purple-400"
+              : state === "speaking"
+                ? "text-amber-400"
+                : "text-white/60"
+        } transition-colors duration-300`}
+      />
+    </button>
+  );
+}

--- a/src/index.css
+++ b/src/index.css
@@ -1211,6 +1211,81 @@ button, a, input, textarea {
   margin: 1em 0;
 }
 
+/* ── Voice Orb ───────────────────────────────────── */
+.home-voice-orb {
+  width: 100px;
+  height: 100px;
+  border-radius: 50%;
+  background: rgba(255, 255, 255, 0.08);
+  backdrop-filter: blur(20px);
+  -webkit-backdrop-filter: blur(20px);
+  border: 2px solid rgba(255, 255, 255, 0.12);
+  cursor: pointer;
+  position: relative;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  transition: all 0.5s ease;
+  outline: none;
+  padding: 0;
+}
+
+.home-voice-orb:disabled {
+  opacity: 0.4;
+  cursor: not-allowed;
+}
+
+/* State-based glow */
+.home-voice-orb[data-state="idle"] {
+  box-shadow: 0 0 30px -5px rgba(255, 255, 255, 0.1);
+  animation: orbBreathe 4s ease-in-out infinite;
+}
+
+.home-voice-orb[data-state="listening"] {
+  border-color: rgba(16, 185, 129, 0.5);
+  box-shadow: 0 0 40px -5px rgba(16, 185, 129, 0.3);
+  animation: orbPulse 1.5s ease-in-out infinite;
+}
+
+.home-voice-orb[data-state="processing"] {
+  border-color: rgba(139, 92, 246, 0.5);
+  box-shadow: 0 0 40px -5px rgba(139, 92, 246, 0.3);
+  animation: orbSpin 2s linear infinite;
+}
+
+.home-voice-orb[data-state="speaking"] {
+  border-color: rgba(245, 158, 11, 0.5);
+  box-shadow: 0 0 40px -5px rgba(245, 158, 11, 0.3);
+  animation: orbPulse 2s ease-in-out infinite;
+}
+
+.home-voice-orb:hover:not(:disabled) {
+  background: rgba(255, 255, 255, 0.12);
+  border-color: rgba(255, 255, 255, 0.2);
+}
+
+.home-voice-orb:active:not(:disabled) {
+  transform: scale(0.95);
+}
+
+@keyframes orbBreathe {
+  0%, 100% { transform: scale(1); opacity: 0.9; }
+  50% { transform: scale(1.03); opacity: 1; }
+}
+
+@keyframes orbPulse {
+  0%, 100% { transform: scale(1); }
+  50% { transform: scale(1.08); }
+}
+
+@keyframes orbSpin {
+  0% { box-shadow: 6px 0 40px -5px rgba(139, 92, 246, 0.4); }
+  25% { box-shadow: 0 6px 40px -5px rgba(139, 92, 246, 0.4); }
+  50% { box-shadow: -6px 0 40px -5px rgba(139, 92, 246, 0.4); }
+  75% { box-shadow: 0 -6px 40px -5px rgba(139, 92, 246, 0.4); }
+  100% { box-shadow: 6px 0 40px -5px rgba(139, 92, 246, 0.4); }
+}
+
 /* ── Responsive adjustments for small screens ────── */
 @media (max-width: 480px) {
   .home-clock {
@@ -1258,6 +1333,10 @@ button, a, input, textarea {
   }
   .home-weather-widget {
     max-width: 720px;
+  }
+  .home-voice-orb {
+    width: 120px;
+    height: 120px;
   }
 }
 


### PR DESCRIPTION
## Summary
- Voice orb component: glassmorphism circle with state-based glow (idle/listening/processing/speaking)
- Web Speech API integration: SpeechRecognition with interim results, 10s silence auto-stop
- Graceful degradation: falls back to keyboard input on unsupported browsers (Firefox)
- CSS-only animations: breathing, pulsing, spinning glow effects
- Integrated into standby view between clock and weather widget
- i18n: en/zh strings for voice states

## Test plan
- [ ] Open /home on Chrome/Edge, tap the orb, speak — verify it transcribes and activates conversation
- [ ] Verify orb glows green while listening, returns to idle after silence
- [ ] Open /home on Firefox, verify orb still works as fallback (keyboard activation)
- [ ] Verify orb doesn't block the general standby tap-to-activate behavior