### PR TITLE
[codex] Refine chat workbench UI

### DIFF
--- a/src/components/chat-thread.tsx
+++ b/src/components/chat-thread.tsx
@@ -861,11 +861,11 @@ export const ThreadAssistantBubble = memo(function ThreadAssistantBubble({
     (tc) => tc.progress.length > 0,
   );
   return (
-    <div className="flex px-4 py-3">
+    <div className="chat-message-row chat-message-row-assistant flex py-3">
       <div
         data-testid="assistant-message"
         data-thread-id={tid}
-        className="group/assistant message-card message-card-assistant animate-shell-rise max-w-[88%] rounded-[14px] rounded-bl-[4px] px-4 py-3 text-sm leading-relaxed text-text"
+        className="chat-assistant-bubble group/assistant message-card message-card-assistant animate-shell-rise rounded-[14px] rounded-bl-[4px] px-4 py-3 text-sm leading-relaxed text-text"
       >
         {message.text ? (
           <MarkdownContent
@@ -1149,9 +1149,9 @@ function ThreadList({
       data-testid="chat-thread"
       data-thread-renderer="v2"
       ref={viewportRef}
-      className="flex-1 min-h-0 overflow-y-auto overscroll-contain"
+      className="chat-thread-viewport flex-1 min-h-0 overflow-y-auto overscroll-contain"
     >
-      <div className="mx-auto max-w-4xl py-6">
+      <div className="chat-thread-inner mx-auto max-w-4xl py-6">
         {threads.map((thread) => (
           <ThreadView
             key={thread.id}
@@ -1251,7 +1251,7 @@ function ChatThreadV2({
         />
       ) : (
         <div className="flex min-h-0 flex-1 flex-col items-center justify-center px-6">
-          <div className="glass-section animate-shell-rise max-w-xl rounded-[12px] px-7 py-9 text-center">
+          <div className="chat-empty-card glass-section animate-shell-rise max-w-xl rounded-[12px] px-7 py-9 text-center">
             <div className="shell-kicker">Conversation Studio</div>
             <h1 className="mb-3 mt-3 text-3xl font-light tracking-tight text-text-strong">
               What can I help with?
@@ -1347,11 +1347,9 @@ function Composer({ mountGhost, unmountGhost }: ComposerProps) {
   // Recording timer
   useEffect(() => {
     if (recording) {
-      setRecordingTime(0);
       timerRef.current = setInterval(() => setRecordingTime((t) => t + 1), 1000);
     } else {
       if (timerRef.current) clearInterval(timerRef.current);
-      setRecordingTime(0);
     }
     return () => {
       if (timerRef.current) clearInterval(timerRef.current);
@@ -1422,6 +1420,7 @@ function Composer({ mountGhost, unmountGhost }: ComposerProps) {
       };
       recorder.start(1000);
       mediaRecorderRef.current = recorder;
+      setRecordingTime(0);
       setRecording(mode);
     } catch (e) {
       setCmdFeedback(
@@ -1436,6 +1435,7 @@ function Composer({ mountGhost, unmountGhost }: ComposerProps) {
       mediaRecorderRef.current.stop();
     }
     mediaRecorderRef.current = null;
+    setRecordingTime(0);
     setRecording(null);
   }, []);
 
@@ -1463,7 +1463,7 @@ function Composer({ mountGhost, unmountGhost }: ComposerProps) {
       setCmdFeedback(`Camera failed: ${e instanceof Error ? e.message : "permission denied"}`);
       setTimeout(() => setCmdFeedback(null), 4000);
     }
-  }, []);
+  }, [cameraStream]);
 
   useEffect(() => {
     if (cameraStream && cameraPreviewRef.current) {
@@ -1860,7 +1860,7 @@ function Composer({ mountGhost, unmountGhost }: ComposerProps) {
 
   return (
     <div
-      className="px-4 pb-6 pt-2"
+      className="chat-composer-wrap pb-6 pt-2"
       onPaste={handlePaste}
     >
       <div
@@ -1945,7 +1945,7 @@ function Composer({ mountGhost, unmountGhost }: ComposerProps) {
         {pendingFiles.length > 0 && (
           <div className="mb-3 flex flex-wrap items-center gap-2.5">
             {pendingFiles.map((pf, i) => (
-              <div key={i} className="message-attachment-card animate-shell-rise relative group rounded-[10px] p-1.5">
+              <div key={i} className="chat-file-preview message-attachment-card animate-shell-rise relative group rounded-[10px] p-1.5">
                 {pf.preview && pf.file.type.startsWith("image/") ? (
                   <img src={pf.preview} alt={pf.file.name} className="h-16 w-16 rounded-[8px] object-cover" />
                 ) : pf.preview && pf.file.type.startsWith("video/") ? (
@@ -1971,7 +1971,7 @@ function Composer({ mountGhost, unmountGhost }: ComposerProps) {
             ))}
           </div>
         )}
-        <div className="composer-shell animate-shell-rise flex flex-col rounded-[12px] p-2">
+        <div className="chat-composer-frame composer-shell animate-shell-rise flex flex-col rounded-[12px] p-2">
           <input
             ref={fileInputRef}
             type="file"
@@ -1998,7 +1998,7 @@ function Composer({ mountGhost, unmountGhost }: ComposerProps) {
               onCompositionStart={() => { composingRef.current = true; }}
               onCompositionEnd={() => { composingRef.current = false; }}
               rows={1}
-              className="flex-1 resize-none bg-transparent px-3 py-2 text-sm text-text placeholder-muted/60 outline-none"
+              className="chat-composer-input flex-1 resize-none bg-transparent px-3 py-2 text-sm text-text placeholder-muted/60 outline-none"
               autoFocus
             />
             <button
@@ -2008,7 +2008,7 @@ function Composer({ mountGhost, unmountGhost }: ComposerProps) {
               // Issue #112.3: also disable while a send is in flight
               // so a quick second click cannot race the first.
               disabled={(isEmpty && pendingFiles.length === 0) || sending}
-              className={`flex shrink-0 items-center justify-center rounded-[10px] disabled:opacity-30 ${
+              className={`chat-send-button flex shrink-0 items-center justify-center rounded-[10px] disabled:opacity-30 ${
                 pendingFiles.length > 0
                   ? "h-10 gap-1.5 px-4 bg-green-600 text-white hover:bg-green-700"
                   : "h-10 w-10 bg-accent text-white hover:bg-accent-dim"
@@ -2030,14 +2030,14 @@ function Composer({ mountGhost, unmountGhost }: ComposerProps) {
                 data-testid="cancel-button"
                 aria-label="Cancel"
                 onClick={handleCancel}
-                className="flex h-10 w-10 shrink-0 items-center justify-center rounded-[10px] bg-red-600 text-white hover:bg-red-700"
+                className="chat-stop-button flex h-10 w-10 shrink-0 items-center justify-center rounded-[10px] bg-red-600 text-white hover:bg-red-700"
               >
                 <Square size={16} />
               </button>
             )}
           </div>
           {/* Bottom row: media buttons */}
-          <div className="composer-toolbar mt-2 flex items-center gap-0.5 px-1 pt-2">
+          <div className="chat-composer-toolbar composer-toolbar mt-2 flex items-center gap-0.5 px-1 pt-2">
             <button
               data-testid="attach-button"
               aria-label="Attach file"

--- a/src/components/user-bubble-shell.tsx
+++ b/src/components/user-bubble-shell.tsx
@@ -72,14 +72,14 @@ export function UserBubbleShell({
     <div
       data-testid={outerTestId}
       {...spreadDataAttributes(outerDataAttributes)}
-      className="flex justify-end px-4 py-3"
+      className="chat-message-row chat-message-row-user flex justify-end py-3"
     >
-      <div className="flex max-w-[74%] flex-col items-end">
+      <div className="chat-user-bubble-stack flex flex-col items-end">
         {showText && (
           <div
             data-testid={textTestId}
             {...spreadDataAttributes(textDataAttributes)}
-            className="message-card message-card-user rounded-[14px] rounded-br-[4px] px-4 py-2.5 text-sm leading-relaxed text-text"
+            className="chat-user-bubble message-card message-card-user rounded-[14px] rounded-br-[4px] px-4 py-2.5 text-sm leading-relaxed text-text"
           >
             {text}
           </div>

--- a/src/index.css
+++ b/src/index.css
@@ -116,6 +116,8 @@ body {
 .chat-shell {
   position: relative;
   isolation: isolate;
+  background:
+    linear-gradient(180deg, var(--color-surface-dark), var(--color-surface));
 }
 
 .chat-shell::before {
@@ -126,6 +128,72 @@ body {
   pointer-events: none;
   background: transparent;
   opacity: 0.9;
+}
+
+.chat-sidebar-panel,
+.chat-main-panel {
+  border-color: color-mix(in srgb, var(--color-border) 82%, var(--color-accent) 18%);
+  background: color-mix(in srgb, var(--color-surface) 90%, var(--color-surface-container) 10%);
+}
+
+.chat-panel-toolbar {
+  border-color: color-mix(in srgb, var(--color-border) 80%, var(--color-accent) 20%);
+  background: color-mix(in srgb, var(--color-surface-container) 76%, var(--color-surface-elevated) 24%);
+}
+
+.chat-sidebar-footer {
+  background: color-mix(in srgb, var(--color-surface-container) 80%, transparent);
+}
+
+.chat-thread-viewport {
+  scroll-padding-block: 1.5rem;
+}
+
+.chat-thread-inner {
+  width: min(100%, 56rem);
+}
+
+.chat-message-row {
+  padding-inline: clamp(0.75rem, 2vw, 1.5rem);
+}
+
+.chat-user-bubble-stack {
+  max-width: min(42rem, 78%);
+}
+
+.chat-assistant-bubble {
+  max-width: min(46rem, 86%);
+}
+
+.chat-empty-card {
+  border-color: color-mix(in srgb, var(--color-accent) 20%, var(--color-border) 80%);
+  background: color-mix(in srgb, var(--color-surface-container) 72%, transparent);
+}
+
+.chat-composer-wrap {
+  padding-inline: clamp(0.75rem, 2vw, 1.5rem);
+}
+
+.chat-composer-frame {
+  border-color: color-mix(in srgb, var(--color-border) 76%, var(--color-accent) 24%);
+  background: color-mix(in srgb, var(--color-surface-elevated) 86%, var(--color-surface-container) 14%);
+}
+
+.chat-composer-frame:focus-within {
+  border-color: color-mix(in srgb, var(--color-accent) 54%, var(--color-border) 46%);
+}
+
+.chat-composer-input {
+  min-height: 2.5rem;
+  line-height: 1.55;
+}
+
+.chat-composer-toolbar {
+  min-height: 2.35rem;
+}
+
+.chat-file-preview {
+  background: color-mix(in srgb, var(--color-surface-container) 78%, var(--color-surface-elevated) 22%);
 }
 
 .glass-panel,
@@ -600,6 +668,82 @@ body {
 
 [data-theme="light"] .message-card-assistant {
   background: color-mix(in srgb, white 78%, var(--color-surface-container) 22%);
+}
+
+[data-theme="light"] .chat-shell {
+  background:
+    linear-gradient(180deg, var(--color-surface-light), var(--color-surface));
+}
+
+[data-theme="light"] .chat-sidebar-panel,
+[data-theme="light"] .chat-main-panel {
+  background: color-mix(in srgb, var(--color-surface) 82%, white 18%);
+}
+
+[data-theme="light"] .chat-panel-toolbar,
+[data-theme="light"] .chat-composer-frame {
+  background: color-mix(in srgb, white 82%, var(--color-surface-container) 18%);
+}
+
+@media (max-width: 720px) {
+  .chat-shell {
+    height: auto;
+    min-height: 100vh;
+    flex-direction: column;
+    overflow-y: auto;
+  }
+
+  .chat-shell > .panel-resize-handle,
+  .chat-content-region > .panel-resize-handle {
+    display: none;
+  }
+
+  .chat-sidebar-panel {
+    width: 100% !important;
+    min-height: 15rem;
+    max-height: 18rem;
+  }
+
+  .chat-content-region {
+    min-height: 35rem;
+    flex: 1 1 auto;
+    flex-direction: column;
+  }
+
+  .chat-main-panel {
+    min-height: 35rem;
+  }
+
+  .chat-content-region.has-media-panel {
+    min-height: auto;
+  }
+
+  .chat-content-region.has-media-panel .chat-main-panel {
+    flex: 0 0 24rem;
+    min-height: 24rem;
+  }
+
+  .chat-media-panel-wrap {
+    width: 100% !important;
+    min-height: 18rem;
+  }
+
+  .chat-panel-toolbar {
+    padding: 0.9rem 1rem;
+  }
+
+  .chat-message-row {
+    padding-inline: 0.75rem;
+  }
+
+  .chat-user-bubble-stack,
+  .chat-assistant-bubble {
+    max-width: 92%;
+  }
+
+  .chat-composer-wrap {
+    padding: 0.5rem 0.75rem 0.75rem;
+  }
 }
 
 /* ── Scrollbar ──────────────────────────────────────── */

--- a/src/layouts/chat-layout.tsx
+++ b/src/layouts/chat-layout.tsx
@@ -1,7 +1,6 @@
 import { type ReactNode, useState, useEffect, useCallback, useMemo } from "react";
 import { useAuth } from "@/auth/auth-context";
 import { useOctosStatus } from "@/hooks/use-octos-status";
-import { useTheme } from "@/hooks/use-theme";
 import { useResizablePanel } from "@/hooks/use-resizable-panel";
 import { CostBar } from "@/components/cost-bar";
 import { RouterModeSwitcher } from "@/components/router-mode-switcher";
@@ -17,7 +16,11 @@ import {
   useContentViewer,
   ContentViewerOverlay,
 } from "@/components/content-viewer";
-import { LogOut, Sun, Moon, Settings, PanelRight } from "lucide-react";
+import {
+  WorkbenchStatusPill,
+  WorkbenchThemeButton,
+} from "@/components/workbench-shell";
+import { LogOut, Settings, PanelRight } from "lucide-react";
 import { useNavigate } from "react-router-dom";
 import { useFileStore } from "@/store/file-store";
 
@@ -41,7 +44,6 @@ export function ChatLayout({ children }: { children: ReactNode }) {
   const { sessions, currentSessionId, currentSessionTitle, historyTopic, renameSession } =
     useSession();
   const status = useOctosStatus();
-  const { theme, toggleTheme } = useTheme();
   const [mediaPanelOpen, setMediaPanelOpen] = useState(false);
   const sessionFiles = useFileStore(currentSessionId);
   const sessionLabels = useMemo(
@@ -102,27 +104,30 @@ export function ChatLayout({ children }: { children: ReactNode }) {
       {/* Sidebar */}
       <aside
         style={{ width: historyPanelWidth }}
-        className="sidebar-scope glass-panel animate-shell-rise flex shrink-0 flex-col overflow-hidden rounded-lg"
+        className="sidebar-scope chat-sidebar-panel glass-panel animate-shell-rise flex shrink-0 flex-col overflow-hidden rounded-lg"
       >
         {/* Header */}
         <div className="px-3 pt-3">
-          <div className="glass-toolbar px-4 py-4">
+          <div className="chat-panel-toolbar glass-toolbar px-4 py-4">
             <div className="flex items-start gap-3">
               <div className="min-w-0 flex-1">
-                <div className="shell-kicker">Octos Workspace</div>
-                <div className="mt-1 text-xl font-semibold tracking-tight text-text-strong">
+                <div className="flex min-w-0 items-center gap-2.5">
+                  <img
+                    src="/images/octos-logo-color.svg"
+                    alt="Octos"
+                    className="h-6 w-auto shrink-0 select-none"
+                  />
+                  <span className="truncate text-sm font-semibold text-text-strong">
+                    Octos
+                  </span>
+                </div>
+                <div className="shell-kicker mt-4">Session Stack</div>
+                <div className="mt-1 text-lg font-semibold tracking-tight text-text-strong">
                   Chat History
                 </div>
               </div>
               <div className="flex items-center gap-2">
-                <button
-                  onClick={toggleTheme}
-                  className="glass-icon-button p-2.5"
-                  title={theme === "dark" ? "Switch to light mode" : "Switch to dark mode"}
-                  aria-label={theme === "dark" ? "Switch to light mode" : "Switch to dark mode"}
-                >
-                  {theme === "dark" ? <Sun size={16} /> : <Moon size={16} />}
-                </button>
+                <WorkbenchThemeButton />
               </div>
             </div>
           </div>
@@ -133,10 +138,13 @@ export function ChatLayout({ children }: { children: ReactNode }) {
 
         {/* Footer */}
         <div className="px-3 pb-3 pt-2">
-          <div className="glass-section rounded-lg px-4 py-3">
+          <div className="chat-sidebar-footer glass-section rounded-lg px-4 py-3">
             {status && status.model && status.model !== "none" && (
-              <div className="mb-2 text-[11px] text-muted/75">
-                {status.provider !== "none" ? `${status.provider}/` : ""}{status.model}
+              <div className="mb-2">
+                <WorkbenchStatusPill>
+                  {status.provider !== "none" ? `${status.provider}/` : ""}
+                  {status.model}
+                </WorkbenchStatusPill>
               </div>
             )}
             {user && (
@@ -171,11 +179,15 @@ export function ChatLayout({ children }: { children: ReactNode }) {
       />
 
       {/* Main + Media Panel */}
-      <div className="flex flex-1 min-w-0 min-h-0 gap-2">
-        <main className="glass-panel animate-shell-rise flex flex-1 min-w-0 flex-col min-h-0 overflow-hidden rounded-lg">
+      <div
+        className={`chat-content-region flex flex-1 min-w-0 min-h-0 gap-2 ${
+          mediaPanelOpen ? "has-media-panel" : ""
+        }`}
+      >
+        <main className="chat-main-panel glass-panel animate-shell-rise flex flex-1 min-w-0 flex-col min-h-0 overflow-hidden rounded-lg">
           {/* Top bar with title + cost + files toggle */}
           <div className="px-3 pt-3">
-            <div className="glass-toolbar px-4 py-4">
+            <div className="chat-panel-toolbar glass-toolbar px-4 py-4">
               <div className="flex items-start gap-4">
                 <div className="min-w-0 flex-1">
                   <div className="shell-kicker">Current Session</div>
@@ -238,7 +250,7 @@ export function ChatLayout({ children }: { children: ReactNode }) {
             />
             <div
               style={{ width: effectiveWidth }}
-              className="animate-shell-rise shrink-0 overflow-hidden transition-[width,opacity,transform] duration-200 ease-out"
+              className="chat-media-panel-wrap animate-shell-rise shrink-0 overflow-hidden transition-[width,opacity,transform] duration-200 ease-out"
             >
               <ContentBrowser
                 open={mediaPanelOpen}


### PR DESCRIPTION
## Summary
- Restyles the chat workbench shell, sidebar, session toolbar, message rows, empty state, composer, and file preview surfaces to match the shared Workbench UI language.
- Fixes mobile chat layout so the sidebar and main panel stack instead of squeezing horizontally; opening the files panel now keeps it full width and visible without mobile resize handles.
- Cleans up related hook lint issues in the composer recording/camera handlers.

## Validation
- `npx eslint src/layouts/chat-layout.tsx src/components/chat-thread.tsx src/components/user-bubble-shell.tsx`
- `git diff --check`
- `npm run build`
- `npm run test:unit -- --reporter=dot` (54 files / 644 tests passed)
- `BASE_URL=http://127.0.0.1:5173 ./node_modules/.bin/playwright test tests/ui-redesign-smoke.spec.ts` (4 passed)
- Playwright visual QA script for `/chat` desktop/mobile and mobile files panel: overflow 0, no console errors, media-panel resize handles hidden
- `BASE_URL=http://127.0.0.1:5173 ./node_modules/.bin/playwright test` (78 passed / 26 skipped / 0 failed)

Claude Code read-only review reported no blocking findings; follow-up cleanup items from that review were addressed before this PR.
