### PR TITLE
Improve OminiX settings diagnostics

### DIFF
--- a/src/settings/ominix-tab.tsx
+++ b/src/settings/ominix-tab.tsx
@@ -20,6 +20,7 @@ import {
   fetchOminixAvailableModels,
   fetchOminixLogs,
   fetchOminixPlatformModels,
+  fetchPlatformSkillHealth,
   fetchPlatformSkillsStatus,
   formatSettingsError,
   installPlatformSkill,
@@ -29,6 +30,7 @@ import {
   type OminixCatalogModel,
   type OminixLogResponse,
   type OminixServiceAction,
+  type PlatformSkillHealth,
   type PlatformSkillInfo,
   type PlatformSkillsStatus,
 } from "./settings-api";
@@ -100,6 +102,30 @@ function resultMessage(result: unknown) {
   if (typeof value.detail === "string" && value.detail.trim()) return value.detail;
   if (typeof value.status === "string" && value.status.trim()) return value.status;
   return "Action completed";
+}
+
+function detailLines(detail: unknown): string[] {
+  if (detail == null) return [];
+  if (typeof detail === "string") return [detail];
+  if (typeof detail === "number" || typeof detail === "boolean") {
+    return [String(detail)];
+  }
+  if (Array.isArray(detail)) {
+    return detail.map((item) =>
+      typeof item === "string" ? item : JSON.stringify(item),
+    );
+  }
+  if (typeof detail === "object") {
+    return Object.entries(detail as Record<string, unknown>).map(([key, value]) => {
+      const rendered = Array.isArray(value)
+        ? value.join(", ")
+        : typeof value === "string" || typeof value === "number" || typeof value === "boolean"
+          ? String(value)
+          : JSON.stringify(value);
+      return `${key}: ${rendered}`;
+    });
+  }
+  return [];
 }
 
 function assertActionOk(result: unknown) {
@@ -433,9 +459,12 @@ function ConfirmBar({
 
 export function OminixTab() {
   const [status, setStatus] = useState<PlatformSkillsStatus | null>(null);
+  const [health, setHealth] = useState<PlatformSkillHealth | null>(null);
   const [platformModels, setPlatformModels] = useState<OminixCatalogModel[]>([]);
   const [availableModels, setAvailableModels] = useState<OminixCatalogModel[]>([]);
   const [logs, setLogs] = useState<OminixLogResponse | null>(null);
+  const [logLines, setLogLines] = useState(80);
+  const [catalogSearch, setCatalogSearch] = useState("");
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
   const [message, setMessage] = useState<string | null>(null);
@@ -446,18 +475,28 @@ export function OminixTab() {
     setLoading(true);
     setError(null);
 
-    const [statusResult, platformResult, availableResult, logsResult] =
+    const [
+      statusResult,
+      healthResult,
+      platformResult,
+      availableResult,
+      logsResult,
+    ] =
       await Promise.allSettled([
         fetchPlatformSkillsStatus(),
+        fetchPlatformSkillHealth("ominix-api"),
         fetchOminixPlatformModels(),
         fetchOminixAvailableModels(),
-        fetchOminixLogs(80),
+        fetchOminixLogs(logLines),
       ]);
 
     const errors: string[] = [];
 
     if (statusResult.status === "fulfilled") setStatus(statusResult.value);
     else errors.push(`status: ${errorMessage(statusResult.reason)}`);
+
+    if (healthResult.status === "fulfilled") setHealth(healthResult.value);
+    else errors.push(`health: ${errorMessage(healthResult.reason)}`);
 
     if (platformResult.status === "fulfilled") setPlatformModels(platformResult.value);
     else errors.push(`models: ${errorMessage(platformResult.reason)}`);
@@ -470,7 +509,7 @@ export function OminixTab() {
 
     setError(errors.length ? errors.join("\n") : null);
     setLoading(false);
-  }, []);
+  }, [logLines]);
 
   useEffect(() => {
     const id = window.setTimeout(() => void load(), 0);
@@ -493,6 +532,26 @@ export function OminixTab() {
         .concat(availableModels.filter((m) => platformModelIds.has(m.id))),
     [availableModels, platformModelIds],
   );
+  const filteredCatalogModels = useMemo(() => {
+    const query = catalogSearch.trim().toLowerCase();
+    if (!query) return catalogModels;
+    return catalogModels.filter((model) =>
+      [
+        model.id,
+        model.name,
+        model.description,
+        model.category,
+        model.role,
+        model.status,
+        ...(model.tags ?? []),
+      ]
+        .filter(Boolean)
+        .join(" ")
+        .toLowerCase()
+        .includes(query),
+    );
+  }, [catalogModels, catalogSearch]);
+  const healthDetailLines = useMemo(() => detailLines(health?.detail), [health]);
 
   async function performAction(key: string, fn: () => Promise<unknown>) {
     setBusyKey(key);
@@ -611,6 +670,40 @@ export function OminixTab() {
               </div>
             </div>
 
+            <div className={`rounded-xl border px-4 py-3 ${statusClass(health?.status === "healthy")}`}>
+              <div className="flex flex-wrap items-start justify-between gap-3">
+                <div>
+                  <div className="text-xs font-semibold uppercase text-muted">
+                    Health probe
+                  </div>
+                  <div className="mt-1 flex items-center gap-2 text-sm font-semibold">
+                    {health?.status === "healthy" ? (
+                      <CheckCircle size={14} />
+                    ) : (
+                      <AlertCircle size={14} />
+                    )}
+                    {health?.status === "healthy"
+                      ? "Probe OK"
+                      : compactText(health?.status, "unknown")}
+                  </div>
+                  <div className="mt-1 truncate font-mono text-[11px] opacity-80">
+                    {compactText(health?.url)}
+                  </div>
+                </div>
+                <div className="min-w-0 max-w-full text-right font-mono text-[11px] opacity-85 sm:max-w-[26rem]">
+                  {healthDetailLines.length > 0 ? (
+                    healthDetailLines.map((line) => (
+                      <div key={line} className="truncate">
+                        {line}
+                      </div>
+                    ))
+                  ) : (
+                    <div>No health detail</div>
+                  )}
+                </div>
+              </div>
+            </div>
+
             <div className="flex flex-wrap gap-2">
               <SmallButton
                 disabled={busy}
@@ -688,14 +781,30 @@ export function OminixTab() {
         </div>
       </Section>
 
-      <Section title="Available Catalog" icon={<CheckCircle size={20} />}>
+      <Section
+        title="Available Catalog"
+        icon={<CheckCircle size={20} />}
+        action={
+          <input
+            value={catalogSearch}
+            onChange={(e) => setCatalogSearch(e.target.value)}
+            placeholder="Search catalog..."
+            className="workbench-input w-64 px-3 py-1.5 text-xs placeholder-muted max-sm:w-full"
+          />
+        }
+      >
+        <div className="mb-3 text-xs text-muted">
+          {filteredCatalogModels.length} of {catalogModels.length} models visible
+        </div>
         <div className="max-h-[28rem] space-y-3 overflow-y-auto pr-1">
-          {catalogModels.length === 0 ? (
+          {filteredCatalogModels.length === 0 ? (
             <div className="rounded-xl bg-surface-container/50 px-4 py-6 text-center text-sm text-muted">
-              No catalog models returned
+              {catalogSearch.trim()
+                ? "No catalog models match the current search"
+                : "No catalog models returned"}
             </div>
           ) : (
-            catalogModels.map((model) => (
+            filteredCatalogModels.map((model) => (
               <AvailableModelRow
                 key={model.id}
                 model={model}
@@ -724,10 +833,22 @@ export function OminixTab() {
         title="Logs"
         icon={<Terminal size={20} />}
         action={
-          <SmallButton disabled={busy} onClick={() => void load()}>
-            <RefreshCw size={12} />
-            Reload
-          </SmallButton>
+          <div className="flex flex-wrap gap-2">
+            {[50, 80, 200].map((count) => (
+              <SmallButton
+                key={count}
+                disabled={busy}
+                tone={logLines === count ? "good" : "default"}
+                onClick={() => setLogLines(count)}
+              >
+                {count} lines
+              </SmallButton>
+            ))}
+            <SmallButton disabled={busy} onClick={() => void load()}>
+              <RefreshCw size={12} />
+              Reload
+            </SmallButton>
+          </div>
         }
       >
         <div className="mb-2 truncate font-mono text-[11px] text-muted">

--- a/src/settings/settings-api.ts
+++ b/src/settings/settings-api.ts
@@ -452,6 +452,13 @@ export interface OminixLogResponse {
   error?: string;
 }
 
+export interface PlatformSkillHealth {
+  name: string;
+  status: string;
+  url: string;
+  detail?: unknown;
+}
+
 export interface OminixCatalogModel {
   id: string;
   name?: string;
@@ -495,6 +502,14 @@ const OMINIX_ADMIN_BASE = "/api/admin/platform-skills/ominix-api";
 
 export async function fetchPlatformSkillsStatus(): Promise<PlatformSkillsStatus> {
   return await request<PlatformSkillsStatus>("/api/admin/platform-skills");
+}
+
+export async function fetchPlatformSkillHealth(
+  name: string,
+): Promise<PlatformSkillHealth> {
+  return await request<PlatformSkillHealth>(
+    `/api/admin/platform-skills/${encodeURIComponent(name)}/health`,
+  );
 }
 
 export async function fetchOminixLogs(lines = 80): Promise<OminixLogResponse> {

--- a/tests/settings-tabs.spec.ts
+++ b/tests/settings-tabs.spec.ts
@@ -14,6 +14,7 @@ interface SettingsMockOptions {
   allowedEmailDeleteError?: { status: number; body: unknown };
   operatorTasksError?: { status: number; body: unknown };
   ominixServiceActionErrors?: Partial<Record<"start" | "stop" | "restart", { status: number; body: unknown }>>;
+  ominixHealthError?: { status: number; body: unknown };
   accessibleProfiles?: AccessibleProfileMock[];
 }
 
@@ -89,6 +90,7 @@ async function installAdminSettingsMocks(
   let removeLocalBody: unknown = null;
   const profileHeaders: Array<string | null> = [];
   const serviceActions: string[] = [];
+  const logLineRequests: number[] = [];
   const accessibleProfiles = options.accessibleProfiles ?? [
     {
       id: "admin",
@@ -236,16 +238,42 @@ async function installAdminSettingsMocks(
     }),
   );
 
-  await page.route("**/api/admin/platform-skills/ominix-api/logs?lines=80", (route) =>
-    route.fulfill({
+  await page.route("**/api/admin/platform-skills/ominix-api/health", (route) => {
+    if (options.ominixHealthError) {
+      void route.fulfill({
+        status: options.ominixHealthError.status,
+        contentType: "application/json",
+        body: JSON.stringify(options.ominixHealthError.body),
+      });
+      return;
+    }
+    void route.fulfill({
+      contentType: "application/json",
+      body: JSON.stringify({
+        name: "ominix-api",
+        status: "healthy",
+        url: "http://localhost:8080",
+        detail: {
+          version: "0.4.2",
+          loaded_models: ["qwen3-asr-1.7b"],
+        },
+      }),
+    });
+  });
+
+  await page.route("**/api/admin/platform-skills/ominix-api/logs?lines=*", (route) => {
+    const url = new URL(route.request().url());
+    const lines = Number(url.searchParams.get("lines") ?? "80");
+    logLineRequests.push(lines);
+    void route.fulfill({
       contentType: "application/json",
       body: JSON.stringify({
         log_path: "/Users/yao/.ominix/api.log",
-        total_lines: 2,
-        lines: ["ominix-api booted", "catalog loaded"],
+        total_lines: lines,
+        lines: ["ominix-api booted", "catalog loaded", `${lines} log line request`],
       }),
-    }),
-  );
+    });
+  });
 
   await page.route("**/api/admin/platform-skills/ominix-api/models/enable", async (route) => {
     enableBody = route.request().postDataJSON();
@@ -305,6 +333,7 @@ async function installAdminSettingsMocks(
     getRemoveLocalBody: () => removeLocalBody,
     getProfileHeaders: () => profileHeaders,
     getServiceActions: () => serviceActions,
+    getLogLineRequests: () => logLineRequests,
   };
 }
 
@@ -970,6 +999,31 @@ test.describe("Settings page — tab smoke tests", () => {
       timeout: TIMEOUT,
     });
     await expect(page.locator("h3", { hasText: "OminiX API" })).toBeVisible();
+  });
+
+  test("OminiX tab exposes health probe, log depth, and catalog filtering", async ({
+    page,
+  }) => {
+    const mocks = await installAdminSettingsMocks(page);
+    await seedAdminSession(page);
+
+    await page.goto("/settings", { waitUntil: "networkidle" });
+    await expect(page.locator(".animate-spin")).toBeHidden({ timeout: TIMEOUT });
+    await clickTab(page, "OminiX");
+
+    await expect(page.getByText("Health probe")).toBeVisible({ timeout: TIMEOUT });
+    await expect(page.getByText("0.4.2")).toBeVisible();
+
+    await page.getByRole("button", { name: "200 lines" }).click();
+    await expect.poll(() => mocks.getLogLineRequests().at(-1)).toBe(200);
+    await expect(page.getByText("200 log line request")).toBeVisible({
+      timeout: TIMEOUT,
+    });
+
+    const catalog = page.locator("section", { hasText: "Available Catalog" });
+    await catalog.getByPlaceholder("Search catalog...").fill("parakeet");
+    await expect(catalog.getByText("Parakeet ASR")).toBeVisible();
+    await expect(catalog.getByText("Qwen3 TTS")).toHaveCount(0);
   });
 
   test("Server tab uses real admin endpoints for settings and token rotation", async ({


### PR DESCRIPTION
## Summary
- Add an OminiX health probe call to the Settings OminiX tab and render returned diagnostic detail.
- Add selectable log depth controls for 50 / 80 / 200 lines.
- Add catalog search/filtering so large OminiX model catalogs are usable.
- Extend Settings Playwright mocks and coverage for health detail, log line depth, and catalog filtering.

## Verification
- npx eslint src/settings/ominix-tab.tsx src/settings/settings-api.ts tests/settings-tabs.spec.ts
- npm run build
- npm run test:unit — 54 files passed, 644 tests passed
- PLAYWRIGHT_BROWSERS_PATH=0 BASE_URL=http://127.0.0.1:5174 npx playwright test tests/settings-tabs.spec.ts --reporter=list — 21 passed
- PLAYWRIGHT_BROWSERS_PATH=0 BASE_URL=http://127.0.0.1:5174 npx playwright test --reporter=list — 85 passed, 26 skipped

Note: Claude Code was attempted for parallel read-only audit, but the configured relay hit its session limit until 6:40am Asia/Tokyo, so this patch was completed from local code/backend evidence.