### PR TITLE
Add live Settings profile smoke

### DIFF
--- a/src/home/use-weather.test.tsx
+++ b/src/home/use-weather.test.tsx
@@ -97,13 +97,9 @@ describe("useWeather", () => {
     });
   });
 
-  it("does not fall back to a hardcoded city when location resolution fails", async () => {
+  it("does not call IP geolocation or fall back to a hardcoded city when location resolution fails", async () => {
     const fetchMock = vi.fn(async (input: RequestInfo | URL) => {
-      const url = String(input);
-      if (url.includes("ipapi.co")) {
-        return new Response("{}", { status: 503 });
-      }
-      throw new Error(`unexpected weather request: ${url}`);
+      throw new Error(`unexpected weather request: ${String(input)}`);
     });
     vi.stubGlobal("fetch", fetchMock);
 
@@ -116,6 +112,6 @@ describe("useWeather", () => {
     await waitFor(() => expect(screen.getByTestId("loading").textContent).toBe("no"));
     expect(screen.getByTestId("error").textContent).toBe("location_unavailable");
     expect(screen.getByTestId("city").textContent).toBe("");
-    expect(fetchMock.mock.calls.some(([url]) => String(url).includes("forecast"))).toBe(false);
+    expect(fetchMock).not.toHaveBeenCalled();
   });
 });

--- a/src/home/use-weather.ts
+++ b/src/home/use-weather.ts
@@ -4,10 +4,10 @@
  * Location resolution waterfall:
  *   1. City name from settings (geocoded via Open-Meteo Geocoding API)
  *   2. Browser Geolocation API
- *   3. IP-based geolocation (ipapi.co)
+ *   3. Weather unavailable if no trusted location source resolves
  *
  * Refreshes every 15 minutes. If all location sources fail, the hook reports
- * an error instead of showing a hardcoded city.
+ * an error instead of calling a third-party IP geolocation endpoint.
  */
 
 import { useState, useEffect, useRef } from "react";
@@ -105,20 +105,6 @@ async function fetchWeather(
   };
 }
 
-async function fetchIpLocation(): Promise<ResolvedLocation> {
-  const res = await fetch("https://ipapi.co/json/");
-  if (!res.ok) throw new Error(`IP geolocation HTTP ${res.status}`);
-  const data = (await res.json()) as {
-    latitude: number;
-    longitude: number;
-    city?: string;
-  };
-  if (typeof data.latitude !== "number" || typeof data.longitude !== "number") {
-    throw new Error("IP geolocation returned invalid coordinates");
-  }
-  return { lat: data.latitude, lon: data.longitude, city: data.city ?? null };
-}
-
 export function useWeather(): WeatherState {
   const { city } = useHomeSettings();
   const [state, setState] = useState<WeatherState>({
@@ -193,13 +179,6 @@ export function useWeather(): WeatherState {
         };
       } catch {
         // Geolocation denied or unavailable
-      }
-
-      // 3. IP-based geolocation
-      try {
-        return await fetchIpLocation();
-      } catch {
-        // IP geolocation also failed
       }
 
       throw new Error("location_unavailable");

--- a/src/settings/profile-tab.tsx
+++ b/src/settings/profile-tab.tsx
@@ -105,6 +105,7 @@ interface ProfileTabProps {
   profile: Profile;
   onProfileUpdated: (p: Profile) => void;
   onNavigateBack?: () => void;
+  canDeleteProfile?: boolean;
 }
 
 type GatewayAction = "start" | "stop" | "restart";
@@ -119,7 +120,12 @@ interface EnvVarRow {
 
 // ── Component ──
 
-export function ProfileTab({ profile, onProfileUpdated, onNavigateBack }: ProfileTabProps) {
+export function ProfileTab({
+  profile,
+  onProfileUpdated,
+  onNavigateBack,
+  canDeleteProfile = false,
+}: ProfileTabProps) {
   // Profile name + editable fields
   const [name, setName] = useState(profile.name);
   const [autoStart, setAutoStart] = useState(profile.enabled);
@@ -650,43 +656,45 @@ export function ProfileTab({ profile, onProfileUpdated, onNavigateBack }: Profil
       </div>
 
       {/* ── Danger zone ── */}
-      <div className="mt-2 border-t border-border/40 pt-6">
-        <div className="rounded-lg border border-red-500/30 bg-red-500/5 p-6">
-          <div className="flex items-center gap-3 mb-4">
-            <div className="flex h-10 w-10 items-center justify-center rounded-xl bg-red-500/10 text-red-400">
-              <AlertTriangle size={20} />
+      {canDeleteProfile && (
+        <div className="mt-2 border-t border-border/40 pt-6">
+          <div className="rounded-lg border border-red-500/30 bg-red-500/5 p-6">
+            <div className="flex items-center gap-3 mb-4">
+              <div className="flex h-10 w-10 items-center justify-center rounded-xl bg-red-500/10 text-red-400">
+                <AlertTriangle size={20} />
+              </div>
+              <div>
+                <h3 className="text-sm font-semibold text-red-400">
+                  {LABELS.dangerZone}
+                </h3>
+                <p className="text-xs text-muted">{LABELS.dangerZoneDesc}</p>
+              </div>
             </div>
-            <div>
-              <h3 className="text-sm font-semibold text-red-400">
-                {LABELS.dangerZone}
-              </h3>
-              <p className="text-xs text-muted">{LABELS.dangerZoneDesc}</p>
-            </div>
-          </div>
 
-          <div className="flex items-center justify-between rounded-xl bg-surface-container/40 px-4 py-3">
-            <div>
-              <p className="text-sm font-medium text-text-strong">
+            <div className="flex items-center justify-between rounded-xl bg-surface-container/40 px-4 py-3">
+              <div>
+                <p className="text-sm font-medium text-text-strong">
+                  {LABELS.deleteProfile}
+                </p>
+                <p className="text-xs text-muted mt-0.5">
+                  {LABELS.deleteProfileBody}
+                </p>
+              </div>
+              <button
+                onClick={() => setDeleteProfileOpen(true)}
+                className="ml-4 shrink-0 flex items-center gap-2 rounded-xl bg-red-600 px-4 py-2 text-sm font-medium text-white hover:bg-red-700 transition"
+              >
+                <Trash2 size={14} />
                 {LABELS.deleteProfile}
-              </p>
-              <p className="text-xs text-muted mt-0.5">
-                {LABELS.deleteProfileBody}
-              </p>
+              </button>
             </div>
-            <button
-              onClick={() => setDeleteProfileOpen(true)}
-              className="ml-4 shrink-0 flex items-center gap-2 rounded-xl bg-red-600 px-4 py-2 text-sm font-medium text-white hover:bg-red-700 transition"
-            >
-              <Trash2 size={14} />
-              {LABELS.deleteProfile}
-            </button>
-          </div>
 
-          {deleteProfileError && (
-            <p className="mt-3 text-xs text-red-400">{deleteProfileError}</p>
-          )}
+            {deleteProfileError && (
+              <p className="mt-3 text-xs text-red-400">{deleteProfileError}</p>
+            )}
+          </div>
         </div>
-      </div>
+      )}
 
       {/* ── Confirm dialogs ── */}
       <ConfirmDialog

--- a/src/settings/settings-api.ts
+++ b/src/settings/settings-api.ts
@@ -160,6 +160,113 @@ export interface Profile {
   status: ProfileStatus;
 }
 
+function asRecord(value: unknown): Record<string, unknown> {
+  return value && typeof value === "object" && !Array.isArray(value)
+    ? (value as Record<string, unknown>)
+    : {};
+}
+
+const DEFAULT_GATEWAY_CONFIG: GatewayConfig = {
+  max_history: null,
+  max_iterations: null,
+  system_prompt: null,
+  max_concurrent_sessions: null,
+  browser_timeout_secs: null,
+  max_output_tokens: null,
+};
+
+const DEFAULT_SANDBOX_CONFIG: SandboxConfig = {
+  enabled: false,
+  mode: "auto",
+  allow_network: false,
+  docker: {
+    image: "ubuntu:24.04",
+    cpu_limit: null,
+    memory_limit: null,
+    pids_limit: null,
+    mount_mode: "rw",
+    extra_binds: [],
+  },
+  read_allow_paths: [],
+};
+
+const DEFAULT_PROFILE_CONFIG: ProfileConfig = {
+  llm: {
+    primary: { family_id: "", model_id: "" },
+    fallbacks: [],
+  },
+  home: null,
+  channels: [],
+  gateway: DEFAULT_GATEWAY_CONFIG,
+  env_vars: {},
+  hooks: [],
+  email: null,
+  api_type: null,
+  admin_mode: false,
+  sandbox: DEFAULT_SANDBOX_CONFIG,
+  adaptive_routing: null,
+  content_routing: null,
+  plugins: { require_signed: false },
+};
+
+export function normalizeProfileConfig(config: Partial<ProfileConfig> | null | undefined): ProfileConfig {
+  const source = asRecord(config);
+  const llm = asRecord(source.llm);
+  const primary = asRecord(llm.primary);
+  const gateway = asRecord(source.gateway);
+  const sandbox = asRecord(source.sandbox);
+  const docker = asRecord(sandbox.docker);
+  const plugins = asRecord(source.plugins);
+
+  return {
+    ...DEFAULT_PROFILE_CONFIG,
+    ...source,
+    llm: {
+      primary: {
+        family_id: typeof primary.family_id === "string" ? primary.family_id : "",
+        model_id: typeof primary.model_id === "string" ? primary.model_id : "",
+        route:
+          primary.route && typeof primary.route === "object"
+            ? (primary.route as LlmPrimary["route"])
+            : null,
+      },
+      fallbacks: Array.isArray(llm.fallbacks) ? (llm.fallbacks as LlmPrimary[]) : [],
+    },
+    channels: Array.isArray(source.channels) ? source.channels : [],
+    gateway: {
+      ...DEFAULT_GATEWAY_CONFIG,
+      ...gateway,
+    },
+    env_vars: asRecord(source.env_vars) as Record<string, string>,
+    hooks: Array.isArray(source.hooks) ? source.hooks : [],
+    email: typeof source.email === "string" ? source.email : null,
+    api_type: typeof source.api_type === "string" ? source.api_type : null,
+    admin_mode: source.admin_mode === true,
+    sandbox: {
+      ...DEFAULT_SANDBOX_CONFIG,
+      ...sandbox,
+      docker: {
+        ...DEFAULT_SANDBOX_CONFIG.docker,
+        ...docker,
+        extra_binds: Array.isArray(docker.extra_binds) ? (docker.extra_binds as string[]) : [],
+      },
+      read_allow_paths: Array.isArray(sandbox.read_allow_paths)
+        ? (sandbox.read_allow_paths as string[])
+        : [],
+    },
+    plugins: {
+      require_signed: plugins.require_signed === true,
+    },
+  };
+}
+
+export function normalizeProfile(profile: Profile): Profile {
+  return {
+    ...profile,
+    config: normalizeProfileConfig(profile.config),
+  };
+}
+
 export interface ProviderModelsRequest {
   provider: string;
   model?: string;
@@ -180,7 +287,7 @@ export interface SkillInfo {
 
 export async function getMyProfile(): Promise<Profile | null> {
   try {
-    return await request<Profile>("/api/my/profile");
+    return normalizeProfile(await request<Profile>("/api/my/profile"));
   } catch {
     return null;
   }
@@ -189,10 +296,10 @@ export async function getMyProfile(): Promise<Profile | null> {
 export async function updateMyProfile(
   patch: { name?: string; enabled?: boolean; config?: Partial<ProfileConfig> },
 ): Promise<Profile> {
-  return await request<Profile>("/api/my/profile", {
+  return normalizeProfile(await request<Profile>("/api/my/profile", {
     method: "PUT",
     body: JSON.stringify(patch),
-  });
+  }));
 }
 
 export function mergeProfileConfig(
@@ -501,7 +608,8 @@ export async function fetchOperatorTasks(): Promise<OperatorTasksResponse | null
 }
 
 export async function fetchAllProfiles(): Promise<Profile[]> {
-  return await request<Profile[]>("/api/admin/profiles");
+  const profiles = await request<Profile[]>("/api/admin/profiles");
+  return profiles.map(normalizeProfile);
 }
 
 export async function startProfile(profileId: string): Promise<string | null> {

--- a/src/settings/settings-page.tsx
+++ b/src/settings/settings-page.tsx
@@ -152,7 +152,11 @@ export function AdminSettingsPage() {
               {!isAdminOnlyTab && profile ? (
                 <>
                   {activeTab === "profile" && (
-                    <ProfileTab profile={profile} onProfileUpdated={setProfile} />
+                    <ProfileTab
+                      profile={profile}
+                      onProfileUpdated={setProfile}
+                      canDeleteProfile={Boolean(portal?.can_access_admin_portal)}
+                    />
                   )}
                   {activeTab === "llm" && (
                     <LlmTab profile={profile} onProfileUpdated={setProfile} />

--- a/tests/helpers.ts
+++ b/tests/helpers.ts
@@ -123,6 +123,58 @@ function harnessReplyFor(message: string): string {
 async function installDefaultE2EHarness(page: Page) {
   const sessions = new Map<string, HarnessSession>();
   let adaptiveMode: "off" | "hedge" | "lane" = "off";
+  let harnessProfile = {
+    id: "admin",
+    name: "Admin",
+    enabled: true,
+    data_dir: null,
+    created_at: "2026-01-01T00:00:00Z",
+    updated_at: "2026-01-01T00:00:00Z",
+    status: {
+      running: false,
+      pid: null,
+      started_at: null,
+      uptime_secs: null,
+    },
+    config: {
+      llm: {
+        primary: { family_id: "openai", model_id: "gpt-5.4" },
+        fallbacks: [],
+      },
+      home: null,
+      channels: [],
+      gateway: {
+        max_history: null,
+        max_iterations: null,
+        system_prompt: null,
+        max_concurrent_sessions: null,
+        browser_timeout_secs: null,
+        max_output_tokens: null,
+      },
+      env_vars: {},
+      hooks: [],
+      email: "admin@localhost",
+      api_type: null,
+      admin_mode: true,
+      sandbox: {
+        enabled: false,
+        mode: "off",
+        allow_network: false,
+        docker: {
+          image: "ubuntu:24.04",
+          cpu_limit: null,
+          memory_limit: null,
+          pids_limit: null,
+          mount_mode: "read_only",
+          extra_binds: [],
+        },
+        read_allow_paths: [],
+      },
+      adaptive_routing: null,
+      content_routing: null,
+      plugins: { require_signed: false },
+    },
+  };
 
   const ensureSession = (id: string): HarnessSession => {
     let session = sessions.get(id);
@@ -197,6 +249,23 @@ async function installDefaultE2EHarness(page: Page) {
       },
     }),
   );
+  await page.route(/\/api\/my\/profile$/, async (route) => {
+    if (route.request().method() === "PUT") {
+      const body = route.request().postDataJSON() as {
+        name?: string;
+        enabled?: boolean;
+        config?: typeof harnessProfile.config;
+      };
+      harnessProfile = {
+        ...harnessProfile,
+        ...(body.name !== undefined ? { name: body.name } : {}),
+        ...(body.enabled !== undefined ? { enabled: body.enabled } : {}),
+        ...(body.config !== undefined ? { config: body.config } : {}),
+        updated_at: new Date().toISOString(),
+      };
+    }
+    await fulfillJson(route, harnessProfile);
+  });
   await page.route(/\/api\/status$/, (route) =>
     fulfillJson(route, {
       version: "test",

--- a/tests/live-settings-profile.spec.ts
+++ b/tests/live-settings-profile.spec.ts
@@ -1,0 +1,122 @@
+import { expect, test, type Page } from "@playwright/test";
+
+test.skip(process.env.OCTOS_LIVE_E2E !== "1", "requires a live octos API server");
+
+const LIVE_TIMEOUT = 30_000;
+
+async function ensureSoloSession(page: Page): Promise<{ token: string; profileId: string }> {
+  await page.goto("/login", { waitUntil: "networkidle" });
+
+  const soloButton = page.getByTestId("solo-continue");
+  await expect(soloButton).toBeVisible({ timeout: LIVE_TIMEOUT });
+  await soloButton.click();
+
+  const form = page.getByTestId("solo-profile-form");
+  if (await form.isVisible({ timeout: 5_000 }).catch(() => false)) {
+    const suffix = Date.now().toString(36);
+    await page.getByTestId("solo-name").fill(`Live Smoke ${suffix}`);
+    await page.getByTestId("solo-username").fill(`live-smoke-${suffix}`);
+    await page.getByTestId("solo-email").fill(`live-smoke-${suffix}@localhost`);
+    await page.getByTestId("solo-submit").click();
+  }
+
+  await page.waitForURL((url) => !url.pathname.endsWith("/login"), {
+    timeout: LIVE_TIMEOUT,
+  });
+
+  const session = await page.evaluate(() => ({
+    token: localStorage.getItem("octos_session_token") || localStorage.getItem("octos_auth_token") || "",
+    profileId: localStorage.getItem("selected_profile") || "",
+  }));
+
+  expect(session.token).toBeTruthy();
+  expect(session.profileId).toBeTruthy();
+  return session;
+}
+
+async function liveApi<T>(
+  page: Page,
+  path: string,
+  init: { method?: string; body?: unknown } = {},
+): Promise<T> {
+  return await page.evaluate(
+    async ({ path, init }) => {
+      const token =
+        localStorage.getItem("octos_session_token") ||
+        localStorage.getItem("octos_auth_token");
+      const profileId = localStorage.getItem("selected_profile");
+      const resp = await fetch(path, {
+        method: init.method ?? "GET",
+        headers: {
+          "Content-Type": "application/json",
+          ...(token ? { Authorization: `Bearer ${token}` } : {}),
+          ...(profileId ? { "X-Profile-Id": profileId } : {}),
+        },
+        body: init.body === undefined ? undefined : JSON.stringify(init.body),
+      });
+      const text = await resp.text();
+      if (!resp.ok) {
+        throw new Error(`${resp.status} ${text}`);
+      }
+      return text ? JSON.parse(text) : null;
+    },
+    { path, init },
+  );
+}
+
+test.describe("live Settings and profile smoke", () => {
+  test("loads Settings tabs without the mocked harness", async ({ page }) => {
+    await ensureSoloSession(page);
+    await page.goto("/settings", { waitUntil: "networkidle" });
+    await expect(page.locator(".animate-spin")).toBeHidden({ timeout: LIVE_TIMEOUT });
+
+    for (const label of ["Profile", "LLM", "Skills", "Channels", "Sandbox", "Tools"]) {
+      const tab = page.locator("aside button", { hasText: label }).first();
+      await expect(tab).toBeVisible({ timeout: LIVE_TIMEOUT });
+      await tab.click();
+      await expect(page.locator("text=No profile available")).toHaveCount(0);
+    }
+  });
+
+  test("persists Home config through the real profile endpoint", async ({ page }) => {
+    await ensureSoloSession(page);
+    const profile = await liveApi<Record<string, unknown>>(page, "/api/my/profile");
+    const config = (profile.config ?? {}) as Record<string, unknown>;
+    const suffix = Date.now().toString(36);
+
+    const nextHome = {
+      settings: {
+        city: `Tokyo Live ${suffix}`,
+        temp_unit: "C",
+        clock_format: "24h",
+        idle_seconds: 45,
+        night_mode: "auto",
+        lang: "en",
+        news_feed_url: "https://feeds.bbci.co.uk/news/rss.xml",
+      },
+      events: [
+        {
+          id: `live-${suffix}`,
+          title: "Live smoke dinner",
+          date: "2026-06-14",
+          time: "19:30",
+        },
+      ],
+      widgets: [{ type: "weather", enabled: true, order: 3 }],
+      metro_layout: { clock: { col: 1, row: 1, w: 4, h: 2 } },
+    };
+
+    await liveApi(page, "/api/my/profile", {
+      method: "PUT",
+      body: {
+        name: profile.name,
+        enabled: profile.enabled,
+        config: { ...config, home: nextHome },
+      },
+    });
+
+    const reloaded = await liveApi<Record<string, unknown>>(page, "/api/my/profile");
+    const reloadedConfig = reloaded.config as Record<string, unknown>;
+    expect(reloadedConfig.home).toMatchObject(nextHome);
+  });
+});

--- a/tests/metro-tiles.spec.ts
+++ b/tests/metro-tiles.spec.ts
@@ -190,6 +190,57 @@ test.describe("Metro tiles", () => {
   });
 
   test("home widget order controls Metro tile order and placement", async ({ page }) => {
+    const widgets = [
+      { type: "weather", enabled: true, order: 0 },
+      { type: "clock", enabled: true, order: 1 },
+      { type: "quick-actions", enabled: true, order: 2 },
+      { type: "voice-orb", enabled: true, order: 3 },
+      { type: "news", enabled: true, order: 4 },
+      { type: "calendar", enabled: true, order: 5 },
+      { type: "timer", enabled: true, order: 6 },
+      { type: "photo-frame", enabled: false, order: 7 },
+      { type: "greeting", enabled: true, order: 8 },
+    ];
+    let profile = {
+      id: "admin",
+      name: "Admin",
+      enabled: true,
+      data_dir: null,
+      created_at: "2026-01-01T00:00:00Z",
+      updated_at: "2026-01-01T00:00:00Z",
+      status: {
+        running: false,
+        pid: null,
+        started_at: null,
+        uptime_secs: null,
+      },
+      config: {
+        home: {
+          widgets,
+          metro_layout: {},
+        },
+      },
+    };
+    await page.route("**/api/my/profile", async (route) => {
+      if (route.request().method() === "PUT") {
+        const body = route.request().postDataJSON() as {
+          config?: Record<string, unknown>;
+        };
+        profile = {
+          ...profile,
+          config: {
+            ...profile.config,
+            ...(body.config ?? {}),
+          },
+        };
+      }
+      await route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify(profile),
+      });
+    });
+
     await page.evaluate(() => {
       localStorage.setItem(
         "octos_home_widgets",

--- a/tests/settings-tabs.spec.ts
+++ b/tests/settings-tabs.spec.ts
@@ -17,6 +17,7 @@ interface SettingsMockOptions {
   ominixServiceActionErrors?: Partial<Record<"start" | "stop" | "restart", { status: number; body: unknown }>>;
   ominixHealthError?: { status: number; body: unknown };
   accessibleProfiles?: AccessibleProfileMock[];
+  canAccessAdminPortal?: boolean;
 }
 
 interface AccessibleProfileMock {
@@ -132,11 +133,11 @@ async function installAdminSettingsMocks(
         },
         profile: activeProfile,
         portal: {
-          kind: "admin",
+          kind: options.canAccessAdminPortal === false ? "profile" : "admin",
           home_profile_id: "admin",
           home_route: "/",
-          can_access_admin_portal: true,
-          can_manage_users: true,
+          can_access_admin_portal: options.canAccessAdminPortal !== false,
+          can_manage_users: options.canAccessAdminPortal !== false,
           sub_account_limit: 10,
           accessible_profiles: accessibleProfiles,
         },
@@ -743,6 +744,22 @@ test.describe("Settings page — tab smoke tests", () => {
         page.locator("text=No profile available").first(),
       ).toBeVisible({ timeout: TIMEOUT });
     }
+  });
+
+  test("Profile tab hides destructive admin actions for profile-only users", async ({ page }) => {
+    await installServerSettingsMocks(page, { canAccessAdminPortal: false });
+    await seedAdminSession(page);
+
+    await page.goto("/settings", { waitUntil: "networkidle" });
+    await expect(page.locator(".animate-spin")).toBeHidden({ timeout: TIMEOUT });
+    await clickTab(page, "Profile");
+
+    await expect(
+      page.locator("h3", { hasText: "Profile Information" }),
+    ).toBeVisible({ timeout: TIMEOUT });
+    await expect(page.getByText("Delete Profile")).toHaveCount(0);
+    await expect(page.locator("aside button", { hasText: "Users" })).toHaveCount(0);
+    await expect(page.locator("aside button", { hasText: "OminiX" })).toHaveCount(0);
   });
 
   test("Profile save surfaces backend validation errors", async ({ page }) => {


### PR DESCRIPTION
## Summary
- normalize partial profile configs returned by live `/api/my/profile` before rendering Settings tabs
- hide profile deletion from profile-only users and cover it with a Settings smoke test
- add a live Settings/profile Playwright smoke that exercises real `/api/my/profile` GET/PUT without the default mocked harness
- make the default E2E harness own `/api/my/profile`, update Metro ordering test to use profile-backed home config, and remove the browser-side IP geolocation fallback that caused localhost CORS console errors

## Verification
- `npm run build`
- `npm run test:unit` -> 56 files passed, 648 tests passed
- `BASE_URL=http://127.0.0.1:5174 ./node_modules/.bin/playwright test --reporter=list` -> 89 passed, 28 skipped, 0 failed
- `BASE_URL=http://127.0.0.1:5174 OCTOS_LIVE_E2E=1 ./node_modules/.bin/playwright test tests/live-settings-profile.spec.ts --workers=1 --reporter=list` -> 2 passed
- local visual smoke against live backend: `/settings` and `/home` rendered with no overlay, no horizontal overflow, no relevant console logs, no page errors

## Notes
- Build still emits existing warnings for generated `[file:...]` CSS utilities and the pre-existing `src/api/sessions.ts` mixed static/dynamic import chunking warning.
- Live backend used local solo mode at `http://127.0.0.1:50080`; frontend dev server used `http://127.0.0.1:5174`.
