### PR TITLE
Fix settings profile sync and Metro tile editing

### DIFF
--- a/src/home/metro-tiles.tsx
+++ b/src/home/metro-tiles.tsx
@@ -51,6 +51,7 @@ interface TileDef {
 
 const COLS = 6;
 const MOBILE_COLS = 4;
+const MAX_ROWS = 12;
 const MOBILE_QUERY = "(max-width: 600px)";
 
 const TILE_DEFS: TileDef[] = [
@@ -68,17 +69,102 @@ const TILE_DEFS: TileDef[] = [
 ];
 
 function loadLayouts(): Record<string, TileLayout> {
+  const defaults = defaultLayouts();
   try {
     const raw = localStorage.getItem(LS_LAYOUT_KEY);
-    if (raw) return JSON.parse(raw);
+    if (raw) return normalizeLayouts(JSON.parse(raw), defaults);
   } catch { /* ignore */ }
+  return defaults;
+}
+
+function defaultLayouts(): Record<string, TileLayout> {
   const out: Record<string, TileLayout> = {};
   for (const t of TILE_DEFS) out[t.id] = { ...t.defaultLayout };
   return out;
 }
 
+function normalizeLayouts(
+  raw: unknown,
+  defaults = defaultLayouts(),
+): Record<string, TileLayout> {
+  const record = raw && typeof raw === "object" ? raw as Record<string, Partial<TileLayout>> : {};
+  const numberOr = (value: unknown, fallback: number) =>
+    typeof value === "number" && Number.isFinite(value) ? value : fallback;
+  const out: Record<string, TileLayout> = {};
+  for (const tile of TILE_DEFS) {
+    const saved = record[tile.id] ?? {};
+    out[tile.id] = {
+      col: numberOr(saved.col, defaults[tile.id].col),
+      row: numberOr(saved.row, defaults[tile.id].row),
+      w: numberOr(saved.w, defaults[tile.id].w),
+      h: numberOr(saved.h, defaults[tile.id].h),
+    };
+  }
+  return out;
+}
+
 function saveLayouts(layouts: Record<string, TileLayout>) {
-  localStorage.setItem(LS_LAYOUT_KEY, JSON.stringify(layouts));
+  try {
+    localStorage.setItem(LS_LAYOUT_KEY, JSON.stringify(layouts));
+  } catch { /* quota exceeded or unavailable */ }
+}
+
+function tilesOverlap(a: TileLayout, b: TileLayout): boolean {
+  return !(
+    a.col + a.w <= b.col ||
+    b.col + b.w <= a.col ||
+    a.row + a.h <= b.row ||
+    b.row + b.h <= a.row
+  );
+}
+
+function hasCollision(
+  id: string,
+  candidate: TileLayout,
+  allLayouts: Record<string, TileLayout>,
+  visibleIds: Set<string>,
+  cols: number,
+): boolean {
+  const clamped = clampLayoutForCols(candidate, cols);
+  for (const otherId of visibleIds) {
+    if (otherId === id) continue;
+    const other = allLayouts[otherId];
+    if (!other) continue;
+    if (tilesOverlap(clamped, clampLayoutForCols(other, cols))) return true;
+  }
+  return false;
+}
+
+function compactLayouts(
+  layouts: Record<string, TileLayout>,
+  visibleIds: Set<string>,
+  cols: number,
+): Record<string, TileLayout> {
+  const sorted = [...visibleIds]
+    .map(id => ({ id, layout: clampLayoutForCols(layouts[id] ?? { col: 1, row: 1, w: 1, h: 1 }, cols) }))
+    .sort((a, b) => a.layout.row - b.layout.row || a.layout.col - b.layout.col);
+
+  const result = { ...layouts };
+  for (const { id, layout } of sorted) {
+    let bestRow = 1;
+    for (let tryRow = 1; tryRow <= layout.row; tryRow++) {
+      const candidate = { ...layout, row: tryRow };
+      const occupied = new Set(visibleIds);
+      let fits = true;
+      for (const otherId of occupied) {
+        if (otherId === id) continue;
+        const other = result[otherId];
+        if (!other) continue;
+        if (tilesOverlap(candidate, clampLayoutForCols(other, cols))) {
+          fits = false;
+          break;
+        }
+      }
+      if (fits) { bestRow = tryRow; break; }
+    }
+    result[id] = { ...layout, row: bestRow };
+  }
+  return result;
 }
 
 function getGridMetrics(gridEl: HTMLElement) {
@@ -97,8 +183,10 @@ function getGridMetrics(gridEl: HTMLElement) {
 
 function clampLayoutForCols(layout: TileLayout, cols: number): TileLayout {
   const w = Math.max(1, Math.min(cols, layout.w));
+  const h = Math.max(1, Math.min(MAX_ROWS, layout.h));
   const col = Math.max(1, Math.min(cols - w + 1, layout.col));
-  return { ...layout, col, w };
+  const row = Math.max(1, Math.min(MAX_ROWS - h + 1, layout.row));
+  return { ...layout, col, w, row, h };
 }
 
 function useMetroGridColumns() {
@@ -283,10 +371,16 @@ function useTileDrag(
   layouts: Record<string, TileLayout>,
   setLayouts: (fn: (prev: Record<string, TileLayout>) => Record<string, TileLayout>) => void,
   editMode: boolean,
+  visibleIds: Set<string>,
 ) {
   const layoutsRef = useRef(layouts);
-  layoutsRef.current = layouts;
+  const visibleIdsRef = useRef(visibleIds);
   const dragRef = useRef<{ id: string; startCol: number; startRow: number; startX: number; startY: number; stepX: number; stepY: number; cols: number } | null>(null);
+
+  useEffect(() => {
+    layoutsRef.current = layouts;
+    visibleIdsRef.current = visibleIds;
+  }, [layouts, visibleIds]);
 
   const onPointerDown = useCallback((e: React.PointerEvent, tileId: string, gridEl: HTMLElement | null) => {
     if (!editMode || !gridEl) return;
@@ -305,8 +399,11 @@ function useTileDrag(
     const dx = Math.round((e.clientX - startX) / stepX);
     const dy = Math.round((e.clientY - startY) / stepY);
     const w = Math.min(cols, layoutsRef.current[id]?.w ?? 1);
+    const h = layoutsRef.current[id]?.h ?? 1;
     const newCol = Math.max(1, Math.min(cols - w + 1, startCol + dx));
-    const newRow = Math.max(1, startRow + dy);
+    const newRow = Math.max(1, Math.min(MAX_ROWS - h + 1, startRow + dy));
+    const candidate = { ...layoutsRef.current[id], col: newCol, row: newRow };
+    if (hasCollision(id, candidate, layoutsRef.current, visibleIdsRef.current, cols)) return;
     setLayouts(prev => ({ ...prev, [id]: { ...prev[id], col: newCol, row: newRow } }));
   }, [setLayouts]);
 
@@ -325,9 +422,10 @@ function useTileResize(
   layouts: Record<string, TileLayout>,
   setLayouts: (fn: (prev: Record<string, TileLayout>) => Record<string, TileLayout>) => void,
   editMode: boolean,
+  visibleIds: Set<string>,
 ) {
   const layoutsRef = useRef(layouts);
-  layoutsRef.current = layouts;
+  const visibleIdsRef = useRef(visibleIds);
   const resizeRef = useRef<{
     id: string;
     startW: number;
@@ -337,7 +435,13 @@ function useTileResize(
     stepX: number;
     stepY: number;
     maxW: number;
+    cols: number;
   } | null>(null);
+
+  useEffect(() => {
+    layoutsRef.current = layouts;
+    visibleIdsRef.current = visibleIds;
+  }, [layouts, visibleIds]);
 
   const onResizePointerDown = useCallback((e: React.PointerEvent, tileId: string, gridEl: HTMLElement | null) => {
     if (!editMode || !gridEl) return;
@@ -358,22 +462,27 @@ function useTileResize(
       stepX,
       stepY,
       maxW: cols - layout.col + 1,
+      cols,
     };
     (e.target as HTMLElement).setPointerCapture(e.pointerId);
   }, [editMode]);
 
   const onResizePointerMove = useCallback((e: React.PointerEvent) => {
     if (!resizeRef.current) return;
-    const { id, startW, startH, startX, startY, stepX, stepY, maxW } = resizeRef.current;
+    const { id, startW, startH, startX, startY, stepX, stepY, maxW, cols } = resizeRef.current;
     const dw = Math.round((e.clientX - startX) / stepX);
     const dh = Math.round((e.clientY - startY) / stepY);
+    const row = layoutsRef.current[id]?.row ?? 1;
+    const maxH = MAX_ROWS - row + 1;
     const newW = Math.max(1, Math.min(maxW, startW + dw));
-    const newH = Math.max(1, Math.min(4, startH + dh));
+    const newH = Math.max(1, Math.min(maxH, startH + dh));
     setLayouts(prev => {
       const cur = prev[id];
       if (!cur) return prev;
       if (cur.w === newW && cur.h === newH) return prev;
-      return { ...prev, [id]: { ...cur, w: newW, h: newH } };
+      const candidate = { ...cur, w: newW, h: newH };
+      if (hasCollision(id, candidate, prev, visibleIdsRef.current, cols)) return prev;
+      return { ...prev, [id]: candidate };
     });
   }, [setLayouts]);
 
@@ -384,7 +493,33 @@ function useTileResize(
     }
   }, []);
 
-  return { onResizePointerDown, onResizePointerMove, onResizePointerUp };
+  const onResizeKeyDown = useCallback((e: React.KeyboardEvent, tileId: string, gridEl: HTMLElement | null) => {
+    if (!editMode || !gridEl) return;
+    const delta = { w: 0, h: 0 };
+    if (e.key === "ArrowRight") delta.w = 1;
+    else if (e.key === "ArrowLeft") delta.w = -1;
+    else if (e.key === "ArrowDown") delta.h = 1;
+    else if (e.key === "ArrowUp") delta.h = -1;
+    else return;
+    e.preventDefault();
+    const { cols } = getGridMetrics(gridEl);
+    setLayouts(prev => {
+      const cur = prev[tileId];
+      if (!cur) return prev;
+      const maxW = cols - cur.col + 1;
+      const maxH = MAX_ROWS - cur.row + 1;
+      const newW = Math.max(1, Math.min(maxW, cur.w + delta.w));
+      const newH = Math.max(1, Math.min(maxH, cur.h + delta.h));
+      if (cur.w === newW && cur.h === newH) return prev;
+      const candidate = { ...cur, w: newW, h: newH };
+      if (hasCollision(tileId, candidate, prev, visibleIdsRef.current, cols)) return prev;
+      const next = { ...prev, [tileId]: candidate };
+      saveLayouts(next);
+      return next;
+    });
+  }, [editMode, setLayouts]);
+
+  return { onResizePointerDown, onResizePointerMove, onResizePointerUp, onResizeKeyDown };
 }
 
 /* ─── Main Metro Tile Grid ─── */
@@ -398,21 +533,26 @@ export function MetroTileGrid({ onActivate, nightActive }: MetroTileGridProps) {
   const gridRef = useRef<HTMLDivElement>(null);
   const gridCols = useMetroGridColumns();
 
-  const drag = useTileDrag(layouts, setLayouts, editMode);
-  const resize = useTileResize(layouts, setLayouts, editMode);
-
   const visibleTiles = useMemo(
     () => TILE_DEFS.filter(t => shouldShowTile(t, widgets, nightActive)),
     [widgets, nightActive],
   );
+  const visibleIds = useMemo(() => new Set(visibleTiles.map(t => t.id)), [visibleTiles]);
+
+  const effectiveLayouts = useMemo(
+    () => compactLayouts(layouts, visibleIds, gridCols),
+    [layouts, visibleIds, gridCols],
+  );
+
+  const drag = useTileDrag(effectiveLayouts, setLayouts, editMode, visibleIds);
+  const resize = useTileResize(effectiveLayouts, setLayouts, editMode, visibleIds);
 
   const handleClick = useCallback(() => {
     if (!settingsOpen && !editMode) onActivate();
   }, [onActivate, settingsOpen, editMode]);
 
   const resetLayout = useCallback(() => {
-    const fresh: Record<string, TileLayout> = {};
-    for (const t of TILE_DEFS) fresh[t.id] = { ...t.defaultLayout };
+    const fresh = defaultLayouts();
     setLayouts(fresh);
     saveLayouts(fresh);
   }, []);
@@ -466,7 +606,7 @@ export function MetroTileGrid({ onActivate, nightActive }: MetroTileGridProps) {
       >
         {visibleTiles.map(tile => {
           const layout = clampLayoutForCols(
-            layouts[tile.id] ?? tile.defaultLayout,
+            effectiveLayouts[tile.id] ?? tile.defaultLayout,
             gridCols,
           );
           return (
@@ -490,9 +630,13 @@ export function MetroTileGrid({ onActivate, nightActive }: MetroTileGridProps) {
                     <GripVertical size={14} className="opacity-40" />
                     <span className="metro-tile-edit-label">{tile.label}</span>
                   </div>
-                  <div
+                  <button
+                    type="button"
                     className="metro-resize-handle"
+                    aria-label={`Resize ${tile.label}`}
+                    tabIndex={0}
                     onPointerDown={(e) => resize.onResizePointerDown(e, tile.id, gridRef.current)}
+                    onKeyDown={(e) => resize.onResizeKeyDown(e, tile.id, gridRef.current)}
                   />
                 </>
               )}

--- a/src/index.css
+++ b/src/index.css
@@ -2279,6 +2279,16 @@ button, a, input, textarea {
   cursor: nwse-resize;
   z-index: 10;
   touch-action: none;
+  background: none;
+  border: none;
+  padding: 0;
+  margin: 0;
+  outline: none;
+}
+.metro-resize-handle:focus-visible {
+  outline: 2px solid rgba(212, 149, 106, 0.8);
+  outline-offset: -2px;
+  border-radius: 4px;
 }
 .metro-resize-handle::after {
   content: "";

--- a/src/layouts/chat-layout.test.tsx
+++ b/src/layouts/chat-layout.test.tsx
@@ -2,6 +2,7 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 import * as React from "react";
 import { act } from "react";
 import { createRoot, type Root } from "react-dom/client";
+import { MemoryRouter } from "react-router-dom";
 
 (globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT =
   true;
@@ -116,11 +117,13 @@ function chatLayoutTree(
   sessionId = SESSION_ID,
 ) {
   return (
-    <SessionContext.Provider value={makeSessionCtx(renameSession, title, sessionId)}>
-      <ChatLayout>
-        <div data-testid="chat-body">thread</div>
-      </ChatLayout>
-    </SessionContext.Provider>
+    <MemoryRouter initialEntries={["/chat"]}>
+      <SessionContext.Provider value={makeSessionCtx(renameSession, title, sessionId)}>
+        <ChatLayout>
+          <div data-testid="chat-body">thread</div>
+        </ChatLayout>
+      </SessionContext.Provider>
+    </MemoryRouter>
   );
 }
 

--- a/src/layouts/chat-layout.tsx
+++ b/src/layouts/chat-layout.tsx
@@ -17,6 +17,7 @@ import {
   ContentViewerOverlay,
 } from "@/components/content-viewer";
 import {
+  WorkbenchRouteNav,
   WorkbenchStatusPill,
   WorkbenchThemeButton,
 } from "@/components/workbench-shell";
@@ -121,6 +122,7 @@ export function ChatLayout({ children }: { children: ReactNode }) {
                     Octos
                   </span>
                 </div>
+                <WorkbenchRouteNav compact />
                 <div className="shell-kicker mt-4">Session Stack</div>
                 <div className="mt-1 text-lg font-semibold tracking-tight text-text-strong">
                   Chat History

--- a/src/settings/ominix-tab.tsx
+++ b/src/settings/ominix-tab.tsx
@@ -706,9 +706,7 @@ export function OminixTab() {
                   )
                 }
                 onDisable={(modelId) =>
-                  void performAction(`disable:${modelId}`, () =>
-                    disableOminixModel(modelId),
-                  )
+                  setPending({ kind: "disable-model", modelId })
                 }
                 onDownload={(modelId) =>
                   setPending({ kind: "download-model", modelId })

--- a/src/settings/settings-page.tsx
+++ b/src/settings/settings-page.tsx
@@ -22,6 +22,7 @@ import {
   WorkbenchTopbar,
 } from "@/components/workbench-shell";
 import { getMyProfile, type Profile } from "./settings-api";
+import { setSelectedProfileId as persistSelectedProfile } from "@/api/client";
 import { ProfileTab } from "./profile-tab";
 import { LlmTab } from "./llm-tab";
 import { SkillsTab } from "./skills-tab";
@@ -93,7 +94,11 @@ export function AdminSettingsPage() {
             {accessibleProfiles.length > 1 && (
               <select
                 value={selectedProfileId}
-                onChange={(e) => setSelectedProfileId(e.target.value)}
+                onChange={(e) => {
+                  const id = e.target.value;
+                  setSelectedProfileId(id);
+                  persistSelectedProfile(id);
+                }}
                 className="workbench-input px-3 py-2 text-sm"
               >
                 {accessibleProfiles.map((p) => (

--- a/src/slides/layouts/slides-editor-layout.tsx
+++ b/src/slides/layouts/slides-editor-layout.tsx
@@ -129,7 +129,7 @@ export function SlidesEditorLayout({
   }
 
   return (
-    <div className="chat-shell workbench-shell flex h-screen flex-col gap-2 p-2">
+    <div className="workbench-shell flex h-screen flex-col gap-2 p-2">
       <WorkbenchTopbar
         backTo="/slides"
         icon={Presentation}

--- a/tests/metro-tiles.spec.ts
+++ b/tests/metro-tiles.spec.ts
@@ -2,16 +2,18 @@ import { expect, test } from "@playwright/test";
 import { login } from "./helpers";
 
 test.describe("Metro tiles", () => {
-  test("resizes a tile in edit mode and persists the layout", async ({ page }) => {
+  test.beforeEach(async ({ page }) => {
     await login(page);
     await page.evaluate(() => localStorage.removeItem("octos_home_metro_layout"));
     await page.goto("/home", { waitUntil: "networkidle" });
-
     await expect(page.locator(".metro-grid")).toBeVisible();
+  });
+
+  test("resizes a tile in edit mode and persists the layout", async ({ page }) => {
     await page.getByRole("button", { name: "Edit" }).click();
 
     const handle = page
-      .locator('.metro-tile[data-tile-id="clock"] .metro-resize-handle')
+      .locator('.metro-tile[data-tile-id="timer"] .metro-resize-handle')
       .first();
     await expect(handle).toBeVisible();
 
@@ -21,17 +23,166 @@ test.describe("Metro tiles", () => {
 
     await page.mouse.move(box.x + box.width / 2, box.y + box.height / 2);
     await page.mouse.down();
-    await page.mouse.move(box.x + box.width / 2 + 220, box.y + box.height / 2 + 110, {
+    await page.mouse.move(box.x + box.width / 2, box.y + box.height / 2 + 110, {
       steps: 6,
     });
     await page.mouse.up();
 
-    const savedClock = await page.evaluate(() => {
+    const savedTimer = await page.evaluate(() => {
       const raw = localStorage.getItem("octos_home_metro_layout");
-      return raw ? JSON.parse(raw).clock : null;
+      return raw ? JSON.parse(raw).timer : null;
     });
 
-    expect(savedClock?.w).toBeGreaterThan(4);
-    expect(savedClock?.h).toBeGreaterThan(2);
+    expect(savedTimer?.h).toBeGreaterThan(1);
+  });
+
+  test("resize persists across reload", async ({ page }) => {
+    await page.getByRole("button", { name: "Edit" }).click();
+
+    const handle = page
+      .locator('.metro-tile[data-tile-id="timer"] .metro-resize-handle')
+      .first();
+    await expect(handle).toBeVisible();
+    const box = await handle.boundingBox();
+    if (!box) return;
+
+    await page.mouse.move(box.x + box.width / 2, box.y + box.height / 2);
+    await page.mouse.down();
+    await page.mouse.move(box.x + box.width / 2, box.y + box.height / 2 + 110, {
+      steps: 4,
+    });
+    await page.mouse.up();
+
+    const savedBefore = await page.evaluate(() => {
+      const raw = localStorage.getItem("octos_home_metro_layout");
+      return raw ? JSON.parse(raw).timer : null;
+    });
+    expect(savedBefore).not.toBeNull();
+
+    await page.reload({ waitUntil: "networkidle" });
+    await expect(page.locator(".metro-grid")).toBeVisible();
+
+    const savedAfter = await page.evaluate(() => {
+      const raw = localStorage.getItem("octos_home_metro_layout");
+      return raw ? JSON.parse(raw).timer : null;
+    });
+    expect(savedAfter?.w).toBe(savedBefore?.w);
+    expect(savedAfter?.h).toBe(savedBefore?.h);
+  });
+
+  test("drag does not cause tile overlap", async ({ page }) => {
+    await page.getByRole("button", { name: "Edit" }).click();
+
+    const weatherTile = page.locator('.metro-tile[data-tile-id="weather"]');
+    await expect(weatherTile).toBeVisible();
+    const weatherBox = await weatherTile.boundingBox();
+    if (!weatherBox) return;
+
+    // Try to drag weather tile directly onto clock tile (col 1-4)
+    await page.mouse.move(
+      weatherBox.x + weatherBox.width / 2,
+      weatherBox.y + weatherBox.height / 2,
+    );
+    await page.mouse.down();
+    await page.mouse.move(
+      weatherBox.x - 200,
+      weatherBox.y,
+      { steps: 6 },
+    );
+    await page.mouse.up();
+
+    // Check that no tiles overlap by examining their grid positions
+    const positions = await page.evaluate(() => {
+      const raw = localStorage.getItem("octos_home_metro_layout");
+      return raw ? JSON.parse(raw) : null;
+    });
+
+    if (positions) {
+      const tiles = Object.entries(positions) as [string, { col: number; row: number; w: number; h: number }][];
+      for (let i = 0; i < tiles.length; i++) {
+        for (let j = i + 1; j < tiles.length; j++) {
+          const [, a] = tiles[i];
+          const [, b] = tiles[j];
+          const overlaps = !(
+            a.col + a.w <= b.col ||
+            b.col + b.w <= a.col ||
+            a.row + a.h <= b.row ||
+            b.row + b.h <= a.row
+          );
+          expect(overlaps).toBe(false);
+        }
+      }
+    }
+  });
+
+  test("mobile viewport clamps tiles to 4 columns", async ({ page }) => {
+    await page.setViewportSize({ width: 400, height: 800 });
+    await page.goto("/home", { waitUntil: "networkidle" });
+    await expect(page.locator(".metro-grid")).toBeVisible();
+
+    const gridCols = await page.evaluate(() => {
+      const grid = document.querySelector(".metro-grid");
+      if (!grid) return 0;
+      const style = getComputedStyle(grid);
+      return style.gridTemplateColumns.split(" ").filter(Boolean).length;
+    });
+    expect(gridCols).toBe(4);
+
+    // Check that no tile extends beyond column 4
+    const tilePositions = await page.evaluate(() => {
+      const tiles = document.querySelectorAll(".metro-tile");
+      return Array.from(tiles).map(t => {
+        const style = t.getAttribute("style") || "";
+        const colMatch = style.match(/grid-column:\s*(\d+)\s*\/\s*span\s*(\d+)/);
+        return colMatch ? { col: Number(colMatch[1]), w: Number(colMatch[2]) } : null;
+      }).filter(Boolean);
+    });
+
+    for (const pos of tilePositions) {
+      if (pos) {
+        expect(pos.col + pos.w - 1).toBeLessThanOrEqual(4);
+      }
+    }
+  });
+
+  test("row position is clamped to MAX_ROWS (12)", async ({ page }) => {
+    // Set a layout with a tile at row 20
+    await page.evaluate(() => {
+      const layouts = {
+        clock: { col: 1, row: 20, w: 4, h: 2 },
+        weather: { col: 5, row: 1, w: 2, h: 2 },
+      };
+      localStorage.setItem("octos_home_metro_layout", JSON.stringify(layouts));
+    });
+    await page.goto("/home", { waitUntil: "networkidle" });
+    await expect(page.locator(".metro-grid")).toBeVisible();
+
+    const clockStyle = await page
+      .locator('.metro-tile[data-tile-id="clock"]')
+      .getAttribute("style");
+    const rowMatch = clockStyle?.match(/grid-row:\s*(\d+)/);
+    if (rowMatch) {
+      expect(Number(rowMatch[1])).toBeLessThanOrEqual(12);
+    }
+  });
+
+  test("resize handle is keyboard accessible", async ({ page }) => {
+    await page.getByRole("button", { name: "Edit" }).click();
+
+    const handle = page.locator(
+      '.metro-tile[data-tile-id="timer"] .metro-resize-handle',
+    );
+    await expect(handle).toBeVisible();
+    expect(await handle.getAttribute("role")).toBeNull();
+    expect(await handle.evaluate(el => el.tagName.toLowerCase())).toBe("button");
+    expect(await handle.getAttribute("aria-label")).toContain("Resize");
+    expect(await handle.getAttribute("tabindex")).toBe("0");
+    await handle.press("ArrowDown");
+
+    const savedTimer = await page.evaluate(() => {
+      const raw = localStorage.getItem("octos_home_metro_layout");
+      return raw ? JSON.parse(raw).timer : null;
+    });
+    expect(savedTimer?.h).toBeGreaterThan(1);
   });
 });

--- a/tests/session-delete.spec.ts
+++ b/tests/session-delete.spec.ts
@@ -1,5 +1,5 @@
 import { test, expect } from "@playwright/test";
-import { login, sendAndWait, createNewSession, SEL } from "./helpers";
+import { login, sendAndWait, createNewSession } from "./helpers";
 
 test.describe("Session deletion", () => {
   test("sidebar deletion removes the session across tabs and from the API", async ({
@@ -16,7 +16,7 @@ test.describe("Session deletion", () => {
     await page.waitForTimeout(2000);
 
     // Get the active session ID from the sidebar
-    const activeItem = page.locator("[data-active='true']").first();
+    const activeItem = page.locator("[data-active='true'][data-session-id]").first();
     const sessionId = await activeItem.getAttribute("data-session-id");
     expect(sessionId).toBeTruthy();
 

--- a/tests/session-recovery.spec.ts
+++ b/tests/session-recovery.spec.ts
@@ -1,10 +1,8 @@
-import { test, expect, type Browser, type Page } from "@playwright/test";
+import { test, expect, type Page } from "@playwright/test";
 import {
   login,
   sendAndWait,
   createNewSession,
-  getInput,
-  getSendButton,
   SEL,
   countAssistantBubbles,
   countUserBubbles,
@@ -16,42 +14,6 @@ import {
 async function resetChat(page: Page) {
   await login(page);
   await createNewSession(page);
-}
-
-async function openAuthedChat(browser: Browser) {
-  const context = await browser.newContext();
-  const page = await context.newPage();
-  await resetChat(page);
-  return { context, page };
-}
-
-async function waitForRecoveredTurn(page: Page, timeoutMs = 90_000) {
-  const deadline = Date.now() + timeoutMs;
-
-  while (Date.now() < deadline) {
-    const assistantCount = await page.locator(SEL.assistantMessage).count();
-    const userCount = await page.locator(SEL.userMessage).count();
-    const streaming = await page
-      .locator(SEL.cancelButton)
-      .isVisible({ timeout: 1_000 })
-      .catch(() => false);
-    const text =
-      assistantCount > 0
-        ? ((await page
-            .locator(SEL.assistantMessage)
-            .last()
-            .textContent()
-            .catch(() => "")) || "").trim()
-        : "";
-
-    if (userCount === 1 && assistantCount === 1 && !streaming && text) {
-      return text;
-    }
-
-    await page.waitForTimeout(2_000);
-  }
-
-  return "";
 }
 
 async function waitForAudioRecovery(page: Page, timeoutMs = 180_000) {
@@ -88,7 +50,9 @@ test.describe("Session recovery", () => {
       if (await active.isVisible({ timeout: 5_000 }).catch(() => false)) {
         sessionId = await active.getAttribute("data-session-id");
       }
-    } catch {}
+    } catch {
+      // Session sidebar refresh is best-effort in this recovery smoke.
+    }
     console.log(`  [reload-twice] sessionId: ${sessionId}`);
 
     // Double reload
@@ -106,7 +70,9 @@ test.describe("Session recovery", () => {
         if (await target.isVisible({ timeout: 10_000 }).catch(() => false)) {
           await target.click();
         }
-      } catch {}
+      } catch {
+        // Reload recovery can pass even if the sidebar item is delayed.
+      }
     }
     // Wait for hydration
     for (let i = 0; i < 10; i++) {
@@ -140,7 +106,7 @@ test.describe("Session recovery", () => {
     await page.waitForTimeout(2_000);
 
     const firstSessionId = await page
-      .locator("[data-active='true']")
+      .locator("[data-active='true'][data-session-id]")
       .first()
       .getAttribute("data-session-id");
     expect(firstSessionId).toBeTruthy();

--- a/tests/session-switching.spec.ts
+++ b/tests/session-switching.spec.ts
@@ -6,8 +6,6 @@ import {
   countAssistantBubbles,
   countUserBubbles,
   getSessionItems,
-  switchToSession,
-  SEL,
   getChatThreadText
 } from "./helpers";
 
@@ -83,7 +81,7 @@ test.describe("Session switching", () => {
 
     // Wait for session list to refresh and capture session 1's active element
     await page.waitForTimeout(2000);
-    const s1Element = page.locator("[data-active='true']").first();
+    const s1Element = page.locator("[data-active='true'][data-session-id]").first();
     const s1Id = await s1Element.getAttribute("data-session-id");
     expect(s1Id).toBeTruthy();
 

--- a/tests/settings-tabs.spec.ts
+++ b/tests/settings-tabs.spec.ts
@@ -14,6 +14,17 @@ interface SettingsMockOptions {
   allowedEmailDeleteError?: { status: number; body: unknown };
   operatorTasksError?: { status: number; body: unknown };
   ominixServiceActionErrors?: Partial<Record<"start" | "stop" | "restart", { status: number; body: unknown }>>;
+  accessibleProfiles?: AccessibleProfileMock[];
+}
+
+interface AccessibleProfileMock {
+  id: string;
+  name: string;
+  parent_id: string | null;
+  relationship: string;
+  api_scope: string;
+  route_base: string;
+  can_manage_sub_accounts: boolean;
 }
 
 const mockProfile = {
@@ -76,7 +87,19 @@ async function installAdminSettingsMocks(
   let disableBody: unknown = null;
   let downloadBody: unknown = null;
   let removeLocalBody: unknown = null;
+  const profileHeaders: Array<string | null> = [];
   const serviceActions: string[] = [];
+  const accessibleProfiles = options.accessibleProfiles ?? [
+    {
+      id: "admin",
+      name: "Admin",
+      parent_id: null,
+      relationship: "self_profile",
+      api_scope: "admin",
+      route_base: "/",
+      can_manage_sub_accounts: true,
+    },
+  ];
 
   await page.route("**/api/auth/status", (route) =>
     route.fulfill({
@@ -110,23 +133,14 @@ async function installAdminSettingsMocks(
           can_access_admin_portal: true,
           can_manage_users: true,
           sub_account_limit: 10,
-          accessible_profiles: [
-            {
-              id: "admin",
-              name: "Admin",
-              parent_id: null,
-              relationship: "self_profile",
-              api_scope: "admin",
-              route_base: "/",
-              can_manage_sub_accounts: true,
-            },
-          ],
+          accessible_profiles: accessibleProfiles,
         },
       }),
     }),
   );
 
   await page.route("**/api/my/profile", async (route) => {
+    profileHeaders.push(route.request().headers()["x-profile-id"] ?? null);
     if (route.request().method() === "PUT" && options.profileUpdateError) {
       await route.fulfill({
         status: options.profileUpdateError.status,
@@ -289,6 +303,7 @@ async function installAdminSettingsMocks(
     getDisableBody: () => disableBody,
     getDownloadBody: () => downloadBody,
     getRemoveLocalBody: () => removeLocalBody,
+    getProfileHeaders: () => profileHeaders,
     getServiceActions: () => serviceActions,
   };
 }
@@ -604,7 +619,7 @@ test.describe("Settings page — tab smoke tests", () => {
     await goToSettings(page);
 
     const baseTabs = ["Profile", "LLM", "Skills", "Channels", "Sandbox", "Tools"];
-    const adminTabs = ["Users", "System", "Server"];
+    const adminTabs = ["Users", "System", "Server", "OminiX"];
     const profileLoaded = await hasProfile(page);
 
     for (const label of baseTabs) {
@@ -620,6 +635,44 @@ test.describe("Settings page — tab smoke tests", () => {
         ).toBeVisible({ timeout: TIMEOUT });
       }
     }
+  });
+
+  test("profile switch persists and updates following API requests", async ({ page }) => {
+    const mocks = await installServerSettingsMocks(page, {
+      accessibleProfiles: [
+        {
+          id: "admin",
+          name: "Admin",
+          parent_id: null,
+          relationship: "self_profile",
+          api_scope: "admin",
+          route_base: "/",
+          can_manage_sub_accounts: true,
+        },
+        {
+          id: "ops",
+          name: "Ops",
+          parent_id: "admin",
+          relationship: "sub_account",
+          api_scope: "profile",
+          route_base: "/profiles/ops",
+          can_manage_sub_accounts: false,
+        },
+      ],
+    });
+    await seedAdminSession(page);
+
+    await page.goto("/settings", { waitUntil: "networkidle" });
+    await expect(page.locator(".animate-spin")).toBeHidden({ timeout: TIMEOUT });
+
+    await page.locator("select.workbench-input").selectOption("ops");
+
+    await expect
+      .poll(() => page.evaluate(() => localStorage.getItem("selected_profile")))
+      .toBe("ops");
+    await expect
+      .poll(() => mocks.getProfileHeaders().at(-1))
+      .toBe("ops");
   });
 
   test("Profile tab renders profile info and gateway status", async ({


### PR DESCRIPTION
## Summary
- persist Settings profile switch into the API client so following requests use the selected profile header
- route OminiX disable through the existing confirmation flow and include OminiX in settings tab smoke coverage
- harden Metro tile editing with resize persistence, keyboard-accessible resize handles, row/column clamping, collision checks, and layout normalization
- add shared route navigation to ChatLayout and tighten session e2e selectors to session rows only

## Verification
- npm run build
- npm run test:unit (54 files, 644 tests passed)
- npx eslint on changed files
- BASE_URL=http://127.0.0.1:5174 npx playwright test tests/settings-tabs.spec.ts tests/metro-tiles.spec.ts tests/ui-redesign-smoke.spec.ts --reporter=list (30 passed)
- BASE_URL=http://127.0.0.1:5174 npx playwright test tests/session-delete.spec.ts tests/session-recovery.spec.ts tests/session-switching.spec.ts --reporter=list (7 passed, 1 skipped)
- BASE_URL=http://127.0.0.1:5174 npx playwright test --reporter=list (84 passed, 26 skipped)

## Notes
- No Pinchtab config was found in this repo.
- Repo-wide npm run lint still has pre-existing unrelated lint debt; changed files pass targeted eslint.
- Claude Code was used for audits/initial candidates, but final diff and verification were reviewed locally.
