### PR TITLE
Refactor global workbench UI shell

### DIFF
--- a/src/components/home-nav.tsx
+++ b/src/components/home-nav.tsx
@@ -1,71 +1,18 @@
-import { useAuth } from "@/auth/auth-context";
-import { useTheme } from "@/hooks/use-theme";
-import { LogOut, Sun, Moon, MessageSquare, Settings } from "lucide-react";
-import { useNavigate } from "react-router-dom";
+import {
+  WorkbenchBrand,
+  WorkbenchRouteNav,
+  WorkbenchThemeButton,
+  WorkbenchUserActions,
+} from "@/components/workbench-shell";
 
 export function HomeNav() {
-  const { user, portal, logout } = useAuth();
-  const { theme, toggleTheme } = useTheme();
-  const navigate = useNavigate();
-
   return (
     <nav className="workbench-topbar flex min-h-16 items-center gap-3 px-5 py-3 max-sm:px-3">
-      <button
-        type="button"
-        onClick={() => navigate("/")}
-        className="flex min-w-0 items-center gap-2.5 text-left"
-        aria-label="Octos home"
-      >
-        <img
-          src="/images/octos-logo-color.svg"
-          alt="Octos"
-          className="h-7 w-auto shrink-0 select-none"
-        />
-        <span className="text-base font-semibold tracking-tight text-text-strong">Octos</span>
-      </button>
-
+      <WorkbenchBrand />
+      <WorkbenchRouteNav compact />
       <div className="flex-1" />
-
-      <button
-        onClick={() => navigate("/chat")}
-        className="workbench-button flex items-center gap-2 px-3 py-2 text-sm max-sm:px-2.5"
-      >
-        <MessageSquare size={16} />
-        <span className="max-sm:hidden">Chat</span>
-      </button>
-      {portal?.can_access_admin_portal && (
-        <button
-          onClick={() => navigate("/settings")}
-          className="glass-icon-button p-2.5"
-          title="Settings"
-          aria-label="Settings"
-        >
-          <Settings size={18} />
-        </button>
-      )}
-      <button
-        onClick={toggleTheme}
-        className="glass-icon-button p-2.5"
-        title={theme === "dark" ? "Light mode" : "Dark mode"}
-        aria-label={theme === "dark" ? "Light mode" : "Dark mode"}
-      >
-        {theme === "dark" ? <Sun size={18} /> : <Moon size={18} />}
-      </button>
-      {user && (
-        <div className="flex min-w-0 items-center gap-2">
-          <span className="max-w-[18rem] truncate text-sm text-muted max-md:hidden">
-            {user.email}
-          </span>
-          <button
-            onClick={logout}
-            className="glass-icon-button p-2"
-            aria-label="Log out"
-            title="Log out"
-          >
-            <LogOut size={16} />
-          </button>
-        </div>
-      )}
+      <WorkbenchThemeButton />
+      <WorkbenchUserActions />
     </nav>
   );
 }

