### PR TITLE
Replace mock home state with profile-backed data

### DIFF
--- a/src/home/constants.ts
+++ b/src/home/constants.ts
@@ -171,7 +171,7 @@ export const HOME_I18N: Record<string, HomeStrings> = {
 
     settingsPhotos: "Photo Frame",
     settingsAddPhoto: "Add Photo URL",
-    settingsPhotoPlaceholder: "https://example.com/photo.jpg",
+    settingsPhotoPlaceholder: "Paste an image URL",
 
     newsHeadlines: "Headlines",
 
@@ -268,7 +268,7 @@ export const HOME_I18N: Record<string, HomeStrings> = {
 
     settingsPhotos: "\u7167\u7247\u76F8\u6846",
     settingsAddPhoto: "\u6DFB\u52A0\u7167\u7247\u94FE\u63A5",
-    settingsPhotoPlaceholder: "https://example.com/photo.jpg",
+    settingsPhotoPlaceholder: "\u7C98\u8D34\u56FE\u7247 URL",
 
     newsHeadlines: "\u5934\u6761",
 
@@ -286,13 +286,6 @@ export const HOME_I18N: Record<string, HomeStrings> = {
       "\u4F60\u80FD\u5E2E\u6211\u505A\u4EC0\u4E48\uFF1F",
     ],
   },
-} as const;
-
-/** Fallback location used when both geolocation and IP-based lookup fail. */
-export const DEFAULT_LOCATION = {
-  lat: 37.7749,
-  lon: -122.4194,
-  city: "San Francisco",
 } as const;
 
 export const HOME_STRINGS = HOME_I18N.en;

--- a/src/home/home-settings-context.test.tsx
+++ b/src/home/home-settings-context.test.tsx
@@ -1,0 +1,223 @@
+import { act, cleanup, render, screen, waitFor } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  HomeSettingsProvider,
+  useHomeSettings,
+  type HomeSettingsContextValue,
+} from "./home-settings-context";
+
+const apiMocks = vi.hoisted(() => ({
+  getMyProfile: vi.fn(),
+  updateMyProfileConfig: vi.fn(),
+}));
+
+vi.mock("@/settings/settings-api", () => ({
+  getMyProfile: apiMocks.getMyProfile,
+  updateMyProfileConfig: apiMocks.updateMyProfileConfig,
+}));
+
+function profileWithHome(home: Record<string, unknown> | null = null) {
+  return {
+    id: "admin",
+    name: "Admin",
+    enabled: true,
+    data_dir: null,
+    created_at: "2026-01-01T00:00:00Z",
+    updated_at: "2026-01-01T00:00:00Z",
+    status: { running: true, pid: 1234, started_at: null, uptime_secs: 3600 },
+    config: {
+      llm: {
+        primary: { family_id: "openai", model_id: "gpt-5.4" },
+        fallbacks: [],
+      },
+      home,
+      channels: [],
+      gateway: {
+        max_history: null,
+        max_iterations: null,
+        system_prompt: null,
+        max_concurrent_sessions: null,
+        browser_timeout_secs: null,
+        max_output_tokens: null,
+      },
+      env_vars: {},
+      hooks: [],
+      email: null,
+      api_type: null,
+      admin_mode: true,
+      sandbox: {
+        enabled: false,
+        mode: "off",
+        allow_network: false,
+        docker: {
+          image: "ubuntu:24.04",
+          cpu_limit: null,
+          memory_limit: null,
+          pids_limit: null,
+          mount_mode: "read_only",
+          extra_binds: [],
+        },
+        read_allow_paths: [],
+      },
+      adaptive_routing: null,
+      content_routing: null,
+      plugins: { require_signed: false },
+    },
+  };
+}
+
+function Probe({ onValue }: { onValue?: (value: HomeSettingsContextValue) => void }) {
+  const home = useHomeSettings();
+  onValue?.(home);
+  return (
+    <div>
+      <span data-testid="city">{home.city}</span>
+      <span data-testid="photos">{home.photos.join("|")}</span>
+      <span data-testid="events">{home.events.map((event) => event.title).join("|")}</span>
+      <button onClick={() => home.update({ city: "Kyoto" })}>Set city</button>
+      <button
+        onClick={() =>
+          home.addEvent({
+            title: "Dinner",
+            time: "19:00",
+            date: "2026-06-14",
+            recurring: "daily",
+          })
+        }
+      >
+        Add event
+      </button>
+      <button onClick={() => home.addPhoto("https://example.test/family.jpg")}>
+        Add photo
+      </button>
+      <button onClick={() => home.setMetroLayout({ clock: { col: 1, row: 1, w: 4, h: 2 } })}>
+        Set layout
+      </button>
+    </div>
+  );
+}
+
+describe("HomeSettingsProvider", () => {
+  beforeEach(() => {
+    cleanup();
+    localStorage.clear();
+    apiMocks.getMyProfile.mockReset();
+    apiMocks.updateMyProfileConfig.mockReset();
+    apiMocks.updateMyProfileConfig.mockImplementation(async (profile, patch) => ({
+      ...profile,
+      config: { ...profile.config, ...patch },
+    }));
+  });
+
+  it("loads Home dashboard state from the profile config", async () => {
+    apiMocks.getMyProfile.mockResolvedValue(
+      profileWithHome({
+        settings: {
+          city: "Tokyo",
+          temp_unit: "F",
+          clock_format: "12h",
+          idle_seconds: 60,
+          night_mode: "on",
+          lang: "zh",
+          news_feed_url: "https://example.test/feed.xml",
+        },
+        events: [
+          {
+            id: "evt-1",
+            title: "Breakfast",
+            time: "08:00",
+            date: "2026-06-14",
+          },
+        ],
+        photos: ["https://example.test/home.jpg"],
+        widgets: [{ type: "clock", enabled: false, order: 1 }],
+        metro_layout: { clock: { col: 1, row: 1, w: 4, h: 2 } },
+      }),
+    );
+
+    render(
+      <HomeSettingsProvider>
+        <Probe />
+      </HomeSettingsProvider>,
+    );
+
+    await waitFor(() => expect(screen.getByTestId("city").textContent).toBe("Tokyo"));
+    expect(screen.getByTestId("events").textContent).toBe("Breakfast");
+    expect(screen.getByTestId("photos").textContent).toBe("https://example.test/home.jpg");
+  });
+
+  it("persists Home edits back into profile config.home", async () => {
+    const profile = profileWithHome({
+      settings: { city: "Tokyo" },
+      events: [],
+      photos: [],
+      widgets: [],
+      metro_layout: {},
+    });
+    apiMocks.getMyProfile.mockResolvedValue(profile);
+
+    render(
+      <HomeSettingsProvider>
+        <Probe />
+      </HomeSettingsProvider>,
+    );
+
+    await waitFor(() => expect(screen.getByTestId("city").textContent).toBe("Tokyo"));
+
+    await act(async () => {
+      screen.getByText("Set city").click();
+      screen.getByText("Add event").click();
+      screen.getByText("Add photo").click();
+      screen.getByText("Set layout").click();
+    });
+
+    await waitFor(() => expect(apiMocks.updateMyProfileConfig).toHaveBeenCalled());
+    const lastCall = apiMocks.updateMyProfileConfig.mock.calls.at(-1);
+    expect(lastCall?.[0]).toMatchObject({ id: "admin" });
+    expect(lastCall?.[1]).toMatchObject({
+      home: {
+        settings: { city: "Kyoto" },
+        events: [expect.objectContaining({ title: "Dinner" })],
+        photos: ["https://example.test/family.jpg"],
+        metro_layout: { clock: { col: 1, row: 1, w: 4, h: 2 } },
+      },
+    });
+  });
+
+  it("migrates legacy localStorage Home data into the profile once", async () => {
+    localStorage.setItem("octos_home_city", "Osaka");
+    localStorage.setItem(
+      "octos_home_events",
+      JSON.stringify([
+        {
+          id: "evt-legacy",
+          title: "Lunch",
+          time: "12:00",
+          date: "2026-06-14",
+        },
+      ]),
+    );
+    localStorage.setItem("octos_home_photos", JSON.stringify(["https://example.test/legacy.jpg"]));
+    apiMocks.getMyProfile.mockResolvedValue(profileWithHome(null));
+
+    render(
+      <HomeSettingsProvider>
+        <Probe />
+      </HomeSettingsProvider>,
+    );
+
+    await waitFor(() => expect(screen.getByTestId("city").textContent).toBe("Osaka"));
+    await waitFor(() =>
+      expect(apiMocks.updateMyProfileConfig).toHaveBeenCalledWith(
+        expect.objectContaining({ id: "admin" }),
+        expect.objectContaining({
+          home: expect.objectContaining({
+            settings: expect.objectContaining({ city: "Osaka" }),
+            events: [expect.objectContaining({ title: "Lunch" })],
+            photos: ["https://example.test/legacy.jpg"],
+          }),
+        }),
+      ),
+    );
+  });
+});

