### PR TITLE
Fix Settings config preservation and warm Home UI

### DIFF
--- a/src/home/home-settings.tsx
+++ b/src/home/home-settings.tsx
@@ -58,7 +58,6 @@ export function HomeSettingsPanel({ open, onClose }: HomeSettingsPanelProps) {
   // Reset drafts each time the panel opens so they pick up latest values.
   const [cityDraft, setCityDraft] = useState(s.city);
   const [feedDraft, setFeedDraft] = useState(s.newsFeedUrl);
-  const [prevOpen, setPrevOpen] = useState(open);
 
   // Event add form state
   const [evTitle, setEvTitle] = useState("");
@@ -69,13 +68,11 @@ export function HomeSettingsPanel({ open, onClose }: HomeSettingsPanelProps) {
   });
   const [evRecurring, setEvRecurring] = useState<CalendarEvent["recurring"]>(undefined);
 
-  if (open && !prevOpen) {
+  useEffect(() => {
+    if (!open) return;
     setCityDraft(s.city);
     setFeedDraft(s.newsFeedUrl);
-  }
-  if (open !== prevOpen) {
-    setPrevOpen(open);
-  }
+  }, [open, s.city, s.newsFeedUrl]);
 
   // Close on Escape
   useEffect(() => {

--- a/src/home/metro-tiles.tsx
+++ b/src/home/metro-tiles.tsx
@@ -55,18 +55,20 @@ const MAX_ROWS = 12;
 const MOBILE_QUERY = "(max-width: 600px)";
 
 const TILE_DEFS: TileDef[] = [
-  { id: "clock", widgetType: "clock", label: "Clock", accent: "#16130f", defaultLayout: { col: 1, row: 1, w: 4, h: 2 } },
-  { id: "weather", widgetType: "weather", label: "Weather", accent: "#2f453b", defaultLayout: { col: 5, row: 1, w: 2, h: 2 } },
-  { id: "quick-chat", widgetType: "quick-chat", label: "Chat", accent: "#9f5a35", defaultLayout: { col: 1, row: 3, w: 1, h: 1 } },
-  { id: "quick-news", widgetType: "quick-news", label: "News", accent: "#7c6545", defaultLayout: { col: 2, row: 3, w: 1, h: 1 } },
-  { id: "quick-music", widgetType: "quick-music", label: "Music", accent: "#4f6d4c", defaultLayout: { col: 3, row: 3, w: 1, h: 1 } },
-  { id: "quick-home", widgetType: "quick-home", label: "Home", accent: "#5c5145", defaultLayout: { col: 4, row: 3, w: 1, h: 1 } },
-  { id: "voice", widgetType: "voice-orb", label: "Voice", accent: "#282119", defaultLayout: { col: 5, row: 3, w: 2, h: 2 } },
-  { id: "news", widgetType: "news", label: "Headlines", accent: "#241c16", defaultLayout: { col: 1, row: 4, w: 4, h: 2 } },
-  { id: "calendar", widgetType: "calendar", label: "Calendar", accent: "#26352f", defaultLayout: { col: 1, row: 6, w: 2, h: 2 } },
-  { id: "timer", widgetType: "timer", label: "Timer", accent: "#463521", defaultLayout: { col: 3, row: 6, w: 2, h: 1 } },
-  { id: "photo", widgetType: "photo-frame", label: "Photos", accent: "#201d18", defaultLayout: { col: 5, row: 5, w: 2, h: 2 } },
+  { id: "clock", widgetType: "clock", label: "Clock", accent: "#1c1712", defaultLayout: { col: 1, row: 1, w: 4, h: 2 } },
+  { id: "weather", widgetType: "weather", label: "Weather", accent: "#405646", defaultLayout: { col: 5, row: 1, w: 2, h: 2 } },
+  { id: "quick-chat", widgetType: "quick-chat", label: "Chat", accent: "#b86f44", defaultLayout: { col: 1, row: 3, w: 1, h: 1 } },
+  { id: "quick-news", widgetType: "quick-news", label: "News", accent: "#8a704f", defaultLayout: { col: 2, row: 3, w: 1, h: 1 } },
+  { id: "quick-music", widgetType: "quick-music", label: "Music", accent: "#647a57", defaultLayout: { col: 3, row: 3, w: 1, h: 1 } },
+  { id: "quick-home", widgetType: "quick-home", label: "Home", accent: "#766250", defaultLayout: { col: 4, row: 3, w: 1, h: 1 } },
+  { id: "voice", widgetType: "voice-orb", label: "Voice", accent: "#30251d", defaultLayout: { col: 5, row: 3, w: 2, h: 2 } },
+  { id: "news", widgetType: "news", label: "Headlines", accent: "#2a211a", defaultLayout: { col: 1, row: 4, w: 4, h: 2 } },
+  { id: "calendar", widgetType: "calendar", label: "Calendar", accent: "#32483c", defaultLayout: { col: 1, row: 6, w: 2, h: 2 } },
+  { id: "timer", widgetType: "timer", label: "Timer", accent: "#5a4227", defaultLayout: { col: 3, row: 6, w: 2, h: 1 } },
+  { id: "photo", widgetType: "photo-frame", label: "Photos", accent: "#241f1a", defaultLayout: { col: 5, row: 5, w: 2, h: 2 } },
 ];
+
+const TILE_INDEX = new Map(TILE_DEFS.map((tile, index) => [tile.id, index]));
 
 function loadLayouts(): Record<string, TileLayout> {
   const defaults = defaultLayouts();
@@ -107,6 +109,58 @@ function saveLayouts(layouts: Record<string, TileLayout>) {
   try {
     localStorage.setItem(LS_LAYOUT_KEY, JSON.stringify(layouts));
   } catch { /* quota exceeded or unavailable */ }
+}
+
+function removeSavedLayouts() {
+  try {
+    localStorage.removeItem(LS_LAYOUT_KEY);
+  } catch { /* quota exceeded or unavailable */ }
+}
+
+function sameLayout(a?: TileLayout, b?: TileLayout): boolean {
+  return Boolean(a && b && a.col === b.col && a.row === b.row && a.w === b.w && a.h === b.h);
+}
+
+function hasCustomLayouts(layouts: Record<string, TileLayout>): boolean {
+  const defaults = defaultLayouts();
+  return TILE_DEFS.some((tile) => !sameLayout(layouts[tile.id], defaults[tile.id]));
+}
+
+function seedVisibleLayouts(
+  prev: Record<string, TileLayout>,
+  source: Record<string, TileLayout>,
+  visibleIds: Set<string>,
+  cols: number,
+): Record<string, TileLayout> {
+  const next = { ...prev };
+  const placed: Record<string, TileLayout> = {};
+  for (const id of visibleIds) {
+    if (source[id]) {
+      next[id] = source[id];
+      placed[id] = source[id];
+    }
+  }
+  for (const tile of TILE_DEFS) {
+    if (visibleIds.has(tile.id)) continue;
+    const layout = firstAvailableLayout(tile, placed, cols);
+    next[tile.id] = layout;
+    placed[tile.id] = layout;
+  }
+  return next;
+}
+
+function widgetTypeForOrder(tile: TileDef): WidgetType {
+  if (tile.id.startsWith("quick-")) return "quick-actions";
+  return tile.widgetType as WidgetType;
+}
+
+function orderedTiles(tiles: TileDef[], widgets: WidgetConfig[]): TileDef[] {
+  const order = new Map(widgets.map((widget) => [widget.type, widget.order]));
+  return [...tiles].sort((a, b) => {
+    const aOrder = order.get(widgetTypeForOrder(a)) ?? Number.MAX_SAFE_INTEGER;
+    const bOrder = order.get(widgetTypeForOrder(b)) ?? Number.MAX_SAFE_INTEGER;
+    return aOrder - bOrder || (TILE_INDEX.get(a.id) ?? 0) - (TILE_INDEX.get(b.id) ?? 0);
+  });
 }
 
 function tilesOverlap(a: TileLayout, b: TileLayout): boolean {
@@ -187,6 +241,38 @@ function clampLayoutForCols(layout: TileLayout, cols: number): TileLayout {
   const col = Math.max(1, Math.min(cols - w + 1, layout.col));
   const row = Math.max(1, Math.min(MAX_ROWS - h + 1, layout.row));
   return { ...layout, col, w, row, h };
+}
+
+function firstAvailableLayout(
+  tile: TileDef,
+  placed: Record<string, TileLayout>,
+  cols: number,
+): TileLayout {
+  const size = clampLayoutForCols(
+    { col: 1, row: 1, w: tile.defaultLayout.w, h: tile.defaultLayout.h },
+    cols,
+  );
+  const placedLayouts = Object.values(placed);
+  for (let row = 1; row <= MAX_ROWS - size.h + 1; row++) {
+    for (let col = 1; col <= cols - size.w + 1; col++) {
+      const candidate = { ...size, col, row };
+      if (!placedLayouts.some((layout) => tilesOverlap(candidate, layout))) {
+        return candidate;
+      }
+    }
+  }
+  return clampLayoutForCols(tile.defaultLayout, cols);
+}
+
+function packLayoutsForTiles(tiles: TileDef[], cols: number): Record<string, TileLayout> {
+  const out = defaultLayouts();
+  const placed: Record<string, TileLayout> = {};
+  for (const tile of tiles) {
+    const layout = firstAvailableLayout(tile, placed, cols);
+    placed[tile.id] = layout;
+    out[tile.id] = layout;
+  }
+  return out;
 }
 
 function useMetroGridColumns() {
@@ -385,6 +471,7 @@ function useTileDrag(
   const onPointerDown = useCallback((e: React.PointerEvent, tileId: string, gridEl: HTMLElement | null) => {
     if (!editMode || !gridEl) return;
     e.preventDefault();
+    e.stopPropagation();
     const { cols, stepX, stepY } = getGridMetrics(gridEl);
     const rawLayout = layoutsRef.current[tileId];
     if (!rawLayout) return;
@@ -404,7 +491,12 @@ function useTileDrag(
     const newRow = Math.max(1, Math.min(MAX_ROWS - h + 1, startRow + dy));
     const candidate = { ...layoutsRef.current[id], col: newCol, row: newRow };
     if (hasCollision(id, candidate, layoutsRef.current, visibleIdsRef.current, cols)) return;
-    setLayouts(prev => ({ ...prev, [id]: { ...prev[id], col: newCol, row: newRow } }));
+    setLayouts(prev => {
+      const next = seedVisibleLayouts(prev, layoutsRef.current, visibleIdsRef.current, cols);
+      next[id] = { ...layoutsRef.current[id], col: newCol, row: newRow };
+      layoutsRef.current = next;
+      return next;
+    });
   }, [setLayouts]);
 
   const onPointerUp = useCallback(() => {
@@ -477,12 +569,15 @@ function useTileResize(
     const newW = Math.max(1, Math.min(maxW, startW + dw));
     const newH = Math.max(1, Math.min(maxH, startH + dh));
     setLayouts(prev => {
-      const cur = prev[id];
+      const base = seedVisibleLayouts(prev, layoutsRef.current, visibleIdsRef.current, cols);
+      const cur = base[id];
       if (!cur) return prev;
       if (cur.w === newW && cur.h === newH) return prev;
       const candidate = { ...cur, w: newW, h: newH };
-      if (hasCollision(id, candidate, prev, visibleIdsRef.current, cols)) return prev;
-      return { ...prev, [id]: candidate };
+      if (hasCollision(id, candidate, base, visibleIdsRef.current, cols)) return prev;
+      const next = { ...base, [id]: candidate };
+      layoutsRef.current = next;
+      return next;
     });
   }, [setLayouts]);
 
@@ -504,7 +599,8 @@ function useTileResize(
     e.preventDefault();
     const { cols } = getGridMetrics(gridEl);
     setLayouts(prev => {
-      const cur = prev[tileId];
+      const base = seedVisibleLayouts(prev, layoutsRef.current, visibleIdsRef.current, cols);
+      const cur = base[tileId];
       if (!cur) return prev;
       const maxW = cols - cur.col + 1;
       const maxH = MAX_ROWS - cur.row + 1;
@@ -512,8 +608,9 @@ function useTileResize(
       const newH = Math.max(1, Math.min(maxH, cur.h + delta.h));
       if (cur.w === newW && cur.h === newH) return prev;
       const candidate = { ...cur, w: newW, h: newH };
-      if (hasCollision(tileId, candidate, prev, visibleIdsRef.current, cols)) return prev;
-      const next = { ...prev, [tileId]: candidate };
+      if (hasCollision(tileId, candidate, base, visibleIdsRef.current, cols)) return prev;
+      const next = { ...base, [tileId]: candidate };
+      layoutsRef.current = next;
       saveLayouts(next);
       return next;
     });
@@ -534,14 +631,26 @@ export function MetroTileGrid({ onActivate, nightActive }: MetroTileGridProps) {
   const gridCols = useMetroGridColumns();
 
   const visibleTiles = useMemo(
-    () => TILE_DEFS.filter(t => shouldShowTile(t, widgets, nightActive)),
+    () => orderedTiles(
+      TILE_DEFS.filter(t => shouldShowTile(t, widgets, nightActive)),
+      widgets,
+    ),
     [widgets, nightActive],
   );
   const visibleIds = useMemo(() => new Set(visibleTiles.map(t => t.id)), [visibleTiles]);
+  const usingCustomLayout = useMemo(() => hasCustomLayouts(layouts), [layouts]);
+  const orderedDefaultLayouts = useMemo(
+    () => packLayoutsForTiles(visibleTiles, gridCols),
+    [visibleTiles, gridCols],
+  );
 
   const effectiveLayouts = useMemo(
-    () => compactLayouts(layouts, visibleIds, gridCols),
-    [layouts, visibleIds, gridCols],
+    () => compactLayouts(
+      usingCustomLayout ? layouts : orderedDefaultLayouts,
+      visibleIds,
+      gridCols,
+    ),
+    [layouts, orderedDefaultLayouts, usingCustomLayout, visibleIds, gridCols],
   );
 
   const drag = useTileDrag(effectiveLayouts, setLayouts, editMode, visibleIds);
@@ -552,9 +661,8 @@ export function MetroTileGrid({ onActivate, nightActive }: MetroTileGridProps) {
   }, [onActivate, settingsOpen, editMode]);
 
   const resetLayout = useCallback(() => {
-    const fresh = defaultLayouts();
-    setLayouts(fresh);
-    saveLayouts(fresh);
+    removeSavedLayouts();
+    setLayouts(defaultLayouts());
   }, []);
 
   const renderTile = useCallback((tile: TileDef): ReactNode => {
@@ -601,6 +709,12 @@ export function MetroTileGrid({ onActivate, nightActive }: MetroTileGridProps) {
       <div
         ref={gridRef}
         className="metro-grid"
+        style={{
+          transform:
+            editMode || settingsOpen
+              ? "none"
+              : `translate3d(${burnIn.offset.x}px, ${burnIn.offset.y}px, 0)`,
+        }}
         onPointerMove={(e) => { drag.onPointerMove(e); resize.onResizePointerMove(e); }}
         onPointerUp={() => { drag.onPointerUp(); resize.onResizePointerUp(); }}
       >

--- a/src/index.css
+++ b/src/index.css
@@ -1,72 +1,72 @@
 @import "tailwindcss";
 @plugin "@tailwindcss/typography";
 
-/* ── Dark theme (default) ─ Graphite workbench ── */
+/* ── Dark theme (default) ─ Evening hearth ── */
 @theme {
   /* Surfaces */
-  --color-surface: #151817;
-  --color-surface-light: #1d2220;
-  --color-surface-dark: #0b0e0d;
-  --color-surface-container: #202522;
-  --color-surface-elevated: #29302c;
+  --color-surface: #1a1714;
+  --color-surface-light: #221e1a;
+  --color-surface-dark: #110f0c;
+  --color-surface-container: #252019;
+  --color-surface-elevated: #2e2820;
 
   /* Accent */
-  --color-accent: #c57b4d;
-  --color-accent-dim: #9d5d39;
-  --color-accent-container: rgba(197, 123, 77, 0.14);
+  --color-accent: #d4a574;
+  --color-accent-dim: #b08654;
+  --color-accent-container: rgba(212, 165, 116, 0.14);
 
   /* Borders & dividers */
-  --color-border: rgba(231, 238, 230, 0.11);
-  --color-outline: rgba(231, 238, 230, 0.18);
+  --color-border: rgba(244, 232, 214, 0.11);
+  --color-outline: rgba(244, 232, 214, 0.18);
 
   /* Text */
-  --color-muted: #99a399;
-  --color-text: #dce5dc;
-  --color-text-strong: #f4fbf3;
+  --color-muted: #a09689;
+  --color-text: #e4ddd4;
+  --color-text-strong: #f8f3ed;
 
   /* Chat bubbles */
-  --color-user-bubble: rgba(197, 123, 77, 0.13);
-  --color-assistant-bubble: #1a1e1c;
+  --color-user-bubble: rgba(212, 165, 116, 0.13);
+  --color-assistant-bubble: #211d18;
 
   /* Semantic */
-  --color-link: #52a99d;
-  --color-heading: #d69a58;
-  --color-heading-accent: #e2b45f;
-  --color-code-inline: #d88b5a;
+  --color-link: #7ca8b8;
+  --color-heading: #dbb07a;
+  --color-heading-accent: #e8c07f;
+  --color-code-inline: #d9a170;
   --color-code-block-bg: #0f0e0c;
   --color-code-header-bg: #191611;
   --color-code-text: #e4dbc9;
-  --color-blockquote-border: #c47445;
-  --color-sidebar: #101412;
-  --color-highlight: #d6a14d;
+  --color-blockquote-border: #d19b6c;
+  --color-sidebar: #15110e;
+  --color-highlight: #d9ad63;
 }
 
 /* ── Light theme ────────────────────────────────────── */
 [data-theme="light"] {
-  --color-surface: #f6f7f4;
+  --color-surface: #f8f7f3;
   --color-surface-light: #ffffff;
-  --color-surface-dark: #e8ebe6;
-  --color-surface-container: #eef1ed;
-  --color-surface-elevated: #fbfdf9;
+  --color-surface-dark: #ecefea;
+  --color-surface-container: #f3f1ec;
+  --color-surface-elevated: #fffefa;
 
-  --color-accent: #a9643f;
-  --color-accent-dim: #844a2f;
-  --color-accent-container: rgba(169, 100, 63, 0.10);
+  --color-accent: #b87a4a;
+  --color-accent-dim: #915f39;
+  --color-accent-container: rgba(184, 122, 74, 0.10);
 
-  --color-border: rgba(28, 30, 27, 0.12);
-  --color-outline: rgba(28, 30, 27, 0.20);
+  --color-border: rgba(35, 39, 34, 0.12);
+  --color-outline: rgba(35, 39, 34, 0.20);
 
-  --color-muted: #626a62;
-  --color-text: #242a25;
-  --color-text-strong: #101511;
+  --color-muted: #7a6f64;
+  --color-text: #2c2520;
+  --color-text-strong: #15100c;
 
   --color-user-bubble: rgba(169, 95, 57, 0.09);
   --color-assistant-bubble: #fbfcfa;
 
-  --color-link: #14786f;
-  --color-heading: #8a5738;
-  --color-heading-accent: #8f6428;
-  --color-code-inline: #a95f39;
+  --color-link: #4d7f91;
+  --color-heading: #9c663d;
+  --color-heading-accent: #a77532;
+  --color-code-inline: #b87a4a;
   --color-code-block-bg: #211d18;
   --color-code-header-bg: #332b22;
   --color-code-text: #f4ecdc;
@@ -113,7 +113,7 @@ body {
   margin: 0;
   background: var(--color-surface-dark);
   color: var(--color-text);
-  font-family: "SF Pro Text", "SF Pro Display", "Inter", -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  font-family: "SF Pro Text", "SF Pro Display", "PingFang SC", "Inter", -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
 }
@@ -403,13 +403,15 @@ body {
   transition:
     background-color 0.16s ease,
     border-color 0.16s ease,
-    transform 0.16s ease;
+    box-shadow 0.18s ease;
 }
 
 .workbench-card:hover {
-  border-color: color-mix(in srgb, var(--color-accent) 34%, var(--color-border) 66%);
-  background: var(--color-surface-container);
-  transform: translateY(-1px);
+  border-color: color-mix(in srgb, var(--color-accent) 38%, var(--color-border) 62%);
+  background: color-mix(in srgb, var(--color-surface-container) 88%, var(--color-accent) 12%);
+  box-shadow:
+    0 0 0 1px var(--color-accent-container),
+    0 10px 28px color-mix(in srgb, var(--color-accent) 12%, transparent);
 }
 
 .workbench-route-card {
@@ -569,6 +571,7 @@ body {
   background: color-mix(in srgb, var(--color-accent) 12%, var(--color-surface-container) 88%);
   color: var(--color-accent);
   box-shadow: inset 3px 0 0 var(--color-accent);
+  border-radius: 0 8px 8px 0;
 }
 
 @media (max-width: 768px) {
@@ -2296,6 +2299,7 @@ button, a, input, textarea {
   width: 100%;
   max-width: 900px;
   margin: 0 auto;
+  transition: transform 0.8s cubic-bezier(0.22, 1, 0.36, 1);
 }
 
 @media (max-width: 600px) {

--- a/src/settings/channels-tab.tsx
+++ b/src/settings/channels-tab.tsx
@@ -1,7 +1,9 @@
 import { useState } from "react";
+import { API_BASE } from "@/lib/constants";
 import {
   Radio,
   Plus,
+  Pencil,
   Trash2,
   Save,
   Loader2,
@@ -12,9 +14,8 @@ import {
 } from "lucide-react";
 import {
   formatSettingsError,
-  updateMyProfile,
+  updateMyProfileConfig,
   type Profile,
-  type ProfileConfig,
 } from "./settings-api";
 import { ConfirmDialog } from "./confirm-dialog";
 
@@ -28,9 +29,13 @@ interface ChannelsTabProps {
 const CHANNEL_TYPES = [
   "telegram",
   "discord",
+  "slack",
   "whatsapp",
   "email",
   "feishu",
+  "twilio",
+  "api",
+  "matrix",
   "wechat",
   "wecom-bot",
   "qq-bot",
@@ -43,13 +48,26 @@ interface ChannelConfig {
   enabled?: boolean;
   token_env?: string;
   webhook_port?: number;
-  allowed_senders?: string;
+  allowed_senders?: string | string[];
   require_mention?: boolean;
+  bot_token_env?: string;
+  app_token_env?: string;
   app_id_env?: string;
   app_secret_env?: string;
   verification_token_env?: string;
   encrypt_key_env?: string;
   region?: "china" | "global";
+  account_sid_env?: string;
+  auth_token_env?: string;
+  from_number?: string;
+  port?: number;
+  auth_token?: string;
+  homeserver?: string;
+  as_token?: string;
+  hs_token?: string;
+  server_name?: string;
+  sender_localpart?: string;
+  user_prefix?: string;
   smtp_host?: string;
   smtp_port?: number;
   username_env?: string;
@@ -70,6 +88,8 @@ function defaultsForType(type: ChannelType): Partial<ChannelConfig> {
       return { token_env: "TELEGRAM_BOT_TOKEN", allowed_senders: "" };
     case "discord":
       return { token_env: "DISCORD_BOT_TOKEN" };
+    case "slack":
+      return { bot_token_env: "SLACK_BOT_TOKEN", app_token_env: "SLACK_APP_TOKEN" };
     case "whatsapp":
       return { bridge_url: "" };
     case "email":
@@ -82,6 +102,25 @@ function defaultsForType(type: ChannelType): Partial<ChannelConfig> {
         encrypt_key_env: "",
         mode: "webhook",
         region: "china",
+      };
+    case "twilio":
+      return {
+        account_sid_env: "TWILIO_ACCOUNT_SID",
+        auth_token_env: "TWILIO_AUTH_TOKEN",
+        from_number: "",
+        mode: "webhook",
+      };
+    case "api":
+      return { port: 9090, auth_token: "" };
+    case "matrix":
+      return {
+        homeserver: "",
+        as_token: "",
+        hs_token: "",
+        server_name: "",
+        sender_localpart: "octos",
+        user_prefix: "octos_",
+        allowed_senders: "",
       };
     case "wechat":
       return { token_env: "WECHAT_BOT_TOKEN", base_url: "https://api.weixin.qq.com/cgi-bin" };
@@ -98,9 +137,13 @@ function channelLabel(type: string): string {
   const labels: Record<string, string> = {
     telegram: "Telegram",
     discord: "Discord",
+    slack: "Slack",
     whatsapp: "WhatsApp",
     email: "Email (SMTP)",
     feishu: "Feishu (Lark)",
+    twilio: "Twilio SMS",
+    api: "Local API",
+    matrix: "Matrix",
     wechat: "WeChat",
     "wecom-bot": "WeCom Bot",
     "qq-bot": "QQ Bot",
@@ -111,7 +154,7 @@ function channelLabel(type: string): string {
 // ── Webhook URL helpers ──
 
 /** Channel types that receive inbound events via webhook. */
-const WEBHOOK_CHANNEL_TYPES = new Set(["feishu"]);
+const WEBHOOK_CHANNEL_TYPES = new Set(["feishu", "twilio"]);
 
 function usesWebhook(channel: ChannelConfig): boolean {
   if (channel.type === "feishu") return channel.mode === "webhook" || !channel.mode;
@@ -119,6 +162,15 @@ function usesWebhook(channel: ChannelConfig): boolean {
 }
 
 function webhookUrl(channelType: string, profileId: string): string {
+  const configuredOrigin =
+    import.meta.env.VITE_WEBHOOK_ORIGIN ??
+    import.meta.env.VITE_PUBLIC_API_ORIGIN;
+  if (configuredOrigin) {
+    return `${String(configuredOrigin).replace(/\/$/, "")}/webhook/${channelType}/${profileId}`;
+  }
+  if (/^https?:\/\//.test(API_BASE)) {
+    return `${new URL(API_BASE).origin}/webhook/${channelType}/${profileId}`;
+  }
   const origin = typeof window !== "undefined" ? window.location.origin : "";
   return `${origin}/webhook/${channelType}/${profileId}`;
 }
@@ -128,6 +180,32 @@ function parseChannels(raw: unknown[]): ChannelConfig[] {
     if (typeof ch === "object" && ch !== null) return ch as ChannelConfig;
     return { type: "unknown" } as ChannelConfig;
   });
+}
+
+function cleanChannelDraft(draft: ChannelConfig): ChannelConfig {
+  const cleaned: ChannelConfig = {
+    type: draft.type,
+    enabled: draft.enabled ?? true,
+  };
+  for (const [key, value] of Object.entries(draft)) {
+    if (key === "type" || key === "enabled") continue;
+    if (key === "allowed_senders" && draft.type === "matrix") {
+      const senders = Array.isArray(value)
+        ? value
+        : String(value ?? "")
+            .split(",")
+            .map((entry) => entry.trim())
+            .filter(Boolean);
+      if (senders.length > 0) {
+        cleaned.allowed_senders = senders;
+      }
+      continue;
+    }
+    if (value !== "" && value != null) {
+      (cleaned as unknown as Record<string, unknown>)[key] = value;
+    }
+  }
+  return cleaned;
 }
 
 // ── Sub-component: form fields for each channel type ──
@@ -172,11 +250,11 @@ function WebhookUrlField({ channelType, profileId }: { channelType: string; prof
 function ChannelFormFields({
   draft,
   onChange,
-  channelId,
+  profileId,
 }: {
   draft: ChannelConfig;
   onChange: (patch: Partial<ChannelConfig>) => void;
-  channelId?: string;
+  profileId?: string;
 }) {
   const field = (
     label: string,
@@ -187,8 +265,14 @@ function ChannelFormFields({
       <label className="mb-1.5 block text-xs font-medium text-muted">{label}</label>
       <input
         type={opts?.type ?? "text"}
-        value={(draft[key] as string | number) ?? ""}
-        onChange={(e) => onChange({ [key]: opts?.type === "number" ? Number(e.target.value) : e.target.value })}
+        value={Array.isArray(draft[key]) ? (draft[key] as string[]).join(", ") : (draft[key] as string | number) ?? ""}
+        onChange={(e) => {
+          const value =
+            opts?.type === "number"
+              ? e.target.value === "" ? undefined : Number(e.target.value)
+              : e.target.value;
+          onChange({ [key]: value });
+        }}
         placeholder={opts?.placeholder}
         className="w-full rounded-xl bg-surface-container px-4 py-2.5 text-sm text-text placeholder-muted/50 outline-none border border-transparent focus:border-accent/30 transition"
       />
@@ -206,6 +290,13 @@ function ChannelFormFields({
     case "discord":
       return (
         field("Token env var", "token_env", { placeholder: "DISCORD_BOT_TOKEN" })
+      );
+    case "slack":
+      return (
+        <>
+          {field("Bot token env var", "bot_token_env", { placeholder: "SLACK_BOT_TOKEN" })}
+          {field("App token env var", "app_token_env", { placeholder: "SLACK_APP_TOKEN" })}
+        </>
       );
     case "whatsapp": {
       return (
@@ -245,9 +336,39 @@ function ChannelFormFields({
               />
             </div>
           </div>
-          {channelId && usesWebhook(draft) && (
-            <WebhookUrlField channelType="feishu" profileId={channelId} />
+          {profileId && usesWebhook(draft) && (
+            <WebhookUrlField channelType="feishu" profileId={profileId} />
           )}
+        </>
+      );
+    case "twilio":
+      return (
+        <>
+          {field("Account SID env var", "account_sid_env", { placeholder: "TWILIO_ACCOUNT_SID" })}
+          {field("Auth token env var", "auth_token_env", { placeholder: "TWILIO_AUTH_TOKEN" })}
+          {field("From number", "from_number", { placeholder: "+15551234567" })}
+          {profileId && usesWebhook(draft) && (
+            <WebhookUrlField channelType="twilio" profileId={profileId} />
+          )}
+        </>
+      );
+    case "api":
+      return (
+        <>
+          {field("Port", "port", { placeholder: "9090", type: "number" })}
+          {field("Auth token", "auth_token", { placeholder: "Optional shared secret" })}
+        </>
+      );
+    case "matrix":
+      return (
+        <>
+          {field("Homeserver", "homeserver", { placeholder: "https://matrix.example.com" })}
+          {field("Application service token", "as_token", { placeholder: "MATRIX_AS_TOKEN" })}
+          {field("Homeserver token", "hs_token", { placeholder: "MATRIX_HS_TOKEN" })}
+          {field("Server name", "server_name", { placeholder: "matrix.example.com" })}
+          {field("Sender localpart", "sender_localpart", { placeholder: "octos" })}
+          {field("User prefix", "user_prefix", { placeholder: "octos_" })}
+          {field("Allowed senders", "allowed_senders", { placeholder: "@yao:matrix.example.com, @home:matrix.example.com" })}
         </>
       );
     case "wechat":
@@ -285,6 +406,8 @@ export function ChannelsTab({ profile, onProfileUpdated }: ChannelsTabProps) {
   const [saved, setSaved] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [pendingRemoveIdx, setPendingRemoveIdx] = useState<number | null>(null);
+  const [editingIdx, setEditingIdx] = useState<number | null>(null);
+  const [editDraft, setEditDraft] = useState<ChannelConfig | null>(null);
 
   // Add-channel form state
   const [showAddForm, setShowAddForm] = useState(false);
@@ -300,13 +423,17 @@ export function ChannelsTab({ profile, onProfileUpdated }: ChannelsTabProps) {
     setDraft((d) => ({ ...d, ...patch }));
   };
 
+  const updateEditDraft = (patch: Partial<ChannelConfig>) => {
+    setEditDraft((d) => d ? { ...d, ...patch } : d);
+  };
+
   // Persist channel list via PUT /api/my/profile
   const persistChannels = async (newChannels: ChannelConfig[]): Promise<boolean> => {
     setSaving(true);
     setError(null);
     try {
-      const result = await updateMyProfile({
-        config: { channels: newChannels } as Partial<ProfileConfig>,
+      const result = await updateMyProfileConfig(profile, {
+        channels: newChannels,
       });
       onProfileUpdated?.(result);
       setSaved(true);
@@ -321,20 +448,33 @@ export function ChannelsTab({ profile, onProfileUpdated }: ChannelsTabProps) {
   };
 
   const handleAdd = async () => {
-    // Strip empty string fields to keep payload clean
-    const cleaned: ChannelConfig = { type: draft.type, enabled: draft.enabled ?? true };
-    for (const [k, v] of Object.entries(draft)) {
-      if (k === "type" || k === "enabled") continue;
-      if (v !== "" && v != null) {
-        (cleaned as unknown as Record<string, unknown>)[k] = v;
-      }
-    }
+    const cleaned = cleanChannelDraft(draft);
     const ok = await persistChannels([...channels, cleaned]);
     if (ok) {
       setShowAddForm(false);
       setDraft({ type: "telegram", enabled: true, ...defaultsForType("telegram") });
       setNewType("telegram");
     }
+  };
+
+  const startEdit = (idx: number) => {
+    setEditingIdx(idx);
+    setEditDraft({ ...channels[idx] });
+    setShowAddForm(false);
+  };
+
+  const cancelEdit = () => {
+    setEditingIdx(null);
+    setEditDraft(null);
+  };
+
+  const handleSaveEdit = async () => {
+    if (editingIdx == null || !editDraft) return;
+    const updated = channels.map((ch, i) =>
+      i === editingIdx ? cleanChannelDraft(editDraft) : ch,
+    );
+    const ok = await persistChannels(updated);
+    if (ok) cancelEdit();
   };
 
   const confirmRemove = async () => {
@@ -440,6 +580,14 @@ export function ChannelsTab({ profile, onProfileUpdated }: ChannelsTabProps) {
                     </button>
                     {/* Delete */}
                     <button
+                      onClick={() => startEdit(idx)}
+                      disabled={saving}
+                      className="shrink-0 rounded-lg p-2 text-muted hover:text-text-strong hover:bg-surface-dark/70 disabled:opacity-40 transition"
+                      title="Edit channel"
+                    >
+                      <Pencil size={14} />
+                    </button>
+                    <button
                       onClick={() => setPendingRemoveIdx(idx)}
                       disabled={saving}
                       className="shrink-0 rounded-lg p-2 text-muted hover:text-red-400 hover:bg-red-500/10 disabled:opacity-40 transition"
@@ -456,6 +604,33 @@ export function ChannelsTab({ profile, onProfileUpdated }: ChannelsTabProps) {
                   {usesWebhook(channel) && (
                     <div className="ml-12 pr-1">
                       <WebhookUrlField channelType={channel.type} profileId={profile.id} />
+                    </div>
+                  )}
+                  {editingIdx === idx && editDraft && (
+                    <div className="ml-12 rounded-xl border border-border/70 bg-surface-dark/40 p-4">
+                      <div className="grid gap-4 md:grid-cols-2">
+                        <ChannelFormFields
+                          draft={editDraft}
+                          onChange={updateEditDraft}
+                          profileId={profile.id}
+                        />
+                      </div>
+                      <div className="mt-4 flex items-center gap-3">
+                        <button
+                          onClick={() => void handleSaveEdit()}
+                          disabled={saving}
+                          className="flex items-center gap-2 rounded-xl bg-accent px-4 py-2 text-xs font-medium text-white hover:bg-accent-dim disabled:opacity-30 transition"
+                        >
+                          {saving ? <Loader2 size={14} className="animate-spin" /> : <Save size={14} />}
+                          Save Channel
+                        </button>
+                        <button
+                          onClick={cancelEdit}
+                          className="rounded-xl border border-border px-4 py-2 text-xs text-muted hover:text-text-strong hover:border-accent/30 transition"
+                        >
+                          Cancel
+                        </button>
+                      </div>
                     </div>
                   )}
                 </div>
@@ -511,7 +686,11 @@ export function ChannelsTab({ profile, onProfileUpdated }: ChannelsTabProps) {
             </div>
 
             {/* Dynamic fields */}
-            <ChannelFormFields draft={draft} onChange={updateDraft} />
+            <ChannelFormFields
+              draft={draft}
+              onChange={updateDraft}
+              profileId={profile.id}
+            />
           </div>
 
           <div className="mt-6 flex items-center gap-3">

--- a/src/settings/llm-tab.tsx
+++ b/src/settings/llm-tab.tsx
@@ -20,7 +20,7 @@ import {
 import { request } from "@/api/client";
 import {
   formatSettingsError,
-  updateMyProfile,
+  updateMyProfileConfig,
   type Profile,
   type LlmPrimary,
 } from "./settings-api";
@@ -229,27 +229,25 @@ export function LlmTab({ profile, onProfileUpdated }: LlmTabProps) {
     };
 
     try {
-      const result = await updateMyProfile({
-        config: {
-          llm: {
-            primary: {
-              family_id: effectiveFamilyId,
-              model_id: effectiveModelId,
-              route: primaryRoute.api_key_env || primaryRoute.base_url ? primaryRoute : null,
-            },
-            fallbacks: fallbacksPayload,
+      const result = await updateMyProfileConfig(profile, {
+        llm: {
+          primary: {
+            family_id: effectiveFamilyId,
+            model_id: effectiveModelId,
+            route: primaryRoute.api_key_env || primaryRoute.base_url ? primaryRoute : null,
           },
-          gateway: {
-            ...profile.config.gateway,
-            system_prompt: form.system_prompt.trim() || null,
-            max_output_tokens: optionalInt(form.max_output_tokens),
-            max_history: optionalInt(form.max_history),
-            max_iterations: optionalInt(form.max_iterations),
-            max_concurrent_sessions: optionalInt(form.max_concurrent_sessions),
-            browser_timeout_secs: optionalInt(form.browser_timeout_secs),
-          },
-          adaptive_routing: { enabled: form.adaptive_routing_enabled },
+          fallbacks: fallbacksPayload,
         },
+        gateway: {
+          ...profile.config.gateway,
+          system_prompt: form.system_prompt.trim() || null,
+          max_output_tokens: optionalInt(form.max_output_tokens),
+          max_history: optionalInt(form.max_history),
+          max_iterations: optionalInt(form.max_iterations),
+          max_concurrent_sessions: optionalInt(form.max_concurrent_sessions),
+          browser_timeout_secs: optionalInt(form.browser_timeout_secs),
+        },
+        adaptive_routing: { enabled: form.adaptive_routing_enabled },
       });
       onProfileUpdated(result);
       const newForm = profileToForm(result);

--- a/src/settings/profile-tab.tsx
+++ b/src/settings/profile-tab.tsx
@@ -15,7 +15,7 @@ import {
   AlertTriangle,
 } from "lucide-react";
 import {
-  updateMyProfile,
+  updateMyProfileConfig,
   formatSettingsError,
   getMyProfile,
   startMyGateway,
@@ -163,13 +163,11 @@ export function ProfileTab({ profile, onProfileUpdated, onNavigateBack }: Profil
     setSaving(true);
     setError(null);
     try {
-      const result = await updateMyProfile({
-        name: name.trim(),
-        enabled: autoStart,
-        config: {
-          admin_mode: adminMode,
-        },
-      });
+      const result = await updateMyProfileConfig(
+        profile,
+        { admin_mode: adminMode },
+        { name: name.trim(), enabled: autoStart },
+      );
       onProfileUpdated(result);
       setSaved(true);
       setTimeout(() => setSaved(false), 2000);
@@ -281,7 +279,7 @@ export function ProfileTab({ profile, onProfileUpdated, onNavigateBack }: Profil
     }
 
     try {
-      const result = await updateMyProfile({ config: { env_vars: envVars } });
+      const result = await updateMyProfileConfig(profile, { env_vars: envVars });
       onProfileUpdated(result);
       // Reset rows from fresh server data
       setEnvRows(

--- a/src/settings/sandbox-tab.tsx
+++ b/src/settings/sandbox-tab.tsx
@@ -10,7 +10,7 @@ import {
 } from "lucide-react";
 import {
   formatSettingsError,
-  updateMyProfile,
+  updateMyProfileConfig,
   type Profile,
   type SandboxConfig,
   type SandboxDocker,
@@ -185,8 +185,8 @@ export function SandboxTab({ profile, onProfileUpdated }: SandboxTabProps) {
     setSaving(true);
     setError(null);
     try {
-      const result = await updateMyProfile({
-        config: { sandbox: formToSandboxConfig(form) },
+      const result = await updateMyProfileConfig(profile, {
+        sandbox: formToSandboxConfig(form),
       });
       onProfileUpdated(result);
       const newForm = profileToForm(result);

--- a/src/settings/settings-api.ts
+++ b/src/settings/settings-api.ts
@@ -146,6 +146,56 @@ export async function updateMyProfile(
   });
 }
 
+export function mergeProfileConfig(
+  current: ProfileConfig,
+  patch: Partial<ProfileConfig>,
+): ProfileConfig {
+  const next: ProfileConfig = {
+    ...current,
+    ...patch,
+  };
+
+  if (patch.llm) {
+    next.llm = {
+      ...current.llm,
+      ...patch.llm,
+      primary: patch.llm.primary ?? current.llm.primary,
+      fallbacks: patch.llm.fallbacks ?? current.llm.fallbacks,
+    };
+  }
+  if (patch.gateway) {
+    next.gateway = { ...current.gateway, ...patch.gateway };
+  }
+  if (patch.sandbox) {
+    next.sandbox = patch.sandbox;
+  }
+  if (patch.env_vars) {
+    next.env_vars = patch.env_vars;
+  }
+  if (patch.channels) {
+    next.channels = patch.channels;
+  }
+  if (patch.hooks) {
+    next.hooks = patch.hooks;
+  }
+  if (patch.plugins) {
+    next.plugins = { ...current.plugins, ...patch.plugins };
+  }
+
+  return next;
+}
+
+export async function updateMyProfileConfig(
+  profile: Profile,
+  config: Partial<ProfileConfig>,
+  patch: { name?: string; enabled?: boolean } = {},
+): Promise<Profile> {
+  return await updateMyProfile({
+    ...patch,
+    config: mergeProfileConfig(profile.config, config),
+  });
+}
+
 export async function getMyProfileSkills(): Promise<SkillInfo[]> {
   const resp = await request<{ skills: SkillInfo[] }>("/api/my/profile/skills");
   return resp.skills ?? [];

--- a/src/settings/tools-tab.tsx
+++ b/src/settings/tools-tab.tsx
@@ -12,7 +12,7 @@ import {
   ToggleLeft,
   ToggleRight,
 } from "lucide-react";
-import { formatSettingsError, updateMyProfile, type Profile } from "./settings-api";
+import { formatSettingsError, updateMyProfileConfig, type Profile } from "./settings-api";
 import { request } from "@/api/client";
 
 interface ToolsTabProps {
@@ -467,7 +467,7 @@ export function ToolsTab({ profile, onProfileUpdated }: ToolsTabProps) {
     setError(null);
     const payload = formToPayload(form, profile);
     try {
-      const result = await updateMyProfile(payload);
+      const result = await updateMyProfileConfig(profile, payload.config);
       onProfileUpdated(result);
       const newForm = profileToForm(result);
       setForm(newForm);

--- a/tests/metro-tiles.spec.ts
+++ b/tests/metro-tiles.spec.ts
@@ -101,15 +101,18 @@ test.describe("Metro tiles", () => {
       const tiles = Object.entries(positions) as [string, { col: number; row: number; w: number; h: number }][];
       for (let i = 0; i < tiles.length; i++) {
         for (let j = i + 1; j < tiles.length; j++) {
-          const [, a] = tiles[i];
-          const [, b] = tiles[j];
+          const [aId, a] = tiles[i];
+          const [bId, b] = tiles[j];
           const overlaps = !(
             a.col + a.w <= b.col ||
             b.col + b.w <= a.col ||
             a.row + a.h <= b.row ||
             b.row + b.h <= a.row
           );
-          expect(overlaps).toBe(false);
+          expect(
+            overlaps,
+            `${aId} overlaps ${bId}: ${JSON.stringify(positions)}`,
+          ).toBe(false);
         }
       }
     }
@@ -184,5 +187,37 @@ test.describe("Metro tiles", () => {
       return raw ? JSON.parse(raw).timer : null;
     });
     expect(savedTimer?.h).toBeGreaterThan(1);
+  });
+
+  test("home widget order controls Metro tile order and placement", async ({ page }) => {
+    await page.evaluate(() => {
+      localStorage.setItem(
+        "octos_home_widgets",
+        JSON.stringify([
+          { type: "weather", enabled: true, order: 0 },
+          { type: "clock", enabled: true, order: 1 },
+          { type: "quick-actions", enabled: true, order: 2 },
+          { type: "voice-orb", enabled: true, order: 3 },
+          { type: "news", enabled: true, order: 4 },
+          { type: "calendar", enabled: true, order: 5 },
+          { type: "timer", enabled: true, order: 6 },
+          { type: "photo-frame", enabled: false, order: 7 },
+          { type: "greeting", enabled: true, order: 8 },
+        ]),
+      );
+      localStorage.removeItem("octos_home_metro_layout");
+    });
+
+    await page.reload({ waitUntil: "networkidle" });
+    await expect(page.locator(".metro-grid")).toBeVisible();
+
+    await expect(page.locator(".metro-tile").first()).toHaveAttribute(
+      "data-tile-id",
+      "weather",
+    );
+    const weatherColumnStart = await page
+      .locator('.metro-tile[data-tile-id="weather"]')
+      .evaluate((el) => getComputedStyle(el).gridColumnStart);
+    expect(weatherColumnStart).toBe("1");
   });
 });

--- a/tests/settings-tabs.spec.ts
+++ b/tests/settings-tabs.spec.ts
@@ -10,6 +10,7 @@ import { test, expect } from "@playwright/test";
 const TIMEOUT = 10_000;
 
 interface SettingsMockOptions {
+  profile?: typeof mockProfile;
   profileUpdateError?: { status: number; body: unknown };
   allowedEmailDeleteError?: { status: number; body: unknown };
   operatorTasksError?: { status: number; body: unknown };
@@ -84,11 +85,13 @@ async function installAdminSettingsMocks(
   page: import("@playwright/test").Page,
   options: SettingsMockOptions = {},
 ) {
+  const activeProfile = options.profile ?? mockProfile;
   let enableBody: unknown = null;
   let disableBody: unknown = null;
   let downloadBody: unknown = null;
   let removeLocalBody: unknown = null;
   const profileHeaders: Array<string | null> = [];
+  const profileUpdateBodies: unknown[] = [];
   const serviceActions: string[] = [];
   const logLineRequests: number[] = [];
   const accessibleProfiles = options.accessibleProfiles ?? [
@@ -127,7 +130,7 @@ async function installAdminSettingsMocks(
           created_at: "2026-01-01T00:00:00Z",
           last_login_at: null,
         },
-        profile: mockProfile,
+        profile: activeProfile,
         portal: {
           kind: "admin",
           home_profile_id: "admin",
@@ -143,6 +146,9 @@ async function installAdminSettingsMocks(
 
   await page.route("**/api/my/profile", async (route) => {
     profileHeaders.push(route.request().headers()["x-profile-id"] ?? null);
+    if (route.request().method() === "PUT") {
+      profileUpdateBodies.push(route.request().postDataJSON());
+    }
     if (route.request().method() === "PUT" && options.profileUpdateError) {
       await route.fulfill({
         status: options.profileUpdateError.status,
@@ -153,7 +159,7 @@ async function installAdminSettingsMocks(
     }
     await route.fulfill({
       contentType: "application/json",
-      body: JSON.stringify(mockProfile),
+      body: JSON.stringify(activeProfile),
     });
   });
 
@@ -332,6 +338,7 @@ async function installAdminSettingsMocks(
     getDownloadBody: () => downloadBody,
     getRemoveLocalBody: () => removeLocalBody,
     getProfileHeaders: () => profileHeaders,
+    getProfileUpdateBodies: () => profileUpdateBodies,
     getServiceActions: () => serviceActions,
     getLogLineRequests: () => logLineRequests,
   };
@@ -352,7 +359,7 @@ async function installServerSettingsMocks(
   await page.route("**/api/admin/profiles", (route) =>
     route.fulfill({
       contentType: "application/json",
-      body: JSON.stringify([mockProfile]),
+        body: JSON.stringify([options.profile ?? mockProfile]),
     }),
   );
 
@@ -790,6 +797,56 @@ test.describe("Settings page — tab smoke tests", () => {
     });
   });
 
+  test("LLM save preserves existing profile config sections", async ({ page }) => {
+    const profileWithConfig = {
+      ...mockProfile,
+      config: {
+        ...mockProfile.config,
+        channels: [
+          {
+            type: "telegram",
+            enabled: true,
+            token_env: "TELEGRAM_BOT_TOKEN",
+            allowed_senders: "1001,1002",
+          },
+        ],
+        env_vars: { KEEP_ME: "secret" },
+        hooks: [{ name: "after_reply", command: "notify" }],
+        sandbox: {
+          ...mockProfile.config.sandbox,
+          enabled: true,
+          mode: "read_only",
+          read_allow_paths: ["/Users/yao/work"],
+        },
+        plugins: { require_signed: true },
+      },
+    };
+    const mocks = await installServerSettingsMocks(page, {
+      profile: profileWithConfig,
+    });
+    await seedAdminSession(page);
+
+    await page.goto("/settings", { waitUntil: "networkidle" });
+    await expect(page.locator(".animate-spin")).toBeHidden({ timeout: TIMEOUT });
+    await clickTab(page, "LLM");
+
+    await page
+      .getByPlaceholder("Optional system prompt override...")
+      .fill("Speak plainly and keep family context.");
+    await page.getByRole("button", { name: "Save Changes" }).click();
+
+    await expect
+      .poll(() => mocks.getProfileUpdateBodies().at(-1))
+      .not.toBeUndefined();
+    const body = mocks.getProfileUpdateBodies().at(-1);
+    const config = (body as { config?: Record<string, unknown> }).config;
+    expect(config?.channels).toEqual(profileWithConfig.config.channels);
+    expect(config?.env_vars).toEqual(profileWithConfig.config.env_vars);
+    expect(config?.hooks).toEqual(profileWithConfig.config.hooks);
+    expect(config?.sandbox).toEqual(profileWithConfig.config.sandbox);
+    expect(config?.plugins).toEqual(profileWithConfig.config.plugins);
+  });
+
   test("Skills tab shows Installed Skills and Octos Hub", async ({
     page,
   }) => {
@@ -815,6 +872,42 @@ test.describe("Settings page — tab smoke tests", () => {
     await expect(
       page.locator("button", { hasText: "Add Channel" }).first(),
     ).toBeVisible({ timeout: TIMEOUT });
+  });
+
+  test("Channels tab can add a Twilio webhook channel", async ({ page }) => {
+    const mocks = await installServerSettingsMocks(page);
+    await seedAdminSession(page);
+
+    await page.goto("/settings", { waitUntil: "networkidle" });
+    await expect(page.locator(".animate-spin")).toBeHidden({ timeout: TIMEOUT });
+    await clickTab(page, "Channels");
+
+    await page.getByRole("button", { name: /^Add Channel$/ }).first().click();
+    const form = page.locator(".glass-section", { hasText: "New Channel" });
+    await form.locator("select").selectOption("twilio");
+    await expect(form.locator("input[readonly]")).toHaveValue(
+      /\/webhook\/twilio\/admin$/,
+      { timeout: TIMEOUT },
+    );
+    await form.getByPlaceholder("TWILIO_ACCOUNT_SID").fill("TWILIO_ACCOUNT_SID");
+    await form.getByPlaceholder("TWILIO_AUTH_TOKEN").fill("TWILIO_AUTH_TOKEN");
+    await form.getByPlaceholder("+15551234567").fill("+15551234567");
+    await form.getByRole("button", { name: /^Add Channel$/ }).click();
+
+    await expect
+      .poll(() => mocks.getProfileUpdateBodies().at(-1))
+      .not.toBeUndefined();
+    const body = mocks.getProfileUpdateBodies().at(-1);
+    const config = (body as { config?: { channels?: unknown[] } }).config;
+    expect(config?.channels).toContainEqual(
+      expect.objectContaining({
+        type: "twilio",
+        enabled: true,
+        account_sid_env: "TWILIO_ACCOUNT_SID",
+        auth_token_env: "TWILIO_AUTH_TOKEN",
+        from_number: "+15551234567",
+      }),
+    );
   });
 
   test("Sandbox tab renders configuration section", async ({ page }) => {


### PR DESCRIPTION
## Summary
- preserve full profile config on Settings saves so LLM/Tools/Sandbox/Profile/Channels updates do not wipe unrelated config sections
- expand Channels setup with Slack, Twilio, API, and Matrix fields plus editable existing channels and webhook-origin support
- make Metro Home respect widget order, preserve safe drag/resize layouts, apply burn-in offset, and warm the global/home visual palette

## Verification
- npm run test:unit: 54 files passed / 644 tests passed
- npm run build: passed (existing CSS/chunk-size warnings only)
- Playwright target: 30 passed / 0 failed for settings-tabs + metro-tiles
- Full Playwright: 88 passed / 26 skipped / 0 failed
- Visual smoke: /home and /settings screenshots rendered, no horizontal overflow