### PR TITLE
Fix OminiX settings actions

### DIFF
--- a/src/settings/ominix-tab.tsx
+++ b/src/settings/ominix-tab.tsx
@@ -36,7 +36,8 @@ type Role = "asr" | "tts";
 
 type PendingAction =
   | { kind: "service"; action: OminixServiceAction }
-  | { kind: "remove-model"; modelId: string }
+  | { kind: "remove-local-model"; modelId: string }
+  | { kind: "disable-model"; modelId: string }
   | { kind: "download-model"; modelId: string }
   | { kind: "remove-skill"; name: string };
 
@@ -54,6 +55,63 @@ function compactText(value: string | null | undefined, fallback = "-") {
   return value && value.trim() ? value : fallback;
 }
 
+function modelStatus(model: OminixCatalogModel) {
+  return model.status?.trim().toLowerCase() ?? "";
+}
+
+function isModelReady(model: OminixCatalogModel) {
+  return ["ready", "downloaded", "installed"].includes(modelStatus(model));
+}
+
+function roleForModel(model: OminixCatalogModel): Role | null {
+  const role = model.role?.trim().toLowerCase();
+  return role === "asr" || role === "tts" ? role : null;
+}
+
+function roleOptionsForModel(model: OminixCatalogModel): Role[] {
+  const explicitRole = roleForModel(model);
+  if (explicitRole) return [explicitRole];
+
+  const haystack = [
+    model.id,
+    model.name,
+    model.category,
+    ...(model.tags ?? []),
+  ]
+    .filter(Boolean)
+    .join(" ")
+    .toLowerCase();
+
+  const roles: Role[] = [];
+  if (/\b(asr|stt|transcrib|speech-to-text)\b/.test(haystack)) roles.push("asr");
+  if (/\b(tts|text-to-speech|synthes)/.test(haystack)) roles.push("tts");
+  return roles.length ? roles : ["asr", "tts"];
+}
+
+function resultMessage(result: unknown) {
+  if (!result || typeof result !== "object") return "Action completed";
+  const value = result as {
+    message?: unknown;
+    detail?: unknown;
+    status?: unknown;
+  };
+  if (typeof value.message === "string" && value.message.trim()) return value.message;
+  if (typeof value.detail === "string" && value.detail.trim()) return value.detail;
+  if (typeof value.status === "string" && value.status.trim()) return value.status;
+  return "Action completed";
+}
+
+function assertActionOk(result: unknown) {
+  if (
+    result &&
+    typeof result === "object" &&
+    "ok" in result &&
+    (result as { ok?: unknown }).ok === false
+  ) {
+    throw new Error(resultMessage(result));
+  }
+}
+
 function Section({
   title,
   icon,
@@ -66,8 +124,8 @@ function Section({
   action?: ReactNode;
 }) {
   return (
-    <section className="glass-section rounded-2xl p-6">
-      <div className="mb-5 flex items-center justify-between gap-4">
+    <section className="glass-section rounded-2xl p-4 sm:p-6">
+      <div className="mb-5 flex flex-wrap items-center justify-between gap-4">
         <div className="flex items-center gap-3">
           <div className="flex h-10 w-10 items-center justify-center rounded-xl bg-accent/10 text-accent">
             {icon}
@@ -85,11 +143,13 @@ function SmallButton({
   children,
   onClick,
   disabled,
+  ariaLabel,
   tone = "default",
 }: {
   children: ReactNode;
   onClick: () => void;
   disabled?: boolean;
+  ariaLabel?: string;
   tone?: "default" | "good" | "danger" | "warn";
 }) {
   const toneClass = {
@@ -103,6 +163,7 @@ function SmallButton({
     <button
       onClick={onClick}
       disabled={disabled}
+      aria-label={ariaLabel}
       className={`inline-flex items-center gap-1.5 rounded-lg border px-2.5 py-1.5 text-xs font-medium transition disabled:opacity-40 ${toneClass}`}
     >
       {children}
@@ -139,29 +200,35 @@ function PlatformModelRow({
   model,
   busy,
   onDownload,
-  onRemove,
+  onDisable,
 }: {
   model: OminixCatalogModel;
   busy: boolean;
   onDownload: (modelId: string) => void;
-  onRemove: (modelId: string) => void;
+  onDisable: (modelId: string) => void;
 }) {
-  const ready = model.status === "ready" || model.status === "downloaded";
+  const ready = isModelReady(model);
   return (
-    <div className="flex items-start justify-between gap-4 rounded-xl border border-border/30 bg-surface-container/50 px-4 py-3">
+    <div className="flex flex-col gap-3 rounded-xl border border-border/30 bg-surface-container/50 px-4 py-3 sm:flex-row sm:items-start sm:justify-between">
       <div className="min-w-0">
-        <div className="truncate text-sm font-medium text-text-strong">
-          {compactText(model.name, model.id)}
+        <div className="flex flex-wrap items-center gap-2">
+          <span className="truncate text-sm font-medium text-text-strong">
+            {compactText(model.name, model.id)}
+          </span>
+          <span className="rounded-md bg-green-400/10 px-1.5 py-0.5 text-[10px] font-semibold text-green-400">
+            Enabled for Octos
+          </span>
         </div>
         <div className="mt-0.5 truncate font-mono text-[11px] text-muted">
           {model.id}
         </div>
         <ModelMeta model={model} />
       </div>
-      <div className="flex shrink-0 flex-wrap justify-end gap-2">
+      <div className="flex shrink-0 flex-wrap gap-2 sm:justify-end">
         {!ready && (
           <SmallButton
             disabled={busy}
+            ariaLabel={`Download ${model.id}`}
             tone="good"
             onClick={() => onDownload(model.id)}
           >
@@ -171,11 +238,11 @@ function PlatformModelRow({
         )}
         <SmallButton
           disabled={busy}
-          tone="danger"
-          onClick={() => onRemove(model.id)}
+          ariaLabel={`Disable ${model.id}`}
+          tone="warn"
+          onClick={() => onDisable(model.id)}
         >
-          <Trash2 size={12} />
-          Remove
+          Disable
         </SmallButton>
       </div>
     </div>
@@ -187,22 +254,35 @@ function AvailableModelRow({
   busy,
   onEnable,
   onDisable,
+  onDownload,
+  onRemoveLocal,
 }: {
   model: OminixCatalogModel;
   busy: boolean;
   onEnable: (modelId: string, role: Role) => void;
   onDisable: (modelId: string) => void;
+  onDownload: (modelId: string) => void;
+  onRemoveLocal: (modelId: string) => void;
 }) {
+  const enabled = Boolean(model.enabled_for_octos);
+  const ready = isModelReady(model);
+  const roleOptions = roleOptionsForModel(model);
+
   return (
-    <div className="flex items-start justify-between gap-4 rounded-xl border border-border/30 bg-surface-container/50 px-4 py-3">
+    <div className="flex flex-col gap-3 rounded-xl border border-border/30 bg-surface-container/50 px-4 py-3 sm:flex-row sm:items-start sm:justify-between">
       <div className="min-w-0">
         <div className="flex flex-wrap items-center gap-2">
           <span className="truncate text-sm font-medium text-text-strong">
             {compactText(model.name, model.id)}
           </span>
-          {model.enabled_for_octos && (
+          {enabled && (
             <span className="rounded-md bg-green-400/10 px-1.5 py-0.5 text-[10px] font-semibold text-green-400">
               Enabled
+            </span>
+          )}
+          {ready && (
+            <span className="rounded-md bg-accent/10 px-1.5 py-0.5 text-[10px] font-semibold text-accent">
+              Downloaded
             </span>
           )}
         </div>
@@ -211,32 +291,50 @@ function AvailableModelRow({
         </div>
         <ModelMeta model={model} />
       </div>
-      <div className="flex shrink-0 flex-wrap justify-end gap-2">
-        {model.enabled_for_octos ? (
+      <div className="flex shrink-0 flex-wrap gap-2 sm:justify-end">
+        {enabled && !ready && (
           <SmallButton
             disabled={busy}
+            ariaLabel={`Download ${model.id}`}
+            tone="good"
+            onClick={() => onDownload(model.id)}
+          >
+            <Download size={12} />
+            Download
+          </SmallButton>
+        )}
+        {!enabled &&
+          roleOptions.map((role) => (
+            <SmallButton
+              key={role}
+              disabled={busy}
+              ariaLabel={`Enable ${role.toUpperCase()} ${model.id}`}
+              tone="good"
+              onClick={() => onEnable(model.id, role)}
+            >
+              Enable {role.toUpperCase()}
+            </SmallButton>
+          ))}
+        {enabled && (
+          <SmallButton
+            disabled={busy}
+            ariaLabel={`Disable ${model.id}`}
             tone="warn"
             onClick={() => onDisable(model.id)}
           >
             Disable
           </SmallButton>
-        ) : (
-          <>
-            <SmallButton
-              disabled={busy}
-              tone="good"
-              onClick={() => onEnable(model.id, "asr")}
-            >
-              Enable ASR
-            </SmallButton>
-            <SmallButton
-              disabled={busy}
-              tone="good"
-              onClick={() => onEnable(model.id, "tts")}
-            >
-              Enable TTS
-            </SmallButton>
-          </>
+        )}
+        {ready && (
+          <SmallButton
+            disabled={busy}
+            ariaLabel={`Remove local model ${model.id}`}
+            tone="danger"
+            onClick={() => onRemoveLocal(model.id)}
+          >
+            <Trash2 size={12} />
+            Remove Local
+          </SmallButton>
         )}
       </div>
     </div>
@@ -255,17 +353,18 @@ function SkillRow({
   onRemove: (name: string) => void;
 }) {
   return (
-    <div className="flex items-center justify-between gap-3 rounded-xl border border-border/30 bg-surface-container/50 px-4 py-3">
+    <div className="flex flex-col gap-3 rounded-xl border border-border/30 bg-surface-container/50 px-4 py-3 sm:flex-row sm:items-center sm:justify-between">
       <div>
         <div className="text-sm font-medium text-text-strong">{skill.name}</div>
         <div className="mt-0.5 text-xs text-muted">
           {skill.installed ? "Installed" : "Not installed"}
         </div>
       </div>
-      <div className="flex shrink-0 gap-2">
+      <div className="flex shrink-0 flex-wrap gap-2 sm:justify-end">
         {!skill.installed && (
           <SmallButton
             disabled={busy}
+            ariaLabel={`Install platform skill ${skill.name}`}
             tone="good"
             onClick={() => onInstall(skill.name)}
           >
@@ -275,6 +374,7 @@ function SkillRow({
         {skill.installed && (
           <SmallButton
             disabled={busy}
+            ariaLabel={`Remove platform skill ${skill.name}`}
             tone="danger"
             onClick={() => onRemove(skill.name)}
           >
@@ -302,9 +402,11 @@ function ConfirmBar({
       ? `${pending.action} ominix-api service?`
       : pending.kind === "download-model"
         ? `Download ${pending.modelId}?`
-        : pending.kind === "remove-model"
+        : pending.kind === "remove-local-model"
           ? `Remove local model ${pending.modelId}?`
-          : `Remove platform skill ${pending.name}?`;
+          : pending.kind === "disable-model"
+            ? `Disable ${pending.modelId} for Octos?`
+            : `Remove platform skill ${pending.name}?`;
 
   return (
     <div className="flex items-center gap-3 rounded-xl border border-yellow-400/30 bg-yellow-400/5 px-4 py-3">
@@ -396,14 +498,8 @@ export function OminixTab() {
     setMessage(null);
     try {
       const result = await fn();
-      const actionMessage =
-        result &&
-        typeof result === "object" &&
-        "message" in result &&
-        typeof (result as { message?: unknown }).message === "string"
-          ? (result as { message: string }).message
-          : "Action completed";
-      setMessage(actionMessage);
+      assertActionOk(result);
+      setMessage(resultMessage(result));
       await load();
     } catch (err) {
       setError(errorMessage(err));
@@ -429,9 +525,15 @@ export function OminixTab() {
       );
       return;
     }
-    if (action.kind === "remove-model") {
+    if (action.kind === "remove-local-model") {
       await performAction(`remove:${action.modelId}`, () =>
         removeOminixModel(action.modelId),
+      );
+      return;
+    }
+    if (action.kind === "disable-model") {
+      await performAction(`disable:${action.modelId}`, () =>
+        disableOminixModel(action.modelId),
       );
       return;
     }
@@ -562,11 +664,11 @@ export function OminixTab() {
         </div>
       </Section>
 
-      <Section title="Platform Models" icon={<Download size={20} />}>
+      <Section title="Enabled Platform Models" icon={<Download size={20} />}>
         <div className="space-y-3">
           {platformModels.length === 0 ? (
             <div className="rounded-xl bg-surface-container/50 px-4 py-6 text-center text-sm text-muted">
-              No platform models returned
+              No models are enabled for Octos
             </div>
           ) : (
             platformModels.map((model) => (
@@ -577,7 +679,7 @@ export function OminixTab() {
                 onDownload={(modelId) =>
                   setPending({ kind: "download-model", modelId })
                 }
-                onRemove={(modelId) => setPending({ kind: "remove-model", modelId })}
+                onDisable={(modelId) => setPending({ kind: "disable-model", modelId })}
               />
             ))
           )}
@@ -605,6 +707,12 @@ export function OminixTab() {
                   void performAction(`disable:${modelId}`, () =>
                     disableOminixModel(modelId),
                   )
+                }
+                onDownload={(modelId) =>
+                  setPending({ kind: "download-model", modelId })
+                }
+                onRemoveLocal={(modelId) =>
+                  setPending({ kind: "remove-local-model", modelId })
                 }
               />
             ))

--- a/src/settings/settings-page.tsx
+++ b/src/settings/settings-page.tsx
@@ -80,7 +80,7 @@ export function AdminSettingsPage() {
 
   return (
     <div className="flex h-screen flex-col bg-surface-dark">
-      <nav className="flex items-center gap-4 px-6 py-4 shrink-0">
+      <nav className="flex shrink-0 items-center gap-4 px-6 py-4 max-md:px-3">
         <button
           onClick={() => navigate(-1)}
           className="rounded-xl p-2 text-muted hover:bg-surface-container hover:text-text-strong transition"
@@ -129,16 +129,16 @@ export function AdminSettingsPage() {
           <Loader2 size={24} className="animate-spin text-muted" />
         </div>
       ) : (
-        <div className="flex flex-1 min-h-0 overflow-hidden">
-          <aside className="w-56 shrink-0 border-r border-border/50 px-3 py-4 overflow-y-auto">
-            <div className="space-y-1">
+        <div className="flex min-h-0 flex-1 overflow-hidden max-md:flex-col">
+          <aside className="w-56 shrink-0 overflow-y-auto border-r border-border/50 px-3 py-4 max-md:w-full max-md:overflow-x-auto max-md:overflow-y-hidden max-md:border-b max-md:border-r-0 max-md:py-2">
+            <div className="space-y-1 max-md:flex max-md:min-w-max max-md:gap-2 max-md:space-y-0">
               {TABS.filter(
                 (t) => !t.adminOnly || portal?.can_access_admin_portal,
               ).map(({ id, label, icon: Icon, adminOnly }) => (
                 <button
                   key={id}
                   onClick={() => setActiveTab(id)}
-                  className={`flex w-full items-center gap-3 rounded-xl px-4 py-3 text-left text-sm font-medium transition ${
+                  className={`flex w-full items-center gap-3 rounded-xl px-4 py-3 text-left text-sm font-medium transition max-md:w-auto max-md:shrink-0 max-md:px-3 ${
                     activeTab === id
                       ? "bg-accent/12 text-accent border border-accent/20"
                       : "text-muted hover:bg-surface-container hover:text-text-strong border border-transparent"
@@ -156,7 +156,7 @@ export function AdminSettingsPage() {
             </div>
           </aside>
 
-          <main className="flex-1 min-w-0 overflow-y-auto px-8 py-6">
+          <main className="min-w-0 flex-1 overflow-y-auto px-8 py-6 max-md:px-4 max-md:py-4">
             <div className={`mx-auto ${isAdminOnlyTab ? "max-w-3xl" : "max-w-2xl"}`}>
               {activeTab === "system" && portal?.can_access_admin_portal && <SystemTab />}
               {activeTab === "server" && portal?.can_access_admin_portal && <ServerTab />}

--- a/tests/queue-modes-live.spec.ts
+++ b/tests/queue-modes-live.spec.ts
@@ -223,7 +223,8 @@ test.describe("Queue mode live tests", () => {
 
     // Interrupt with a simple question
     console.log("Interrupting with simple question...");
-    await input.fill("What is 2+2? Just the number.");
+    const interruptMarker = "INTERRUPT_OK_731";
+    await input.fill(`Reply with exactly: ${interruptMarker}`);
     await sendBtn.click();
 
     // Wait for the simple answer
@@ -235,7 +236,7 @@ test.describe("Queue mode live tests", () => {
         );
         return Array.from(bubbles).some((el) => {
           const text = (el.textContent || "").trim();
-          return /4/.test(text) || /four/i.test(text);
+          return text.includes("INTERRUPT_OK_731");
         });
       },
       undefined,
@@ -251,7 +252,7 @@ test.describe("Queue mode live tests", () => {
     const hasAnswer = bubbles.some(
       (b) =>
         b.role === "assistant" &&
-        (/4/.test(b.text) || /four/i.test(b.text)),
+        b.text.includes(interruptMarker),
     );
     expect(hasAnswer).toBe(true);
 

--- a/tests/settings-tabs.spec.ts
+++ b/tests/settings-tabs.spec.ts
@@ -63,6 +63,10 @@ const mockProfile = {
 
 async function installAdminSettingsMocks(page: import("@playwright/test").Page) {
   let enableBody: unknown = null;
+  let disableBody: unknown = null;
+  let downloadBody: unknown = null;
+  let removeLocalBody: unknown = null;
+  const serviceActions: string[] = [];
 
   await page.route("**/api/auth/status", (route) =>
     route.fulfill({
@@ -153,6 +157,15 @@ async function installAdminSettingsMocks(page: import("@playwright/test").Page) 
             storage: { total_size_display: "1.7 GB" },
             runtime: { memory_required_mb: 4096 },
           },
+          {
+            id: "qwen3-tts",
+            name: "Qwen3 TTS",
+            role: "tts",
+            status: "not_downloaded",
+            category: "speech",
+            storage: { total_size_display: "2.1 GB" },
+            runtime: { memory_required_mb: 4096 },
+          },
         ],
       }),
     }),
@@ -169,6 +182,14 @@ async function installAdminSettingsMocks(page: import("@playwright/test").Page) 
             enabled_for_octos: true,
             role: "asr",
             status: "ready",
+            category: "speech",
+          },
+          {
+            id: "qwen3-tts",
+            name: "Qwen3 TTS",
+            enabled_for_octos: true,
+            role: "tts",
+            status: "not_downloaded",
             category: "speech",
           },
           {
@@ -202,8 +223,46 @@ async function installAdminSettingsMocks(page: import("@playwright/test").Page) 
     });
   });
 
+  await page.route("**/api/admin/platform-skills/ominix-api/models/disable", async (route) => {
+    disableBody = route.request().postDataJSON();
+    await route.fulfill({
+      contentType: "application/json",
+      body: JSON.stringify({ ok: true, message: "disabled" }),
+    });
+  });
+
+  await page.route("**/api/admin/platform-skills/ominix-api/models/download", async (route) => {
+    downloadBody = route.request().postDataJSON();
+    await route.fulfill({
+      contentType: "application/json",
+      body: JSON.stringify({ ok: true, message: "download started" }),
+    });
+  });
+
+  await page.route("**/api/admin/platform-skills/ominix-api/models/remove", async (route) => {
+    removeLocalBody = route.request().postDataJSON();
+    await route.fulfill({
+      contentType: "application/json",
+      body: JSON.stringify({ ok: true, message: "removed local model" }),
+    });
+  });
+
+  for (const action of ["start", "stop", "restart"]) {
+    await page.route(`**/api/admin/platform-skills/ominix-api/${action}`, async (route) => {
+      serviceActions.push(action);
+      await route.fulfill({
+        contentType: "application/json",
+        body: JSON.stringify({ ok: true, message: `${action}ed` }),
+      });
+    });
+  }
+
   return {
     getEnableBody: () => enableBody,
+    getDisableBody: () => disableBody,
+    getDownloadBody: () => downloadBody,
+    getRemoveLocalBody: () => removeLocalBody,
+    getServiceActions: () => serviceActions,
   };
 }
 
@@ -676,7 +735,7 @@ test.describe("Settings page — tab smoke tests", () => {
     ).toBeVisible({ timeout: TIMEOUT });
   });
 
-  test("OminiX tab loads platform API data and sends model enable request", async ({
+  test("OminiX tab wires allowlist, download, local remove, and service actions", async ({
     page,
   }) => {
     const mocks = await installAdminSettingsMocks(page);
@@ -692,18 +751,53 @@ test.describe("Settings page — tab smoke tests", () => {
     await expect(page.getByText("Healthy")).toBeVisible({ timeout: TIMEOUT });
     await expect(page.getByText("LaunchAgent registered")).toBeVisible();
     await expect(page.getByText("Qwen3 ASR").first()).toBeVisible();
+    await expect(page.getByText("Qwen3 TTS").first()).toBeVisible();
+    await expect(
+      page.locator("h3", { hasText: "Enabled Platform Models" }),
+    ).toBeVisible({ timeout: TIMEOUT });
     await expect(page.getByText("ominix-api booted")).toBeVisible();
 
-    await page.getByRole("button", { name: "Enable ASR" }).click();
+    await page.getByRole("button", { name: "Download qwen3-tts" }).first().click();
+    await expect(page.getByText("Download qwen3-tts?")).toBeVisible({
+      timeout: TIMEOUT,
+    });
+    await page.getByRole("button", { name: "Confirm" }).click();
+    await expect.poll(() => mocks.getDownloadBody()).toEqual({
+      model_id: "qwen3-tts",
+    });
+
+    await page.getByRole("button", { name: "Enable ASR parakeet-asr" }).click();
     await expect.poll(() => mocks.getEnableBody()).toEqual({
       model_id: "parakeet-asr",
       role: "asr",
+    });
+
+    await page.getByRole("button", { name: "Disable qwen3-asr-1.7b" }).first().click();
+    await expect(
+      page.getByText("Disable qwen3-asr-1.7b for Octos?"),
+    ).toBeVisible({ timeout: TIMEOUT });
+    await page.getByRole("button", { name: "Confirm" }).click();
+    await expect.poll(() => mocks.getDisableBody()).toEqual({
+      model_id: "qwen3-asr-1.7b",
+    });
+
+    await page
+      .getByRole("button", { name: "Remove local model qwen3-asr-1.7b" })
+      .click();
+    await expect(
+      page.getByText("Remove local model qwen3-asr-1.7b?"),
+    ).toBeVisible({ timeout: TIMEOUT });
+    await page.getByRole("button", { name: "Confirm" }).click();
+    await expect.poll(() => mocks.getRemoveLocalBody()).toEqual({
+      model_id: "qwen3-asr-1.7b",
     });
 
     await page.getByRole("button", { name: "Restart" }).click();
     await expect(
       page.getByText("restart ominix-api service?"),
     ).toBeVisible({ timeout: TIMEOUT });
+    await page.getByRole("button", { name: "Confirm" }).click();
+    await expect.poll(() => mocks.getServiceActions()).toEqual(["restart"]);
   });
 
   test("Server tab uses real admin endpoints for settings and token rotation", async ({


### PR DESCRIPTION
## Summary

- Fix OminiX settings model actions so Octos allowlist disable, OminiX model download, and local model removal are separate operations.
- Rename the allowlisted model section to `Enabled Platform Models`, add accessible action labels, surface `ok: false` action responses as errors, and improve mobile settings layout.
- Harden the interrupt queue E2E assertion to wait for a deterministic marker instead of accidentally matching timestamps.

## Root Cause

`GET /api/admin/platform-skills/ominix-api/models` returns the Octos platform allowlist, not the local OminiX download inventory. The UI previously exposed that list with a destructive-looking `Remove` action wired to `/models/remove`, which deletes local model files rather than disabling Octos use.

## Validation

- `npm run build`
- `BASE_URL=http://127.0.0.1:5173 npx playwright test tests/settings-tabs.spec.ts -g "OminiX"`
- `BASE_URL=http://127.0.0.1:5173 npx playwright test tests/settings-tabs.spec.ts`
- `BASE_URL=http://127.0.0.1:5173 npx playwright test tests/queue-modes-live.spec.ts -g "interrupt mode"`
- `BASE_URL=http://127.0.0.1:5173 npx playwright test` → 70 passed, 26 skipped, 0 failed

## Notes

Browser QA used a temporary local mock API behind the Vite proxy to verify `/settings` → OminiX rendering and the Download confirmation flow. Desktop and mobile screenshots showed no console errors; mobile settings navigation now collapses to a horizontal tab strip and model action buttons wrap cleanly.