--- a/src/home/home-settings-context.tsx
+++ b/src/home/home-settings-context.tsx
@@ -1,31 +1,34 @@
 /**
- * Home Settings Context — centralised settings state for the Home UI.
+ * Home Settings Context.
  *
- * Reads initial values from localStorage (keys prefixed `octos_home_`),
- * exposes typed getters and an `update` function that persists changes
- * back to localStorage.
- *
- * Wrap the Home page root with `<HomeSettingsProvider>` and consume via
- * `useHomeSettings()`.
+ * Profile config is the canonical store. The legacy localStorage keys remain
+ * as migration/offline cache so existing Home dashboards keep their data.
  */
 
 import {
   createContext,
   useCallback,
   useContext,
+  useEffect,
   useMemo,
+  useRef,
   useState,
   type ReactNode,
 } from "react";
+import {
+  getMyProfile,
+  updateMyProfileConfig,
+  type HomeProfileConfig,
+  type Profile,
+} from "@/settings/settings-api";
 import { HOME_I18N, type HomeStrings } from "./constants";
 import {
+  DEFAULT_WIDGETS,
   readWidgets,
   writeWidgets,
   type WidgetConfig,
   type WidgetType,
 } from "./widget-registry";
-
-// ── Types ───────────────────────────────────────────────────────
 
 export type TempUnit = "C" | "F";
 export type ClockFormat = "12h" | "24h";
@@ -42,26 +45,52 @@ export interface HomeSettings {
   newsFeedUrl: string;
 }
 