--- a/src/components/workbench-shell.tsx
+++ b/src/components/workbench-shell.tsx
@@ -1,0 +1,298 @@
+import {
+  ArrowLeft,
+  ArrowRight,
+  Globe,
+  Home,
+  LogOut,
+  MessageSquare,
+  Mic,
+  MonitorSmartphone,
+  Moon,
+  Presentation,
+  Settings,
+  Sun,
+  type LucideIcon,
+} from "lucide-react";
+import { type ReactNode } from "react";
+import { Link, useLocation, useNavigate } from "react-router-dom";
+
+import { useAuth } from "@/auth/auth-context";
+import { useTheme } from "@/hooks/use-theme";
+
+type WorkbenchTone = "default" | "accent" | "success" | "warning" | "danger";
+
+const routeItems: Array<{
+  to: string;
+  label: string;
+  icon: LucideIcon;
+  adminOnly?: boolean;
+}> = [
+  { to: "/", label: "Home", icon: Home },
+  { to: "/chat", label: "Chat", icon: MessageSquare },
+  { to: "/slides", label: "Slides", icon: Presentation },
+  { to: "/sites", label: "Sites", icon: Globe },
+  { to: "/home", label: "Display", icon: MonitorSmartphone },
+  { to: "/voice", label: "Voice", icon: Mic },
+  { to: "/settings", label: "Settings", icon: Settings, adminOnly: true },
+];
+
+function isRouteActive(pathname: string, to: string) {
+  if (to === "/") return pathname === "/";
+  return pathname === to || pathname.startsWith(`${to}/`);
+}
+
+export function WorkbenchPage({
+  children,
+  className = "",
+}: {
+  children: ReactNode;
+  className?: string;
+}) {
+  return (
+    <div className={`workbench-shell flex h-screen flex-col ${className}`}>
+      {children}
+    </div>
+  );
+}
+
+export function WorkbenchBrand() {
+  return (
+    <Link
+      to="/"
+      className="workbench-brand flex min-w-0 items-center gap-2.5 text-left"
+      aria-label="Octos home"
+    >
+      <img
+        src="/images/octos-logo-color.svg"
+        alt="Octos"
+        className="h-7 w-auto shrink-0 select-none"
+      />
+      <span className="text-base font-semibold tracking-tight text-text-strong max-sm:hidden">
+        Octos
+      </span>
+    </Link>
+  );
+}
+
+export function WorkbenchRouteNav({ compact = false }: { compact?: boolean }) {
+  const { portal } = useAuth();
+  const location = useLocation();
+
+  return (
+    <div className="workbench-route-nav flex min-w-0 items-center gap-1 overflow-x-auto">
+      {routeItems
+        .filter((item) => !item.adminOnly || portal?.can_access_admin_portal)
+        .map(({ to, label, icon: Icon }) => {
+          const active = isRouteActive(location.pathname, to);
+          return (
+            <Link
+              key={to}
+              to={to}
+              className="workbench-route-link flex shrink-0 items-center gap-1.5 px-2.5 py-2 text-sm"
+              data-active={active ? "true" : undefined}
+            >
+              <Icon size={15} />
+              <span className={compact ? "max-lg:hidden" : "max-md:hidden"}>
+                {label}
+              </span>
+            </Link>
+          );
+        })}
+    </div>
+  );
+}
+
+export function WorkbenchThemeButton() {
+  const { theme, toggleTheme } = useTheme();
+  const label = theme === "dark" ? "Light mode" : "Dark mode";
+
+  return (
+    <button
+      type="button"
+      onClick={toggleTheme}
+      className="glass-icon-button p-2.5"
+      title={label}
+      aria-label={label}
+    >
+      {theme === "dark" ? <Sun size={18} /> : <Moon size={18} />}
+    </button>
+  );
+}
+
+export function WorkbenchUserActions() {
+  const { user, logout } = useAuth();
+  if (!user) return null;
+
+  return (
+    <div className="flex min-w-0 items-center gap-2">
+      <span className="max-w-[18rem] truncate text-sm text-muted max-xl:hidden">
+        {user.email}
+      </span>
+      <button
+        type="button"
+        onClick={logout}
+        className="glass-icon-button p-2"
+        aria-label="Log out"
+        title="Log out"
+      >
+        <LogOut size={16} />
+      </button>
+    </div>
+  );
+}
+
+export function WorkbenchTopbar({
+  backTo,
+  onBack,
+  icon: Icon,
+  context,
+  title,
+  subtitle,
+  badge,
+  actions,
+  afterTitle,
+}: {
+  backTo?: string;
+  onBack?: () => void;
+  icon?: LucideIcon;
+  context?: string;
+  title: ReactNode;
+  subtitle?: ReactNode;
+  badge?: ReactNode;
+  actions?: ReactNode;
+  afterTitle?: ReactNode;
+}) {
+  const navigate = useNavigate();
+  const backButton = backTo || onBack;
+  const titleClass =
+    "truncate text-lg font-semibold tracking-tight text-text-strong";
+  const titleIsPrimitive = typeof title === "string" || typeof title === "number";
+
+  return (
+    <nav className="workbench-topbar shrink-0">
+      <div className="workbench-topbar-inner flex min-h-16 items-center gap-3 px-5 py-3 max-sm:px-3">
+        {backButton && (
+          <button
+            type="button"
+            onClick={() => (onBack ? onBack() : navigate(backTo!))}
+            className="glass-icon-button p-2"
+            title="Go back"
+            aria-label="Go back"
+          >
+            <ArrowLeft size={18} />
+          </button>
+        )}
+        {Icon && (
+          <div className="workbench-icon-tile flex h-10 w-10 shrink-0 items-center justify-center">
+            <Icon size={18} />
+          </div>
+        )}
+        <div className="min-w-0 flex-1">
+          {context && <div className="shell-kicker">{context}</div>}
+          <div className="flex min-w-0 items-center gap-2">
+            {titleIsPrimitive ? (
+              <h1 className={titleClass}>{title}</h1>
+            ) : (
+              <div className={titleClass} role="heading" aria-level={1}>
+                {title}
+              </div>
+            )}
+            {badge}
+          </div>
+          {subtitle && (
+            <div className="mt-0.5 truncate text-xs text-muted">{subtitle}</div>
+          )}
+          {afterTitle}
+        </div>
+        {actions && (
+          <div className="flex min-w-0 shrink-0 flex-wrap items-center justify-end gap-2">
+            {actions}
+          </div>
+        )}
+      </div>
+    </nav>
+  );
+}
+
+export function WorkbenchSectionHeader({
+  title,
+  description,
+  action,
+}: {
+  title: ReactNode;
+  description?: ReactNode;
+  action?: ReactNode;
+}) {
+  return (
+    <div className="mb-3 flex items-end justify-between gap-3">
+      <div className="min-w-0">
+        <h2 className="text-sm font-semibold text-text-strong">{title}</h2>
+        {description && (
+          <p className="mt-0.5 text-xs text-muted">{description}</p>
+        )}
+      </div>
+      {action}
+    </div>
+  );
+}
+
+export function WorkbenchStatusPill({
+  children,
+  tone = "default",
+}: {
+  children: ReactNode;
+  tone?: WorkbenchTone;
+}) {
+  return (
+    <span className="workbench-status-pill" data-tone={tone}>
+      {children}
+    </span>
+  );
+}
+
+export function WorkbenchRouteCard({
+  icon: Icon,
+  title,
+  description,
+  to,
+  onClick,
+  meta,
+}: {
+  icon: LucideIcon;
+  title: ReactNode;
+  description: ReactNode;
+  to?: string;
+  onClick?: () => void;
+  meta?: ReactNode;
+}) {
+  const navigate = useNavigate();
+  const handleClick = () => {
+    if (onClick) {
+      onClick();
+      return;
+    }
+    if (to) navigate(to);
+  };
+
+  return (
+    <button
+      type="button"
+      onClick={handleClick}
+      className="workbench-card workbench-route-card flex min-h-28 items-center gap-4 p-5 text-left"
+    >
+      <div className="workbench-icon-tile flex h-11 w-11 shrink-0 items-center justify-center">
+        <Icon size={24} />
+      </div>
+      <div className="min-w-0 flex-1">
+        <div className="text-sm font-medium text-text-strong">{title}</div>
+        <div className="mt-1 text-xs text-muted">{description}</div>
+        {meta && <div className="mt-3 text-[11px] text-muted/70">{meta}</div>}
+      </div>
+      <ArrowRight
+        className="route-card-arrow text-muted"
+        size={17}
+        aria-hidden="true"
+      />
+    </button>
+  );
+}

--- a/src/index.css
+++ b/src/index.css
@@ -75,6 +75,30 @@
   --color-highlight: #b5842f;
 }
 
+:root {
+  --workbench-success-border: rgba(74, 222, 128, 0.28);
+  --workbench-success-bg: rgba(74, 222, 128, 0.08);
+  --workbench-success-text: #6ee7a0;
+  --workbench-warning-border: rgba(251, 191, 36, 0.3);
+  --workbench-warning-bg: rgba(251, 191, 36, 0.08);
+  --workbench-warning-text: #facc15;
+  --workbench-danger-border: rgba(248, 113, 113, 0.3);
+  --workbench-danger-bg: rgba(248, 113, 113, 0.08);
+  --workbench-danger-text: #f87171;
+}
+
+[data-theme="light"] {
+  --workbench-success-border: rgba(22, 101, 52, 0.28);
+  --workbench-success-bg: rgba(22, 101, 52, 0.08);
+  --workbench-success-text: #166534;
+  --workbench-warning-border: rgba(133, 77, 14, 0.28);
+  --workbench-warning-bg: rgba(133, 77, 14, 0.08);
+  --workbench-warning-text: #854d0e;
+  --workbench-danger-border: rgba(185, 28, 28, 0.28);
+  --workbench-danger-bg: rgba(185, 28, 28, 0.08);
+  --workbench-danger-text: #b91c1c;
+}
+
 /* ── Base ───────────────────────────────────────────── */
 html, body, #root {
   height: 100%;
