### PR TITLE
Fix settings errors and OminiX flows

### DIFF
--- a/src/settings/channels-tab.tsx
+++ b/src/settings/channels-tab.tsx
@@ -10,7 +10,13 @@ import {
   ChevronDown,
   Copy,
 } from "lucide-react";
-import { updateMyProfile, type Profile, type ProfileConfig } from "./settings-api";
+import {
+  formatSettingsError,
+  updateMyProfile,
+  type Profile,
+  type ProfileConfig,
+} from "./settings-api";
+import { ConfirmDialog } from "./confirm-dialog";
 
 interface ChannelsTabProps {
   profile: Profile;
@@ -278,6 +284,7 @@ export function ChannelsTab({ profile, onProfileUpdated }: ChannelsTabProps) {
   const [saving, setSaving] = useState(false);
   const [saved, setSaved] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  const [pendingRemoveIdx, setPendingRemoveIdx] = useState<number | null>(null);
 
   // Add-channel form state
   const [showAddForm, setShowAddForm] = useState(false);
@@ -297,18 +304,20 @@ export function ChannelsTab({ profile, onProfileUpdated }: ChannelsTabProps) {
   const persistChannels = async (newChannels: ChannelConfig[]): Promise<boolean> => {
     setSaving(true);
     setError(null);
-    const result = await updateMyProfile({
-      config: { channels: newChannels } as Partial<ProfileConfig>,
-    });
-    setSaving(false);
-    if (result) {
+    try {
+      const result = await updateMyProfile({
+        config: { channels: newChannels } as Partial<ProfileConfig>,
+      });
       onProfileUpdated?.(result);
       setSaved(true);
       setTimeout(() => setSaved(false), 2000);
       return true;
+    } catch (err) {
+      setError(formatSettingsError(err, "Failed to update channels."));
+      return false;
+    } finally {
+      setSaving(false);
     }
-    setError("Failed to update channels.");
-    return false;
   };
 
   const handleAdd = async () => {
@@ -328,10 +337,10 @@ export function ChannelsTab({ profile, onProfileUpdated }: ChannelsTabProps) {
     }
   };
 
-  const handleRemove = async (idx: number) => {
-    const ch = channels[idx];
-    const label = channelLabel(ch?.type ?? "unknown");
-    if (!window.confirm(`Remove ${label} channel?`)) return;
+  const confirmRemove = async () => {
+    if (pendingRemoveIdx == null) return;
+    const idx = pendingRemoveIdx;
+    setPendingRemoveIdx(null);
     const updated = channels.filter((_, i) => i !== idx);
     await persistChannels(updated);
   };
@@ -431,7 +440,7 @@ export function ChannelsTab({ profile, onProfileUpdated }: ChannelsTabProps) {
                     </button>
                     {/* Delete */}
                     <button
-                      onClick={() => handleRemove(idx)}
+                      onClick={() => setPendingRemoveIdx(idx)}
                       disabled={saving}
                       className="shrink-0 rounded-lg p-2 text-muted hover:text-red-400 hover:bg-red-500/10 disabled:opacity-40 transition"
                       title="Remove channel"
@@ -527,6 +536,19 @@ export function ChannelsTab({ profile, onProfileUpdated }: ChannelsTabProps) {
           </div>
         </div>
       )}
+      <ConfirmDialog
+        open={pendingRemoveIdx != null}
+        title="Remove Channel"
+        body={
+          pendingRemoveIdx != null && channels[pendingRemoveIdx]
+            ? `Remove ${channelLabel(channels[pendingRemoveIdx].type)} channel?`
+            : "Remove this channel?"
+        }
+        confirmLabel="Remove Channel"
+        variant="danger"
+        onConfirm={() => void confirmRemove()}
+        onCancel={() => setPendingRemoveIdx(null)}
+      />
     </div>
   );
 }

--- a/src/settings/confirm-dialog.tsx
+++ b/src/settings/confirm-dialog.tsx
@@ -33,17 +33,22 @@ export function ConfirmDialog({
   onCancel,
 }: ConfirmDialogProps) {
   const confirmRef = useRef<HTMLButtonElement>(null);
+  const cancelRef = useRef<HTMLButtonElement>(null);
 
-  // Focus the confirm button when opening; close on Escape.
+  // Focus the safer action for destructive dialogs; close on Escape.
   useEffect(() => {
     if (!open) return;
-    confirmRef.current?.focus();
+    if (variant === "danger") {
+      cancelRef.current?.focus();
+    } else {
+      confirmRef.current?.focus();
+    }
     const handleKey = (e: KeyboardEvent) => {
       if (e.key === "Escape") onCancel();
     };
     document.addEventListener("keydown", handleKey);
     return () => document.removeEventListener("keydown", handleKey);
-  }, [open, onCancel]);
+  }, [open, onCancel, variant]);
 
   if (!open) return null;
 
@@ -73,6 +78,7 @@ export function ConfirmDialog({
         {/* Actions */}
         <div className="flex items-center justify-end gap-3">
           <button
+            ref={cancelRef}
             onClick={onCancel}
             className="rounded-xl border border-border px-4 py-2 text-sm text-muted hover:text-text-strong hover:border-accent/30 transition"
           >

--- a/src/settings/llm-tab.tsx
+++ b/src/settings/llm-tab.tsx
@@ -18,7 +18,12 @@ import {
   Info,
 } from "lucide-react";
 import { request } from "@/api/client";
-import { updateMyProfile, type Profile, type LlmPrimary } from "./settings-api";
+import {
+  formatSettingsError,
+  updateMyProfile,
+  type Profile,
+  type LlmPrimary,
+} from "./settings-api";
 import {
   LLM_PROVIDERS,
   findProvider,
@@ -223,39 +228,39 @@ export function LlmTab({ profile, onProfileUpdated }: LlmTabProps) {
       base_url: needsBaseUrl ? form.base_url.trim() || null : null,
     };
 
-    const result = await updateMyProfile({
-      config: {
-        llm: {
-          primary: {
-            family_id: effectiveFamilyId,
-            model_id: effectiveModelId,
-            route: primaryRoute.api_key_env || primaryRoute.base_url ? primaryRoute : null,
+    try {
+      const result = await updateMyProfile({
+        config: {
+          llm: {
+            primary: {
+              family_id: effectiveFamilyId,
+              model_id: effectiveModelId,
+              route: primaryRoute.api_key_env || primaryRoute.base_url ? primaryRoute : null,
+            },
+            fallbacks: fallbacksPayload,
           },
-          fallbacks: fallbacksPayload,
+          gateway: {
+            ...profile.config.gateway,
+            system_prompt: form.system_prompt.trim() || null,
+            max_output_tokens: optionalInt(form.max_output_tokens),
+            max_history: optionalInt(form.max_history),
+            max_iterations: optionalInt(form.max_iterations),
+            max_concurrent_sessions: optionalInt(form.max_concurrent_sessions),
+            browser_timeout_secs: optionalInt(form.browser_timeout_secs),
+          },
+          adaptive_routing: { enabled: form.adaptive_routing_enabled },
         },
-        gateway: {
-          ...profile.config.gateway,
-          system_prompt: form.system_prompt.trim() || null,
-          max_output_tokens: optionalInt(form.max_output_tokens),
-          max_history: optionalInt(form.max_history),
-          max_iterations: optionalInt(form.max_iterations),
-          max_concurrent_sessions: optionalInt(form.max_concurrent_sessions),
-          browser_timeout_secs: optionalInt(form.browser_timeout_secs),
-        },
-        adaptive_routing: { enabled: form.adaptive_routing_enabled },
-      },
-    });
-
-    setSaving(false);
-    if (result) {
+      });
       onProfileUpdated(result);
       const newForm = profileToForm(result);
       setForm(newForm);
       setOriginal(newForm);
       setSaved(true);
       setTimeout(() => setSaved(false), 2000);
-    } else {
-      setError("Failed to update LLM config.");
+    } catch (err) {
+      setError(formatSettingsError(err, "Failed to update LLM config."));
+    } finally {
+      setSaving(false);
     }
   };
 

--- a/src/settings/ominix-tab.tsx
+++ b/src/settings/ominix-tab.tsx
@@ -21,6 +21,7 @@ import {
   fetchOminixLogs,
   fetchOminixPlatformModels,
   fetchPlatformSkillsStatus,
+  formatSettingsError,
   installPlatformSkill,
   removeOminixModel,
   removePlatformSkill,
@@ -42,7 +43,7 @@ type PendingAction =
   | { kind: "remove-skill"; name: string };
 
 function errorMessage(err: unknown): string {
-  return err instanceof Error ? err.message : String(err);
+  return formatSettingsError(err, "OminiX action failed.");
 }
 
 function statusClass(ok: boolean) {
@@ -472,7 +473,8 @@ export function OminixTab() {
   }, []);
 
   useEffect(() => {
-    void load();
+    const id = window.setTimeout(() => void load(), 0);
+    return () => window.clearTimeout(id);
   }, [load]);
 
   const runningLabel = status?.ominix_api.healthy ? "Healthy" : "Unreachable";

--- a/src/settings/profile-tab.tsx
+++ b/src/settings/profile-tab.tsx
@@ -16,6 +16,7 @@ import {
 } from "lucide-react";
 import {
   updateMyProfile,
+  formatSettingsError,
   getMyProfile,
   startMyGateway,
   stopMyGateway,
@@ -161,30 +162,31 @@ export function ProfileTab({ profile, onProfileUpdated, onNavigateBack }: Profil
     if (!name.trim()) return;
     setSaving(true);
     setError(null);
-    const result = await updateMyProfile({
-      name: name.trim(),
-      enabled: autoStart,
-      config: {
-        admin_mode: adminMode,
-      },
-    });
-    setSaving(false);
-    if (result) {
+    try {
+      const result = await updateMyProfile({
+        name: name.trim(),
+        enabled: autoStart,
+        config: {
+          admin_mode: adminMode,
+        },
+      });
       onProfileUpdated(result);
       setSaved(true);
       setTimeout(() => setSaved(false), 2000);
-    } else {
-      setError(LABELS.saveFailed);
+    } catch (err) {
+      setError(formatSettingsError(err, LABELS.saveFailed));
+    } finally {
+      setSaving(false);
     }
   };
 
   const handleDeleteProfile = async () => {
     setDeleteProfileError(null);
-    const ok = await deleteAdminProfile(profile.id);
-    if (ok) {
+    try {
+      await deleteAdminProfile(profile.id);
       onNavigateBack?.();
-    } else {
-      setDeleteProfileError(LABELS.deleteProfileFailed);
+    } catch (err) {
+      setDeleteProfileError(formatSettingsError(err, LABELS.deleteProfileFailed));
     }
   };
 
@@ -205,12 +207,17 @@ export function ProfileTab({ profile, onProfileUpdated, onNavigateBack }: Profil
           : action === "stop"
             ? stopMyGateway
             : restartMyGateway;
-      const result = await fn();
-      if (!result?.ok) {
-        setGatewayError(result?.message ?? `Failed to ${action} gateway.`);
+      try {
+        const result = await fn();
+        if (!result.ok) {
+          setGatewayError(result.message ?? `Failed to ${action} gateway.`);
+        }
+      } catch (err) {
+        setGatewayError(formatSettingsError(err, `Failed to ${action} gateway.`));
+      } finally {
+        await refreshProfile();
+        setGatewayLoading(null);
       }
-      await refreshProfile();
-      setGatewayLoading(null);
     },
     [refreshProfile],
   );
@@ -273,10 +280,8 @@ export function ProfileTab({ profile, onProfileUpdated, onNavigateBack }: Profil
       }
     }
 
-    const result = await updateMyProfile({ config: { env_vars: envVars } });
-    setEnvSaving(false);
-
-    if (result) {
+    try {
+      const result = await updateMyProfile({ config: { env_vars: envVars } });
       onProfileUpdated(result);
       // Reset rows from fresh server data
       setEnvRows(
@@ -290,8 +295,10 @@ export function ProfileTab({ profile, onProfileUpdated, onNavigateBack }: Profil
       );
       setEnvSaved(true);
       setTimeout(() => setEnvSaved(false), 2000);
-    } else {
-      setEnvError(LABELS.envSaveFailed);
+    } catch (err) {
+      setEnvError(formatSettingsError(err, LABELS.envSaveFailed));
+    } finally {
+      setEnvSaving(false);
     }
   };
 

--- a/src/settings/sandbox-tab.tsx
+++ b/src/settings/sandbox-tab.tsx
@@ -8,7 +8,13 @@ import {
   Plus,
   X,
 } from "lucide-react";
-import { updateMyProfile, type Profile, type SandboxConfig, type SandboxDocker } from "./settings-api";
+import {
+  formatSettingsError,
+  updateMyProfile,
+  type Profile,
+  type SandboxConfig,
+  type SandboxDocker,
+} from "./settings-api";
 
 interface SandboxTabProps {
   profile: Profile;
@@ -178,19 +184,20 @@ export function SandboxTab({ profile, onProfileUpdated }: SandboxTabProps) {
   const handleSave = async () => {
     setSaving(true);
     setError(null);
-    const result = await updateMyProfile({
-      config: { sandbox: formToSandboxConfig(form) },
-    });
-    setSaving(false);
-    if (result) {
+    try {
+      const result = await updateMyProfile({
+        config: { sandbox: formToSandboxConfig(form) },
+      });
       onProfileUpdated(result);
       const newForm = profileToForm(result);
       setForm(newForm);
       setOriginal(newForm);
       setSaved(true);
       setTimeout(() => setSaved(false), 2000);
-    } else {
-      setError("Failed to update sandbox config.");
+    } catch (err) {
+      setError(formatSettingsError(err, "Failed to update sandbox config."));
+    } finally {
+      setSaving(false);
     }
   };
 

--- a/src/settings/server-tab.tsx
+++ b/src/settings/server-tab.tsx
@@ -13,6 +13,7 @@ import {
 } from "lucide-react";
 import {
   fetchAllProfiles,
+  formatSettingsError,
   startProfile,
   stopProfile,
   type Profile,
@@ -252,13 +253,20 @@ export function ServerTab() {
 
   const load = useCallback(async () => {
     setError(null);
-    const data = await fetchAllProfiles();
-    setProfiles(data);
-    setLoading(false);
+    try {
+      const data = await fetchAllProfiles();
+      setProfiles(data);
+    } catch (err) {
+      setError(formatSettingsError(err, "Failed to load profiles."));
+      setProfiles([]);
+    } finally {
+      setLoading(false);
+    }
   }, []);
 
   useEffect(() => {
-    void load();
+    const id = window.setTimeout(() => void load(), 0);
+    return () => window.clearTimeout(id);
   }, [load]);
 
   // Load admin settings

--- a/src/settings/settings-api.ts
+++ b/src/settings/settings-api.ts
@@ -1,5 +1,52 @@
 import { request } from "@/api/client";
 
+function stringFromUnknown(value: unknown): string | null {
+  return typeof value === "string" && value.trim() ? value.trim() : null;
+}
+
+function apiErrorMessageFromBody(body: unknown): string | null {
+  if (!body || typeof body !== "object") return null;
+  const record = body as Record<string, unknown>;
+  const direct =
+    stringFromUnknown(record.detail) ??
+    stringFromUnknown(record.message) ??
+    stringFromUnknown(record.error);
+  if (direct) return direct;
+
+  if (Array.isArray(record.detail)) {
+    const parts = record.detail
+      .map((item) => {
+        if (typeof item === "string") return item;
+        if (!item || typeof item !== "object") return null;
+        const entry = item as Record<string, unknown>;
+        return stringFromUnknown(entry.msg) ?? stringFromUnknown(entry.message);
+      })
+      .filter((item): item is string => Boolean(item));
+    if (parts.length > 0) return parts.join("; ");
+  }
+
+  return null;
+}
+
+export function formatSettingsError(
+  err: unknown,
+  fallback = "Request failed.",
+): string {
+  if (err instanceof Error) {
+    const trimmed = err.message.trim();
+    if (trimmed) {
+      try {
+        const parsed = JSON.parse(trimmed);
+        return apiErrorMessageFromBody(parsed) ?? trimmed;
+      } catch {
+        return trimmed;
+      }
+    }
+  }
+  if (typeof err === "string" && err.trim()) return err.trim();
+  return fallback;
+}
+
 // ── Types (aligned with real /api/my/profile response) ──
 
 export interface LlmPrimary {
@@ -92,24 +139,16 @@ export async function getMyProfile(): Promise<Profile | null> {
 
 export async function updateMyProfile(
   patch: { name?: string; enabled?: boolean; config?: Partial<ProfileConfig> },
-): Promise<Profile | null> {
-  try {
-    return await request<Profile>("/api/my/profile", {
-      method: "PUT",
-      body: JSON.stringify(patch),
-    });
-  } catch {
-    return null;
-  }
+): Promise<Profile> {
+  return await request<Profile>("/api/my/profile", {
+    method: "PUT",
+    body: JSON.stringify(patch),
+  });
 }
 
 export async function getMyProfileSkills(): Promise<SkillInfo[]> {
-  try {
-    const resp = await request<{ skills: SkillInfo[] }>("/api/my/profile/skills");
-    return resp.skills ?? [];
-  } catch {
-    return [];
-  }
+  const resp = await request<{ skills: SkillInfo[] }>("/api/my/profile/skills");
+  return resp.skills ?? [];
 }
 
 export async function getMyProfileStatus(): Promise<ProfileStatus | null> {
@@ -120,45 +159,28 @@ export async function getMyProfileStatus(): Promise<ProfileStatus | null> {
   }
 }
 
-export async function startMyGateway(): Promise<{ ok: boolean; message?: string } | null> {
-  try {
-    return await request<{ ok: boolean; message?: string }>("/api/my/profile/start", {
-      method: "POST",
-    });
-  } catch {
-    return null;
-  }
+export async function startMyGateway(): Promise<{ ok: boolean; message?: string }> {
+  return await request<{ ok: boolean; message?: string }>("/api/my/profile/start", {
+    method: "POST",
+  });
 }
 
-export async function stopMyGateway(): Promise<{ ok: boolean; message?: string } | null> {
-  try {
-    return await request<{ ok: boolean; message?: string }>("/api/my/profile/stop", {
-      method: "POST",
-    });
-  } catch {
-    return null;
-  }
+export async function stopMyGateway(): Promise<{ ok: boolean; message?: string }> {
+  return await request<{ ok: boolean; message?: string }>("/api/my/profile/stop", {
+    method: "POST",
+  });
 }
 
-export async function restartMyGateway(): Promise<{ ok: boolean; message?: string } | null> {
-  try {
-    return await request<{ ok: boolean; message?: string }>("/api/my/profile/restart", {
-      method: "POST",
-    });
-  } catch {
-    return null;
-  }
+export async function restartMyGateway(): Promise<{ ok: boolean; message?: string }> {
+  return await request<{ ok: boolean; message?: string }>("/api/my/profile/restart", {
+    method: "POST",
+  });
 }
 
-export async function removeSkill(name: string): Promise<boolean> {
-  try {
-    await request<void>(`/api/my/profile/skills/${encodeURIComponent(name)}`, {
-      method: "DELETE",
-    });
-    return true;
-  } catch {
-    return false;
-  }
+export async function removeSkill(name: string): Promise<void> {
+  await request<void>(`/api/my/profile/skills/${encodeURIComponent(name)}`, {
+    method: "DELETE",
+  });
 }
 
 export interface InstallSkillResponse {
@@ -166,18 +188,16 @@ export interface InstallSkillResponse {
   installed: string[];
   skipped: string[];
   deps_installed: string[];
+  message?: string;
+  error?: string;
+  detail?: string;
 }
 
-export async function installSkill(source: string): Promise<boolean> {
-  try {
-    const resp = await request<InstallSkillResponse>("/api/my/profile/skills", {
-      method: "POST",
-      body: JSON.stringify({ repo: source }),
-    });
-    return resp.ok;
-  } catch {
-    return false;
-  }
+export async function installSkill(source: string): Promise<InstallSkillResponse> {
+  return await request<InstallSkillResponse>("/api/my/profile/skills", {
+    method: "POST",
+    body: JSON.stringify({ repo: source }),
+  });
 }
 
 // ── Hub / Registry ──
@@ -196,12 +216,8 @@ export interface HubPackage {
 }
 
 export async function getSkillRegistry(): Promise<HubPackage[]> {
-  try {
-    const resp = await request<{ packages: HubPackage[] }>("/api/my/profile/skills/registry");
-    return resp.packages ?? [];
-  } catch {
-    return [];
-  }
+  const resp = await request<{ packages: HubPackage[] }>("/api/my/profile/skills/registry");
+  return resp.packages ?? [];
 }
 
 // ── Admin: Users management ──
@@ -243,13 +259,9 @@ function normalizeAdminUser(user: AdminUserResponse): AdminUser {
 }
 
 export async function getAdminUsers(): Promise<AdminUser[]> {
-  try {
-    const resp = await request<AdminUserResponse[] | { users: AdminUserResponse[] }>("/api/admin/users");
-    const users = Array.isArray(resp) ? resp : (resp.users ?? []);
-    return users.map(normalizeAdminUser);
-  } catch {
-    return [];
-  }
+  const resp = await request<AdminUserResponse[] | { users: AdminUserResponse[] }>("/api/admin/users");
+  const users = Array.isArray(resp) ? resp : (resp.users ?? []);
+  return users.map(normalizeAdminUser);
 }
 
 export async function createAdminUser(parentProfileId: string, body: {
@@ -258,34 +270,25 @@ export async function createAdminUser(parentProfileId: string, body: {
   sub_account_id: string;
   public_subdomain: string;
   note?: string;
-}): Promise<ProfileResponseEnvelope | null> {
-  try {
-    return await request<ProfileResponseEnvelope>(
-      `/api/admin/profiles/${encodeURIComponent(parentProfileId)}/accounts`,
-      {
-        method: "POST",
-        body: JSON.stringify({
-          sub_account_id: body.sub_account_id,
-          public_subdomain: body.public_subdomain,
-          name: body.name,
-          email: body.email,
-        }),
-      },
-    );
-  } catch {
-    return null;
-  }
+}): Promise<ProfileResponseEnvelope> {
+  return await request<ProfileResponseEnvelope>(
+    `/api/admin/profiles/${encodeURIComponent(parentProfileId)}/accounts`,
+    {
+      method: "POST",
+      body: JSON.stringify({
+        sub_account_id: body.sub_account_id,
+        public_subdomain: body.public_subdomain,
+        name: body.name,
+        email: body.email,
+      }),
+    },
+  );
 }
 
-export async function deleteAdminUser(id: string): Promise<boolean> {
-  try {
-    await request<void>(`/api/admin/users/${encodeURIComponent(id)}`, {
-      method: "DELETE",
-    });
-    return true;
-  } catch {
-    return false;
-  }
+export async function deleteAdminUser(id: string): Promise<void> {
+  await request<void>(`/api/admin/users/${encodeURIComponent(id)}`, {
+    method: "DELETE",
+  });
 }
 
 // ── Admin: Allowed Emails ──
@@ -303,35 +306,21 @@ export interface AllowedEmail {
 }
 
 export async function getAllowedEmails(): Promise<AllowedEmail[]> {
-  try {
-    const resp = await request<AllowedEmail[] | { emails?: AllowedEmail[]; entries?: AllowedEmail[] }>("/api/admin/allowed-emails");
-    return Array.isArray(resp) ? resp : (resp.entries ?? resp.emails ?? []);
-  } catch {
-    return [];
-  }
+  const resp = await request<AllowedEmail[] | { emails?: AllowedEmail[]; entries?: AllowedEmail[] }>("/api/admin/allowed-emails");
+  return Array.isArray(resp) ? resp : (resp.entries ?? resp.emails ?? []);
 }
 
-export async function addAllowedEmail(email: string): Promise<boolean> {
-  try {
-    await request<void>("/api/admin/allowed-emails", {
-      method: "POST",
-      body: JSON.stringify({ email }),
-    });
-    return true;
-  } catch {
-    return false;
-  }
+export async function addAllowedEmail(email: string): Promise<void> {
+  await request<void>("/api/admin/allowed-emails", {
+    method: "POST",
+    body: JSON.stringify({ email }),
+  });
 }
 
-export async function removeAllowedEmail(email: string): Promise<boolean> {
-  try {
-    await request<void>(`/api/admin/allowed-emails/${encodeURIComponent(email)}`, {
-      method: "DELETE",
-    });
-    return true;
-  } catch {
-    return false;
-  }
+export async function removeAllowedEmail(email: string): Promise<void> {
+  await request<void>(`/api/admin/allowed-emails/${encodeURIComponent(email)}`, {
+    method: "DELETE",
+  });
 }
 
 // ── Admin API types ──
@@ -391,27 +380,15 @@ export interface OperatorTasksResponse {
 // ── Admin API calls ──
 
 export async function fetchOperatorSummary(): Promise<OperatorSummary | null> {
-  try {
-    return await request<OperatorSummary>("/api/admin/operator/summary");
-  } catch {
-    return null;
-  }
+  return await request<OperatorSummary>("/api/admin/operator/summary");
 }
 
 export async function fetchOperatorTasks(): Promise<OperatorTasksResponse | null> {
-  try {
-    return await request<OperatorTasksResponse>("/api/admin/operator/tasks");
-  } catch {
-    return null;
-  }
+  return await request<OperatorTasksResponse>("/api/admin/operator/tasks");
 }
 
 export async function fetchAllProfiles(): Promise<Profile[]> {
-  try {
-    return await request<Profile[]>("/api/admin/profiles");
-  } catch {
-    return [];
-  }
+  return await request<Profile[]>("/api/admin/profiles");
 }
 
 export async function startProfile(profileId: string): Promise<string | null> {
@@ -421,7 +398,7 @@ export async function startProfile(profileId: string): Promise<string | null> {
     });
     return null;
   } catch (err) {
-    return err instanceof Error ? err.message : "Failed to start";
+    return formatSettingsError(err, "Failed to start");
   }
 }
 
@@ -432,19 +409,14 @@ export async function stopProfile(profileId: string): Promise<string | null> {
     });
     return null;
   } catch (err) {
-    return err instanceof Error ? err.message : "Failed to stop";
+    return formatSettingsError(err, "Failed to stop");
   }
 }
 
-export async function deleteAdminProfile(profileId: string): Promise<boolean> {
-  try {
-    await request<void>(`/api/admin/profiles/${encodeURIComponent(profileId)}`, {
-      method: "DELETE",
-    });
-    return true;
-  } catch {
-    return false;
-  }
+export async function deleteAdminProfile(profileId: string): Promise<void> {
+  await request<void>(`/api/admin/profiles/${encodeURIComponent(profileId)}`, {
+    method: "DELETE",
+  });
 }
 
 // ── Admin: OminiX platform skills ──

--- a/src/settings/skills-tab.tsx
+++ b/src/settings/skills-tab.tsx
@@ -1,6 +1,30 @@
 import { useState, useEffect, useRef } from "react";
 import { Puzzle, Loader2, Wrench, RefreshCw, Trash2, Plus, Download, Package, Search, Check, Tag } from "lucide-react";
-import { getMyProfileSkills, removeSkill, installSkill, getSkillRegistry, type SkillInfo, type HubPackage } from "./settings-api";
+import {
+  formatSettingsError,
+  getMyProfileSkills,
+  removeSkill,
+  installSkill,
+  getSkillRegistry,
+  type SkillInfo,
+  type HubPackage,
+} from "./settings-api";
+import { ConfirmDialog } from "./confirm-dialog";
+
+function installFailureMessage(result: {
+  message?: string;
+  error?: string;
+  detail?: string;
+  skipped?: string[];
+}, fallback: string) {
+  if (result.message?.trim()) return result.message.trim();
+  if (result.error?.trim()) return result.error.trim();
+  if (result.detail?.trim()) return result.detail.trim();
+  if (result.skipped && result.skipped.length > 0) {
+    return `${fallback} Skipped: ${result.skipped.join(", ")}`;
+  }
+  return fallback;
+}
 
 export function SkillsTab() {
   const [skills, setSkills] = useState<SkillInfo[]>([]);
@@ -15,6 +39,7 @@ export function SkillsTab() {
 
   // Track which skill is being removed
   const [removingSkill, setRemovingSkill] = useState<string | null>(null);
+  const [pendingRemoveSkill, setPendingRemoveSkill] = useState<string | null>(null);
 
   // Octos Hub state
   const [hubPackages, setHubPackages] = useState<HubPackage[]>([]);
@@ -24,38 +49,60 @@ export function SkillsTab() {
 
   const refreshSkills = async () => {
     setError(null);
-    const data = await getMyProfileSkills();
-    if (mountedRef.current) {
-      setSkills(data);
+    try {
+      const data = await getMyProfileSkills();
+      if (mountedRef.current) {
+        setSkills(data);
+      }
+    } catch (err) {
+      if (mountedRef.current) {
+        setError(formatSettingsError(err, "Failed to load installed skills."));
+      }
     }
   };
 
   useEffect(() => {
     mountedRef.current = true;
     let cancelled = false;
-    Promise.all([getMyProfileSkills(), getSkillRegistry()]).then(([skillData, registryData]) => {
-      if (!cancelled) {
-        setSkills(skillData);
+    Promise.allSettled([getMyProfileSkills(), getSkillRegistry()]).then(
+      ([skillResult, registryResult]) => {
+        if (cancelled) return;
+        const errors: string[] = [];
+        if (skillResult.status === "fulfilled") {
+          setSkills(skillResult.value);
+        } else {
+          errors.push(formatSettingsError(skillResult.reason, "Failed to load installed skills."));
+        }
+        if (registryResult.status === "fulfilled") {
+          setHubPackages(registryResult.value);
+        } else {
+          errors.push(formatSettingsError(registryResult.reason, "Failed to load Octos Hub registry."));
+        }
+        if (errors.length > 0) setError(errors.join("\n"));
         setLoading(false);
-        setHubPackages(registryData);
         setHubLoading(false);
-      }
-    });
+      },
+    );
     return () => { cancelled = true; mountedRef.current = false; };
   }, []);
 
-  const handleRemove = async (name: string) => {
-    if (!window.confirm(`Remove skill '${name}'?`)) return;
+  const confirmRemove = async () => {
+    const name = pendingRemoveSkill;
+    if (!name) return;
+    setPendingRemoveSkill(null);
     setRemovingSkill(name);
     setError(null);
-    const ok = await removeSkill(name);
-    if (mountedRef.current) {
-      setRemovingSkill(null);
-      if (ok) {
+    try {
+      await removeSkill(name);
+      if (mountedRef.current) {
         await refreshSkills();
-      } else {
-        setError(`Failed to remove skill '${name}'.`);
       }
+    } catch (err) {
+      if (mountedRef.current) {
+        setError(formatSettingsError(err, `Failed to remove skill '${name}'.`));
+      }
+    } finally {
+      if (mountedRef.current) setRemovingSkill(null);
     }
   };
 
@@ -65,16 +112,24 @@ export function SkillsTab() {
     setInstalling(true);
     setError(null);
     setInstallMessage(null);
-    const ok = await installSkill(source);
-    if (mountedRef.current) {
-      setInstalling(false);
-      if (ok) {
+    try {
+      const result = await installSkill(source);
+      if (!result.ok) {
+        throw new Error(
+          installFailureMessage(result, "Skill install was rejected by the server."),
+        );
+      }
+      if (mountedRef.current) {
         setInstallSource("");
         setInstallMessage("Skill installed. Restart gateway to load new skills.");
         await refreshSkills();
-      } else {
-        setError(`Failed to install skill from '${source}'.`);
       }
+    } catch (err) {
+      if (mountedRef.current) {
+        setError(formatSettingsError(err, `Failed to install skill from '${source}'.`));
+      }
+    } finally {
+      if (mountedRef.current) setInstalling(false);
     }
   };
 
@@ -82,15 +137,23 @@ export function SkillsTab() {
     setInstallingHub(pkg.name);
     setError(null);
     setInstallMessage(null);
-    const ok = await installSkill(pkg.repo);
-    if (mountedRef.current) {
-      setInstallingHub(null);
-      if (ok) {
+    try {
+      const result = await installSkill(pkg.repo);
+      if (!result.ok) {
+        throw new Error(
+          installFailureMessage(result, "Skill package install was rejected by the server."),
+        );
+      }
+      if (mountedRef.current) {
         setInstallMessage(`Skill package '${pkg.name}' installed. Restart gateway to load new skills.`);
         await refreshSkills();
-      } else {
-        setError(`Failed to install skill package '${pkg.name}'.`);
       }
+    } catch (err) {
+      if (mountedRef.current) {
+        setError(formatSettingsError(err, `Failed to install skill package '${pkg.name}'.`));
+      }
+    } finally {
+      if (mountedRef.current) setInstallingHub(null);
     }
   };
 
@@ -196,7 +259,7 @@ export function SkillsTab() {
                   <span>{skill.tool_count} tool{skill.tool_count === 1 ? "" : "s"}</span>
                 </div>
                 <button
-                  onClick={() => handleRemove(skill.name)}
+                  onClick={() => setPendingRemoveSkill(skill.name)}
                   disabled={removingSkill === skill.name}
                   className="shrink-0 rounded-lg p-2 text-muted hover:text-red-400 hover:bg-red-500/10 disabled:opacity-40 transition"
                   title={`Remove ${skill.name}`}
@@ -398,6 +461,15 @@ export function SkillsTab() {
           </div>
         )}
       </div>
+      <ConfirmDialog
+        open={pendingRemoveSkill != null}
+        title="Remove Skill"
+        body={pendingRemoveSkill ? `Remove skill '${pendingRemoveSkill}'?` : "Remove this skill?"}
+        confirmLabel="Remove Skill"
+        variant="danger"
+        onConfirm={() => void confirmRemove()}
+        onCancel={() => setPendingRemoveSkill(null)}
+      />
     </div>
   );
 }

--- a/src/settings/system-tab.tsx
+++ b/src/settings/system-tab.tsx
@@ -21,6 +21,7 @@ import {
 import {
   fetchOperatorSummary,
   fetchOperatorTasks,
+  formatSettingsError,
   type OperatorSummary,
   type OperatorTasksResponse,
   type BreakdownEntry,
@@ -329,6 +330,7 @@ const LOG_LEVEL_COLOR: Record<LogLine["level"], string> = {
 
 function LiveLogsPanel() {
   const [lines, setLines] = useState<LogLine[]>([]);
+  const [bufferedCount, setBufferedCount] = useState(0);
   const [paused, setPaused] = useState(false);
   const [connected, setConnected] = useState(false);
   const [error, setError] = useState<string | null>(null);
@@ -346,6 +348,7 @@ function LiveLogsPanel() {
       level: classifyLine(cleaned),
     };
     lineBufferRef.current = [...lineBufferRef.current, line].slice(-MAX_LOG_LINES);
+    setBufferedCount(lineBufferRef.current.length);
     if (!pausedRef.current) {
       setLines([...lineBufferRef.current]);
     }
@@ -389,8 +392,9 @@ function LiveLogsPanel() {
   }, [addLine]);
 
   useEffect(() => {
-    connect();
+    const id = window.setTimeout(connect, 0);
     return () => {
+      window.clearTimeout(id);
       esRef.current?.close();
       esRef.current = null;
     };
@@ -415,6 +419,7 @@ function LiveLogsPanel() {
 
   const handleClear = () => {
     lineBufferRef.current = [];
+    setBufferedCount(0);
     setLines([]);
   };
 
@@ -475,7 +480,7 @@ function LiveLogsPanel() {
         {paused && lines.length > 0 && (
           <div className="pointer-events-none sticky bottom-0 left-0 right-0 flex justify-center pb-1">
             <span className="rounded-full bg-zinc-800/90 px-3 py-1 text-[10px] text-yellow-400 border border-yellow-400/20">
-              Paused — {lineBufferRef.current.length} lines buffered
+              Paused — {bufferedCount} lines buffered
             </span>
           </div>
         )}
@@ -504,28 +509,36 @@ export function SystemTab() {
     else setRefreshing(true);
     setError(null);
 
-    try {
-      const [s, t] = await Promise.all([
-        fetchOperatorSummary(),
-        fetchOperatorTasks(),
-      ]);
-      if (!s) {
-        setError("Failed to fetch operator summary. The admin API may be unavailable.");
-      }
-      setSummary(s);
-      setTasks(t);
-    } catch {
-      setError("Network error while fetching operator data.");
-    } finally {
-      setLoading(false);
-      setRefreshing(false);
+    const [summaryResult, tasksResult] = await Promise.allSettled([
+      fetchOperatorSummary(),
+      fetchOperatorTasks(),
+    ]);
+    const errors: string[] = [];
+
+    if (summaryResult.status === "fulfilled") {
+      setSummary(summaryResult.value);
+    } else {
+      setSummary(null);
+      errors.push(formatSettingsError(summaryResult.reason, "Failed to fetch operator summary."));
     }
+
+    if (tasksResult.status === "fulfilled") {
+      setTasks(tasksResult.value);
+    } else {
+      setTasks(null);
+      errors.push(formatSettingsError(tasksResult.reason, "Failed to fetch operator tasks."));
+    }
+
+    setError(errors.length ? errors.join("\n") : null);
+    setLoading(false);
+    setRefreshing(false);
   }, []);
 
   useEffect(() => {
-    void load();
+    const id = window.setTimeout(() => void load(), 0);
     timerRef.current = setInterval(() => void load(true), AUTO_REFRESH_MS);
     return () => {
+      window.clearTimeout(id);
       if (timerRef.current) clearInterval(timerRef.current);
     };
   }, [load]);
@@ -597,6 +610,16 @@ export function SystemTab() {
           Refresh
         </button>
       </div>
+
+      {error && (
+        <div
+          role="alert"
+          className="flex items-start gap-3 rounded-lg border border-red-400/30 bg-red-400/10 px-4 py-3 text-sm text-red-300"
+        >
+          <AlertCircle size={16} className="mt-0.5 shrink-0" />
+          <span className="whitespace-pre-wrap">{error}</span>
+        </div>
+      )}
 
       {/* Collection overview */}
       {collection && (

--- a/src/settings/tools-tab.tsx
+++ b/src/settings/tools-tab.tsx
@@ -12,7 +12,7 @@ import {
   ToggleLeft,
   ToggleRight,
 } from "lucide-react";
-import { updateMyProfile, type Profile } from "./settings-api";
+import { formatSettingsError, updateMyProfile, type Profile } from "./settings-api";
 import { request } from "@/api/client";
 
 interface ToolsTabProps {
@@ -466,17 +466,18 @@ export function ToolsTab({ profile, onProfileUpdated }: ToolsTabProps) {
     setSaving(true);
     setError(null);
     const payload = formToPayload(form, profile);
-    const result = await updateMyProfile(payload);
-    setSaving(false);
-    if (result) {
+    try {
+      const result = await updateMyProfile(payload);
       onProfileUpdated(result);
       const newForm = profileToForm(result);
       setForm(newForm);
       setOriginal(newForm);
       setSaved(true);
       setTimeout(() => setSaved(false), 2000);
-    } else {
-      setError("Failed to update tools config.");
+    } catch (err) {
+      setError(formatSettingsError(err, "Failed to update tools config."));
+    } finally {
+      setSaving(false);
     }
   };
 

--- a/src/settings/users-tab.tsx
+++ b/src/settings/users-tab.tsx
@@ -16,10 +16,12 @@ import {
   getAllowedEmails,
   addAllowedEmail,
   removeAllowedEmail,
+  formatSettingsError,
   type AdminUser,
   type AllowedEmail,
   type Profile,
 } from "./settings-api";
+import { ConfirmDialog } from "./confirm-dialog";
 
 // ── Create Sub-Account form ──
 
@@ -61,20 +63,21 @@ function CreateSubAccountForm({
     setSaving(true);
     setError(null);
     const subAccountId = userId.trim() || deriveSubAccountId(email.trim());
-    const result = await createAdminUser(parentProfileId, {
-      email: email.trim(),
-      name: displayName.trim(),
-      sub_account_id: subAccountId,
-      public_subdomain: subAccountId,
-      ...(note.trim() ? { note: note.trim() } : {}),
-    });
-    setSaving(false);
-    if (result) {
+    try {
+      await createAdminUser(parentProfileId, {
+        email: email.trim(),
+        name: displayName.trim(),
+        sub_account_id: subAccountId,
+        public_subdomain: subAccountId,
+        ...(note.trim() ? { note: note.trim() } : {}),
+      });
       reset();
       setOpen(false);
       onCreated();
-    } else {
-      setError("Failed to create sub-account. The server may have rejected the request.");
+    } catch (err) {
+      setError(formatSettingsError(err, "Failed to create sub-account. The server may have rejected the request."));
+    } finally {
+      setSaving(false);
     }
   };
 
@@ -184,22 +187,37 @@ function AllowedEmailsSection() {
   const [loading, setLoading] = useState(true);
   const [newEmail, setNewEmail] = useState("");
   const [adding, setAdding] = useState(false);
+  const [removingEmail, setRemovingEmail] = useState<string | null>(null);
+  const [pendingRemoveEmail, setPendingRemoveEmail] = useState<string | null>(null);
   const [error, setError] = useState<string | null>(null);
 
   const refresh = useCallback(async () => {
-    const data = await getAllowedEmails();
-    setEmails(data);
-    setLoading(false);
+    try {
+      const data = await getAllowedEmails();
+      setEmails(data);
+    } catch (err) {
+      setError(formatSettingsError(err, "Failed to load allowed emails."));
+    } finally {
+      setLoading(false);
+    }
   }, []);
 
   useEffect(() => {
     let cancelled = false;
-    getAllowedEmails().then((data) => {
-      if (!cancelled) {
-        setEmails(data);
-        setLoading(false);
-      }
-    });
+    getAllowedEmails()
+      .then((data) => {
+        if (!cancelled) {
+          setEmails(data);
+        }
+      })
+      .catch((err) => {
+        if (!cancelled) {
+          setError(formatSettingsError(err, "Failed to load allowed emails."));
+        }
+      })
+      .finally(() => {
+        if (!cancelled) setLoading(false);
+      });
     return () => { cancelled = true; };
   }, []);
 
@@ -208,22 +226,30 @@ function AllowedEmailsSection() {
     if (!newEmail.trim()) return;
     setAdding(true);
     setError(null);
-    const ok = await addAllowedEmail(newEmail.trim());
-    setAdding(false);
-    if (ok) {
+    try {
+      await addAllowedEmail(newEmail.trim());
       setNewEmail("");
       await refresh();
-    } else {
-      setError("Failed to add email to the allowlist.");
+    } catch (err) {
+      setError(formatSettingsError(err, "Failed to add email to the allowlist."));
+    } finally {
+      setAdding(false);
     }
   };
 
-  const handleRemove = async (email: string) => {
-    const confirmed = window.confirm(`Remove '${email}' from the allowlist?`);
-    if (!confirmed) return;
-    const ok = await removeAllowedEmail(email);
-    if (ok) {
+  const confirmRemove = async () => {
+    const email = pendingRemoveEmail;
+    if (!email) return;
+    setPendingRemoveEmail(null);
+    setRemovingEmail(email);
+    setError(null);
+    try {
+      await removeAllowedEmail(email);
       await refresh();
+    } catch (err) {
+      setError(formatSettingsError(err, `Failed to remove '${email}' from the allowlist.`));
+    } finally {
+      setRemovingEmail(null);
     }
   };
 
@@ -283,16 +309,34 @@ function AllowedEmailsSection() {
                 <span className="text-sm text-text truncate">{entry.email}</span>
               </div>
               <button
-                onClick={() => handleRemove(entry.email)}
+                onClick={() => setPendingRemoveEmail(entry.email)}
+                disabled={removingEmail === entry.email}
                 className="shrink-0 rounded-lg p-1.5 text-muted hover:bg-red-500/10 hover:text-red-400 transition"
                 title={`Remove ${entry.email}`}
               >
-                <Trash2 size={14} />
+                {removingEmail === entry.email ? (
+                  <Loader2 size={14} className="animate-spin" />
+                ) : (
+                  <Trash2 size={14} />
+                )}
               </button>
             </div>
           ))}
         </div>
       )}
+      <ConfirmDialog
+        open={pendingRemoveEmail != null}
+        title="Remove Allowed Email"
+        body={
+          pendingRemoveEmail
+            ? `Remove '${pendingRemoveEmail}' from the allowlist?`
+            : "Remove this email from the allowlist?"
+        }
+        confirmLabel="Remove Email"
+        variant="danger"
+        onConfirm={() => void confirmRemove()}
+        onCancel={() => setPendingRemoveEmail(null)}
+      />
     </div>
   );
 }
@@ -302,32 +346,49 @@ function AllowedEmailsSection() {
 export function UsersTab({ profile }: { profile: Profile }) {
   const [users, setUsers] = useState<AdminUser[]>([]);
   const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [pendingDeleteUser, setPendingDeleteUser] = useState<AdminUser | null>(null);
+  const [deletingUserId, setDeletingUserId] = useState<string | null>(null);
 
   const refresh = useCallback(async () => {
-    const data = await getAdminUsers();
-    setUsers(data);
-    setLoading(false);
+    try {
+      const data = await getAdminUsers();
+      setUsers(data);
+    } catch (err) {
+      setError(formatSettingsError(err, "Failed to load users."));
+    } finally {
+      setLoading(false);
+    }
   }, []);
 
   useEffect(() => {
     let cancelled = false;
-    getAdminUsers().then((data) => {
-      if (!cancelled) {
-        setUsers(data);
-        setLoading(false);
-      }
-    });
+    getAdminUsers()
+      .then((data) => {
+        if (!cancelled) setUsers(data);
+      })
+      .catch((err) => {
+        if (!cancelled) setError(formatSettingsError(err, "Failed to load users."));
+      })
+      .finally(() => {
+        if (!cancelled) setLoading(false);
+      });
     return () => { cancelled = true; };
   }, []);
 
-  const handleDelete = async (user: AdminUser) => {
-    const confirmed = window.confirm(
-      `Delete account '${user.email}'? This will also delete the profile and stop its gateway.`,
-    );
-    if (!confirmed) return;
-    const ok = await deleteAdminUser(user.id);
-    if (ok) {
+  const confirmDeleteUser = async () => {
+    const user = pendingDeleteUser;
+    if (!user) return;
+    setPendingDeleteUser(null);
+    setDeletingUserId(user.id);
+    setError(null);
+    try {
+      await deleteAdminUser(user.id);
       await refresh();
+    } catch (err) {
+      setError(formatSettingsError(err, `Failed to delete account '${user.email}'.`));
+    } finally {
+      setDeletingUserId(null);
     }
   };
 
@@ -364,6 +425,12 @@ export function UsersTab({ profile }: { profile: Profile }) {
         <div className="mb-5">
           <CreateSubAccountForm parentProfileId={profile.id} onCreated={refresh} />
         </div>
+
+        {error && (
+          <div className="mb-4 rounded-xl border border-red-400/30 bg-red-400/5 px-4 py-3 text-xs text-red-300">
+            {error}
+          </div>
+        )}
 
         {loading ? (
           <div className="flex justify-center py-10">
@@ -416,11 +483,16 @@ export function UsersTab({ profile }: { profile: Profile }) {
                 {/* Delete */}
                 <div className="flex justify-end">
                   <button
-                    onClick={() => handleDelete(u)}
-                    className="rounded-lg p-1.5 text-muted hover:bg-red-500/10 hover:text-red-400 transition"
+                    onClick={() => setPendingDeleteUser(u)}
+                    disabled={deletingUserId === u.id}
+                    className="rounded-lg p-1.5 text-muted hover:bg-red-500/10 hover:text-red-400 disabled:opacity-40 transition"
                     title={`Delete ${u.email}`}
                   >
-                    <Trash2 size={14} />
+                    {deletingUserId === u.id ? (
+                      <Loader2 size={14} className="animate-spin" />
+                    ) : (
+                      <Trash2 size={14} />
+                    )}
                   </button>
                 </div>
               </div>
@@ -431,6 +503,19 @@ export function UsersTab({ profile }: { profile: Profile }) {
 
       {/* Allowed emails */}
       <AllowedEmailsSection />
+      <ConfirmDialog
+        open={pendingDeleteUser != null}
+        title="Delete Account"
+        body={
+          pendingDeleteUser
+            ? `Delete account '${pendingDeleteUser.email}'? This will also delete the profile and stop its gateway.`
+            : "Delete this account?"
+        }
+        confirmLabel="Delete Account"
+        variant="danger"
+        onConfirm={() => void confirmDeleteUser()}
+        onCancel={() => setPendingDeleteUser(null)}
+      />
     </div>
   );
 }

--- a/tests/settings-tabs.spec.ts
+++ b/tests/settings-tabs.spec.ts
@@ -9,6 +9,13 @@ import { test, expect } from "@playwright/test";
 
 const TIMEOUT = 10_000;
 
+interface SettingsMockOptions {
+  profileUpdateError?: { status: number; body: unknown };
+  allowedEmailDeleteError?: { status: number; body: unknown };
+  operatorTasksError?: { status: number; body: unknown };
+  ominixServiceActionErrors?: Partial<Record<"start" | "stop" | "restart", { status: number; body: unknown }>>;
+}
+
 const mockProfile = {
   id: "admin",
   name: "Admin",
@@ -61,7 +68,10 @@ const mockProfile = {
   },
 };
 
-async function installAdminSettingsMocks(page: import("@playwright/test").Page) {
+async function installAdminSettingsMocks(
+  page: import("@playwright/test").Page,
+  options: SettingsMockOptions = {},
+) {
   let enableBody: unknown = null;
   let disableBody: unknown = null;
   let downloadBody: unknown = null;
@@ -116,12 +126,20 @@ async function installAdminSettingsMocks(page: import("@playwright/test").Page) 
     }),
   );
 
-  await page.route("**/api/my/profile", (route) =>
-    route.fulfill({
+  await page.route("**/api/my/profile", async (route) => {
+    if (route.request().method() === "PUT" && options.profileUpdateError) {
+      await route.fulfill({
+        status: options.profileUpdateError.status,
+        contentType: "application/json",
+        body: JSON.stringify(options.profileUpdateError.body),
+      });
+      return;
+    }
+    await route.fulfill({
       contentType: "application/json",
       body: JSON.stringify(mockProfile),
-    }),
-  );
+    });
+  });
 
   await page.route("**/api/admin/platform-skills", (route) =>
     route.fulfill({
@@ -250,6 +268,15 @@ async function installAdminSettingsMocks(page: import("@playwright/test").Page) 
   for (const action of ["start", "stop", "restart"]) {
     await page.route(`**/api/admin/platform-skills/ominix-api/${action}`, async (route) => {
       serviceActions.push(action);
+      const error = options.ominixServiceActionErrors?.[action as "start" | "stop" | "restart"];
+      if (error) {
+        await route.fulfill({
+          status: error.status,
+          contentType: "application/json",
+          body: JSON.stringify(error.body),
+        });
+        return;
+      }
       await route.fulfill({
         contentType: "application/json",
         body: JSON.stringify({ ok: true, message: `${action}ed` }),
@@ -266,8 +293,11 @@ async function installAdminSettingsMocks(page: import("@playwright/test").Page) 
   };
 }
 
-async function installServerSettingsMocks(page: import("@playwright/test").Page) {
-  const baseMocks = await installAdminSettingsMocks(page);
+async function installServerSettingsMocks(
+  page: import("@playwright/test").Page,
+  options: SettingsMockOptions = {},
+) {
+  const baseMocks = await installAdminSettingsMocks(page, options);
   let watchdogBody: unknown = null;
   let deploymentBody: unknown = null;
   let rotateBody: unknown = null;
@@ -325,6 +355,22 @@ async function installServerSettingsMocks(page: import("@playwright/test").Page)
         ],
       }),
     });
+  });
+
+  await page.route("**/api/admin/allowed-emails/*", async (route) => {
+    if (route.request().method() === "DELETE") {
+      if (options.allowedEmailDeleteError) {
+        await route.fulfill({
+          status: options.allowedEmailDeleteError.status,
+          contentType: "application/json",
+          body: JSON.stringify(options.allowedEmailDeleteError.body),
+        });
+        return;
+      }
+      await route.fulfill({ status: 204, body: "" });
+      return;
+    }
+    await route.fallback();
   });
 
   await page.route("**/api/admin/profiles/admin/accounts", async (route) => {
@@ -420,8 +466,15 @@ async function installServerSettingsMocks(page: import("@playwright/test").Page)
     }),
   );
 
-  await page.route("**/api/admin/operator/tasks", (route) =>
-    route.fulfill({
+  await page.route("**/api/admin/operator/tasks", (route) => {
+    if (options.operatorTasksError) {
+      return route.fulfill({
+        status: options.operatorTasksError.status,
+        contentType: "application/json",
+        body: JSON.stringify(options.operatorTasksError.body),
+      });
+    }
+    return route.fulfill({
       contentType: "application/json",
       body: JSON.stringify({
         generated_at: "2026-01-01T00:00:00Z",
@@ -434,8 +487,8 @@ async function installServerSettingsMocks(page: import("@playwright/test").Page)
         sources: [],
         partial: false,
       }),
-    }),
-  );
+    });
+  });
 
   await page.route("**/health", (route) =>
     route.fulfill({
@@ -593,6 +646,27 @@ test.describe("Settings page — tab smoke tests", () => {
     }
   });
 
+  test("Profile save surfaces backend validation errors", async ({ page }) => {
+    await installServerSettingsMocks(page, {
+      profileUpdateError: {
+        status: 400,
+        body: { detail: "Display name already exists" },
+      },
+    });
+    await seedAdminSession(page);
+
+    await page.goto("/settings", { waitUntil: "networkidle" });
+    await expect(page.locator(".animate-spin")).toBeHidden({ timeout: TIMEOUT });
+    await clickTab(page, "Profile");
+
+    await page.getByPlaceholder("Enter display name").fill("Admin Duplicate");
+    await page.getByRole("button", { name: "Save Changes" }).click();
+
+    await expect(page.getByText("Display name already exists")).toBeVisible({
+      timeout: TIMEOUT,
+    });
+  });
+
   test("LLM tab renders provider selector and fallback section", async ({
     page,
   }) => {
@@ -721,6 +795,27 @@ test.describe("Settings page — tab smoke tests", () => {
     ).toBeVisible({ timeout: TIMEOUT });
   });
 
+  test("System tab surfaces partial operator task load failures", async ({ page }) => {
+    await installServerSettingsMocks(page, {
+      operatorTasksError: {
+        status: 503,
+        body: { detail: "operator tasks unavailable" },
+      },
+    });
+    await seedAdminSession(page);
+
+    await page.goto("/settings", { waitUntil: "networkidle" });
+    await expect(page.locator(".animate-spin")).toBeHidden({ timeout: TIMEOUT });
+    await clickTab(page, "System");
+
+    await expect(
+      page.locator("h3", { hasText: "Operator Overview" }),
+    ).toBeVisible({ timeout: TIMEOUT });
+    await expect(page.getByText("operator tasks unavailable")).toBeVisible({
+      timeout: TIMEOUT,
+    });
+  });
+
   test("Server tab shows Deployment Mode (admin)", async ({ page }) => {
     await goToSettings(page);
     const profileLoaded = await hasProfile(page);
@@ -800,6 +895,30 @@ test.describe("Settings page — tab smoke tests", () => {
     await expect.poll(() => mocks.getServiceActions()).toEqual(["restart"]);
   });
 
+  test("OminiX service actions surface backend error details", async ({ page }) => {
+    await installAdminSettingsMocks(page, {
+      ominixServiceActionErrors: {
+        restart: {
+          status: 500,
+          body: { detail: "launchctl failed" },
+        },
+      },
+    });
+    await seedAdminSession(page);
+
+    await page.goto("/settings", { waitUntil: "networkidle" });
+    await expect(page.locator(".animate-spin")).toBeHidden({ timeout: TIMEOUT });
+    await clickTab(page, "OminiX");
+
+    await page.getByRole("button", { name: "Restart" }).click();
+    await page.getByRole("button", { name: "Confirm" }).click();
+
+    await expect(page.getByText("launchctl failed", { exact: true })).toBeVisible({
+      timeout: TIMEOUT,
+    });
+    await expect(page.locator("h3", { hasText: "OminiX API" })).toBeVisible();
+  });
+
   test("Server tab uses real admin endpoints for settings and token rotation", async ({
     page,
   }) => {
@@ -856,6 +975,33 @@ test.describe("Settings page — tab smoke tests", () => {
       public_subdomain: "nana",
       name: "Nana",
       email: "nana@example.com",
+    });
+  });
+
+  test("Users allowlist remove uses in-app confirmation and reports backend errors", async ({
+    page,
+  }) => {
+    await installServerSettingsMocks(page, {
+      allowedEmailDeleteError: {
+        status: 500,
+        body: { detail: "Allowlist delete failed" },
+      },
+    });
+    await seedAdminSession(page);
+
+    await page.goto("/settings", { waitUntil: "networkidle" });
+    await expect(page.locator(".animate-spin")).toBeHidden({ timeout: TIMEOUT });
+    await clickTab(page, "Users");
+
+    await page.getByTitle("Remove allowed@localhost").click();
+    await expect(page.getByRole("heading", { name: "Remove Allowed Email" })).toBeVisible({
+      timeout: TIMEOUT,
+    });
+    await expect(page.getByRole("button", { name: "Cancel" })).toBeFocused();
+    await page.getByRole("button", { name: "Remove Email" }).click();
+
+    await expect(page.getByText("Allowlist delete failed")).toBeVisible({
+      timeout: TIMEOUT,
     });
   });
 


### PR DESCRIPTION
## Summary
- Surface real backend error details across Settings tabs instead of swallowing failures or showing generic copy.
- Replace Settings window.confirm flows with in-app confirmation dialogs, with danger dialogs focusing Cancel first.
- Harden OminiX service/model actions and admin user/allowlist paths, plus partial System-tab operator failures.
- Add Playwright coverage for Profile validation errors, OminiX service errors, System partial operator failures, and Users allowlist removal.

## Verification
- `npx eslint <changed settings/test files>`: passed
- `npm run build`: passed (existing Vite/css/chunk warnings only)
- `npm run test:unit -- --reporter=dot`: 51 files / 636 tests passed
- `BASE_URL=http://127.0.0.1:5173 ./node_modules/.bin/playwright test tests/settings-tabs.spec.ts`: 19 passed
- `BASE_URL=http://127.0.0.1:5173 ./node_modules/.bin/playwright test`: 76 passed, 26 skipped

## Notes
- Full `npm run lint` still fails on existing repo-wide lint debt (164 errors, 3 warnings); the files touched by this PR pass eslint.
- In-app browser reached `/settings` but redirected to `/login`; Settings UI verification uses Playwright with deterministic mocked auth/admin endpoints.
