### PR TITLE
feat(home): news headlines + calendar events widgets with settings

### DIFF
--- a/src/home/constants.ts
+++ b/src/home/constants.ts
@@ -65,7 +65,21 @@ export interface HomeStrings {
   widgetQuickActions: string;
   widgetVoiceOrb: string;
   widgetGreeting: string;
+  widgetNews: string;
+  widgetCalendar: string;
   settingsWidgets: string;
+
+  // News widget
+  newsHeadlines: string;
+
+  // Calendar widget
+  calendarToday: string;
+  calendarNoEvents: string;
+
+  // Settings — News & Events
+  settingsNewsFeed: string;
+  settingsEvents: string;
+  settingsAddEvent: string;
 
   // Suggestion prompts
   suggestions: readonly string[];
@@ -142,7 +156,18 @@ export const HOME_I18N: Record<string, HomeStrings> = {
     widgetQuickActions: "Quick Actions",
     widgetVoiceOrb: "Voice",
     widgetGreeting: "Greeting",
+    widgetNews: "News",
+    widgetCalendar: "Calendar",
     settingsWidgets: "Widgets",
+
+    newsHeadlines: "Headlines",
+
+    calendarToday: "Today",
+    calendarNoEvents: "No events today",
+
+    settingsNewsFeed: "News Feed URL",
+    settingsEvents: "Events",
+    settingsAddEvent: "Add Event",
 
     suggestions: [
       "What's the weather like today?",
@@ -222,7 +247,18 @@ export const HOME_I18N: Record<string, HomeStrings> = {
     widgetQuickActions: "\u5FEB\u6377\u64CD\u4F5C",
     widgetVoiceOrb: "\u8BED\u97F3",
     widgetGreeting: "\u95EE\u5019",
+    widgetNews: "\u65B0\u95FB",
+    widgetCalendar: "\u65E5\u5386",
     settingsWidgets: "\u7EC4\u4EF6",
+
+    newsHeadlines: "\u5934\u6761",
+
+    calendarToday: "\u4ECA\u5929",
+    calendarNoEvents: "\u4ECA\u5929\u6CA1\u6709\u65E5\u7A0B",
+
+    settingsNewsFeed: "\u65B0\u95FB\u6E90",
+    settingsEvents: "\u65E5\u7A0B",
+    settingsAddEvent: "\u6DFB\u52A0\u65E5\u7A0B",
 
     suggestions: [
       "\u4ECA\u5929\u5929\u6C14\u600E\u4E48\u6837\uFF1F",

--- a/src/home/home-settings-context.tsx
+++ b/src/home/home-settings-context.tsx
@@ -39,6 +39,7 @@ export interface HomeSettings {
   idleSeconds: number;
   nightMode: NightMode;
   lang: Lang;
+  newsFeedUrl: string;
 }
 
 export interface HomeSettingsContextValue extends HomeSettings {
@@ -58,6 +59,8 @@ export interface HomeSettingsContextValue extends HomeSettings {
 
 // ── Storage helpers ─────────────────────────────────────────────
 
+export const DEFAULT_FEED_URL = "http://feeds.bbci.co.uk/news/rss.xml";
+
 const KEYS = {
   city: "octos_home_city",
   tempUnit: "octos_home_temp_unit",
@@ -65,6 +68,7 @@ const KEYS = {
   idleSeconds: "octos_home_idle_seconds",
   nightMode: "octos_home_night_mode",
   lang: "octos_home_lang",
+  newsFeedUrl: "octos_home_news_feed_url",
 } as const;
 
 function readLS(): HomeSettings {
@@ -79,6 +83,7 @@ function readLS(): HomeSettings {
     nightMode:
       (localStorage.getItem(KEYS.nightMode) as NightMode) || "auto",
     lang: (localStorage.getItem(KEYS.lang) as Lang) || "en",
+    newsFeedUrl: localStorage.getItem(KEYS.newsFeedUrl) ?? DEFAULT_FEED_URL,
   };
 }
 
@@ -89,6 +94,7 @@ function writeLS(s: HomeSettings) {
   localStorage.setItem(KEYS.idleSeconds, String(s.idleSeconds));
   localStorage.setItem(KEYS.nightMode, s.nightMode);
   localStorage.setItem(KEYS.lang, s.lang);
+  localStorage.setItem(KEYS.newsFeedUrl, s.newsFeedUrl);
 }
 
 function clampIdle(n: number): number {

--- a/src/home/home-settings.tsx
+++ b/src/home/home-settings.tsx
@@ -7,15 +7,17 @@
  */
 
 import { useCallback, useEffect, useRef, useState } from "react";
-import { Settings, X, ChevronUp, ChevronDown, Clock, CloudSun, Zap, Mic, MessageCircle } from "lucide-react";
+import { Settings, X, ChevronUp, ChevronDown, Clock, CloudSun, Zap, Mic, MessageCircle, Newspaper, CalendarDays, Trash2, Plus } from "lucide-react";
 import {
   useHomeSettings,
+  DEFAULT_FEED_URL,
   type ClockFormat,
   type Lang,
   type NightMode,
   type TempUnit,
 } from "./home-settings-context";
 import type { WidgetType } from "./widget-registry";
+import { useEvents, type CalendarEvent } from "./use-events";
 
 // ── Gear button (placed in standby view) ───────────────────────
 
@@ -48,11 +50,25 @@ interface HomeSettingsPanelProps {
 export function HomeSettingsPanel({ open, onClose }: HomeSettingsPanelProps) {
   const s = useHomeSettings();
   const panelRef = useRef<HTMLDivElement>(null);
-  // Reset draft each time the panel opens so it picks up the latest value.
+  const { allEvents, addEvent, removeEvent } = useEvents();
+
+  // Reset drafts each time the panel opens so they pick up latest values.
   const [cityDraft, setCityDraft] = useState(s.city);
+  const [feedDraft, setFeedDraft] = useState(s.newsFeedUrl);
   const [prevOpen, setPrevOpen] = useState(open);
+
+  // Event add form state
+  const [evTitle, setEvTitle] = useState("");
+  const [evTime, setEvTime] = useState("09:00");
+  const [evDate, setEvDate] = useState(() => {
+    const d = new Date();
+    return `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, "0")}-${String(d.getDate()).padStart(2, "0")}`;
+  });
+  const [evRecurring, setEvRecurring] = useState<CalendarEvent["recurring"]>(undefined);
+
   if (open && !prevOpen) {
     setCityDraft(s.city);
+    setFeedDraft(s.newsFeedUrl);
   }
   if (open !== prevOpen) {
     setPrevOpen(open);
@@ -75,6 +91,21 @@ export function HomeSettingsPanel({ open, onClose }: HomeSettingsPanelProps) {
       s.update({ city: trimmed });
     }
   }, [cityDraft, s]);
+
+  // Commit news feed URL on blur / Enter
+  const commitFeed = useCallback(() => {
+    const trimmed = feedDraft.trim();
+    if (trimmed !== s.newsFeedUrl) {
+      s.update({ newsFeedUrl: trimmed });
+    }
+  }, [feedDraft, s]);
+
+  const handleAddEvent = useCallback(() => {
+    const title = evTitle.trim();
+    if (!title) return;
+    addEvent({ title, time: evTime, date: evDate, recurring: evRecurring });
+    setEvTitle("");
+  }, [evTitle, evTime, evDate, evRecurring, addEvent]);
 
   const t = s.strings;
 
@@ -180,6 +211,108 @@ export function HomeSettingsPanel({ open, onClose }: HomeSettingsPanelProps) {
             />
           </SettingsField>
 
+          {/* News Feed URL */}
+          <SettingsField label={t.settingsNewsFeed}>
+            <input
+              type="text"
+              value={feedDraft}
+              onChange={(e) => setFeedDraft(e.target.value)}
+              onBlur={commitFeed}
+              onKeyDown={(e) => {
+                if (e.key === "Enter") commitFeed();
+              }}
+              placeholder={DEFAULT_FEED_URL}
+              className="home-settings-input"
+            />
+          </SettingsField>
+
+          {/* Events */}
+          <SettingsField label={t.settingsEvents}>
+            <div className="space-y-2">
+              {/* Existing events list */}
+              {allEvents.length > 0 && (
+                <div className="space-y-1 max-h-40 overflow-y-auto">
+                  {allEvents.map((ev) => (
+                    <div
+                      key={ev.id}
+                      className="flex items-center gap-2 rounded-lg px-2 py-1.5 bg-white/5"
+                    >
+                      <span className="text-xs text-white/40 tabular-nums shrink-0">
+                        {ev.time}
+                      </span>
+                      <span className="flex-1 text-sm text-white/70 truncate">
+                        {ev.title}
+                      </span>
+                      {ev.recurring && (
+                        <span className="text-[10px] text-blue-400/70 shrink-0">
+                          {ev.recurring}
+                        </span>
+                      )}
+                      <button
+                        onClick={() => removeEvent(ev.id)}
+                        className="p-1 rounded hover:bg-white/10 transition-colors shrink-0"
+                        aria-label="Delete event"
+                      >
+                        <Trash2 size={13} className="text-white/30 hover:text-red-400" />
+                      </button>
+                    </div>
+                  ))}
+                </div>
+              )}
+
+              {/* Add event form */}
+              <div className="home-event-form space-y-2 pt-1">
+                <input
+                  type="text"
+                  value={evTitle}
+                  onChange={(e) => setEvTitle(e.target.value)}
+                  placeholder={t.settingsAddEvent}
+                  className="home-settings-input"
+                  onKeyDown={(e) => {
+                    if (e.key === "Enter") handleAddEvent();
+                  }}
+                />
+                <div className="flex gap-2">
+                  <input
+                    type="time"
+                    value={evTime}
+                    onChange={(e) => setEvTime(e.target.value)}
+                    className="home-settings-input flex-1"
+                  />
+                  <input
+                    type="date"
+                    value={evDate}
+                    onChange={(e) => setEvDate(e.target.value)}
+                    className="home-settings-input flex-1"
+                  />
+                </div>
+                <div className="flex items-center gap-2">
+                  <select
+                    value={evRecurring ?? ""}
+                    onChange={(e) =>
+                      setEvRecurring(
+                        e.target.value === "" ? undefined : (e.target.value as "daily" | "weekly"),
+                      )
+                    }
+                    className="home-settings-input flex-1"
+                  >
+                    <option value="">No repeat</option>
+                    <option value="daily">Daily</option>
+                    <option value="weekly">Weekly</option>
+                  </select>
+                  <button
+                    onClick={handleAddEvent}
+                    disabled={!evTitle.trim()}
+                    className="flex items-center justify-center gap-1 rounded-lg px-3 py-2 text-sm font-medium bg-blue-500/20 text-blue-300 hover:bg-blue-500/30 transition-colors disabled:opacity-30 disabled:cursor-not-allowed"
+                  >
+                    <Plus size={14} />
+                    {t.settingsAddEvent}
+                  </button>
+                </div>
+              </div>
+            </div>
+          </SettingsField>
+
           {/* Widgets */}
           <SettingsField label={t.settingsWidgets}>
             <div className="space-y-1">
@@ -259,6 +392,8 @@ const WIDGET_ICONS: Record<WidgetType, typeof Clock> = {
   "quick-actions": Zap,
   "voice-orb": Mic,
   greeting: MessageCircle,
+  news: Newspaper,
+  calendar: CalendarDays,
 };
 
 function widgetLabel(type: WidgetType, t: ReturnType<typeof useHomeSettings>["strings"]): string {
@@ -268,6 +403,8 @@ function widgetLabel(type: WidgetType, t: ReturnType<typeof useHomeSettings>["st
     "quick-actions": t.widgetQuickActions,
     "voice-orb": t.widgetVoiceOrb,
     greeting: t.widgetGreeting,
+    news: t.widgetNews,
+    calendar: t.widgetCalendar,
   };
   return map[type];
 }

--- a/src/home/standby-view.tsx
+++ b/src/home/standby-view.tsx
@@ -15,7 +15,7 @@
  */
 
 import { useCallback, useMemo, useState } from "react";
-import { MessageSquare, Newspaper, Music, Home } from "lucide-react";
+import { MessageSquare, Newspaper, Music, Home, CalendarDays } from "lucide-react";
 import { useClock } from "./use-clock";
 import { useWeather } from "./use-weather";
 import { useHomeSettings } from "./home-settings-context";
@@ -23,6 +23,8 @@ import { useBurnInProtection } from "./use-burn-in-protection";
 import { SettingsGearButton, HomeSettingsPanel } from "./home-settings";
 import { VoiceOrb } from "./voice-orb";
 import { useVoiceInput } from "./use-voice-input";
+import { useNews, timeAgo } from "./use-news";
+import { useEvents } from "./use-events";
 
 interface StandbyViewProps {
   onActivate: (prefill?: string) => void;
@@ -38,9 +40,11 @@ function isWidgetOn(widgets: import("./widget-registry").WidgetConfig[], type: i
 export function StandbyView({ onActivate, nightActive }: StandbyViewProps) {
   const clock = useClock();
   const weather = useWeather();
-  const { strings, tempUnit, clockFormat, widgets } = useHomeSettings();
+  const { strings, tempUnit, clockFormat, widgets, newsFeedUrl } = useHomeSettings();
   const burnIn = useBurnInProtection();
   const [settingsOpen, setSettingsOpen] = useState(false);
+  const news = useNews(newsFeedUrl);
+  const events = useEvents();
 
   const voice = useVoiceInput({
     onResult: (text) => onActivate(text),
@@ -256,6 +260,101 @@ export function StandbyView({ onActivate, nightActive }: StandbyViewProps) {
               </span>
             </button>
           ))}
+        </div>
+      )}
+
+      {/* News widget — hidden in night mode or when disabled */}
+      {!nightActive && isWidgetOn(widgets, "news") && (
+        <div className="home-widget home-news-widget mt-8 mx-4 px-5 py-4">
+          {/* Header */}
+          <div className="flex items-center gap-2 mb-3">
+            <Newspaper size={16} className="text-amber-400/70" />
+            <span className="text-sm font-medium text-white/50">
+              {strings.newsHeadlines}
+            </span>
+          </div>
+
+          {news.loading && news.items.length === 0 ? (
+            <div className="flex gap-4 overflow-hidden">
+              {[0, 1, 2].map((i) => (
+                <div key={i} className="home-news-card animate-pulse shrink-0">
+                  <div className="h-4 w-36 rounded bg-white/10 mb-2" />
+                  <div className="h-3 w-20 rounded bg-white/5" />
+                </div>
+              ))}
+            </div>
+          ) : news.error ? (
+            <span className="text-sm text-white/30">{news.error}</span>
+          ) : (
+            <div className="home-news-strip flex gap-3 overflow-x-auto pb-1">
+              {news.items.map((item, i) => (
+                <button
+                  key={i}
+                  className="home-news-card shrink-0"
+                  onClick={(e) => {
+                    e.stopPropagation();
+                    onActivate(`Tell me more about: ${item.title}`);
+                  }}
+                  aria-label={item.title}
+                >
+                  <p className="home-news-title text-sm font-medium text-white/80 leading-snug">
+                    {item.title}
+                  </p>
+                  <span className="text-xs text-white/30 mt-auto pt-1">
+                    {timeAgo(item.pubDate)}
+                  </span>
+                </button>
+              ))}
+            </div>
+          )}
+        </div>
+      )}
+
+      {/* Calendar widget — hidden in night mode or when disabled */}
+      {!nightActive && isWidgetOn(widgets, "calendar") && (
+        <div className="home-widget home-calendar-widget mt-4 mx-4 px-5 py-4">
+          {/* Header */}
+          <div className="flex items-center gap-2 mb-3">
+            <CalendarDays size={16} className="text-blue-400/70" />
+            <span className="text-sm font-medium text-white/50">
+              {strings.calendarToday}
+            </span>
+          </div>
+
+          {events.todayEvents.length === 0 ? (
+            <span className="text-sm text-white/25">{strings.calendarNoEvents}</span>
+          ) : (
+            <div className="home-calendar-list space-y-1.5 max-h-[180px] overflow-y-auto">
+              {events.todayEvents.slice(0, 4).map((ev) => {
+                // Highlight upcoming events (within next 2 hours).
+                const [h, m] = ev.time.split(":").map(Number);
+                const evMin = h * 60 + m;
+                const nowMin = clock.date.getHours() * 60 + clock.date.getMinutes();
+                const isUpcoming = evMin >= nowMin && evMin - nowMin <= 120;
+                const isPast = evMin < nowMin;
+
+                return (
+                  <div
+                    key={ev.id}
+                    className={`home-event-item flex items-center gap-3 rounded-lg px-3 py-2 ${
+                      isUpcoming
+                        ? "bg-blue-500/10 border border-blue-500/20"
+                        : isPast
+                          ? "opacity-40"
+                          : "bg-white/[0.03]"
+                    }`}
+                  >
+                    <span className="text-sm tabular-nums text-white/50 font-medium shrink-0">
+                      {ev.time}
+                    </span>
+                    <span className="text-sm text-white/75 truncate">
+                      {ev.title}
+                    </span>
+                  </div>
+                );
+              })}
+            </div>
+          )}
         </div>
       )}
 

--- a/src/home/use-events.ts
+++ b/src/home/use-events.ts
@@ -1,0 +1,145 @@
+/**
+ * useEvents — manual calendar events stored in localStorage.
+ *
+ * Events are keyed under `octos_home_events`.  Supports daily/weekly
+ * recurrence.  Exposes today's events and the upcoming 3-day window.
+ */
+
+import { useCallback, useMemo, useSyncExternalStore } from "react";
+
+// ── Types ───────────────────────────────────────────────────────
+
+export interface CalendarEvent {
+  id: string;
+  title: string;
+  /** "HH:MM" */
+  time: string;
+  /** "YYYY-MM-DD" */
+  date: string;
+  recurring?: "daily" | "weekly";
+}
+
+export interface EventsState {
+  todayEvents: CalendarEvent[];
+  upcomingEvents: CalendarEvent[];
+}
+
+// ── Storage helpers ─────────────────────────────────────────────
+
+const LS_KEY = "octos_home_events";
+
+function readEvents(): CalendarEvent[] {
+  try {
+    const raw = localStorage.getItem(LS_KEY);
+    if (!raw) return [];
+    const parsed = JSON.parse(raw);
+    return Array.isArray(parsed) ? parsed : [];
+  } catch {
+    return [];
+  }
+}
+
+function writeEvents(events: CalendarEvent[]): void {
+  localStorage.setItem(LS_KEY, JSON.stringify(events));
+  // Notify all useSyncExternalStore subscribers.
+  window.dispatchEvent(new Event("octos-events-change"));
+}
+
+/** Generate a short pseudo-random id. */
+function makeId(): string {
+  return Math.random().toString(36).slice(2, 10);
+}
+
+// ── Subscribe / snapshot (for useSyncExternalStore) ─────────────
+
+function subscribe(cb: () => void) {
+  window.addEventListener("octos-events-change", cb);
+  window.addEventListener("storage", cb);
+  return () => {
+    window.removeEventListener("octos-events-change", cb);
+    window.removeEventListener("storage", cb);
+  };
+}
+
+function getSnapshot(): CalendarEvent[] {
+  return readEvents();
+}
+
+// ── Date helpers ────────────────────────────────────────────────
+
+function fmtDate(d: Date): string {
+  const y = d.getFullYear();
+  const m = String(d.getMonth() + 1).padStart(2, "0");
+  const day = String(d.getDate()).padStart(2, "0");
+  return `${y}-${m}-${day}`;
+}
+
+function dayOfWeek(dateStr: string): number {
+  return new Date(dateStr + "T00:00:00").getDay();
+}
+
+function matchesDate(event: CalendarEvent, target: string): boolean {
+  if (event.date === target) return true;
+  if (!event.recurring) return false;
+  // Only match if event date <= target date.
+  if (event.date > target) return false;
+  if (event.recurring === "daily") return true;
+  if (event.recurring === "weekly") return dayOfWeek(event.date) === dayOfWeek(target);
+  return false;
+}
+
+function sortByTime(a: CalendarEvent, b: CalendarEvent): number {
+  return a.time.localeCompare(b.time);
+}
+
+// ── Hook ────────────────────────────────────────────────────────
+
+export function useEvents() {
+  const events = useSyncExternalStore(subscribe, getSnapshot, getSnapshot);
+
+  const { todayEvents, upcomingEvents } = useMemo<EventsState>(() => {
+    const now = new Date();
+    const todayStr = fmtDate(now);
+
+    const todayList: CalendarEvent[] = [];
+    const upcomingList: CalendarEvent[] = [];
+
+    // Build date strings for upcoming 3 days (excluding today).
+    const upcomingDates: string[] = [];
+    for (let i = 1; i <= 3; i++) {
+      const d = new Date(now);
+      d.setDate(d.getDate() + i);
+      upcomingDates.push(fmtDate(d));
+    }
+
+    for (const ev of events) {
+      if (matchesDate(ev, todayStr)) todayList.push(ev);
+      for (const ud of upcomingDates) {
+        if (matchesDate(ev, ud)) {
+          upcomingList.push({ ...ev, date: ud });
+          break; // only first match per event in upcoming window
+        }
+      }
+    }
+
+    todayList.sort(sortByTime);
+    upcomingList.sort((a, b) => a.date.localeCompare(b.date) || sortByTime(a, b));
+
+    return { todayEvents: todayList, upcomingEvents: upcomingList };
+  }, [events]);
+
+  const addEvent = useCallback(
+    (event: Omit<CalendarEvent, "id">) => {
+      const all = readEvents();
+      all.push({ ...event, id: makeId() });
+      writeEvents(all);
+    },
+    [],
+  );
+
+  const removeEvent = useCallback((id: string) => {
+    writeEvents(readEvents().filter((e) => e.id !== id));
+  }, []);
+
+  return { todayEvents, upcomingEvents, allEvents: events, addEvent, removeEvent };
+}

--- a/src/home/use-news.ts
+++ b/src/home/use-news.ts
@@ -1,0 +1,90 @@
+/**
+ * useNews — fetches RSS feed headlines via rss2json.com proxy (handles CORS).
+ *
+ * Polls every 30 minutes.  Returns top 4 items with title, link, pubDate,
+ * and optional thumbnail.
+ */
+
+import { useCallback, useEffect, useRef, useState } from "react";
+
+export interface NewsItem {
+  title: string;
+  link: string;
+  pubDate: string;
+  thumbnail?: string;
+}
+
+export interface NewsState {
+  items: NewsItem[];
+  loading: boolean;
+  error: string | null;
+}
+
+const POLL_MS = 30 * 60 * 1000; // 30 minutes
+const MAX_ITEMS = 4;
+
+export function useNews(feedUrl: string): NewsState {
+  const [state, setState] = useState<NewsState>({
+    items: [],
+    loading: true,
+    error: null,
+  });
+
+  // Keep a ref so the interval closure always sees the latest URL.
+  const urlRef = useRef(feedUrl);
+  urlRef.current = feedUrl;
+
+  const fetchNews = useCallback(async () => {
+    const url = urlRef.current;
+    if (!url) {
+      setState({ items: [], loading: false, error: null });
+      return;
+    }
+
+    try {
+      setState((prev) => ({ ...prev, loading: prev.items.length === 0 }));
+
+      const endpoint = `https://api.rss2json.com/v1/api.json?rss_url=${encodeURIComponent(url)}`;
+      const res = await fetch(endpoint);
+      if (!res.ok) throw new Error(`HTTP ${res.status}`);
+
+      const data = await res.json();
+      if (data.status !== "ok") throw new Error(data.message ?? "Feed error");
+
+      const items: NewsItem[] = (data.items ?? [])
+        .slice(0, MAX_ITEMS)
+        .map((item: Record<string, unknown>) => ({
+          title: String(item.title ?? ""),
+          link: String(item.link ?? ""),
+          pubDate: String(item.pubDate ?? ""),
+          thumbnail: item.thumbnail ? String(item.thumbnail) : item.enclosure && (item.enclosure as Record<string, unknown>).link ? String((item.enclosure as Record<string, unknown>).link) : undefined,
+        }));
+
+      setState({ items, loading: false, error: null });
+    } catch (err) {
+      setState((prev) => ({
+        ...prev,
+        loading: false,
+        error: err instanceof Error ? err.message : "Unknown error",
+      }));
+    }
+  }, []);
+
+  useEffect(() => {
+    fetchNews();
+    const id = setInterval(fetchNews, POLL_MS);
+    return () => clearInterval(id);
+  }, [fetchNews, feedUrl]);
+
+  return state;
+}
+
+/** Human-friendly relative time. */
+export function timeAgo(dateStr: string): string {
+  const diff = Date.now() - new Date(dateStr).getTime();
+  if (Number.isNaN(diff) || diff < 0) return "";
+  const hours = Math.floor(diff / 3600000);
+  if (hours < 1) return "just now";
+  if (hours < 24) return `${hours}h ago`;
+  return `${Math.floor(hours / 24)}d ago`;
+}

--- a/src/home/widget-registry.ts
+++ b/src/home/widget-registry.ts
@@ -10,7 +10,9 @@ export type WidgetType =
   | "weather"
   | "quick-actions"
   | "voice-orb"
-  | "greeting";
+  | "greeting"
+  | "news"
+  | "calendar";
 
 export interface WidgetConfig {
   type: WidgetType;
@@ -24,17 +26,29 @@ export const DEFAULT_WIDGETS: WidgetConfig[] = [
   { type: "voice-orb", enabled: true, order: 2 },
   { type: "weather", enabled: true, order: 3 },
   { type: "quick-actions", enabled: true, order: 4 },
+  { type: "news", enabled: true, order: 5 },
+  { type: "calendar", enabled: true, order: 6 },
 ];
 
 const LS_KEY = "octos_home_widgets";
 
-/** Read widget config from localStorage, falling back to defaults. */
+/** Read widget config from localStorage, falling back to defaults.
+ *  If persisted config is missing newly-added widget types, merge them in. */
 export function readWidgets(): WidgetConfig[] {
   try {
     const raw = localStorage.getItem(LS_KEY);
     if (!raw) return DEFAULT_WIDGETS;
     const parsed = JSON.parse(raw) as WidgetConfig[];
     if (!Array.isArray(parsed) || parsed.length === 0) return DEFAULT_WIDGETS;
+    // Merge any missing default widgets (added in newer versions).
+    const types = new Set(parsed.map((w) => w.type));
+    const maxOrder = Math.max(...parsed.map((w) => w.order), 0);
+    let nextOrder = maxOrder + 1;
+    for (const dw of DEFAULT_WIDGETS) {
+      if (!types.has(dw.type)) {
+        parsed.push({ ...dw, order: nextOrder++ });
+      }
+    }
     return parsed;
   } catch {
     return DEFAULT_WIDGETS;

--- a/src/index.css
+++ b/src/index.css
@@ -1458,3 +1458,103 @@ button, a, input, textarea {
 .home-suggestion-card:active {
   transform: scale(0.98);
 }
+
+/* ── News widget ─────────────────────────────────── */
+.home-news-widget {
+  max-width: 640px;
+  width: 100%;
+}
+
+.home-news-strip {
+  scrollbar-width: none;
+  -webkit-overflow-scrolling: touch;
+}
+
+.home-news-strip::-webkit-scrollbar {
+  display: none;
+}
+
+.home-news-card {
+  display: flex;
+  flex-direction: column;
+  min-width: 200px;
+  max-width: 240px;
+  padding: 0.85rem 1rem;
+  background: rgba(255, 255, 255, 0.04);
+  backdrop-filter: blur(16px);
+  -webkit-backdrop-filter: blur(16px);
+  border: 1px solid rgba(255, 255, 255, 0.07);
+  border-radius: 14px;
+  cursor: pointer;
+  text-align: left;
+  outline: none;
+  transition:
+    background 0.2s ease,
+    border-color 0.2s ease,
+    transform 0.15s ease;
+}
+
+.home-news-card:hover,
+.home-news-card:focus-visible {
+  background: rgba(255, 255, 255, 0.08);
+  border-color: rgba(255, 255, 255, 0.14);
+  transform: translateY(-2px);
+}
+
+.home-news-card:active {
+  transform: scale(0.97);
+}
+
+.home-news-title {
+  display: -webkit-box;
+  -webkit-line-clamp: 2;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+/* ── Calendar widget ─────────────────────────────── */
+.home-calendar-widget {
+  max-width: 640px;
+  width: 100%;
+}
+
+.home-calendar-list {
+  scrollbar-width: thin;
+  scrollbar-color: rgba(255, 255, 255, 0.08) transparent;
+}
+
+.home-event-item {
+  transition: background 0.2s ease, opacity 0.2s ease;
+}
+
+/* ── Event form in settings ──────────────────────── */
+.home-event-form select {
+  appearance: none;
+  background-image: url("data:image/svg+xml;charset=utf-8,%3Csvg xmlns='http://www.w3.org/2000/svg' width='16' height='16' viewBox='0 0 16 16'%3E%3Cpath fill='rgba(255,255,255,0.4)' d='M4.5 6L8 9.5 11.5 6z'/%3E%3C/svg%3E");
+  background-repeat: no-repeat;
+  background-position: right 8px center;
+  padding-right: 28px;
+}
+
+/* ── Responsive: news + calendar on small screens ── */
+@media (max-width: 480px) {
+  .home-news-widget,
+  .home-calendar-widget {
+    margin-left: 0.5rem;
+    margin-right: 0.5rem;
+    padding-left: 0.75rem;
+    padding-right: 0.75rem;
+  }
+
+  .home-news-card {
+    min-width: 170px;
+  }
+}
+
+@media (min-width: 1280px) {
+  .home-news-widget,
+  .home-calendar-widget {
+    max-width: 720px;
+  }
+}


### PR DESCRIPTION
Two new real data widgets for the smart screen:
- **News**: RSS headlines via rss2json.com (configurable feed URL, default BBC News), horizontal scroll cards, 30min refresh, tap to discuss
- **Calendar**: Manual event management in settings, daily/weekly recurrence, today+3-day view, time-based highlighting
- Widget registry auto-upgrade for existing users
- Full settings UI: feed URL input, event CRUD with inline form
- i18n: en/zh for all new strings