@@ -229,6 +253,45 @@ body {
   background: var(--color-surface);
 }
 
+.workbench-topbar-inner {
+  width: 100%;
+}
+
+.workbench-brand {
+  border-radius: 8px;
+  padding: 0.25rem 0.4rem;
+}
+
+.workbench-brand:hover {
+  background: var(--color-surface-container);
+}
+
+.workbench-route-nav {
+  scrollbar-width: none;
+}
+
+.workbench-route-nav::-webkit-scrollbar {
+  display: none;
+}
+
+.workbench-route-link {
+  border: 1px solid transparent;
+  border-radius: 8px;
+  color: var(--color-muted);
+}
+
+.workbench-route-link:hover {
+  border-color: var(--color-border);
+  background: var(--color-surface-container);
+  color: var(--color-text-strong);
+}
+
+.workbench-route-link[data-active="true"] {
+  border-color: color-mix(in srgb, var(--color-accent) 42%, var(--color-border) 58%);
+  background: color-mix(in srgb, var(--color-accent) 11%, var(--color-surface-container) 89%);
+  color: var(--color-accent);
+}
+
 .workbench-rail {
   border-right: 1px solid var(--color-border);
   background: var(--color-surface);
@@ -259,6 +322,20 @@ body {
 .workbench-card:hover {
   border-color: color-mix(in srgb, var(--color-accent) 34%, var(--color-border) 66%);
   background: var(--color-surface-container);
+}
+
+.workbench-route-card {
+  align-items: stretch;
+}
+
+.workbench-route-card .route-card-arrow {
+  align-self: center;
+  font-size: 1rem;
+  line-height: 1;
+}
+
+.workbench-route-card:hover .route-card-arrow {
+  color: var(--color-accent);
 }
 
 .workbench-button {
@@ -305,6 +382,44 @@ body {
   font-size: 0.6875rem;
   font-weight: 600;
   letter-spacing: 0;
+}
+
+.workbench-status-pill {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
+  border: 1px solid var(--color-border);
+  border-radius: 6px;
+  background: var(--color-surface-container);
+  color: var(--color-muted);
+  padding: 0.25rem 0.55rem;
+  font-size: 0.6875rem;
+  font-weight: 650;
+  line-height: 1;
+}
+
+.workbench-status-pill[data-tone="accent"] {
+  border-color: color-mix(in srgb, var(--color-accent) 42%, var(--color-border) 58%);
+  background: color-mix(in srgb, var(--color-accent) 11%, var(--color-surface-container) 89%);
+  color: var(--color-accent);
+}
+
+.workbench-status-pill[data-tone="success"] {
+  border-color: var(--workbench-success-border);
+  background: var(--workbench-success-bg);
+  color: var(--workbench-success-text);
+}
+
+.workbench-status-pill[data-tone="warning"] {
+  border-color: var(--workbench-warning-border);
+  background: var(--workbench-warning-bg);
+  color: var(--workbench-warning-text);
+}
+
+.workbench-status-pill[data-tone="danger"] {
+  border-color: var(--workbench-danger-border);
+  background: var(--workbench-danger-bg);
+  color: var(--workbench-danger-text);
 }
 
 .workbench-input {

--- a/src/pages/home-page.tsx
+++ b/src/pages/home-page.tsx
@@ -1,13 +1,25 @@
 import { useNavigate } from "react-router-dom";
 import { HomeNav } from "@/components/home-nav";
-import { MessageSquare, ArrowRight, Presentation, Globe, MonitorSmartphone, Mic } from "lucide-react";
+import {
+  Globe,
+  MessageSquare,
+  Mic,
+  MonitorSmartphone,
+  Presentation,
+} from "lucide-react";
 import { unlockAudio } from "@/home/voice/audio-playback";
+import {
+  WorkbenchPage,
+  WorkbenchRouteCard,
+  WorkbenchSectionHeader,
+  WorkbenchStatusPill,
+} from "@/components/workbench-shell";
 
 export function HomePage() {
   const navigate = useNavigate();
 
   return (
-    <div className="workbench-shell flex h-screen flex-col">
+    <WorkbenchPage>
       <HomeNav />
 
       <div className="flex-1 overflow-y-auto">
@@ -18,101 +30,68 @@ export function HomePage() {
               <h1 className="mt-2 text-2xl font-semibold tracking-tight text-text-strong">
                 Octos Workspace
               </h1>
+              <p className="mt-2 max-w-2xl text-sm leading-6 text-muted">
+                Chat, generate decks, scaffold sites, and operate local voice
+                workflows from one compact control surface.
+              </p>
             </div>
-            <div className="workbench-badge px-2.5 py-1.5">AI workbench</div>
+            <WorkbenchStatusPill tone="accent">AI workbench</WorkbenchStatusPill>
           </header>
 
           <section>
-            <div className="mb-3 flex items-center justify-between gap-3">
-              <h2 className="text-sm font-semibold text-text-strong">Workspaces</h2>
-              <span className="text-xs text-muted">Chat, decks, sites</span>
-            </div>
+            <WorkbenchSectionHeader
+              title="Workspaces"
+              description="Primary production surfaces"
+            />
             <div className="grid grid-cols-1 gap-3 md:grid-cols-3">
-            <button
-              onClick={() => navigate("/chat")}
-              className="workbench-card flex min-h-28 items-center gap-4 p-5 text-left"
-            >
-              <div className="workbench-icon-tile flex h-11 w-11 shrink-0 items-center justify-center">
-                <MessageSquare size={24} />
-              </div>
-              <div className="min-w-0 flex-1">
-                <div className="text-sm font-medium text-text-strong">Start chat</div>
-                <div className="mt-1 text-xs text-muted">Session workspace</div>
-              </div>
-              <ArrowRight size={16} className="ml-auto shrink-0 text-muted" />
-            </button>
-            <button
-              onClick={() => navigate("/slides")}
-              className="workbench-card flex min-h-28 items-center gap-4 p-5 text-left"
-            >
-              <div className="workbench-icon-tile flex h-11 w-11 shrink-0 items-center justify-center">
-                <Presentation size={24} />
-              </div>
-              <div className="min-w-0 flex-1">
-                <div className="text-sm font-medium text-text-strong">Slides</div>
-                <div className="mt-1 text-xs text-muted">Deck workspace</div>
-              </div>
-              <ArrowRight size={16} className="ml-auto shrink-0 text-muted" />
-            </button>
-            <button
-              onClick={() => navigate("/sites")}
-              className="workbench-card flex min-h-28 items-center gap-4 p-5 text-left"
-            >
-              <div className="workbench-icon-tile flex h-11 w-11 shrink-0 items-center justify-center">
-                <Globe size={24} />
-              </div>
-              <div className="min-w-0 flex-1">
-                <div className="text-sm font-medium text-text-strong">Sites</div>
-                <div className="mt-1 text-xs text-muted">Site workspace</div>
-              </div>
-              <ArrowRight size={16} className="ml-auto shrink-0 text-muted" />
-            </button>
+              <WorkbenchRouteCard
+                icon={MessageSquare}
+                title="Start chat"
+                description="Session workspace"
+                to="/chat"
+              />
+              <WorkbenchRouteCard
+                icon={Presentation}
+                title="Slides"
+                description="Deck workspace"
+                to="/slides"
+              />
+              <WorkbenchRouteCard
+                icon={Globe}
+                title="Sites"
+                description="Site workspace"
+                to="/sites"
+              />
             </div>
           </section>
 
           <section>
-            <div className="mb-3 flex items-center justify-between gap-3">
-              <h2 className="text-sm font-semibold text-text-strong">Utilities</h2>
-              <span className="text-xs text-muted">Display and voice</span>
-            </div>
+            <WorkbenchSectionHeader
+              title="Utilities"
+              description="Ambient display and hands-free voice"
+            />
             <div className="grid grid-cols-1 gap-3 md:grid-cols-2">
-            <button
-              onClick={() => navigate("/home")}
-              className="workbench-card flex min-h-24 w-full items-center gap-4 p-5 text-left"
-            >
-              <div className="workbench-icon-tile flex h-11 w-11 shrink-0 items-center justify-center">
-                <MonitorSmartphone size={24} />
-              </div>
-              <div className="min-w-0 flex-1">
-                <div className="text-sm font-medium text-text-strong">Home Assistant</div>
-                <div className="mt-1 text-xs text-muted">Ambient display</div>
-              </div>
-              <ArrowRight size={16} className="ml-auto shrink-0 text-muted" />
-            </button>
-
-            <button
-              onClick={() => {
-                // Unlock the Web Audio context INSIDE this click gesture so the
-                // voice reply (which arrives seconds later, off-gesture) can
-                // play — browser autoplay policy blocks a later resume().
-                unlockAudio();
-                navigate("/voice");
-              }}
-              className="workbench-card flex min-h-24 w-full items-center gap-4 p-5 text-left"
-            >
-              <div className="workbench-icon-tile flex h-11 w-11 shrink-0 items-center justify-center">
-                <Mic size={24} />
-              </div>
-              <div className="min-w-0 flex-1">
-                <div className="text-sm font-medium text-text-strong">Voice</div>
-                <div className="mt-1 text-xs text-muted">Hands-free session</div>
-              </div>
-              <ArrowRight size={16} className="ml-auto shrink-0 text-muted" />
-            </button>
+              <WorkbenchRouteCard
+                icon={MonitorSmartphone}
+                title="Home Assistant"
+                description="Ambient display"
+                to="/home"
+              />
+              <WorkbenchRouteCard
+                icon={Mic}
+                title="Voice"
+                description="Hands-free session"
+                onClick={() => {
+                  // Unlock the Web Audio context inside this click gesture so
+                  // the voice reply can play after the async response arrives.
+                  unlockAudio();
+                  navigate("/voice");
+                }}
+              />
             </div>
           </section>
         </div>
       </div>
-    </div>
+    </WorkbenchPage>
   );
 }

--- a/src/settings/settings-page.tsx
+++ b/src/settings/settings-page.tsx
@@ -1,11 +1,7 @@
 import { useState, useEffect } from "react";
 import { useNavigate } from "react-router-dom";
 import { useAuth } from "@/auth/auth-context";
-import { useTheme } from "@/hooks/use-theme";
 import {
-  ArrowLeft,
-  Sun,
-  Moon,
   User,
   Cpu,
   Puzzle,
@@ -17,7 +13,14 @@ import {
   Server,
   Waves,
   Loader2,
+  Settings as SettingsIcon,
 } from "lucide-react";
+import {
+  WorkbenchPage,
+  WorkbenchStatusPill,
+  WorkbenchThemeButton,
+  WorkbenchTopbar,
+} from "@/components/workbench-shell";
 import { getMyProfile, type Profile } from "./settings-api";
 import { ProfileTab } from "./profile-tab";
 import { LlmTab } from "./llm-tab";
@@ -53,9 +56,8 @@ const TABS: TabDef[] = [
 ];
 
 export function AdminSettingsPage() {
-  const navigate = useNavigate();
   const { portal } = useAuth();
-  const { theme, toggleTheme } = useTheme();
+  const navigate = useNavigate();
   const [activeTab, setActiveTab] = useState<TabId>("profile");
   const [profile, setProfile] = useState<Profile | null>(null);
   const [loading, setLoading] = useState(true);
@@ -79,52 +81,32 @@ export function AdminSettingsPage() {
   const isAdminOnlyTab = activeTab === "system" || activeTab === "server" || activeTab === "users" || activeTab === "ominix";
 
   return (
-    <div className="workbench-shell flex h-screen flex-col">
-      <nav className="workbench-topbar flex shrink-0 items-center gap-4 px-5 py-3 max-md:px-3">
-        <button
-          onClick={() => navigate(-1)}
-          className="glass-icon-button p-2"
-          title="Go back"
-          aria-label="Go back"
-        >
-          <ArrowLeft size={18} />
-        </button>
-        <div className="flex items-center gap-2.5">
-          <img
-            src="/images/octos-logo-color.svg"
-            alt="Octos"
-            className="h-6 w-auto select-none"
-          />
-          <span className="text-base font-semibold tracking-tight text-text-strong">
-            Settings
-          </span>
-        </div>
-
-        <div className="flex-1" />
-
-        {accessibleProfiles.length > 1 && (
-          <select
-            value={selectedProfileId}
-            onChange={(e) => setSelectedProfileId(e.target.value)}
-            className="workbench-input px-3 py-2 text-sm"
-          >
-            {accessibleProfiles.map((p) => (
-              <option key={p.id} value={p.id}>
-                {p.name || p.id}
-              </option>
-            ))}
-          </select>
-        )}
-
-        <button
-          onClick={toggleTheme}
-          className="glass-icon-button p-2.5"
-          title={theme === "dark" ? "Light mode" : "Dark mode"}
-          aria-label={theme === "dark" ? "Light mode" : "Dark mode"}
-        >
-          {theme === "dark" ? <Sun size={18} /> : <Moon size={18} />}
-        </button>
-      </nav>
+    <WorkbenchPage>
+      <WorkbenchTopbar
+        onBack={() => navigate(-1)}
+        icon={SettingsIcon}
+        context="Octos Control"
+        title="Settings"
+        subtitle="Profile, models, channels, operators, and local runtime"
+        actions={
+          <>
+            {accessibleProfiles.length > 1 && (
+              <select
+                value={selectedProfileId}
+                onChange={(e) => setSelectedProfileId(e.target.value)}
+                className="workbench-input px-3 py-2 text-sm"
+              >
+                {accessibleProfiles.map((p) => (
+                  <option key={p.id} value={p.id}>
+                    {p.name || p.id}
+                  </option>
+                ))}
+              </select>
+            )}
+            <WorkbenchThemeButton />
+          </>
+        }
+      />
 
       {loading ? (
         <div className="flex flex-1 items-center justify-center">
@@ -149,8 +131,8 @@ export function AdminSettingsPage() {
                   <Icon size={16} />
                   {label}
                   {adminOnly && (
-                    <span className="workbench-badge ml-auto px-1.5 py-0.5 text-[9px] text-accent/80">
-                      Admin
+                    <span className="ml-auto">
+                      <WorkbenchStatusPill tone="accent">Admin</WorkbenchStatusPill>
                     </span>
                   )}
                 </button>
@@ -194,6 +176,6 @@ export function AdminSettingsPage() {
           </main>
         </div>
       )}
-    </div>
+    </WorkbenchPage>
   );
 }

--- a/src/sites/layouts/sites-editor-layout.tsx
+++ b/src/sites/layouts/sites-editor-layout.tsx
@@ -1,11 +1,14 @@
 import { useCallback, useRef, useState } from "react";
-import { ArrowLeft, FolderOpen, Globe, MessageSquare, Moon, Sun } from "lucide-react";
-import { Link } from "react-router-dom";
+import { FolderOpen, Globe, MessageSquare } from "lucide-react";
 
 import type { ContentEntry } from "@/api/content";
 import { ContentViewerOverlay, type ViewerState } from "@/components/content-viewer";
 import { useResizablePanel } from "@/hooks/use-resizable-panel";
-import { useTheme } from "@/hooks/use-theme";
+import {
+  WorkbenchStatusPill,
+  WorkbenchThemeButton,
+  WorkbenchTopbar,
+} from "@/components/workbench-shell";
 
 import { useSites } from "../context/sites-context";
 import { ProjectFiles } from "../components/project-files";
@@ -21,7 +24,6 @@ export function SitesEditorLayout({
   const [showChat, setShowChat] = useState(true);
   const [showFiles, setShowFiles] = useState(true);
   const { project, save } = useSites();
-  const { theme, toggleTheme } = useTheme();
   const [editingTitle, setEditingTitle] = useState(false);
   const titleInputRef = useRef<HTMLInputElement>(null);
   const {
@@ -98,29 +100,21 @@ export function SitesEditorLayout({
   }
 
   const projectStatus = project?.scaffoldError
-    ? { label: "Error", className: "bg-red-500/10 text-red-300" }
+    ? { label: "Error", tone: "danger" as const }
     : !project?.scaffolded
-      ? { label: "Scaffolding", className: "bg-amber-500/10 text-amber-300" }
+      ? { label: "Scaffolding", tone: "warning" as const }
       : project?.previewUrl
-        ? { label: "HTTPS Preview", className: "bg-emerald-500/10 text-emerald-300" }
-        : { label: "Ready", className: "bg-surface-container text-muted" };
+        ? { label: "HTTPS Preview", tone: "success" as const }
+        : { label: "Ready", tone: "default" as const };
 
   return (
     <div className="workbench-shell flex h-screen flex-col">
-      <div className="workbench-topbar flex flex-wrap items-center justify-between gap-3 px-4 py-3">
-        <div className="flex min-w-0 flex-wrap items-center gap-3">
-          <Link
-            to="/sites"
-            className="glass-icon-button flex items-center gap-1.5 px-3 py-2 text-sm"
-          >
-            <ArrowLeft size={16} />
-            Back
-          </Link>
-          <div className="h-5 w-px bg-border" />
-          <div className="workbench-icon-tile flex h-9 w-9 items-center justify-center">
-            <Globe size={16} />
-          </div>
-          {editingTitle ? (
+      <WorkbenchTopbar
+        backTo="/sites"
+        icon={Globe}
+        context="Site Workspace"
+        title={
+          editingTitle ? (
             <input
               ref={titleInputRef}
               defaultValue={project?.title || ""}
@@ -137,62 +131,57 @@ export function SitesEditorLayout({
               }}
             />
           ) : (
-            <span
-              className="max-w-sm cursor-pointer truncate text-sm font-medium text-text-strong transition hover:text-accent"
+            <button
+              type="button"
+              className="max-w-sm truncate text-left transition hover:text-accent"
               onClick={() => setEditingTitle(true)}
               title="Click to rename"
             >
               {project?.title || "Untitled Site"}
-            </span>
-          )}
-          {project && (
-            <span className="workbench-badge px-2 py-0.5 text-xs">
-              {project.template}
-            </span>
-          )}
-          {project && (
-            <span className={`rounded-md px-2 py-0.5 text-xs ${projectStatus.className}`}>
-              {projectStatus.label}
-            </span>
-          )}
-        </div>
-        <div className="flex items-center gap-3">
-          {project?.id && (
-            <SitesTaskStatusIndicator
-              sessionId={project.id}
-              historyTopic={project.preset ? `site ${project.preset}` : undefined}
-              profileId={project.profileId}
-            />
-          )}
-          <div className="flex items-center gap-1">
-          <button
-            onClick={toggleTheme}
-            className="glass-icon-button p-2"
-            title={theme === "dark" ? "Switch to light mode" : "Switch to dark mode"}
-          >
-            {theme === "dark" ? <Sun size={16} /> : <Moon size={16} />}
-          </button>
-          <button
-            onClick={() => setShowChat((value) => !value)}
-            className={`glass-icon-button p-2 ${
-              showChat ? "is-active" : ""
-            }`}
-            title="Toggle chat"
-          >
-            <MessageSquare size={16} />
-          </button>
-          <button
-            onClick={() => setShowFiles((value) => !value)}
-            className={`glass-icon-button p-2 ${
-              showFiles ? "is-active" : ""
-            }`}
-            title="Toggle files"
-          >
-            <FolderOpen size={16} />
-          </button>
-          </div>
-        </div>
-      </div>
+            </button>
+          )
+        }
+        badge={
+          project ? (
+            <>
+              <WorkbenchStatusPill>{project.template}</WorkbenchStatusPill>
+              <WorkbenchStatusPill tone={projectStatus.tone}>
+                {projectStatus.label}
+              </WorkbenchStatusPill>
+            </>
+          ) : undefined
+        }
+        actions={
+          <>
+            {project?.id && (
+              <SitesTaskStatusIndicator
+                sessionId={project.id}
+                historyTopic={project.preset ? `site ${project.preset}` : undefined}
+                profileId={project.profileId}
+              />
+            )}
+            <WorkbenchThemeButton />
+            <button
+              onClick={() => setShowChat((value) => !value)}
+              className={`glass-icon-button p-2 ${
+                showChat ? "is-active" : ""
+              }`}
+              title="Toggle chat"
+            >
+              <MessageSquare size={16} />
+            </button>
+            <button
+              onClick={() => setShowFiles((value) => !value)}
+              className={`glass-icon-button p-2 ${
+                showFiles ? "is-active" : ""
+              }`}
+              title="Toggle files"
+            >
+              <FolderOpen size={16} />
+            </button>
+          </>
+        }
+      />
 
       <div className="flex min-h-0 flex-1 gap-2 overflow-hidden p-2 max-lg:flex-col max-lg:overflow-y-auto">
         {showChat && (

--- a/src/sites/pages/sites-gallery-page.tsx
+++ b/src/sites/pages/sites-gallery-page.tsx
@@ -1,8 +1,14 @@
-import { ArrowLeft, Globe, Plus } from "lucide-react";
+import { Globe, Plus } from "lucide-react";
 import { Link, useNavigate } from "react-router-dom";
 
 import { SITE_PRESETS, type SitePreset } from "../types";
 import { useSiteProjects } from "../store";
+import {
+  WorkbenchPage,
+  WorkbenchSectionHeader,
+  WorkbenchStatusPill,
+  WorkbenchTopbar,
+} from "@/components/workbench-shell";
 
 export function SitesGalleryPage() {
   const { projects, create } = useSiteProjects();
@@ -14,34 +20,25 @@ export function SitesGalleryPage() {
   }
 
   return (
-    <div className="workbench-shell min-h-screen">
-      <div className="workbench-topbar">
-        <div className="mx-auto flex max-w-6xl flex-wrap items-center justify-between gap-4 px-6 py-4 max-sm:px-3">
-          <div className="flex min-w-0 items-center gap-3">
-            <Link to="/" className="glass-icon-button flex h-9 w-9 items-center justify-center">
-              <ArrowLeft size={16} />
-            </Link>
-            <div className="workbench-icon-tile flex h-9 w-9 items-center justify-center">
-              <Globe size={18} />
-            </div>
-            <div className="min-w-0">
-              <h1 className="truncate text-lg font-semibold text-text-strong">Site Studio</h1>
-              <p className="text-xs text-muted">
-                Project library and scaffold presets
-              </p>
-            </div>
-          </div>
-          <span className="workbench-badge px-2 py-1">
+    <WorkbenchPage>
+      <WorkbenchTopbar
+        backTo="/"
+        icon={Globe}
+        context="Creation Workspace"
+        title="Site Studio"
+        subtitle="Project library and scaffold presets"
+        badge={
+          <WorkbenchStatusPill>
             {projects.length} project{projects.length !== 1 ? "s" : ""}
-          </span>
-        </div>
-      </div>
+          </WorkbenchStatusPill>
+        }
+      />
 
       <div className="mx-auto max-w-6xl px-6 py-8 max-sm:px-3">
-        <div className="mb-3 flex items-center justify-between gap-3">
-          <h2 className="text-sm font-semibold text-text-strong">Create</h2>
-          <span className="text-xs text-muted">Preset scaffolds</span>
-        </div>
+        <WorkbenchSectionHeader
+          title="Create"
+          description="Preset scaffolds"
+        />
         <div className="grid gap-4 md:grid-cols-2 xl:grid-cols-4">
           {(Object.entries(SITE_PRESETS) as Array<[SitePreset, (typeof SITE_PRESETS)[SitePreset]]>).map(
             ([preset, definition]) => (
@@ -51,9 +48,9 @@ export function SitesGalleryPage() {
                 className="workbench-card min-h-44 p-5 text-left"
               >
                 <div className="flex items-center justify-between">
-                  <span className="workbench-badge px-2 py-0.5 text-[10px] text-accent">
+                  <WorkbenchStatusPill tone="accent">
                     {definition.label}
-                  </span>
+                  </WorkbenchStatusPill>
                   <Plus size={16} className="text-muted" />
                 </div>
                 <h3 className="mt-4 text-xl font-semibold text-text-strong">
@@ -72,9 +69,10 @@ export function SitesGalleryPage() {
 
         {projects.length > 0 && (
           <div className="mt-10">
-            <div className="mb-4 text-xs font-semibold uppercase text-muted">
-              Recent Sessions
-            </div>
+            <WorkbenchSectionHeader
+              title="Recent Sessions"
+              description="Scaffolded site workspaces"
+            />
             <div className="grid gap-3 md:grid-cols-2 xl:grid-cols-3">
               {projects.map((project) => (
                 <Link
@@ -95,6 +93,6 @@ export function SitesGalleryPage() {
           </div>
         )}
       </div>
-    </div>
+    </WorkbenchPage>
   );
 }

--- a/src/slides/layouts/slides-editor-layout.tsx
+++ b/src/slides/layouts/slides-editor-layout.tsx
@@ -1,13 +1,9 @@
 import { useCallback, useRef, useState } from "react";
 import {
-  ArrowLeft,
   FolderOpen,
   MessageSquare,
-  Moon,
   Presentation,
-  Sun,
 } from "lucide-react";
-import { Link } from "react-router-dom";
 
 import type { ContentEntry } from "@/api/content";
 import {
@@ -17,7 +13,11 @@ import {
 import { useResizablePanel } from "@/hooks/use-resizable-panel";
 import { useSlides } from "../context/slides-context";
 import { ProjectFiles } from "../components/project-files";
-import { useTheme } from "@/hooks/use-theme";
+import {
+  WorkbenchStatusPill,
+  WorkbenchThemeButton,
+  WorkbenchTopbar,
+} from "@/components/workbench-shell";
 
 export function SlidesEditorLayout({
   previewPanel,
@@ -35,7 +35,6 @@ export function SlidesEditorLayout({
   const [showChat, setShowChat] = useState(true);
   const [showFiles, setShowFiles] = useState(true);
   const { project, save } = useSlides();
-  const { theme, toggleTheme } = useTheme();
   const [editingTitle, setEditingTitle] = useState(false);
   const titleInputRef = useRef<HTMLInputElement>(null);
   const {
@@ -131,63 +130,48 @@ export function SlidesEditorLayout({
 
   return (
     <div className="chat-shell workbench-shell flex h-screen flex-col gap-2 p-2">
-      {/* Header */}
-      <div className="glass-panel rounded-lg p-2">
-        <div className="glass-toolbar flex flex-wrap items-center justify-between gap-4 px-4 py-3">
-          <div className="flex min-w-0 flex-wrap items-center gap-3">
-            <Link
-              to="/slides"
-              className="glass-icon-button flex items-center gap-1.5 px-3 py-2 text-sm"
-            >
-              <ArrowLeft size={16} />
-              Back
-            </Link>
-            <div className="h-8 w-px self-stretch bg-border" />
-            <div className="workbench-icon-tile flex h-10 w-10 items-center justify-center text-accent">
-              <Presentation size={16} />
-            </div>
-            <div className="min-w-0">
-              <div className="shell-kicker">Slides Workspace</div>
-              {editingTitle ? (
-                <input
-                  ref={titleInputRef}
-                  defaultValue={project?.title || ""}
-                  className="workbench-input mt-1 max-w-sm px-3 py-2 text-lg font-semibold tracking-tight"
-                  autoFocus
-                  onBlur={(e) => {
-                    const v = e.target.value.trim();
-                    if (v && v !== project?.title) save({ title: v });
-                    setEditingTitle(false);
-                  }}
-                  onKeyDown={(e) => {
-                    if (e.key === "Enter") e.currentTarget.blur();
-                    if (e.key === "Escape") setEditingTitle(false);
-                  }}
-                />
-              ) : (
-                <span
-                  className="block max-w-sm truncate text-lg font-semibold tracking-tight text-text-strong transition hover:text-accent"
-                  onClick={() => setEditingTitle(true)}
-                  title="Click to rename"
-                >
-                  {project?.title || "Untitled Deck"}
-                </span>
-              )}
-            </div>
-            {project && (
-              <span className="workbench-badge px-3 py-1.5 text-xs">
-                {project.slides.length} slides
-              </span>
-            )}
-          </div>
-          <div className="flex items-center gap-2">
+      <WorkbenchTopbar
+        backTo="/slides"
+        icon={Presentation}
+        context="Slides Workspace"
+        title={
+          editingTitle ? (
+            <input
+              ref={titleInputRef}
+              defaultValue={project?.title || ""}
+              className="workbench-input max-w-sm px-3 py-2 text-lg font-semibold tracking-tight"
+              autoFocus
+              onBlur={(e) => {
+                const v = e.target.value.trim();
+                if (v && v !== project?.title) save({ title: v });
+                setEditingTitle(false);
+              }}
+              onKeyDown={(e) => {
+                if (e.key === "Enter") e.currentTarget.blur();
+                if (e.key === "Escape") setEditingTitle(false);
+              }}
+            />
+          ) : (
             <button
-              onClick={toggleTheme}
-              className="glass-icon-button p-2.5"
-              title={theme === "dark" ? "Switch to light mode" : "Switch to dark mode"}
+              type="button"
+              className="block max-w-sm truncate text-left transition hover:text-accent"
+              onClick={() => setEditingTitle(true)}
+              title="Click to rename"
             >
-              {theme === "dark" ? <Sun size={16} /> : <Moon size={16} />}
+              {project?.title || "Untitled Deck"}
             </button>
+          )
+        }
+        badge={
+          project ? (
+            <WorkbenchStatusPill>
+              {project.slides.length} slides
+            </WorkbenchStatusPill>
+          ) : undefined
+        }
+        actions={
+          <>
+            <WorkbenchThemeButton />
             <button
               onClick={() => setShowChat(!showChat)}
               className={`glass-icon-button p-2.5 ${
@@ -206,9 +190,9 @@ export function SlidesEditorLayout({
             >
               <FolderOpen size={16} />
             </button>
-          </div>
-        </div>
-      </div>
+          </>
+        }
+      />
 
       {/* Layout: chat (left) + preview (center) + files (right) */}
       <div className="flex flex-1 min-h-0 gap-2 overflow-hidden max-lg:flex-col max-lg:overflow-y-auto">

--- a/src/slides/pages/slides-gallery-page.tsx
+++ b/src/slides/pages/slides-gallery-page.tsx
@@ -1,10 +1,16 @@
 import { useState, useMemo } from "react";
 import { Link, useNavigate } from "react-router-dom";
-import { Presentation, Plus, Search, ArrowLeft } from "lucide-react";
+import { Presentation, Plus, Search } from "lucide-react";
 
 import { AuthenticatedFileImage } from "../components/authenticated-file-image";
 import { useSlidesProjects, searchSlidesProjects } from "../store";
 import { TEMPLATES, TEMPLATE_COLORS } from "../constants";
+import {
+  WorkbenchPage,
+  WorkbenchSectionHeader,
+  WorkbenchStatusPill,
+  WorkbenchTopbar,
+} from "@/components/workbench-shell";
 
 export function SlidesGalleryPage() {
   const { projects, create } = useSlidesProjects();
@@ -46,23 +52,20 @@ export function SlidesGalleryPage() {
   };
 
   return (
-    <div className="workbench-shell min-h-screen">
-      {/* Header */}
-      <div className="workbench-topbar">
-        <div className="mx-auto flex max-w-6xl flex-wrap items-center justify-between gap-4 px-6 py-4 max-sm:px-3">
-          <div className="flex min-w-0 items-center gap-3">
-            <Link to="/" className="glass-icon-button flex h-9 w-9 items-center justify-center">
-              <ArrowLeft size={16} />
-            </Link>
-            <div className="workbench-icon-tile flex h-9 w-9 items-center justify-center">
-              <Presentation size={18} />
-            </div>
-            <h1 className="truncate text-lg font-semibold text-text-strong">Slides Gallery</h1>
-            <span className="workbench-badge px-2 py-1">
-              {projects.length} deck{projects.length !== 1 ? "s" : ""}
-            </span>
-          </div>
-          <div className="flex min-w-0 flex-wrap items-center gap-2">
+    <WorkbenchPage>
+      <WorkbenchTopbar
+        backTo="/"
+        icon={Presentation}
+        context="Creation Workspace"
+        title="Slides"
+        subtitle="Deck library and generation sessions"
+        badge={
+          <WorkbenchStatusPill>
+            {projects.length} deck{projects.length !== 1 ? "s" : ""}
+          </WorkbenchStatusPill>
+        }
+        actions={
+          <>
             <div className="relative min-w-0 max-sm:w-full">
               <Search
                 size={14}
@@ -88,9 +91,9 @@ export function SlidesGalleryPage() {
               <Plus size={14} />
               New Deck
             </button>
-          </div>
-        </div>
-      </div>
+          </>
+        }
+      />
 
       {/* Filter bar */}
       <div className="mx-auto max-w-6xl px-6 py-3 max-sm:px-3">
@@ -117,6 +120,10 @@ export function SlidesGalleryPage() {
 
       {/* Grid */}
       <div className="mx-auto max-w-6xl px-6 py-4 max-sm:px-3">
+        <WorkbenchSectionHeader
+          title="Library"
+          description="Recent decks, generated outputs, and local drafts"
+        />
         {filtered.length === 0 ? (
           <div className="workbench-panel-muted py-20 text-center text-muted">
             <Presentation size={48} className="mx-auto mb-4 opacity-30" />
@@ -175,6 +182,6 @@ export function SlidesGalleryPage() {
           </div>
         )}
       </div>
-    </div>
+    </WorkbenchPage>
   );
 }

--- a/tests/ui-redesign-smoke.spec.ts
+++ b/tests/ui-redesign-smoke.spec.ts
@@ -200,4 +200,38 @@ test.describe("UI redesign shell smoke", () => {
       }
     });
   }
+
+  test("home shell exposes the shared route navigation", async ({ page }) => {
+    await page.setViewportSize({ width: 1440, height: 900 });
+    await page.goto("/", { waitUntil: "networkidle" });
+
+    for (const label of [
+      "Home",
+      "Chat",
+      "Slides",
+      "Sites",
+      "Display",
+      "Voice",
+      "Settings",
+    ]) {
+      await expect(
+        page.getByRole("link", { name: label, exact: true }),
+      ).toBeVisible();
+    }
+  });
+
+  test("workspace surfaces use the shared topbar titles", async ({ page }) => {
+    await page.setViewportSize({ width: 1440, height: 900 });
+
+    for (const surface of [
+      { path: "/settings", context: "Octos Control", title: "Settings" },
+      { path: "/slides", context: "Creation Workspace", title: "Slides" },
+      { path: "/sites", context: "Creation Workspace", title: "Site Studio" },
+    ]) {
+      await page.goto(surface.path, { waitUntil: "networkidle" });
+      await expect(page.getByText(surface.context).first()).toBeVisible();
+      await expect(page.getByRole("heading", { name: surface.title })).toBeVisible();
+      await expectNoHorizontalOverflow(page);
+    }
+  });
 });


### PR DESCRIPTION
## Summary
- Add a shared Workbench shell/topbar/navigation/status component set and wire it into Home, Settings, Slides, and Sites surfaces.
- Unify gallery/editor chrome for Slides and Sites while preserving editor resize/chat/files controls.
- Add UI smoke coverage for shared navigation, topbar titles, and desktop/mobile horizontal overflow.

## Verification
- `npx eslint src/components/workbench-shell.tsx src/components/home-nav.tsx src/pages/home-page.tsx src/settings/settings-page.tsx src/slides/pages/slides-gallery-page.tsx src/sites/pages/sites-gallery-page.tsx src/slides/layouts/slides-editor-layout.tsx src/sites/layouts/sites-editor-layout.tsx tests/ui-redesign-smoke.spec.ts`
- `git diff --check`
- `npm run build` (passes; existing CSS file-property, dynamic import, and chunk-size warnings remain)
- `npm run test:unit -- --reporter=dot` → 51 files / 636 tests passed
- `BASE_URL=http://127.0.0.1:5173 ./node_modules/.bin/playwright test tests/ui-redesign-smoke.spec.ts` → 4 passed
- `BASE_URL=http://127.0.0.1:5173 ./node_modules/.bin/playwright test` → 78 passed / 26 skipped / 0 failed

## Review notes
- Claude Code performed a read-only diff review; the actionable findings were addressed before final verification: Settings back behavior now uses history back, status pill semantic tones use light-theme-safe colors, and Sites preset badges use the shared status pill.