### PR TITLE
fix(home): stop /home crash + restore tsc build

### DIFF
--- a/src/home/use-events.ts
+++ b/src/home/use-events.ts
@@ -61,8 +61,32 @@ function subscribe(cb: () => void) {
   };
 }
 
+// Cache the snapshot by raw localStorage string so the returned reference is
+// stable across renders when the stored data hasn't changed. `readEvents()`
+// parses JSON into a fresh array every call; handing that straight to
+// `useSyncExternalStore` made `getSnapshot` return a new reference each render
+// → "getSnapshot should be cached" → infinite re-render loop (Maximum update
+// depth). Recompute only when the underlying raw string actually changes.
+let snapshotRaw: string | null | undefined;
+let snapshotValue: CalendarEvent[] = [];
+
 function getSnapshot(): CalendarEvent[] {
-  return readEvents();
+  let raw: string | null = null;
+  try {
+    raw = localStorage.getItem(LS_KEY);
+  } catch {
+    raw = null;
+  }
+  if (raw !== snapshotRaw) {
+    snapshotRaw = raw;
+    try {
+      const parsed = raw ? JSON.parse(raw) : [];
+      snapshotValue = Array.isArray(parsed) ? parsed : [];
+    } catch {
+      snapshotValue = [];
+    }
+  }
+  return snapshotValue;
 }
 
 // ── Date helpers ────────────────────────────────────────────────

--- a/src/home/use-photos.ts
+++ b/src/home/use-photos.ts
@@ -32,6 +32,28 @@ function writePhotos(urls: string[]) {
   emit();
 }
 
+// Cache the snapshot by raw localStorage string so the returned reference is
+// stable across renders when the data hasn't changed. Passing `readPhotos`
+// (a fresh array every call) straight to `useSyncExternalStore` returned a new
+// reference each render → "getSnapshot should be cached" → infinite re-render
+// loop (Maximum update depth) → /home crash. Recompute only on real change.
+let snapshotRaw: string | null | undefined;
+let snapshotValue: string[] = [];
+
+function getPhotosSnapshot(): string[] {
+  let raw: string | null = null;
+  try {
+    raw = localStorage.getItem(LS_KEY);
+  } catch {
+    raw = null;
+  }
+  if (raw !== snapshotRaw) {
+    snapshotRaw = raw;
+    snapshotValue = readPhotos();
+  }
+  return snapshotValue;
+}
+
 function subscribe(cb: () => void) {
   listeners.push(cb);
   return () => {
@@ -40,7 +62,11 @@ function subscribe(cb: () => void) {
 }
 
 export function usePhotos() {
-  const photos = useSyncExternalStore(subscribe, readPhotos, readPhotos);
+  const photos = useSyncExternalStore(
+    subscribe,
+    getPhotosSnapshot,
+    getPhotosSnapshot,
+  );
   const [index, setIndex] = useState(0);
   const timerRef = useRef<ReturnType<typeof setInterval> | undefined>(undefined);
 

--- a/src/home/use-voice-input.ts
+++ b/src/home/use-voice-input.ts
@@ -67,7 +67,9 @@ export interface VoiceInputOptions {
 const SILENCE_TIMEOUT = 10_000;
 
 export function useVoiceInput(options: VoiceInputOptions): VoiceInputState {
-  const { onResult, lang = "en-US" } = options;
+  // `onResult` is read via `optionsRef.current` (kept fresh below), not the
+  // destructured value — so it isn't pulled out here.
+  const { lang = "en-US" } = options;
   const [orbState, setOrbState] = useState<OrbState>("idle");
   const [transcript, setTranscript] = useState("");
   const [isSupported] = useState(() => getSpeechRecognition() !== null);


### PR DESCRIPTION
## Summary

Fixes two pre-existing breakages on `main` (both independent of the voice feature; surfaced while testing #199):

1. **`/home` crashes** with `Maximum update depth exceeded`. `useEvents`' `getSnapshot` returned `readEvents()` — a freshly parsed array on every call — so `useSyncExternalStore` saw a new reference each render and looped (`The result of getSnapshot should be cached to avoid an infinite loop` → `StandbyView` / `HomeSettingsPanel` crash). Now the snapshot is cached by the raw localStorage string and only recomputed when the stored data actually changes.

2. **`npm run build` fails `tsc -b`** on `src/home/use-voice-input.ts` (TS6133: `onResult` is destructured but only read via `optionsRef.current.onResult`). Dropped from the destructure.

## Verification

`npm run build` (`tsc -b && vite build`) now exits 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)