### PR TITLE
Redesign touch workbench shell

### DIFF
--- a/src/components/home-nav.tsx
+++ b/src/components/home-nav.tsx
@@ -7,12 +7,14 @@ import {
 
 export function HomeNav() {
   return (
-    <nav className="workbench-topbar flex min-h-16 items-center gap-3 px-5 py-3 max-sm:px-3">
-      <WorkbenchBrand />
-      <WorkbenchRouteNav compact />
-      <div className="flex-1" />
-      <WorkbenchThemeButton />
-      <WorkbenchUserActions />
+    <nav className="workbench-topbar shrink-0">
+      <div className="workbench-topbar-inner flex min-h-16 items-center gap-3 px-5 py-3 max-sm:px-3">
+        <WorkbenchBrand />
+        <WorkbenchRouteNav compact />
+        <div className="flex-1" />
+        <WorkbenchThemeButton />
+        <WorkbenchUserActions />
+      </div>
     </nav>
   );
 }

--- a/src/components/workbench-shell.tsx
+++ b/src/components/workbench-shell.tsx
@@ -49,7 +49,7 @@ export function WorkbenchPage({
   className?: string;
 }) {
   return (
-    <div className={`workbench-shell flex h-screen flex-col ${className}`}>
+    <div className={`workbench-shell flex h-screen flex-col overflow-hidden ${className}`}>
       {children}
     </div>
   );
@@ -67,7 +67,7 @@ export function WorkbenchBrand() {
         alt="Octos"
         className="h-7 w-auto shrink-0 select-none"
       />
-      <span className="text-base font-semibold tracking-tight text-text-strong max-sm:hidden">
+      <span className="text-base font-semibold text-text-strong max-sm:hidden">
         Octos
       </span>
     </Link>
@@ -79,7 +79,7 @@ export function WorkbenchRouteNav({ compact = false }: { compact?: boolean }) {
   const location = useLocation();
 
   return (
-    <div className="workbench-route-nav flex min-w-0 items-center gap-1 overflow-x-auto">
+    <div className="workbench-route-nav flex min-w-0 items-center gap-1.5 overflow-x-auto">
       {routeItems
         .filter((item) => !item.adminOnly || portal?.can_access_admin_portal)
         .map(({ to, label, icon: Icon }) => {
@@ -88,7 +88,8 @@ export function WorkbenchRouteNav({ compact = false }: { compact?: boolean }) {
             <Link
               key={to}
               to={to}
-              className="workbench-route-link flex shrink-0 items-center gap-1.5 px-2.5 py-2 text-sm"
+              className="workbench-route-link flex shrink-0 items-center gap-1.5 px-3 py-2 text-sm"
+              aria-current={active ? "page" : undefined}
               data-active={active ? "true" : undefined}
             >
               <Icon size={15} />
@@ -165,12 +166,12 @@ export function WorkbenchTopbar({
   const navigate = useNavigate();
   const backButton = backTo || onBack;
   const titleClass =
-    "truncate text-lg font-semibold tracking-tight text-text-strong";
+    "truncate text-lg font-semibold text-text-strong";
   const titleIsPrimitive = typeof title === "string" || typeof title === "number";
 
   return (
     <nav className="workbench-topbar shrink-0">
-      <div className="workbench-topbar-inner flex min-h-16 items-center gap-3 px-5 py-3 max-sm:px-3">
+      <div className="workbench-topbar-inner flex min-h-16 items-center gap-3 px-5 py-3 max-sm:flex-wrap max-sm:px-3">
         {backButton && (
           <button
             type="button"
@@ -187,7 +188,7 @@ export function WorkbenchTopbar({
             <Icon size={18} />
           </div>
         )}
-        <div className="min-w-0 flex-1">
+        <div className="workbench-topbar-title min-w-0 flex-1">
           {context && <div className="shell-kicker">{context}</div>}
           <div className="flex min-w-0 items-center gap-2">
             {titleIsPrimitive ? (
@@ -205,7 +206,7 @@ export function WorkbenchTopbar({
           {afterTitle}
         </div>
         {actions && (
-          <div className="flex min-w-0 shrink-0 flex-wrap items-center justify-end gap-2">
+          <div className="workbench-topbar-actions flex min-w-0 shrink-0 flex-wrap items-center justify-end gap-2">
             {actions}
           </div>
         )}
@@ -224,7 +225,7 @@ export function WorkbenchSectionHeader({
   action?: ReactNode;
 }) {
   return (
-    <div className="mb-3 flex items-end justify-between gap-3">
+    <div className="workbench-section-header mb-3 flex items-end justify-between gap-3">
       <div className="min-w-0">
         <h2 className="text-sm font-semibold text-text-strong">{title}</h2>
         {description && (
@@ -278,7 +279,7 @@ export function WorkbenchRouteCard({
     <button
       type="button"
       onClick={handleClick}
-      className="workbench-card workbench-route-card flex min-h-28 items-center gap-4 p-5 text-left"
+      className="workbench-card workbench-route-card flex min-h-32 items-center gap-4 p-5 text-left"
     >
       <div className="workbench-icon-tile flex h-11 w-11 shrink-0 items-center justify-center">
         <Icon size={24} />

--- a/src/index.css
+++ b/src/index.css
@@ -4,66 +4,66 @@
 /* ── Dark theme (default) ─ Graphite workbench ── */
 @theme {
   /* Surfaces */
-  --color-surface: #151411;
-  --color-surface-light: #1d1b17;
-  --color-surface-dark: #0b0b0a;
-  --color-surface-container: #211f1a;
-  --color-surface-elevated: #2a261f;
+  --color-surface: #151817;
+  --color-surface-light: #1d2220;
+  --color-surface-dark: #0b0e0d;
+  --color-surface-container: #202522;
+  --color-surface-elevated: #29302c;
 
   /* Accent */
-  --color-accent: #c47445;
-  --color-accent-dim: #9f5a35;
-  --color-accent-container: rgba(196, 116, 69, 0.14);
+  --color-accent: #c57b4d;
+  --color-accent-dim: #9d5d39;
+  --color-accent-container: rgba(197, 123, 77, 0.14);
 
   /* Borders & dividers */
-  --color-border: rgba(244, 236, 220, 0.11);
-  --color-outline: rgba(244, 236, 220, 0.17);
+  --color-border: rgba(231, 238, 230, 0.11);
+  --color-outline: rgba(231, 238, 230, 0.18);
 
   /* Text */
-  --color-muted: #938b7b;
-  --color-text: #ded6c7;
-  --color-text-strong: #fbf6ea;
+  --color-muted: #99a399;
+  --color-text: #dce5dc;
+  --color-text-strong: #f4fbf3;
 
   /* Chat bubbles */
-  --color-user-bubble: rgba(196, 116, 69, 0.13);
-  --color-assistant-bubble: #1b1915;
+  --color-user-bubble: rgba(197, 123, 77, 0.13);
+  --color-assistant-bubble: #1a1e1c;
 
   /* Semantic */
-  --color-link: #5aa49a;
-  --color-heading: #d49a57;
+  --color-link: #52a99d;
+  --color-heading: #d69a58;
   --color-heading-accent: #e2b45f;
   --color-code-inline: #d88b5a;
   --color-code-block-bg: #0f0e0c;
   --color-code-header-bg: #191611;
   --color-code-text: #e4dbc9;
   --color-blockquote-border: #c47445;
-  --color-sidebar: #0f0e0c;
-  --color-highlight: #d4a04c;
+  --color-sidebar: #101412;
+  --color-highlight: #d6a14d;
 }
 
 /* ── Light theme ────────────────────────────────────── */
 [data-theme="light"] {
-  --color-surface: #f4f5f2;
+  --color-surface: #f6f7f4;
   --color-surface-light: #ffffff;
-  --color-surface-dark: #e3e5e0;
-  --color-surface-container: #eceeeb;
-  --color-surface-elevated: #fbfcfa;
+  --color-surface-dark: #e8ebe6;
+  --color-surface-container: #eef1ed;
+  --color-surface-elevated: #fbfdf9;
 
-  --color-accent: #a95f39;
-  --color-accent-dim: #854627;
-  --color-accent-container: rgba(169, 95, 57, 0.10);
+  --color-accent: #a9643f;
+  --color-accent-dim: #844a2f;
+  --color-accent-container: rgba(169, 100, 63, 0.10);
 
   --color-border: rgba(28, 30, 27, 0.12);
   --color-outline: rgba(28, 30, 27, 0.20);
 
-  --color-muted: #656a61;
-  --color-text: #252722;
-  --color-text-strong: #10120f;
+  --color-muted: #626a62;
+  --color-text: #242a25;
+  --color-text-strong: #101511;
 
   --color-user-bubble: rgba(169, 95, 57, 0.09);
   --color-assistant-bubble: #fbfcfa;
 
-  --color-link: #18776f;
+  --color-link: #14786f;
   --color-heading: #8a5738;
   --color-heading-accent: #8f6428;
   --color-code-inline: #a95f39;
@@ -76,6 +76,10 @@
 }
 
 :root {
+  --workbench-touch-target: 2.75rem;
+  --workbench-touch-target-sm: 2.5rem;
+  --workbench-page-gutter: clamp(1rem, 2vw, 1.5rem);
+  --workbench-panel-shadow: 0 18px 42px rgba(0, 0, 0, 0.22);
   --workbench-success-border: rgba(74, 222, 128, 0.28);
   --workbench-success-bg: rgba(74, 222, 128, 0.08);
   --workbench-success-text: #6ee7a0;
@@ -88,6 +92,7 @@
 }
 
 [data-theme="light"] {
+  --workbench-panel-shadow: 0 14px 34px rgba(20, 26, 22, 0.08);
   --workbench-success-border: rgba(22, 101, 52, 0.28);
   --workbench-success-bg: rgba(22, 101, 52, 0.08);
   --workbench-success-text: #166534;
@@ -312,22 +317,29 @@ body {
 
 .workbench-shell {
   min-height: 100vh;
-  background: var(--color-surface-dark);
+  background:
+    linear-gradient(180deg, color-mix(in srgb, var(--color-surface-dark) 92%, var(--color-link) 8%), var(--color-surface-dark));
   color: var(--color-text);
 }
 
 .workbench-topbar {
   border-bottom: 1px solid var(--color-border);
-  background: var(--color-surface);
+  background: color-mix(in srgb, var(--color-surface) 92%, transparent);
+  backdrop-filter: blur(16px);
+  -webkit-backdrop-filter: blur(16px);
+  position: relative;
+  z-index: 20;
 }
 
 .workbench-topbar-inner {
   width: 100%;
+  min-height: 4.5rem;
 }
 
 .workbench-brand {
   border-radius: 8px;
-  padding: 0.25rem 0.4rem;
+  min-height: var(--workbench-touch-target-sm);
+  padding: 0.35rem 0.45rem;
 }
 
 .workbench-brand:hover {
@@ -336,6 +348,8 @@ body {
 
 .workbench-route-nav {
   scrollbar-width: none;
+  min-width: 0;
+  mask-image: linear-gradient(90deg, transparent, #000 0.75rem, #000 calc(100% - 0.75rem), transparent);
 }
 
 .workbench-route-nav::-webkit-scrollbar {
@@ -346,6 +360,8 @@ body {
   border: 1px solid transparent;
   border-radius: 8px;
   color: var(--color-muted);
+  min-height: var(--workbench-touch-target-sm);
+  line-height: 1;
 }
 
 .workbench-route-link:hover {
@@ -358,17 +374,19 @@ body {
   border-color: color-mix(in srgb, var(--color-accent) 42%, var(--color-border) 58%);
   background: color-mix(in srgb, var(--color-accent) 11%, var(--color-surface-container) 89%);
   color: var(--color-accent);
+  box-shadow: inset 0 -2px 0 color-mix(in srgb, var(--color-accent) 72%, transparent);
 }
 
 .workbench-rail {
   border-right: 1px solid var(--color-border);
-  background: var(--color-surface);
+  background: color-mix(in srgb, var(--color-surface) 88%, var(--color-surface-container) 12%);
 }
 
 .workbench-panel {
   border: 1px solid var(--color-border);
   border-radius: 8px;
   background: var(--color-surface);
+  box-shadow: var(--workbench-panel-shadow);
 }
 
 .workbench-panel-muted {
@@ -381,6 +399,7 @@ body {
   border: 1px solid var(--color-border);
   border-radius: 8px;
   background: var(--color-surface);
+  box-shadow: 0 8px 24px rgba(0, 0, 0, 0.12);
   transition:
     background-color 0.16s ease,
     border-color 0.16s ease,
@@ -390,6 +409,7 @@ body {
 .workbench-card:hover {
   border-color: color-mix(in srgb, var(--color-accent) 34%, var(--color-border) 66%);
   background: var(--color-surface-container);
+  transform: translateY(-1px);
 }
 
 .workbench-route-card {
@@ -411,6 +431,7 @@ body {
   border-radius: 8px;
   background: var(--color-surface-container);
   color: var(--color-text);
+  min-height: var(--workbench-touch-target-sm);
   transition:
     background-color 0.16s ease,
     border-color 0.16s ease,
@@ -421,6 +442,12 @@ body {
   border-color: color-mix(in srgb, var(--color-accent) 34%, var(--color-border) 66%);
   background: var(--color-surface-elevated);
   color: var(--color-text-strong);
+}
+
+.workbench-button[data-active="true"] {
+  border-color: color-mix(in srgb, var(--color-accent) 46%, var(--color-border) 54%);
+  background: color-mix(in srgb, var(--color-accent) 12%, var(--color-surface-container) 88%);
+  color: var(--color-accent);
 }
 
 .workbench-button-primary {
@@ -440,6 +467,8 @@ body {
   border-radius: 8px;
   background: color-mix(in srgb, var(--color-accent) 10%, var(--color-surface-container) 90%);
   color: var(--color-accent);
+  min-height: var(--workbench-touch-target-sm);
+  min-width: var(--workbench-touch-target-sm);
 }
 
 .workbench-badge {
@@ -463,7 +492,8 @@ body {
   padding: 0.25rem 0.55rem;
   font-size: 0.6875rem;
   font-weight: 650;
-  line-height: 1;
+  line-height: 1.15;
+  min-height: 1.65rem;
 }
 
 .workbench-status-pill[data-tone="accent"] {
@@ -495,11 +525,83 @@ body {
   border-radius: 8px;
   background: var(--color-surface-container);
   color: var(--color-text);
+  min-height: var(--workbench-touch-target-sm);
 }
 
 .workbench-input:focus {
   border-color: color-mix(in srgb, var(--color-accent) 48%, var(--color-border) 52%);
   outline: none;
+}
+
+.workbench-topbar-actions .glass-icon-button,
+.glass-icon-button {
+  min-height: var(--workbench-touch-target-sm);
+  min-width: var(--workbench-touch-target-sm);
+}
+
+.settings-rail {
+  box-shadow: inset -1px 0 0 color-mix(in srgb, var(--color-text-strong) 3%, transparent);
+}
+
+.settings-tab-strip {
+  scrollbar-width: none;
+}
+
+.settings-tab-strip::-webkit-scrollbar {
+  display: none;
+}
+
+.settings-tab-button {
+  min-height: var(--workbench-touch-target);
+  border-color: transparent;
+  background: transparent;
+  color: var(--color-muted);
+}
+
+.settings-tab-button:hover {
+  border-color: color-mix(in srgb, var(--color-border) 74%, var(--color-accent) 26%);
+  background: color-mix(in srgb, var(--color-surface-container) 72%, transparent);
+  color: var(--color-text-strong);
+}
+
+.settings-tab-button[data-active="true"] {
+  border-color: color-mix(in srgb, var(--color-accent) 46%, var(--color-border) 54%);
+  background: color-mix(in srgb, var(--color-accent) 12%, var(--color-surface-container) 88%);
+  color: var(--color-accent);
+  box-shadow: inset 3px 0 0 var(--color-accent);
+}
+
+@media (max-width: 768px) {
+  .workbench-topbar-inner {
+    min-height: 4rem;
+    align-items: center;
+  }
+
+  .workbench-topbar-title {
+    min-width: 10rem;
+  }
+
+  .workbench-topbar-actions:has(.workbench-topbar-search) {
+    flex-basis: 100%;
+    width: 100%;
+    justify-content: stretch;
+  }
+
+  .workbench-topbar-search {
+    width: 100%;
+  }
+
+  .workbench-route-link,
+  .settings-tab-button,
+  .glass-icon-button,
+  .workbench-button,
+  .workbench-input {
+    min-height: var(--workbench-touch-target);
+  }
+
+  .settings-tab-button[data-active="true"] {
+    box-shadow: inset 0 -3px 0 var(--color-accent);
+  }
 }
 
 .message-card {

--- a/src/pages/home-page.tsx
+++ b/src/pages/home-page.tsx
@@ -1,11 +1,15 @@
 import { useNavigate } from "react-router-dom";
+import { useState, type ReactNode } from "react";
 import { HomeNav } from "@/components/home-nav";
 import {
+  Activity,
+  ArrowRight,
   Globe,
   MessageSquare,
   Mic,
   MonitorSmartphone,
   Presentation,
+  Settings,
 } from "lucide-react";
 import { unlockAudio } from "@/home/voice/audio-playback";
 import {
@@ -15,78 +19,158 @@ import {
   WorkbenchStatusPill,
 } from "@/components/workbench-shell";
 
+function readStoredCount(key: string): number {
+  try {
+    const raw = localStorage.getItem(key);
+    const parsed = raw ? JSON.parse(raw) : [];
+    return Array.isArray(parsed) ? parsed.length : 0;
+  } catch {
+    return 0;
+  }
+}
+
+function useLocalProjectCounts() {
+  const [counts] = useState(() => ({
+    slides: readStoredCount("octos-slides-projects"),
+    sites: readStoredCount("octos-sites-projects"),
+  }));
+
+  return counts;
+}
+
+function QuickAction({
+  children,
+  onClick,
+}: {
+  children: ReactNode;
+  onClick: () => void;
+}) {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      className="workbench-button flex items-center justify-between gap-3 px-4 text-left text-sm font-semibold"
+    >
+      <span>{children}</span>
+      <ArrowRight size={16} aria-hidden="true" />
+    </button>
+  );
+}
+
 export function HomePage() {
   const navigate = useNavigate();
+  const counts = useLocalProjectCounts();
 
   return (
     <WorkbenchPage>
       <HomeNav />
 
       <div className="flex-1 overflow-y-auto">
-        <div className="mx-auto flex w-full max-w-6xl flex-col gap-8 px-6 py-8 max-sm:px-3">
-          <header className="flex flex-wrap items-end justify-between gap-4 border-b border-border pb-5">
-            <div>
-              <p className="text-xs font-semibold uppercase text-muted">Command Center</p>
-              <h1 className="mt-2 text-2xl font-semibold tracking-tight text-text-strong">
+        <div className="mx-auto flex w-full max-w-7xl flex-col gap-7 px-6 py-7 max-sm:px-3">
+          <header className="grid gap-5 border-b border-border pb-6 lg:grid-cols-[minmax(0,1fr)_22rem]">
+            <div className="min-w-0">
+              <div className="flex flex-wrap items-center gap-2">
+                <p className="shell-kicker">Command Center</p>
+                <WorkbenchStatusPill tone="accent">Local workbench</WorkbenchStatusPill>
+              </div>
+              <h1 className="mt-3 text-3xl font-semibold text-text-strong max-sm:text-2xl">
                 Octos Workspace
               </h1>
-              <p className="mt-2 max-w-2xl text-sm leading-6 text-muted">
-                Chat, generate decks, scaffold sites, and operate local voice
-                workflows from one compact control surface.
+              <p className="mt-3 max-w-2xl text-sm leading-6 text-muted">
+                Jump back into active sessions, creative workspaces, and local
+                runtime controls from one dense surface.
               </p>
+              <div className="mt-5 grid max-w-2xl grid-cols-1 gap-2 sm:grid-cols-3">
+                <QuickAction onClick={() => navigate("/chat")}>Start chat</QuickAction>
+                <QuickAction onClick={() => navigate("/slides")}>Create deck</QuickAction>
+                <QuickAction onClick={() => navigate("/sites")}>Create site</QuickAction>
+              </div>
             </div>
-            <WorkbenchStatusPill tone="accent">AI workbench</WorkbenchStatusPill>
+            <div className="grid grid-cols-2 gap-3">
+              <div className="workbench-card p-4">
+                <Activity size={18} className="text-link" />
+                <div className="mt-3 text-2xl font-semibold text-text-strong">Ready</div>
+                <div className="mt-1 text-xs text-muted">Workbench shell</div>
+              </div>
+              <div className="workbench-card p-4">
+                <Presentation size={18} className="text-accent" />
+                <div className="mt-3 text-2xl font-semibold text-text-strong">{counts.slides}</div>
+                <div className="mt-1 text-xs text-muted">Local decks</div>
+              </div>
+              <div className="workbench-card p-4">
+                <Globe size={18} className="text-link" />
+                <div className="mt-3 text-2xl font-semibold text-text-strong">{counts.sites}</div>
+                <div className="mt-1 text-xs text-muted">Local sites</div>
+              </div>
+              <div className="workbench-card p-4">
+                <MonitorSmartphone size={18} className="text-accent" />
+                <div className="mt-3 text-2xl font-semibold text-text-strong">Touch</div>
+                <div className="mt-1 text-xs text-muted">Display mode</div>
+              </div>
+            </div>
           </header>
 
           <section>
             <WorkbenchSectionHeader
-              title="Workspaces"
-              description="Primary production surfaces"
+              title="Production Surfaces"
+              description="Work areas with persistent outputs"
             />
             <div className="grid grid-cols-1 gap-3 md:grid-cols-3">
               <WorkbenchRouteCard
                 icon={MessageSquare}
-                title="Start chat"
-                description="Session workspace"
+                title="Chat"
+                description="Session stack and task output"
                 to="/chat"
+                meta="Conversation runtime"
               />
               <WorkbenchRouteCard
                 icon={Presentation}
                 title="Slides"
-                description="Deck workspace"
+                description="Deck generation and preview"
                 to="/slides"
+                meta={`${counts.slides} local deck${counts.slides === 1 ? "" : "s"}`}
               />
               <WorkbenchRouteCard
                 icon={Globe}
                 title="Sites"
-                description="Site workspace"
+                description="Site scaffold and file output"
                 to="/sites"
+                meta={`${counts.sites} local site${counts.sites === 1 ? "" : "s"}`}
               />
             </div>
           </section>
 
           <section>
             <WorkbenchSectionHeader
-              title="Utilities"
-              description="Ambient display and hands-free voice"
+              title="Runtime Controls"
+              description="Touch display, voice, and administrative surfaces"
             />
-            <div className="grid grid-cols-1 gap-3 md:grid-cols-2">
+            <div className="grid grid-cols-1 gap-3 md:grid-cols-3">
               <WorkbenchRouteCard
                 icon={MonitorSmartphone}
-                title="Home Assistant"
-                description="Ambient display"
+                title="Display"
+                description="Ambient touch console"
                 to="/home"
+                meta="Metro grid"
               />
               <WorkbenchRouteCard
                 icon={Mic}
                 title="Voice"
-                description="Hands-free session"
+                description="Hands-free session control"
                 onClick={() => {
                   // Unlock the Web Audio context inside this click gesture so
                   // the voice reply can play after the async response arrives.
                   unlockAudio();
                   navigate("/voice");
                 }}
+                meta="Audio runtime"
+              />
+              <WorkbenchRouteCard
+                icon={Settings}
+                title="Settings"
+                description="Profiles, models, and local services"
+                to="/settings"
+                meta="Admin control"
               />
             </div>
           </section>

--- a/src/settings/settings-page.tsx
+++ b/src/settings/settings-page.tsx
@@ -119,19 +119,16 @@ export function AdminSettingsPage() {
         </div>
       ) : (
         <div className="flex min-h-0 flex-1 overflow-hidden max-md:flex-col">
-          <aside className="workbench-rail w-60 shrink-0 overflow-y-auto px-3 py-4 max-md:w-full max-md:overflow-x-auto max-md:overflow-y-hidden max-md:border-b max-md:border-r-0 max-md:py-2">
-            <div className="space-y-1 max-md:flex max-md:min-w-max max-md:gap-2 max-md:space-y-0">
+          <aside className="workbench-rail settings-rail w-60 shrink-0 overflow-y-auto px-3 py-4 max-md:w-full max-md:overflow-x-auto max-md:overflow-y-hidden max-md:border-b max-md:border-r-0 max-md:py-2">
+            <div className="settings-tab-strip space-y-1 max-md:flex max-md:min-w-max max-md:gap-2 max-md:space-y-0">
               {TABS.filter(
                 (t) => !t.adminOnly || portal?.can_access_admin_portal,
               ).map(({ id, label, icon: Icon, adminOnly }) => (
                 <button
                   key={id}
                   onClick={() => setActiveTab(id)}
-                  className={`flex w-full items-center gap-3 rounded-lg border px-4 py-3 text-left text-sm font-medium transition max-md:w-auto max-md:shrink-0 max-md:px-3 ${
-                    activeTab === id
-                      ? "border-accent/40 bg-accent/10 text-accent"
-                      : "border-transparent text-muted hover:bg-surface-container hover:text-text-strong"
-                  }`}
+                  data-active={activeTab === id ? "true" : undefined}
+                  className="settings-tab-button flex w-full items-center gap-3 rounded-lg border px-4 py-3 text-left text-sm font-medium transition max-md:w-auto max-md:shrink-0 max-md:px-3"
                 >
                   <Icon size={16} />
                   {label}

--- a/src/sites/pages/sites-gallery-page.tsx
+++ b/src/sites/pages/sites-gallery-page.tsx
@@ -1,4 +1,13 @@
-import { Globe, Plus } from "lucide-react";
+import { useMemo, useState } from "react";
+import {
+  Clock3,
+  FileCode2,
+  Globe,
+  LayoutTemplate,
+  Plus,
+  Search,
+  type LucideIcon,
+} from "lucide-react";
 import { Link, useNavigate } from "react-router-dom";
 
 import { SITE_PRESETS, type SitePreset } from "../types";
@@ -10,9 +19,77 @@ import {
   WorkbenchTopbar,
 } from "@/components/workbench-shell";
 
+function formatShortDate(value: number): string {
+  return new Date(value).toLocaleDateString(undefined, {
+    month: "short",
+    day: "numeric",
+  });
+}
+
+function SiteStat({
+  icon: Icon,
+  label,
+  value,
+  tone = "default",
+}: {
+  icon: LucideIcon;
+  label: string;
+  value: string | number;
+  tone?: "default" | "accent" | "link";
+}) {
+  const color =
+    tone === "accent" ? "text-accent" : tone === "link" ? "text-link" : "text-muted";
+  return (
+    <div className="rounded-lg border border-border bg-surface-container/70 p-4">
+      <Icon size={17} className={color} aria-hidden="true" />
+      <div className="mt-3 text-2xl font-semibold text-text-strong">{value}</div>
+      <div className="mt-1 text-xs text-muted">{label}</div>
+    </div>
+  );
+}
+
 export function SitesGalleryPage() {
   const { projects, create } = useSiteProjects();
   const navigate = useNavigate();
+  const [search, setSearch] = useState("");
+  const [kindFilter, setKindFilter] = useState<"all" | string>("all");
+
+  const presetEntries = useMemo(
+    () =>
+      Object.entries(SITE_PRESETS) as Array<
+        [SitePreset, (typeof SITE_PRESETS)[SitePreset]]
+      >,
+    [],
+  );
+
+  const siteKinds = useMemo(
+    () => Array.from(new Set(presetEntries.map(([, definition]) => definition.siteKind))),
+    [presetEntries],
+  );
+
+  const filteredProjects = useMemo(() => {
+    const q = search.trim().toLowerCase();
+    return projects.filter((project) => {
+      const matchesQuery =
+        !q ||
+        project.title.toLowerCase().includes(q) ||
+        project.template.toLowerCase().includes(q) ||
+        project.siteKind.toLowerCase().includes(q) ||
+        project.slug.toLowerCase().includes(q);
+      const matchesKind = kindFilter === "all" || project.siteKind === kindFilter;
+      return matchesQuery && matchesKind;
+    });
+  }, [projects, search, kindFilter]);
+
+  const summary = useMemo(() => {
+    const scaffolded = projects.filter((project) => project.scaffolded).length;
+    const latest = projects[0]?.updatedAt;
+    return {
+      scaffolded,
+      presetCount: presetEntries.length,
+      latestLabel: latest ? formatShortDate(latest) : "No sites",
+    };
+  }, [projects, presetEntries.length]);
 
   function handleCreate(preset: SitePreset) {
     const project = create(preset);
@@ -32,67 +109,177 @@ export function SitesGalleryPage() {
             {projects.length} project{projects.length !== 1 ? "s" : ""}
           </WorkbenchStatusPill>
         }
+        actions={
+          <div className="workbench-topbar-search relative min-w-0 max-sm:w-full">
+            <Search
+              size={14}
+              className="absolute left-3 top-1/2 -translate-y-1/2 text-muted"
+            />
+            <input
+              value={search}
+              onChange={(e) => setSearch(e.target.value)}
+              placeholder="Search sites..."
+              className="workbench-input w-64 py-1.5 pl-9 pr-3 text-sm placeholder-muted max-sm:w-full"
+            />
+          </div>
+        }
       />
 
-      <div className="mx-auto max-w-6xl px-6 py-8 max-sm:px-3">
-        <WorkbenchSectionHeader
-          title="Create"
-          description="Preset scaffolds"
-        />
-        <div className="grid gap-4 md:grid-cols-2 xl:grid-cols-4">
-          {(Object.entries(SITE_PRESETS) as Array<[SitePreset, (typeof SITE_PRESETS)[SitePreset]]>).map(
-            ([preset, definition]) => (
-              <button
-                key={preset}
-                onClick={() => handleCreate(preset)}
-                className="workbench-card min-h-44 p-5 text-left"
-              >
-                <div className="flex items-center justify-between">
-                  <WorkbenchStatusPill tone="accent">
-                    {definition.label}
-                  </WorkbenchStatusPill>
-                  <Plus size={16} className="text-muted" />
+      <main className="flex-1 overflow-y-auto">
+        <div className="mx-auto flex w-full max-w-7xl flex-col gap-5 px-6 py-6 max-sm:px-3">
+          <section className="grid gap-4 lg:grid-cols-[minmax(0,1.35fr)_minmax(18rem,0.65fr)]">
+            <div className="workbench-panel p-5">
+              <div className="flex flex-wrap items-start justify-between gap-4">
+                <div className="min-w-0">
+                  <p className="shell-kicker">Site Production</p>
+                  <h2 className="mt-2 text-xl font-semibold text-text-strong">
+                    Scaffold, preview, and return to local web projects.
+                  </h2>
+                  <p className="mt-2 max-w-2xl text-sm leading-6 text-muted">
+                    Presets map to concrete templates; recent sessions keep their
+                    slug, site kind, and scaffold state visible.
+                  </p>
                 </div>
-                <h3 className="mt-4 text-xl font-semibold text-text-strong">
-                  {definition.title}
-                </h3>
-                <p className="mt-3 text-sm leading-6 text-muted">
-                  {definition.description}
-                </p>
-                <div className="mt-4 text-[11px] font-semibold uppercase text-muted/70">
-                  {definition.template}
-                </div>
-              </button>
-            ),
-          )}
-        </div>
+                <WorkbenchStatusPill tone="accent">
+                  {filteredProjects.length} visible
+                </WorkbenchStatusPill>
+              </div>
+              <div className="mt-5 grid grid-cols-2 gap-3 md:grid-cols-4">
+                <SiteStat
+                  icon={Globe}
+                  label="Projects"
+                  value={projects.length}
+                  tone="accent"
+                />
+                <SiteStat
+                  icon={FileCode2}
+                  label="Scaffolded"
+                  value={summary.scaffolded}
+                />
+                <SiteStat
+                  icon={LayoutTemplate}
+                  label="Presets"
+                  value={summary.presetCount}
+                  tone="link"
+                />
+                <SiteStat
+                  icon={Clock3}
+                  label="Latest update"
+                  value={summary.latestLabel}
+                />
+              </div>
+            </div>
 
-        {projects.length > 0 && (
-          <div className="mt-10">
+            <div className="workbench-panel-muted p-5">
+              <p className="shell-kicker">Preset Router</p>
+              <h2 className="mt-2 text-lg font-semibold text-text-strong">
+                Choose the output shape before generation.
+              </h2>
+              <p className="mt-2 text-sm leading-6 text-muted">
+                Course, docs, product app, and tool presets keep the site editor
+                grounded in the right file structure.
+              </p>
+              <div className="mt-5 flex flex-wrap gap-2">
+                {["all", ...siteKinds].map((kind) => (
+                  <button
+                    key={kind}
+                    type="button"
+                    onClick={() => setKindFilter(kind)}
+                    data-active={kindFilter === kind ? "true" : undefined}
+                    className="workbench-button px-3 text-xs font-medium capitalize"
+                  >
+                    {kind}
+                  </button>
+                ))}
+              </div>
+            </div>
+          </section>
+
+          <section>
+            <WorkbenchSectionHeader
+              title="Create"
+              description="Preset scaffolds"
+            />
+            <div className="grid gap-4 md:grid-cols-2 xl:grid-cols-4">
+              {presetEntries.map(([preset, definition]) => (
+                <button
+                  key={preset}
+                  type="button"
+                  onClick={() => handleCreate(preset)}
+                  className="workbench-card flex min-h-56 flex-col p-5 text-left"
+                >
+                  <div className="flex items-center justify-between gap-3">
+                    <WorkbenchStatusPill tone="accent">
+                      {definition.label}
+                    </WorkbenchStatusPill>
+                    <div className="workbench-icon-tile flex h-10 w-10 items-center justify-center">
+                      <Plus size={16} aria-hidden="true" />
+                    </div>
+                  </div>
+                  <h3 className="mt-5 text-xl font-semibold text-text-strong">
+                    {definition.title}
+                  </h3>
+                  <p className="mt-3 text-sm leading-6 text-muted">
+                    {definition.description}
+                  </p>
+                  <div className="mt-auto flex flex-wrap items-center gap-2 pt-5 text-[11px] font-semibold uppercase text-muted/70">
+                    <span>{definition.template}</span>
+                    <span className="h-1 w-1 rounded-full bg-muted/40" />
+                    <span>{definition.siteKind}</span>
+                  </div>
+                </button>
+              ))}
+            </div>
+          </section>
+
+          <section>
             <WorkbenchSectionHeader
               title="Recent Sessions"
               description="Scaffolded site workspaces"
             />
-            <div className="grid gap-3 md:grid-cols-2 xl:grid-cols-3">
-              {projects.map((project) => (
-                <Link
-                  key={project.id}
-                  to={`/sites/${project.id}`}
-                  className="workbench-card p-4"
-                >
-                  <div className="text-sm font-medium text-text-strong">{project.title}</div>
-                  <div className="mt-1 text-xs text-muted">
-                    {project.template} / {project.siteKind}
-                  </div>
-                  <div className="mt-3 text-[11px] text-muted/70">
-                    Updated {new Date(project.updatedAt).toLocaleString()}
-                  </div>
-                </Link>
-              ))}
-            </div>
-          </div>
-        )}
-      </div>
+            {filteredProjects.length === 0 ? (
+              <div className="workbench-panel-muted py-16 text-center text-muted">
+                <Globe size={42} className="mx-auto mb-4 opacity-30" />
+                <p className="text-sm">
+                  {search || kindFilter !== "all"
+                    ? "No sites match the current filters."
+                    : "No site projects yet. Pick a preset to create one."}
+                </p>
+              </div>
+            ) : (
+              <div className="grid gap-3 md:grid-cols-2 xl:grid-cols-3">
+                {filteredProjects.map((project) => (
+                  <Link
+                    key={project.id}
+                    to={`/sites/${project.id}`}
+                    className="workbench-card p-4"
+                  >
+                    <div className="flex items-start justify-between gap-3">
+                      <div className="min-w-0">
+                        <div className="truncate text-base font-semibold text-text-strong">
+                          {project.title}
+                        </div>
+                        <div className="mt-1 text-xs text-muted">
+                          {project.template} / {project.siteKind}
+                        </div>
+                      </div>
+                      <WorkbenchStatusPill tone={project.scaffolded ? "success" : "default"}>
+                        {project.scaffolded ? "Ready" : "Draft"}
+                      </WorkbenchStatusPill>
+                    </div>
+                    <div className="mt-4 rounded-md border border-border bg-surface-dark px-3 py-2 font-mono text-xs text-muted">
+                      /{project.slug}
+                    </div>
+                    <div className="mt-3 text-[11px] text-muted/70">
+                      Updated {formatShortDate(project.updatedAt)}
+                    </div>
+                  </Link>
+                ))}
+              </div>
+            )}
+          </section>
+        </div>
+      </main>
     </WorkbenchPage>
   );
 }

--- a/src/slides/pages/slides-gallery-page.tsx
+++ b/src/slides/pages/slides-gallery-page.tsx
@@ -1,6 +1,14 @@
 import { useState, useMemo } from "react";
 import { Link, useNavigate } from "react-router-dom";
-import { Presentation, Plus, Search } from "lucide-react";
+import {
+  Clock3,
+  Layers3,
+  Presentation,
+  Plus,
+  Search,
+  Sparkles,
+  type LucideIcon,
+} from "lucide-react";
 
 import { AuthenticatedFileImage } from "../components/authenticated-file-image";
 import { useSlidesProjects, searchSlidesProjects } from "../store";
@@ -11,6 +19,35 @@ import {
   WorkbenchStatusPill,
   WorkbenchTopbar,
 } from "@/components/workbench-shell";
+
+function formatShortDate(value: number): string {
+  return new Date(value).toLocaleDateString(undefined, {
+    month: "short",
+    day: "numeric",
+  });
+}
+
+function DeckStat({
+  icon: Icon,
+  label,
+  value,
+  tone = "default",
+}: {
+  icon: LucideIcon;
+  label: string;
+  value: string | number;
+  tone?: "default" | "accent" | "link";
+}) {
+  const color =
+    tone === "accent" ? "text-accent" : tone === "link" ? "text-link" : "text-muted";
+  return (
+    <div className="rounded-lg border border-border bg-surface-container/70 p-4">
+      <Icon size={17} className={color} aria-hidden="true" />
+      <div className="mt-3 text-2xl font-semibold text-text-strong">{value}</div>
+      <div className="mt-1 text-xs text-muted">{label}</div>
+    </div>
+  );
+}
 
 export function SlidesGalleryPage() {
   const { projects, create } = useSlidesProjects();
@@ -30,6 +67,19 @@ export function SlidesGalleryPage() {
     }
     return results;
   }, [projects, search, filter, recentCutoff]);
+
+  const summary = useMemo(() => {
+    const totalSlides = projects.reduce((sum, project) => sum + project.slides.length, 0);
+    const recentCount = projects.filter((project) => project.updatedAt > recentCutoff).length;
+    const templateCount = new Set(projects.map((project) => project.template)).size;
+    const latest = projects[0]?.updatedAt;
+    return {
+      totalSlides,
+      recentCount,
+      templateCount,
+      latestLabel: latest ? formatShortDate(latest) : "No decks",
+    };
+  }, [projects, recentCutoff]);
 
   const handleNew = () => {
     const project = create("Untitled Deck");
@@ -66,7 +116,7 @@ export function SlidesGalleryPage() {
         }
         actions={
           <>
-            <div className="relative min-w-0 max-sm:w-full">
+            <div className="workbench-topbar-search relative min-w-0 max-sm:w-full">
               <Search
                 size={14}
                 className="absolute left-3 top-1/2 -translate-y-1/2 text-muted"
@@ -95,9 +145,82 @@ export function SlidesGalleryPage() {
         }
       />
 
-      {/* Filter bar */}
-      <div className="mx-auto max-w-6xl px-6 py-3 max-sm:px-3">
-        <div className="flex flex-wrap gap-2">
+      <main className="flex-1 overflow-y-auto">
+        <div className="mx-auto flex w-full max-w-7xl flex-col gap-5 px-6 py-6 max-sm:px-3">
+          <section className="grid gap-4 lg:grid-cols-[minmax(0,1.35fr)_minmax(18rem,0.65fr)]">
+            <div className="workbench-panel p-5">
+              <div className="flex flex-wrap items-start justify-between gap-4">
+                <div className="min-w-0">
+                  <p className="shell-kicker">Deck Operations</p>
+                  <h2 className="mt-2 text-xl font-semibold text-text-strong">
+                    Draft, generate, and return to local decks.
+                  </h2>
+                  <p className="mt-2 max-w-2xl text-sm leading-6 text-muted">
+                    Search across deck titles, tags, slide titles, and notes; filter by
+                    template when the library grows.
+                  </p>
+                </div>
+                <WorkbenchStatusPill tone="accent">
+                  {filtered.length} visible
+                </WorkbenchStatusPill>
+              </div>
+              <div className="mt-5 grid grid-cols-2 gap-3 md:grid-cols-4">
+                <DeckStat
+                  icon={Presentation}
+                  label="Decks"
+                  value={projects.length}
+                  tone="accent"
+                />
+                <DeckStat
+                  icon={Layers3}
+                  label="Slides"
+                  value={summary.totalSlides}
+                />
+                <DeckStat
+                  icon={Sparkles}
+                  label="Templates used"
+                  value={summary.templateCount}
+                  tone="link"
+                />
+                <DeckStat
+                  icon={Clock3}
+                  label="Latest update"
+                  value={summary.latestLabel}
+                />
+              </div>
+            </div>
+
+            <div className="workbench-panel-muted p-5">
+              <p className="shell-kicker">Generation Lane</p>
+              <h2 className="mt-2 text-lg font-semibold text-text-strong">
+                Start with a blank deck or seed a demo.
+              </h2>
+              <p className="mt-2 text-sm leading-6 text-muted">
+                The gallery stays local-first; generated outputs are persisted in the
+                browser library before you open the editor.
+              </p>
+              <div className="mt-5 grid gap-2">
+                <button
+                  type="button"
+                  onClick={handleNew}
+                  className="workbench-button workbench-button-primary flex items-center justify-between gap-3 px-4 py-3 text-left text-sm font-semibold"
+                >
+                  <span>New blank deck</span>
+                  <Plus size={16} aria-hidden="true" />
+                </button>
+                <button
+                  type="button"
+                  onClick={handleDemo}
+                  className="workbench-button flex items-center justify-between gap-3 px-4 py-3 text-left text-sm font-semibold"
+                >
+                  <span>Seed business demo</span>
+                  <Sparkles size={16} aria-hidden="true" />
+                </button>
+              </div>
+            </div>
+          </section>
+
+          <div className="workbench-panel-muted flex flex-wrap items-center gap-2 p-3">
           {[
             { value: "all", label: "All" },
             ...TEMPLATES,
@@ -105,83 +228,79 @@ export function SlidesGalleryPage() {
           ].map((t) => (
             <button
               key={t.value}
+              type="button"
               onClick={() => setFilter(t.value)}
-              className={`rounded-md border px-3 py-1 text-xs font-medium transition ${
-                filter === t.value
-                  ? "border-accent/40 bg-accent/10 text-accent"
-                  : "border-border bg-surface text-muted hover:bg-surface-container hover:text-text-strong"
-              }`}
+              data-active={filter === t.value ? "true" : undefined}
+              className="workbench-button px-3 text-xs font-medium"
             >
               {t.label}
             </button>
           ))}
-        </div>
-      </div>
+          </div>
 
-      {/* Grid */}
-      <div className="mx-auto max-w-6xl px-6 py-4 max-sm:px-3">
-        <WorkbenchSectionHeader
-          title="Library"
-          description="Recent decks, generated outputs, and local drafts"
-        />
-        {filtered.length === 0 ? (
-          <div className="workbench-panel-muted py-20 text-center text-muted">
-            <Presentation size={48} className="mx-auto mb-4 opacity-30" />
-            <p className="text-sm">
-              {search
-                ? "No slides match your search."
-                : "No slide decks yet. Create one to get started."}
-            </p>
-          </div>
-        ) : (
-          <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4">
-            {filtered.map((p) => (
-              <Link
-                key={p.id}
-                to={`/slides/${p.id}`}
-                className="workbench-card group overflow-hidden"
-              >
-                {/* Thumbnail */}
-                <div className="flex aspect-video items-center justify-center bg-surface-dark">
-                  {p.slides[0]?.thumbnailUrl ? (
-                    <AuthenticatedFileImage
-                      filePath={p.slides[0].thumbnailUrl}
-                      alt={p.title}
-                      className="h-full w-full object-cover"
-                    />
-                  ) : (
-                    <Presentation
-                      size={32}
-                      className="text-muted/30 group-hover:text-muted/50 transition"
-                    />
-                  )}
-                </div>
-                {/* Info */}
-                <div className="p-3">
-                  <h3 className="truncate text-sm font-medium text-text-strong">
-                    {p.title}
-                  </h3>
-                  <div className="flex items-center gap-2 mt-1.5">
-                    <span
-                      className={`rounded px-1.5 py-0.5 text-[10px] font-bold ${
-                        TEMPLATE_COLORS[p.template] || "bg-gray-500/20 text-gray-400"
-                      }`}
-                    >
-                      {p.template}
-                    </span>
-                    <span className="text-[10px] text-muted">
-                      {p.slides.length} slides
-                    </span>
-                    <span className="text-[10px] text-muted">
-                      {new Date(p.updatedAt).toLocaleDateString()}
-                    </span>
-                  </div>
-                </div>
-              </Link>
-            ))}
-          </div>
-        )}
-      </div>
+          <section>
+            <WorkbenchSectionHeader
+              title="Library"
+              description="Recent decks, generated outputs, and local drafts"
+            />
+            {filtered.length === 0 ? (
+              <div className="workbench-panel-muted py-20 text-center text-muted">
+                <Presentation size={48} className="mx-auto mb-4 opacity-30" />
+                <p className="text-sm">
+                  {search
+                    ? "No slides match your search."
+                    : "No slide decks yet. Create one to get started."}
+                </p>
+              </div>
+            ) : (
+              <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4">
+                {filtered.map((p) => (
+                  <Link
+                    key={p.id}
+                    to={`/slides/${p.id}`}
+                    className="workbench-card group flex min-h-64 flex-col overflow-hidden"
+                  >
+                    <div className="flex aspect-video items-center justify-center bg-surface-dark">
+                      {p.slides[0]?.thumbnailUrl ? (
+                        <AuthenticatedFileImage
+                          filePath={p.slides[0].thumbnailUrl}
+                          alt={p.title}
+                          className="h-full w-full object-cover"
+                        />
+                      ) : (
+                        <Presentation
+                          size={36}
+                          className="text-muted/30 transition group-hover:text-muted/50"
+                        />
+                      )}
+                    </div>
+                    <div className="flex flex-1 flex-col p-4">
+                      <h3 className="truncate text-base font-semibold text-text-strong">
+                        {p.title}
+                      </h3>
+                      <div className="mt-3 flex flex-wrap items-center gap-2">
+                        <span
+                          className={`rounded px-2 py-1 text-[10px] font-bold ${
+                            TEMPLATE_COLORS[p.template] || "bg-gray-500/20 text-gray-400"
+                          }`}
+                        >
+                          {p.template}
+                        </span>
+                        <span className="text-xs text-muted">
+                          {p.slides.length} slide{p.slides.length === 1 ? "" : "s"}
+                        </span>
+                      </div>
+                      <div className="mt-auto pt-4 text-[11px] text-muted/70">
+                        Updated {formatShortDate(p.updatedAt)}
+                      </div>
+                    </div>
+                  </Link>
+                ))}
+              </div>
+            )}
+          </section>
+        </div>
+      </main>
     </WorkbenchPage>
   );
 }


### PR DESCRIPTION
## Summary
- Refresh the shared workbench shell tokens, topbar behavior, navigation, cards, buttons, and settings tabs.
- Rework Home into a denser command center with quick actions and route cards.
- Redesign Slides and Sites galleries with search, filters, stats, and denser production panels.

## Verification
- npx eslint src/pages/home-page.tsx
- npm run build
- npm run test:unit — 54 files passed, 644 tests passed
- PLAYWRIGHT_BROWSERS_PATH=0 BASE_URL=http://127.0.0.1:5174 npx playwright test --reporter=list — 84 passed, 26 skipped

Note: Playwright used local browser cache because the global Playwright cache was missing/locked by another install during the first full run.