-export interface HomeSettingsContextValue extends HomeSettings {
-  /** Localised string table for the active language. */
-  strings: HomeStrings;
-  /** Partially update settings (only changed keys). */
-  update: (patch: Partial<HomeSettings>) => void;
-  /** Current widget configuration. */
-  widgets: WidgetConfig[];
-  /** Replace the entire widget config. */
-  setWidgets: (widgets: WidgetConfig[]) => void;
-  /** Toggle a single widget on/off. */
-  toggleWidget: (type: WidgetType) => void;
-  /** Move a widget up or down in order. */
-  moveWidget: (type: WidgetType, direction: "up" | "down") => void;
+export interface CalendarEvent {
+  id: string;
+  title: string;
+  /** "HH:MM" */
+  time: string;
+  /** "YYYY-MM-DD" */
+  date: string;
+  recurring?: "daily" | "weekly";
 }
 
-// ── Storage helpers ─────────────────────────────────────────────
+export interface TileLayout {
+  col: number;
+  row: number;
+  w: number;
+  h: number;
+}
 
-export const DEFAULT_FEED_URL = "http://feeds.bbci.co.uk/news/rss.xml";
+interface HomeData {
+  settings: HomeSettings;
+  widgets: WidgetConfig[];
+  events: CalendarEvent[];
+  photos: string[];
+  metroLayout: Record<string, TileLayout>;
+}
 
-const KEYS = {
+export interface HomeSettingsContextValue extends HomeSettings {
+  strings: HomeStrings;
+  update: (patch: Partial<HomeSettings>) => void;
+  widgets: WidgetConfig[];
+  setWidgets: (widgets: WidgetConfig[]) => void;
+  toggleWidget: (type: WidgetType) => void;
+  moveWidget: (type: WidgetType, direction: "up" | "down") => void;
+  events: CalendarEvent[];
+  addEvent: (event: Omit<CalendarEvent, "id">) => void;
+  removeEvent: (id: string) => void;
+  photos: string[];
+  addPhoto: (url: string) => void;
+  removePhoto: (url: string) => void;
+  metroLayout: Record<string, TileLayout>;
+  setMetroLayout: (layouts: Record<string, TileLayout>) => void;
+  profileBacked: boolean;
+}
+
+export const DEFAULT_FEED_URL = "https://feeds.bbci.co.uk/news/rss.xml";
+
+const SETTINGS_KEYS = {
   city: "octos_home_city",
   tempUnit: "octos_home_temp_unit",
   clockFormat: "octos_home_clock_format",
@@ -71,96 +100,455 @@ const KEYS = {
   newsFeedUrl: "octos_home_news_feed_url",
 } as const;
 
-function readLS(): HomeSettings {
-  return {
-    city: localStorage.getItem(KEYS.city) ?? "",
-    tempUnit: (localStorage.getItem(KEYS.tempUnit) as TempUnit) || "C",
-    clockFormat:
-      (localStorage.getItem(KEYS.clockFormat) as ClockFormat) || "24h",
-    idleSeconds: clampIdle(
-      Number(localStorage.getItem(KEYS.idleSeconds)) || 30,
-    ),
-    nightMode:
-      (localStorage.getItem(KEYS.nightMode) as NightMode) || "auto",
-    lang: (localStorage.getItem(KEYS.lang) as Lang) || "en",
-    newsFeedUrl: localStorage.getItem(KEYS.newsFeedUrl) ?? DEFAULT_FEED_URL,
-  };
+const EVENTS_KEY = "octos_home_events";
+const PHOTOS_KEY = "octos_home_photos";
+const METRO_LAYOUT_KEY = "octos_home_metro_layout";
+
+const DEFAULT_SETTINGS: HomeSettings = {
+  city: "",
+  tempUnit: "C",
+  clockFormat: "24h",
+  idleSeconds: 30,
+  nightMode: "auto",
+  lang: "en",
+  newsFeedUrl: DEFAULT_FEED_URL,
+};
+
+function storageGet(key: string): string | null {
+  try {
+    return localStorage.getItem(key);
+  } catch {
+    return null;
+  }
 }
 
-function writeLS(s: HomeSettings) {
-  localStorage.setItem(KEYS.city, s.city);
-  localStorage.setItem(KEYS.tempUnit, s.tempUnit);
-  localStorage.setItem(KEYS.clockFormat, s.clockFormat);
-  localStorage.setItem(KEYS.idleSeconds, String(s.idleSeconds));
-  localStorage.setItem(KEYS.nightMode, s.nightMode);
-  localStorage.setItem(KEYS.lang, s.lang);
-  localStorage.setItem(KEYS.newsFeedUrl, s.newsFeedUrl);
+function storageSet(key: string, value: string): void {
+  try {
+    localStorage.setItem(key, value);
+  } catch {
+    // Offline cache best-effort only.
+  }
 }
 
 function clampIdle(n: number): number {
   return Math.max(10, Math.min(300, Math.round(n)));
 }
 
-// ── Context ─────────────────────────────────────────────────────
+function asTempUnit(value: unknown, fallback: TempUnit): TempUnit {
+  return value === "C" || value === "F" ? value : fallback;
+}
+
+function asClockFormat(value: unknown, fallback: ClockFormat): ClockFormat {
+  return value === "12h" || value === "24h" ? value : fallback;
+}
+
+function asNightMode(value: unknown, fallback: NightMode): NightMode {
+  return value === "auto" || value === "on" || value === "off" ? value : fallback;
+}
+
+function asLang(value: unknown, fallback: Lang): Lang {
+  return value === "en" || value === "zh" ? value : fallback;
+}
+
+function readLegacySettings(): HomeSettings {
+  return {
+    city: storageGet(SETTINGS_KEYS.city) ?? DEFAULT_SETTINGS.city,
+    tempUnit: asTempUnit(storageGet(SETTINGS_KEYS.tempUnit), DEFAULT_SETTINGS.tempUnit),
+    clockFormat: asClockFormat(
+      storageGet(SETTINGS_KEYS.clockFormat),
+      DEFAULT_SETTINGS.clockFormat,
+    ),
+    idleSeconds: clampIdle(
+      Number(storageGet(SETTINGS_KEYS.idleSeconds)) || DEFAULT_SETTINGS.idleSeconds,
+    ),
+    nightMode: asNightMode(storageGet(SETTINGS_KEYS.nightMode), DEFAULT_SETTINGS.nightMode),
+    lang: asLang(storageGet(SETTINGS_KEYS.lang), DEFAULT_SETTINGS.lang),
+    newsFeedUrl: storageGet(SETTINGS_KEYS.newsFeedUrl) ?? DEFAULT_SETTINGS.newsFeedUrl,
+  };
+}
+
+function writeLegacySettings(settings: HomeSettings): void {
+  storageSet(SETTINGS_KEYS.city, settings.city);
+  storageSet(SETTINGS_KEYS.tempUnit, settings.tempUnit);
+  storageSet(SETTINGS_KEYS.clockFormat, settings.clockFormat);
+  storageSet(SETTINGS_KEYS.idleSeconds, String(settings.idleSeconds));
+  storageSet(SETTINGS_KEYS.nightMode, settings.nightMode);
+  storageSet(SETTINGS_KEYS.lang, settings.lang);
+  storageSet(SETTINGS_KEYS.newsFeedUrl, settings.newsFeedUrl);
+}
+
+function readJsonArray<T>(key: string, guard: (value: unknown) => value is T): T[] {
+  try {
+    const raw = storageGet(key);
+    if (!raw) return [];
+    const parsed = JSON.parse(raw);
+    return Array.isArray(parsed) ? parsed.filter(guard) : [];
+  } catch {
+    return [];
+  }
+}
+
+function isCalendarEvent(value: unknown): value is CalendarEvent {
+  if (!value || typeof value !== "object") return false;
+  const event = value as Record<string, unknown>;
+  const recurring = event.recurring;
+  return (
+    typeof event.id === "string" &&
+    typeof event.title === "string" &&
+    typeof event.time === "string" &&
+    typeof event.date === "string" &&
+    (recurring === undefined || recurring === "daily" || recurring === "weekly")
+  );
+}
+
+function readLegacyEvents(): CalendarEvent[] {
+  return readJsonArray(EVENTS_KEY, isCalendarEvent);
+}
+
+function writeLegacyEvents(events: CalendarEvent[]): void {
+  storageSet(EVENTS_KEY, JSON.stringify(events));
+  window.dispatchEvent(new Event("octos-events-change"));
+}
+
+function readLegacyPhotos(): string[] {
+  return readJsonArray(PHOTOS_KEY, (value): value is string =>
+    typeof value === "string" && value.trim() !== "",
+  );
+}
+
+function writeLegacyPhotos(photos: string[]): void {
+  storageSet(PHOTOS_KEY, JSON.stringify(photos));
+}
+
+function isTileLayout(value: unknown): value is TileLayout {
+  if (!value || typeof value !== "object") return false;
+  const layout = value as Record<string, unknown>;
+  return ["col", "row", "w", "h"].every(
+    (key) => typeof layout[key] === "number" && Number.isFinite(layout[key]),
+  );
+}
+
+function readLegacyMetroLayout(): Record<string, TileLayout> {
+  try {
+    const raw = storageGet(METRO_LAYOUT_KEY);
+    if (!raw) return {};
+    const parsed = JSON.parse(raw);
+    if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) return {};
+    return Object.fromEntries(
+      Object.entries(parsed as Record<string, unknown>).filter((entry): entry is [string, TileLayout] =>
+        typeof entry[0] === "string" && isTileLayout(entry[1]),
+      ),
+    );
+  } catch {
+    return {};
+  }
+}
+
+function writeLegacyMetroLayout(layouts: Record<string, TileLayout>): void {
+  storageSet(METRO_LAYOUT_KEY, JSON.stringify(layouts));
+}
+
+function readLegacyHomeData(): HomeData {
+  return {
+    settings: readLegacySettings(),
+    widgets: readWidgets(),
+    events: readLegacyEvents(),
+    photos: readLegacyPhotos(),
+    metroLayout: readLegacyMetroLayout(),
+  };
+}
+
+function writeLegacyHomeData(data: HomeData): void {
+  writeLegacySettings(data.settings);
+  writeWidgets(data.widgets);
+  writeLegacyEvents(data.events);
+  writeLegacyPhotos(data.photos);
+  writeLegacyMetroLayout(data.metroLayout);
+}
+
+function normalizeWidgets(value: unknown, fallback: WidgetConfig[]): WidgetConfig[] {
+  if (!Array.isArray(value)) return fallback;
+  const incoming = value
+    .filter((item): item is WidgetConfig => {
+      if (!item || typeof item !== "object") return false;
+      const widget = item as Record<string, unknown>;
+      return (
+        typeof widget.type === "string" &&
+        typeof widget.enabled === "boolean" &&
+        typeof widget.order === "number" &&
+        Number.isFinite(widget.order)
+      );
+    });
+  if (incoming.length === 0) return fallback;
+  const known = new Set(DEFAULT_WIDGETS.map((widget) => widget.type));
+  const cleaned = incoming.filter((widget) => known.has(widget.type));
+  const existing = new Set(cleaned.map((widget) => widget.type));
+  let nextOrder = Math.max(0, ...cleaned.map((widget) => widget.order)) + 1;
+  for (const widget of DEFAULT_WIDGETS) {
+    if (!existing.has(widget.type)) {
+      cleaned.push({ ...widget, order: nextOrder++ });
+    }
+  }
+  return cleaned;
+}
+
+function normalizeEvents(value: unknown, fallback: CalendarEvent[]): CalendarEvent[] {
+  return Array.isArray(value) ? value.filter(isCalendarEvent) : fallback;
+}
+
+function normalizePhotos(value: unknown, fallback: string[]): string[] {
+  return Array.isArray(value)
+    ? value.filter((item): item is string => typeof item === "string" && item.trim() !== "")
+    : fallback;
+}
+
+function normalizeMetroLayout(
+  value: unknown,
+  fallback: Record<string, TileLayout>,
+): Record<string, TileLayout> {
+  if (!value || typeof value !== "object" || Array.isArray(value)) return fallback;
+  return Object.fromEntries(
+    Object.entries(value as Record<string, unknown>).filter((entry): entry is [string, TileLayout] =>
+      typeof entry[0] === "string" && isTileLayout(entry[1]),
+    ),
+  );
+}
+
+function mergeProfileHome(
+  home: HomeProfileConfig | null | undefined,
+  legacy: HomeData,
+): HomeData {
+  const settings = home?.settings ?? {};
+  return {
+    settings: {
+      city: typeof settings.city === "string" ? settings.city : legacy.settings.city,
+      tempUnit: asTempUnit(settings.temp_unit, legacy.settings.tempUnit),
+      clockFormat: asClockFormat(settings.clock_format, legacy.settings.clockFormat),
+      idleSeconds:
+        typeof settings.idle_seconds === "number"
+          ? clampIdle(settings.idle_seconds)
+          : legacy.settings.idleSeconds,
+      nightMode: asNightMode(settings.night_mode, legacy.settings.nightMode),
+      lang: asLang(settings.lang, legacy.settings.lang),
+      newsFeedUrl:
+        typeof settings.news_feed_url === "string" && settings.news_feed_url.trim()
+          ? settings.news_feed_url
+          : legacy.settings.newsFeedUrl,
+    },
+    widgets: normalizeWidgets(home?.widgets, legacy.widgets),
+    events: normalizeEvents(home?.events, legacy.events),
+    photos: normalizePhotos(home?.photos, legacy.photos),
+    metroLayout: normalizeMetroLayout(home?.metro_layout, legacy.metroLayout),
+  };
+}
+
+function homeHasAnyData(home: HomeProfileConfig | null | undefined): boolean {
+  return Boolean(
+    home &&
+      (home.settings ||
+        (home.events?.length ?? 0) > 0 ||
+        (home.photos?.length ?? 0) > 0 ||
+        (home.widgets?.length ?? 0) > 0 ||
+        Object.keys(home.metro_layout ?? {}).length > 0),
+  );
+}
+
+function serializeHome(data: HomeData): HomeProfileConfig {
+  return {
+    settings: {
+      city: data.settings.city,
+      temp_unit: data.settings.tempUnit,
+      clock_format: data.settings.clockFormat,
+      idle_seconds: data.settings.idleSeconds,
+      night_mode: data.settings.nightMode,
+      lang: data.settings.lang,
+      news_feed_url: data.settings.newsFeedUrl,
+    },
+    events: data.events,
+    photos: data.photos,
+    widgets: data.widgets,
+    metro_layout: data.metroLayout,
+  };
+}
+
+function makeId(): string {
+  if (typeof crypto !== "undefined" && typeof crypto.randomUUID === "function") {
+    return crypto.randomUUID();
+  }
+  return `home-${Date.now().toString(36)}`;
+}
 
 const Ctx = createContext<HomeSettingsContextValue | null>(null);
 
 export function HomeSettingsProvider({ children }: { children: ReactNode }) {
-  const [settings, setSettings] = useState<HomeSettings>(readLS);
-  const [widgets, setWidgetsRaw] = useState<WidgetConfig[]>(readWidgets);
+  const [homeData, setHomeData] = useState<HomeData>(readLegacyHomeData);
+  const [profileBacked, setProfileBacked] = useState(false);
+  const profileRef = useRef<Profile | null>(null);
+  const saveSeqRef = useRef(0);
+
+  const persistHomeData = useCallback((next: HomeData) => {
+    writeLegacyHomeData(next);
+    const profile = profileRef.current;
+    if (!profile) return;
+
+    const seq = ++saveSeqRef.current;
+    updateMyProfileConfig(profile, { home: serializeHome(next) })
+      .then((updated) => {
+        if (seq >= saveSeqRef.current) {
+          profileRef.current = updated;
+          setProfileBacked(true);
+        }
+      })
+      .catch((err) => {
+        console.warn("[home] failed to persist profile-backed home config", err);
+      });
+  }, []);
+
+  useEffect(() => {
+    let cancelled = false;
+    getMyProfile()
+      .then((profile) => {
+        if (cancelled || !profile) return;
+        profileRef.current = profile;
+        setProfileBacked(true);
+
+        const legacy = readLegacyHomeData();
+        const next = mergeProfileHome(profile.config.home, legacy);
+        setHomeData(next);
+        writeLegacyHomeData(next);
+
+        if (!homeHasAnyData(profile.config.home)) {
+          persistHomeData(next);
+        }
+      })
+      .catch((err) => {
+        console.warn("[home] failed to load profile-backed home config", err);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [persistHomeData]);
+
+  const commit = useCallback((producer: (prev: HomeData) => HomeData) => {
+    setHomeData((prev) => {
+      const next = producer(prev);
+      persistHomeData(next);
+      return next;
+    });
+  }, [persistHomeData]);
 
   const update = useCallback((patch: Partial<HomeSettings>) => {
-    setSettings((prev) => {
-      const next = { ...prev, ...patch };
+    commit((prev) => {
+      const settings = { ...prev.settings, ...patch };
       if (patch.idleSeconds !== undefined) {
-        next.idleSeconds = clampIdle(patch.idleSeconds);
+        settings.idleSeconds = clampIdle(patch.idleSeconds);
       }
-      writeLS(next);
-      return next;
+      return { ...prev, settings };
     });
-  }, []);
+  }, [commit]);
 
-  const setWidgets = useCallback((next: WidgetConfig[]) => {
-    setWidgetsRaw(next);
-    writeWidgets(next);
-  }, []);
+  const setWidgets = useCallback((widgets: WidgetConfig[]) => {
+    commit((prev) => ({ ...prev, widgets: normalizeWidgets(widgets, prev.widgets) }));
+  }, [commit]);
 
   const toggleWidget = useCallback((type: WidgetType) => {
-    setWidgetsRaw((prev) => {
-      const next = prev.map((w) =>
-        w.type === type ? { ...w, enabled: !w.enabled } : w,
-      );
-      writeWidgets(next);
-      return next;
-    });
-  }, []);
+    commit((prev) => ({
+      ...prev,
+      widgets: prev.widgets.map((widget) =>
+        widget.type === type ? { ...widget, enabled: !widget.enabled } : widget,
+      ),
+    }));
+  }, [commit]);
 
   const moveWidget = useCallback((type: WidgetType, direction: "up" | "down") => {
-    setWidgetsRaw((prev) => {
-      const sorted = [...prev].sort((a, b) => a.order - b.order);
-      const idx = sorted.findIndex((w) => w.type === type);
+    commit((prev) => {
+      const sorted = [...prev.widgets].sort((a, b) => a.order - b.order);
+      const idx = sorted.findIndex((widget) => widget.type === type);
       if (idx < 0) return prev;
       const swapIdx = direction === "up" ? idx - 1 : idx + 1;
       if (swapIdx < 0 || swapIdx >= sorted.length) return prev;
-      // Swap orders
-      const next = sorted.map((w, i) => {
-        if (i === idx) return { ...w, order: sorted[swapIdx].order };
-        if (i === swapIdx) return { ...w, order: sorted[idx].order };
-        return w;
+      const widgets = sorted.map((widget, i) => {
+        if (i === idx) return { ...widget, order: sorted[swapIdx].order };
+        if (i === swapIdx) return { ...widget, order: sorted[idx].order };
+        return widget;
       });
-      writeWidgets(next);
-      return next;
+      return { ...prev, widgets };
     });
-  }, []);
+  }, [commit]);
+
+  const addEvent = useCallback((event: Omit<CalendarEvent, "id">) => {
+    commit((prev) => ({
+      ...prev,
+      events: [...prev.events, { ...event, id: makeId() }],
+    }));
+  }, [commit]);
+
+  const removeEvent = useCallback((id: string) => {
+    commit((prev) => ({
+      ...prev,
+      events: prev.events.filter((event) => event.id !== id),
+    }));
+  }, [commit]);
+
+  const addPhoto = useCallback((url: string) => {
+    const trimmed = url.trim();
+    if (!trimmed) return;
+    commit((prev) =>
+      prev.photos.includes(trimmed)
+        ? prev
+        : { ...prev, photos: [...prev.photos, trimmed] },
+    );
+  }, [commit]);
+
+  const removePhoto = useCallback((url: string) => {
+    commit((prev) => ({
+      ...prev,
+      photos: prev.photos.filter((photo) => photo !== url),
+    }));
+  }, [commit]);
+
+  const setMetroLayout = useCallback((layouts: Record<string, TileLayout>) => {
+    commit((prev) => ({ ...prev, metroLayout: layouts }));
+  }, [commit]);
 
   const strings = useMemo(
-    () => HOME_I18N[settings.lang] ?? HOME_I18N.en,
-    [settings.lang],
+    () => HOME_I18N[homeData.settings.lang] ?? HOME_I18N.en,
+    [homeData.settings.lang],
   );
 
   const value = useMemo<HomeSettingsContextValue>(
-    () => ({ ...settings, strings, update, widgets, setWidgets, toggleWidget, moveWidget }),
-    [settings, strings, update, widgets, setWidgets, toggleWidget, moveWidget],
+    () => ({
+      ...homeData.settings,
+      strings,
+      update,
+      widgets: homeData.widgets,
+      setWidgets,
+      toggleWidget,
+      moveWidget,
+      events: homeData.events,
+      addEvent,
+      removeEvent,
+      photos: homeData.photos,
+      addPhoto,
+      removePhoto,
+      metroLayout: homeData.metroLayout,
+      setMetroLayout,
+      profileBacked,
+    }),
+    [
+      homeData,
+      strings,
+      update,
+      setWidgets,
+      toggleWidget,
+      moveWidget,
+      addEvent,
+      removeEvent,
+      addPhoto,
+      removePhoto,
+      setMetroLayout,
+      profileBacked,
+    ],
   );
 
   return <Ctx value={value}>{children}</Ctx>;

--- a/src/home/metro-tiles.tsx
+++ b/src/home/metro-tiles.tsx
@@ -27,8 +27,6 @@ import { PhotoFrame } from "./photo-frame";
 import { SettingsGearButton, HomeSettingsPanel } from "./home-settings";
 import type { WidgetConfig, WidgetType } from "./widget-registry";
 
-const LS_LAYOUT_KEY = "octos_home_metro_layout";
-
 interface MetroTileGridProps {
   onActivate: (prefill?: string) => void;
   nightActive: boolean;
@@ -70,15 +68,6 @@ const TILE_DEFS: TileDef[] = [
 
 const TILE_INDEX = new Map(TILE_DEFS.map((tile, index) => [tile.id, index]));
 
-function loadLayouts(): Record<string, TileLayout> {
-  const defaults = defaultLayouts();
-  try {
-    const raw = localStorage.getItem(LS_LAYOUT_KEY);
-    if (raw) return normalizeLayouts(JSON.parse(raw), defaults);
-  } catch { /* ignore */ }
-  return defaults;
-}
-
 function defaultLayouts(): Record<string, TileLayout> {
   const out: Record<string, TileLayout> = {};
   for (const t of TILE_DEFS) out[t.id] = { ...t.defaultLayout };
@@ -103,18 +92,6 @@ function normalizeLayouts(
     };
   }
   return out;
-}
-
-function saveLayouts(layouts: Record<string, TileLayout>) {
-  try {
-    localStorage.setItem(LS_LAYOUT_KEY, JSON.stringify(layouts));
-  } catch { /* quota exceeded or unavailable */ }
-}
-
-function removeSavedLayouts() {
-  try {
-    localStorage.removeItem(LS_LAYOUT_KEY);
-  } catch { /* quota exceeded or unavailable */ }
 }
 
 function sameLayout(a?: TileLayout, b?: TileLayout): boolean {
@@ -456,6 +433,7 @@ function VoiceTile({ onActivate, lang }: { onActivate: (text?: string) => void; 
 function useTileDrag(
   layouts: Record<string, TileLayout>,
   setLayouts: (fn: (prev: Record<string, TileLayout>) => Record<string, TileLayout>) => void,
+  commitLayouts: (layouts: Record<string, TileLayout>) => void,
   editMode: boolean,
   visibleIds: Set<string>,
 ) {
@@ -502,9 +480,9 @@ function useTileDrag(
   const onPointerUp = useCallback(() => {
     if (dragRef.current) {
       dragRef.current = null;
-      saveLayouts(layoutsRef.current);
+      commitLayouts(layoutsRef.current);
     }
-  }, []);
+  }, [commitLayouts]);
 
   return { onPointerDown, onPointerMove, onPointerUp };
 }
@@ -513,6 +491,7 @@ function useTileDrag(
 function useTileResize(
   layouts: Record<string, TileLayout>,
   setLayouts: (fn: (prev: Record<string, TileLayout>) => Record<string, TileLayout>) => void,
+  commitLayouts: (layouts: Record<string, TileLayout>) => void,
   editMode: boolean,
   visibleIds: Set<string>,
 ) {
@@ -584,9 +563,9 @@ function useTileResize(
   const onResizePointerUp = useCallback(() => {
     if (resizeRef.current) {
       resizeRef.current = null;
-      saveLayouts(layoutsRef.current);
+      commitLayouts(layoutsRef.current);
     }
-  }, []);
+  }, [commitLayouts]);
 
   const onResizeKeyDown = useCallback((e: React.KeyboardEvent, tileId: string, gridEl: HTMLElement | null) => {
     if (!editMode || !gridEl) return;
@@ -598,23 +577,26 @@ function useTileResize(
     else return;
     e.preventDefault();
     const { cols } = getGridMetrics(gridEl);
-    setLayouts(prev => {
-      const base = seedVisibleLayouts(prev, layoutsRef.current, visibleIdsRef.current, cols);
-      const cur = base[tileId];
-      if (!cur) return prev;
-      const maxW = cols - cur.col + 1;
-      const maxH = MAX_ROWS - cur.row + 1;
-      const newW = Math.max(1, Math.min(maxW, cur.w + delta.w));
-      const newH = Math.max(1, Math.min(maxH, cur.h + delta.h));
-      if (cur.w === newW && cur.h === newH) return prev;
-      const candidate = { ...cur, w: newW, h: newH };
-      if (hasCollision(tileId, candidate, base, visibleIdsRef.current, cols)) return prev;
-      const next = { ...base, [tileId]: candidate };
-      layoutsRef.current = next;
-      saveLayouts(next);
-      return next;
-    });
-  }, [editMode, setLayouts]);
+    const base = seedVisibleLayouts(
+      layoutsRef.current,
+      layoutsRef.current,
+      visibleIdsRef.current,
+      cols,
+    );
+    const cur = base[tileId];
+    if (!cur) return;
+    const maxW = cols - cur.col + 1;
+    const maxH = MAX_ROWS - cur.row + 1;
+    const newW = Math.max(1, Math.min(maxW, cur.w + delta.w));
+    const newH = Math.max(1, Math.min(maxH, cur.h + delta.h));
+    if (cur.w === newW && cur.h === newH) return;
+    const candidate = { ...cur, w: newW, h: newH };
+    if (hasCollision(tileId, candidate, base, visibleIdsRef.current, cols)) return;
+    const next = { ...base, [tileId]: candidate };
+    layoutsRef.current = next;
+    setLayouts(() => next);
+    commitLayouts(next);
+  }, [editMode, setLayouts, commitLayouts]);
 
   return { onResizePointerDown, onResizePointerMove, onResizePointerUp, onResizeKeyDown };
 }
@@ -622,13 +604,19 @@ function useTileResize(
 /* ─── Main Metro Tile Grid ─── */
 
 export function MetroTileGrid({ onActivate, nightActive }: MetroTileGridProps) {
-  const [layouts, setLayouts] = useState(loadLayouts);
   const [settingsOpen, setSettingsOpen] = useState(false);
   const [editMode, setEditMode] = useState(false);
-  const { strings, widgets, lang } = useHomeSettings();
+  const { strings, widgets, lang, metroLayout, setMetroLayout } = useHomeSettings();
+  const [layouts, setLayouts] = useState(() =>
+    normalizeLayouts(metroLayout, defaultLayouts()),
+  );
   const burnIn = useBurnInProtection();
   const gridRef = useRef<HTMLDivElement>(null);
   const gridCols = useMetroGridColumns();
+
+  useEffect(() => {
+    setLayouts(normalizeLayouts(metroLayout, defaultLayouts()));
+  }, [metroLayout]);
 
   const visibleTiles = useMemo(
     () => orderedTiles(
@@ -653,17 +641,21 @@ export function MetroTileGrid({ onActivate, nightActive }: MetroTileGridProps) {
     [layouts, orderedDefaultLayouts, usingCustomLayout, visibleIds, gridCols],
   );
 
-  const drag = useTileDrag(effectiveLayouts, setLayouts, editMode, visibleIds);
-  const resize = useTileResize(effectiveLayouts, setLayouts, editMode, visibleIds);
+  const commitLayouts = useCallback((next: Record<string, TileLayout>) => {
+    setLayouts(next);
+    setMetroLayout(next);
+  }, [setMetroLayout]);
+
+  const drag = useTileDrag(effectiveLayouts, setLayouts, commitLayouts, editMode, visibleIds);
+  const resize = useTileResize(effectiveLayouts, setLayouts, commitLayouts, editMode, visibleIds);
 
   const handleClick = useCallback(() => {
     if (!settingsOpen && !editMode) onActivate();
   }, [onActivate, settingsOpen, editMode]);
 
   const resetLayout = useCallback(() => {
-    removeSavedLayouts();
-    setLayouts(defaultLayouts());
-  }, []);
+    commitLayouts(defaultLayouts());
+  }, [commitLayouts]);
 
   const renderTile = useCallback((tile: TileDef): ReactNode => {
     switch (tile.id) {

--- a/src/home/use-events.ts
+++ b/src/home/use-events.ts
@@ -1,95 +1,16 @@
 /**
- * useEvents — manual calendar events stored in localStorage.
- *
- * Events are keyed under `octos_home_events`.  Supports daily/weekly
- * recurrence.  Exposes today's events and the upcoming 3-day window.
+ * useEvents — derives calendar views from profile-backed Home settings.
  */
 
-import { useCallback, useMemo, useSyncExternalStore } from "react";
+import { useMemo } from "react";
+import { useHomeSettings, type CalendarEvent } from "./home-settings-context";
 
-// ── Types ───────────────────────────────────────────────────────
-
-export interface CalendarEvent {
-  id: string;
-  title: string;
-  /** "HH:MM" */
-  time: string;
-  /** "YYYY-MM-DD" */
-  date: string;
-  recurring?: "daily" | "weekly";
-}
+export type { CalendarEvent };
 
 export interface EventsState {
   todayEvents: CalendarEvent[];
   upcomingEvents: CalendarEvent[];
 }
-
-// ── Storage helpers ─────────────────────────────────────────────
-
-const LS_KEY = "octos_home_events";
-
-function readEvents(): CalendarEvent[] {
-  try {
-    const raw = localStorage.getItem(LS_KEY);
-    if (!raw) return [];
-    const parsed = JSON.parse(raw);
-    return Array.isArray(parsed) ? parsed : [];
-  } catch {
-    return [];
-  }
-}
-
-function writeEvents(events: CalendarEvent[]): void {
-  localStorage.setItem(LS_KEY, JSON.stringify(events));
-  // Notify all useSyncExternalStore subscribers.
-  window.dispatchEvent(new Event("octos-events-change"));
-}
-
-/** Generate a short pseudo-random id. */
-function makeId(): string {
-  return Math.random().toString(36).slice(2, 10);
-}
-
-// ── Subscribe / snapshot (for useSyncExternalStore) ─────────────
-
-function subscribe(cb: () => void) {
-  window.addEventListener("octos-events-change", cb);
-  window.addEventListener("storage", cb);
-  return () => {
-    window.removeEventListener("octos-events-change", cb);
-    window.removeEventListener("storage", cb);
-  };
-}
-
-// Cache the snapshot by raw localStorage string so the returned reference is
-// stable across renders when the stored data hasn't changed. `readEvents()`
-// parses JSON into a fresh array every call; handing that straight to
-// `useSyncExternalStore` made `getSnapshot` return a new reference each render
-// → "getSnapshot should be cached" → infinite re-render loop (Maximum update
-// depth). Recompute only when the underlying raw string actually changes.
-let snapshotRaw: string | null | undefined;
-let snapshotValue: CalendarEvent[] = [];
-
-function getSnapshot(): CalendarEvent[] {
-  let raw: string | null = null;
-  try {
-    raw = localStorage.getItem(LS_KEY);
-  } catch {
-    raw = null;
-  }
-  if (raw !== snapshotRaw) {
-    snapshotRaw = raw;
-    try {
-      const parsed = raw ? JSON.parse(raw) : [];
-      snapshotValue = Array.isArray(parsed) ? parsed : [];
-    } catch {
-      snapshotValue = [];
-    }
-  }
-  return snapshotValue;
-}
-
-// ── Date helpers ────────────────────────────────────────────────
 
 function fmtDate(d: Date): string {
   const y = d.getFullYear();
@@ -99,13 +20,12 @@ function fmtDate(d: Date): string {
 }
 
 function dayOfWeek(dateStr: string): number {
-  return new Date(dateStr + "T00:00:00").getDay();
+  return new Date(`${dateStr}T00:00:00`).getDay();
 }
 
 function matchesDate(event: CalendarEvent, target: string): boolean {
   if (event.date === target) return true;
   if (!event.recurring) return false;
-  // Only match if event date <= target date.
   if (event.date > target) return false;
   if (event.recurring === "daily") return true;
   if (event.recurring === "weekly") return dayOfWeek(event.date) === dayOfWeek(target);
@@ -116,19 +36,15 @@ function sortByTime(a: CalendarEvent, b: CalendarEvent): number {
   return a.time.localeCompare(b.time);
 }
 
-// ── Hook ────────────────────────────────────────────────────────
-
 export function useEvents() {
-  const events = useSyncExternalStore(subscribe, getSnapshot, getSnapshot);
+  const { events, addEvent, removeEvent } = useHomeSettings();
 
   const { todayEvents, upcomingEvents } = useMemo<EventsState>(() => {
     const now = new Date();
     const todayStr = fmtDate(now);
-
     const todayList: CalendarEvent[] = [];
     const upcomingList: CalendarEvent[] = [];
 
-    // Build date strings for upcoming 3 days (excluding today).
     const upcomingDates: string[] = [];
     for (let i = 1; i <= 3; i++) {
       const d = new Date(now);
@@ -136,12 +52,12 @@ export function useEvents() {
       upcomingDates.push(fmtDate(d));
     }
 
-    for (const ev of events) {
-      if (matchesDate(ev, todayStr)) todayList.push(ev);
-      for (const ud of upcomingDates) {
-        if (matchesDate(ev, ud)) {
-          upcomingList.push({ ...ev, date: ud });
-          break; // only first match per event in upcoming window
+    for (const event of events) {
+      if (matchesDate(event, todayStr)) todayList.push(event);
+      for (const date of upcomingDates) {
+        if (matchesDate(event, date)) {
+          upcomingList.push({ ...event, date });
+          break;
         }
       }
     }
@@ -151,19 +67,6 @@ export function useEvents() {
 
     return { todayEvents: todayList, upcomingEvents: upcomingList };
   }, [events]);
-
-  const addEvent = useCallback(
-    (event: Omit<CalendarEvent, "id">) => {
-      const all = readEvents();
-      all.push({ ...event, id: makeId() });
-      writeEvents(all);
-    },
-    [],
-  );
-
-  const removeEvent = useCallback((id: string) => {
-    writeEvents(readEvents().filter((e) => e.id !== id));
-  }, []);
 
   return { todayEvents, upcomingEvents, allEvents: events, addEvent, removeEvent };
 }

--- a/src/home/use-photos.ts
+++ b/src/home/use-photos.ts
@@ -1,81 +1,22 @@
 /**
- * Photo frame hook — cycles through user-provided image URLs.
- *
- * URLs are stored in localStorage (`octos_home_photos`).
- * Cycles every 30 seconds with a new index.
+ * Photo frame hook — cycles through profile-backed user image URLs.
  */
 
-import { useCallback, useEffect, useRef, useState, useSyncExternalStore } from "react";
+import { useEffect, useState } from "react";
+import { useHomeSettings } from "./home-settings-context";
 
-const LS_KEY = "octos_home_photos";
 const CYCLE_MS = 30_000;
 
-let listeners: Array<() => void> = [];
-
-function emit() {
-  for (const fn of listeners) fn();
-}
-
-function readPhotos(): string[] {
-  try {
-    const raw = localStorage.getItem(LS_KEY);
-    if (!raw) return [];
-    const parsed = JSON.parse(raw);
-    return Array.isArray(parsed) ? parsed.filter((u): u is string => typeof u === "string" && u.trim() !== "") : [];
-  } catch {
-    return [];
-  }
-}
-
-function writePhotos(urls: string[]) {
-  localStorage.setItem(LS_KEY, JSON.stringify(urls));
-  emit();
-}
-
-// Cache the snapshot by raw localStorage string so the returned reference is
-// stable across renders when the data hasn't changed. Passing `readPhotos`
-// (a fresh array every call) straight to `useSyncExternalStore` returned a new
-// reference each render → "getSnapshot should be cached" → infinite re-render
-// loop (Maximum update depth) → /home crash. Recompute only on real change.
-let snapshotRaw: string | null | undefined;
-let snapshotValue: string[] = [];
-
-function getPhotosSnapshot(): string[] {
-  let raw: string | null = null;
-  try {
-    raw = localStorage.getItem(LS_KEY);
-  } catch {
-    raw = null;
-  }
-  if (raw !== snapshotRaw) {
-    snapshotRaw = raw;
-    snapshotValue = readPhotos();
-  }
-  return snapshotValue;
-}
-
-function subscribe(cb: () => void) {
-  listeners.push(cb);
-  return () => {
-    listeners = listeners.filter((fn) => fn !== cb);
-  };
-}
-
 export function usePhotos() {
-  const photos = useSyncExternalStore(
-    subscribe,
-    getPhotosSnapshot,
-    getPhotosSnapshot,
-  );
+  const { photos, addPhoto, removePhoto } = useHomeSettings();
   const [index, setIndex] = useState(0);
-  const timerRef = useRef<ReturnType<typeof setInterval> | undefined>(undefined);
 
   useEffect(() => {
     if (photos.length <= 1) return;
-    timerRef.current = setInterval(() => {
+    const timer = setInterval(() => {
       setIndex((prev) => (prev + 1) % photos.length);
     }, CYCLE_MS);
-    return () => clearInterval(timerRef.current);
+    return () => clearInterval(timer);
   }, [photos.length]);
 
   useEffect(() => {
@@ -83,19 +24,6 @@ export function usePhotos() {
       setIndex(0);
     }
   }, [photos.length, index]);
-
-  const addPhoto = useCallback((url: string) => {
-    const trimmed = url.trim();
-    if (!trimmed) return;
-    const current = readPhotos();
-    if (!current.includes(trimmed)) {
-      writePhotos([...current, trimmed]);
-    }
-  }, []);
-
-  const removePhoto = useCallback((url: string) => {
-    writePhotos(readPhotos().filter((u) => u !== url));
-  }, []);
 
   return {
     photos,

--- a/src/home/use-weather.test.tsx
+++ b/src/home/use-weather.test.tsx
@@ -1,0 +1,121 @@
+import { render, screen, waitFor, cleanup } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { HomeSettingsProvider } from "./home-settings-context";
+import { useWeather } from "./use-weather";
+
+const apiMocks = vi.hoisted(() => ({
+  getMyProfile: vi.fn(),
+  updateMyProfileConfig: vi.fn(),
+}));
+
+vi.mock("@/settings/settings-api", () => ({
+  getMyProfile: apiMocks.getMyProfile,
+  updateMyProfileConfig: apiMocks.updateMyProfileConfig,
+}));
+
+function profileWithoutHomeCity() {
+  return {
+    id: "admin",
+    name: "Admin",
+    enabled: true,
+    data_dir: null,
+    created_at: "2026-01-01T00:00:00Z",
+    updated_at: "2026-01-01T00:00:00Z",
+    status: { running: true, pid: 1234, started_at: null, uptime_secs: 3600 },
+    config: {
+      llm: {
+        primary: { family_id: "openai", model_id: "gpt-5.4" },
+        fallbacks: [],
+      },
+      home: {
+        settings: { city: "" },
+        events: [],
+        photos: [],
+        widgets: [],
+        metro_layout: {},
+      },
+      channels: [],
+      gateway: {
+        max_history: null,
+        max_iterations: null,
+        system_prompt: null,
+        max_concurrent_sessions: null,
+        browser_timeout_secs: null,
+        max_output_tokens: null,
+      },
+      env_vars: {},
+      hooks: [],
+      email: null,
+      api_type: null,
+      admin_mode: true,
+      sandbox: {
+        enabled: false,
+        mode: "off",
+        allow_network: false,
+        docker: {
+          image: "ubuntu:24.04",
+          cpu_limit: null,
+          memory_limit: null,
+          pids_limit: null,
+          mount_mode: "read_only",
+          extra_binds: [],
+        },
+        read_allow_paths: [],
+      },
+      adaptive_routing: null,
+      content_routing: null,
+      plugins: { require_signed: false },
+    },
+  };
+}
+
+function WeatherProbe() {
+  const weather = useWeather();
+  return (
+    <div>
+      <span data-testid="loading">{weather.loading ? "yes" : "no"}</span>
+      <span data-testid="error">{weather.error ?? ""}</span>
+      <span data-testid="city">{weather.city ?? ""}</span>
+    </div>
+  );
+}
+
+describe("useWeather", () => {
+  beforeEach(() => {
+    cleanup();
+    localStorage.clear();
+    apiMocks.getMyProfile.mockReset();
+    apiMocks.updateMyProfileConfig.mockReset();
+    apiMocks.getMyProfile.mockResolvedValue(profileWithoutHomeCity());
+    apiMocks.updateMyProfileConfig.mockImplementation(async (profile, patch) => ({
+      ...profile,
+      config: { ...profile.config, ...patch },
+    }));
+    Object.defineProperty(navigator, "geolocation", {
+      configurable: true,
+      value: undefined,
+    });
+  });
+
+  it("does not fall back to a hardcoded city when location resolution fails", async () => {
+    const fetchMock = vi.fn(async (input: RequestInfo | URL) => {
+      const url = String(input);
+      if (url.includes("ipapi.co")) {
+        return new Response("{}", { status: 503 });
+      }
+      throw new Error(`unexpected weather request: ${url}`);
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    render(
+      <HomeSettingsProvider>
+        <WeatherProbe />
+      </HomeSettingsProvider>,
+    );
+
+    await waitFor(() => expect(screen.getByTestId("loading").textContent).toBe("no"));
+    expect(screen.getByTestId("error").textContent).toBe("location_unavailable");
+    expect(screen.getByTestId("city").textContent).toBe("");
+    expect(fetchMock.mock.calls.some(([url]) => String(url).includes("forecast"))).toBe(false);
+  });
+});

--- a/src/home/use-weather.ts
+++ b/src/home/use-weather.ts
@@ -5,14 +5,13 @@
  *   1. City name from settings (geocoded via Open-Meteo Geocoding API)
  *   2. Browser Geolocation API
  *   3. IP-based geolocation (ipapi.co)
- *   4. Hardcoded default (San Francisco)
  *
- * Refreshes every 15 minutes. Never shows "unavailable" — the
- * default-city fallback guarantees a result.
+ * Refreshes every 15 minutes. If all location sources fail, the hook reports
+ * an error instead of showing a hardcoded city.
  */
 
 import { useState, useEffect, useRef } from "react";
-import { WMO_WEATHER, DEFAULT_LOCATION } from "./constants";
+import { WMO_WEATHER } from "./constants";
 import { useHomeSettings } from "./home-settings-context";
 
 export interface HourlyForecastItem {
@@ -203,19 +202,23 @@ export function useWeather(): WeatherState {
         // IP geolocation also failed
       }
 
-      // 4. Hardcoded default
-      return {
-        lat: DEFAULT_LOCATION.lat,
-        lon: DEFAULT_LOCATION.lon,
-        city: DEFAULT_LOCATION.city,
-      };
+      throw new Error("location_unavailable");
     }
 
     void (async () => {
-      const loc = await resolveLocation();
-      if (cancelled) return;
-      locationRef.current = loc;
-      await load(loc);
+      try {
+        const loc = await resolveLocation();
+        if (cancelled) return;
+        locationRef.current = loc;
+        await load(loc);
+      } catch (err) {
+        if (cancelled) return;
+        setState((prev) => ({
+          ...prev,
+          loading: false,
+          error: err instanceof Error ? err.message : "location_unavailable",
+        }));
+      }
     })();
 
     timerRef.current = setInterval(() => {

--- a/src/settings/channels-tab.tsx
+++ b/src/settings/channels-tab.tsx
@@ -368,7 +368,7 @@ function ChannelFormFields({
           {field("Server name", "server_name", { placeholder: "matrix.example.com" })}
           {field("Sender localpart", "sender_localpart", { placeholder: "octos" })}
           {field("User prefix", "user_prefix", { placeholder: "octos_" })}
-          {field("Allowed senders", "allowed_senders", { placeholder: "@yao:matrix.example.com, @home:matrix.example.com" })}
+          {field("Allowed senders", "allowed_senders", { placeholder: "@user:matrix.example.com, @bot:matrix.example.com" })}
         </>
       );
     case "wechat":

--- a/src/settings/llm-tab.tsx
+++ b/src/settings/llm-tab.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import {
   Cpu,
   Save,
@@ -19,6 +19,7 @@ import {
 } from "lucide-react";
 import { request } from "@/api/client";
 import {
+  fetchProviderModels,
   formatSettingsError,
   updateMyProfileConfig,
   type Profile,
@@ -43,6 +44,11 @@ interface LlmTabProps {
 interface FallbackEntry {
   family_id: string;
   model_id: string;
+}
+
+interface ModelOption {
+  id: string;
+  name: string;
 }
 
 interface LlmFormState {
@@ -124,6 +130,39 @@ function optionalInt(value: string): number | null {
   return Number.isNaN(n) ? null : n;
 }
 
+function modelNameFromId(id: string): string {
+  return id
+    .split(/[-_:/]+/)
+    .filter(Boolean)
+    .map((part) => part.charAt(0).toUpperCase() + part.slice(1))
+    .join(" ");
+}
+
+function mergeModelOptions(
+  staticModels: ModelOption[],
+  fetchedIds: string[],
+  configuredModelId: string,
+): ModelOption[] {
+  const options: ModelOption[] = [];
+  const seen = new Set<string>();
+  const add = (model: ModelOption) => {
+    if (!model.id || seen.has(model.id)) return;
+    seen.add(model.id);
+    options.push(model);
+  };
+
+  for (const model of staticModels) add(model);
+  for (const id of fetchedIds) add({ id, name: modelNameFromId(id) || id });
+  if (
+    configuredModelId &&
+    configuredModelId !== "__custom__" &&
+    !seen.has(configuredModelId)
+  ) {
+    add({ id: configuredModelId, name: `${configuredModelId} (configured)` });
+  }
+  return options;
+}
+
 /* ─── Shared UI atoms ─── */
 
 const inputClass =
@@ -144,14 +183,25 @@ export function LlmTab({ profile, onProfileUpdated }: LlmTabProps) {
   const [error, setError] = useState<string | null>(null);
   const [testStatus, setTestStatus] = useState<TestStatus>("idle");
   const [testMessage, setTestMessage] = useState<string | null>(null);
+  const [providerModelIds, setProviderModelIds] = useState<Record<string, string[]>>({});
+  const [modelCatalogLoading, setModelCatalogLoading] = useState(false);
+  const [modelCatalogError, setModelCatalogError] = useState<string | null>(null);
 
   const isDirty = JSON.stringify(form) !== JSON.stringify(original);
   const isCustom = form.family_id === "__custom_family__";
   const selectedProvider = isCustom ? undefined : findProvider(form.family_id);
-  const providerModels = selectedProvider?.models ?? [];
   const needsBaseUrl = selectedProvider
     ? showsBaseUrl(selectedProvider)
     : isCustom;
+  const providerModels = useMemo(
+    () =>
+      mergeModelOptions(
+        selectedProvider?.models ?? [],
+        selectedProvider ? (providerModelIds[selectedProvider.id] ?? []) : [],
+        form.model_id,
+      ),
+    [form.model_id, providerModelIds, selectedProvider],
+  );
 
   /* ── Derived effective IDs (what we send to API) ── */
   const effectiveFamilyId = isCustom
@@ -162,6 +212,58 @@ export function LlmTab({ profile, onProfileUpdated }: LlmTabProps) {
     : form.model_id === "__custom__"
       ? form.custom_model_id
       : form.model_id;
+
+  useEffect(() => {
+    if (!selectedProvider) {
+      setModelCatalogLoading(false);
+      setModelCatalogError(null);
+      return;
+    }
+
+    const controller = new AbortController();
+    const provider = selectedProvider;
+    const baseUrl = showsBaseUrl(provider)
+      ? form.base_url.trim()
+      : provider.defaultBaseUrl;
+
+    setModelCatalogLoading(true);
+    setModelCatalogError(null);
+    void fetchProviderModels(
+      {
+        provider: provider.id,
+        model: form.model_id || provider.models[0]?.id || "",
+        api_key_env: provider.envKey || undefined,
+        api_key: provider.envKey ? undefined : "not-required",
+        base_url: baseUrl || undefined,
+        profile_id: profile.id,
+      },
+      { signal: controller.signal },
+    )
+      .then((ids) => {
+        setProviderModelIds((prev) => ({ ...prev, [provider.id]: ids }));
+        if (ids.length > 0) {
+          setForm((current) =>
+            current.family_id === provider.id && !current.model_id
+              ? { ...current, model_id: ids[0] }
+              : current,
+          );
+        }
+      })
+      .catch((err) => {
+        if (err instanceof DOMException && err.name === "AbortError") return;
+        setModelCatalogError("Live model catalog unavailable; using saved/static options.");
+      })
+      .finally(() => {
+        if (!controller.signal.aborted) setModelCatalogLoading(false);
+      });
+
+    return () => controller.abort();
+  }, [
+    form.base_url,
+    form.model_id,
+    profile.id,
+    selectedProvider,
+  ]);
 
   /* ── Provider change ── */
   const handleProviderChange = (newFamilyId: string) => {
@@ -337,6 +439,11 @@ export function LlmTab({ profile, onProfileUpdated }: LlmTabProps) {
                 ))}
                 <option value="__custom__">Custom model...</option>
               </select>
+              {(modelCatalogLoading || modelCatalogError) && (
+                <p className="mt-2 text-xs text-muted">
+                  {modelCatalogLoading ? "Loading live model catalog..." : modelCatalogError}
+                </p>
+              )}
             </div>
           )}
 
@@ -454,7 +561,13 @@ export function LlmTab({ profile, onProfileUpdated }: LlmTabProps) {
 
           {form.fallbacks.map((entry, idx) => {
             const fbProvider = findProvider(entry.family_id);
-            const fbModels = fbProvider?.models ?? [];
+            const fbModels = fbProvider
+              ? mergeModelOptions(
+                  fbProvider.models,
+                  providerModelIds[fbProvider.id] ?? [],
+                  entry.model_id,
+                )
+              : [];
             return (
               <div
                 key={idx}

--- a/src/settings/settings-api.ts
+++ b/src/settings/settings-api.ts
@@ -84,11 +84,51 @@ export interface SandboxConfig {
   read_allow_paths: string[];
 }
 
+export interface HomeProfileSettings {
+  city?: string | null;
+  temp_unit?: string | null;
+  clock_format?: string | null;
+  idle_seconds?: number | null;
+  night_mode?: string | null;
+  lang?: string | null;
+  news_feed_url?: string | null;
+}
+
+export interface HomeProfileEvent {
+  id: string;
+  title: string;
+  time: string;
+  date: string;
+  recurring?: string | null;
+}
+
+export interface HomeProfileWidget {
+  type: string;
+  enabled: boolean;
+  order: number;
+}
+
+export interface HomeProfileTileLayout {
+  col: number;
+  row: number;
+  w: number;
+  h: number;
+}
+
+export interface HomeProfileConfig {
+  settings?: HomeProfileSettings | null;
+  events?: HomeProfileEvent[];
+  photos?: string[];
+  widgets?: HomeProfileWidget[];
+  metro_layout?: Record<string, HomeProfileTileLayout>;
+}
+
 export interface ProfileConfig {
   llm: {
     primary: LlmPrimary;
     fallbacks: LlmPrimary[];
   };
+  home?: HomeProfileConfig | null;
   channels: unknown[];
   gateway: GatewayConfig;
   env_vars: Record<string, string>;
@@ -118,6 +158,15 @@ export interface Profile {
   created_at: string;
   updated_at: string;
   status: ProfileStatus;
+}
+
+export interface ProviderModelsRequest {
+  provider: string;
+  model?: string;
+  api_key?: string;
+  api_key_env?: string;
+  base_url?: string;
+  profile_id?: string;
 }
 
 export interface SkillInfo {
@@ -169,6 +218,9 @@ export function mergeProfileConfig(
   if (patch.sandbox) {
     next.sandbox = patch.sandbox;
   }
+  if (patch.home !== undefined) {
+    next.home = patch.home;
+  }
   if (patch.env_vars) {
     next.env_vars = patch.env_vars;
   }
@@ -193,6 +245,17 @@ export async function updateMyProfileConfig(
   return await updateMyProfile({
     ...patch,
     config: mergeProfileConfig(profile.config, config),
+  });
+}
+
+export async function fetchProviderModels(
+  body: ProviderModelsRequest,
+  options: Pick<RequestInit, "signal"> = {},
+): Promise<string[]> {
+  return await request<string[]>("/api/my/provider-models", {
+    method: "POST",
+    body: JSON.stringify(body),
+    signal: options.signal,
   });
 }
 

--- a/src/slides/pages/slides-gallery-page.tsx
+++ b/src/slides/pages/slides-gallery-page.tsx
@@ -86,21 +86,6 @@ export function SlidesGalleryPage() {
     navigate(`/slides/${project.id}`);
   };
 
-  const handleDemo = () => {
-    const project = create("AI Industry Report 2026", {
-      template: "business",
-      tags: ["business", "ai", "2026"],
-      slides: [
-        { index: 0, title: "AI Industry Report 2026", notes: "Title slide", layout: "title" as const },
-        { index: 1, title: "Market Overview", notes: "Global AI market reached $500B in 2026", layout: "content" as const },
-        { index: 2, title: "Key Players", notes: "Top companies by market cap and revenue", layout: "two-column" as const },
-        { index: 3, title: "Technology Trends", notes: "LLMs, multimodal AI, autonomous agents", layout: "content" as const },
-        { index: 4, title: "Conclusion", notes: "AI continues to accelerate across industries", layout: "conclusion" as const },
-      ],
-    });
-    navigate(`/slides/${project.id}`);
-  };
-
   return (
     <WorkbenchPage>
       <WorkbenchTopbar
@@ -128,12 +113,6 @@ export function SlidesGalleryPage() {
                 className="workbench-input w-64 py-1.5 pl-9 pr-3 text-sm placeholder-muted max-sm:w-full"
               />
             </div>
-            <button
-              onClick={handleDemo}
-              className="workbench-button flex items-center gap-1.5 px-3 py-1.5 text-sm font-medium"
-            >
-              Demo
-            </button>
             <button
               onClick={handleNew}
               className="workbench-button workbench-button-primary flex items-center gap-1.5 px-3 py-1.5 text-sm font-medium"
@@ -193,11 +172,11 @@ export function SlidesGalleryPage() {
             <div className="workbench-panel-muted p-5">
               <p className="shell-kicker">Generation Lane</p>
               <h2 className="mt-2 text-lg font-semibold text-text-strong">
-                Start with a blank deck or seed a demo.
+                Start with a real deck.
               </h2>
               <p className="mt-2 text-sm leading-6 text-muted">
-                The gallery stays local-first; generated outputs are persisted in the
-                browser library before you open the editor.
+                The gallery stays local-first; only decks you create or generate are
+                persisted in the browser library before you open the editor.
               </p>
               <div className="mt-5 grid gap-2">
                 <button
@@ -207,14 +186,6 @@ export function SlidesGalleryPage() {
                 >
                   <span>New blank deck</span>
                   <Plus size={16} aria-hidden="true" />
-                </button>
-                <button
-                  type="button"
-                  onClick={handleDemo}
-                  className="workbench-button flex items-center justify-between gap-3 px-4 py-3 text-left text-sm font-semibold"
-                >
-                  <span>Seed business demo</span>
-                  <Sparkles size={16} aria-hidden="true" />
                 </button>
               </div>
             </div>

--- a/tests/settings-tabs.spec.ts
+++ b/tests/settings-tabs.spec.ts
@@ -355,6 +355,7 @@ async function installServerSettingsMocks(
   let createdSubAccountBody: unknown = null;
   let testSearchBody: unknown = null;
   let testProviderBody: unknown = null;
+  let providerModelsBody: unknown = null;
 
   await page.route("**/api/admin/profiles", (route) =>
     route.fulfill({
@@ -460,6 +461,14 @@ async function installServerSettingsMocks(
     await route.fulfill({
       contentType: "application/json",
       body: JSON.stringify({ ok: true, message: "OK" }),
+    });
+  });
+
+  await page.route("**/api/my/provider-models", async (route) => {
+    providerModelsBody = route.request().postDataJSON();
+    await route.fulfill({
+      contentType: "application/json",
+      body: JSON.stringify(["gpt-5.4", "gpt-5.5-live"]),
     });
   });
 
@@ -616,6 +625,7 @@ async function installServerSettingsMocks(
     getCreatedSubAccountBody: () => createdSubAccountBody,
     getTestSearchBody: () => testSearchBody,
     getTestProviderBody: () => testProviderBody,
+    getProviderModelsBody: () => providerModelsBody,
   };
 }
 
@@ -773,6 +783,7 @@ test.describe("Settings page — tab smoke tests", () => {
     await expect(
       page.locator("h3", { hasText: "Fallback Models" }),
     ).toBeVisible({ timeout: TIMEOUT });
+    await expect(page.locator('option[value="gpt-5.5-live"]')).toHaveCount(1);
   });
 
   test("LLM tab tests provider with selected model and route data", async ({


### PR DESCRIPTION
## Summary
- persist Home dashboard settings, widgets, calendar events, photo URLs, and Metro tile layout through profile config instead of using localStorage as the source of truth
- remove fake Home/Slides defaults: no San Francisco weather fallback, no example.com photo URL, no generated demo slide deck
- wire Settings > LLM model selection to `/api/my/provider-models`, with saved/static options as a fallback

## Notes
- This web change gracefully keeps the local/offline cache, but canonical Home persistence requires the matching octos profile schema change for `config.home`.
- Playwright harness mocks are still test fixtures; product UI no longer presents those mock values as real Home/Slides content.

## Verification
- `npm run test:unit` → 56 files / 648 tests passed
- `npm run build` → passed
- `BASE_URL=http://127.0.0.1:5173 ./node_modules/.bin/playwright test` → 88 passed, 26 skipped, 0 failed
- `cargo test -p octos-cli profile_config_patch --lib` in octos schema branch → 8 passed
- `cargo fmt --check` in octos schema branch → passed