### PR TITLE
Expand live Settings smoke coverage

### DIFF
--- a/tests/live-settings-profile.spec.ts
+++ b/tests/live-settings-profile.spec.ts
@@ -64,6 +64,24 @@ async function liveApi<T>(
   );
 }
 
+async function expectNoRuntimeOverlay(page: Page) {
+  const state = await page.evaluate(() => ({
+    hasOverlay: Boolean(
+      document.querySelector("[plugin-vite], vite-error-overlay, #webpack-dev-server-client-overlay"),
+    ),
+    horizontalOverflow:
+      document.documentElement.scrollWidth > document.documentElement.clientWidth + 1,
+    runtimeErrorText: /TypeError|ReferenceError|Cannot read properties|Internal server error/i.test(
+      document.body.innerText,
+    ),
+  }));
+  expect(state).toEqual({
+    hasOverlay: false,
+    horizontalOverflow: false,
+    runtimeErrorText: false,
+  });
+}
+
 test.describe("live Settings and profile smoke", () => {
   test("loads Settings tabs without the mocked harness", async ({ page }) => {
     await ensureSoloSession(page);
@@ -76,6 +94,46 @@ test.describe("live Settings and profile smoke", () => {
       await tab.click();
       await expect(page.locator("text=No profile available")).toHaveCount(0);
     }
+  });
+
+  test("loads admin Settings tabs and OminiX offline state without mocks", async ({ page }) => {
+    await ensureSoloSession(page);
+    await page.goto("/settings", { waitUntil: "networkidle" });
+    await expect(page.locator(".animate-spin")).toBeHidden({ timeout: LIVE_TIMEOUT });
+
+    const usersTab = page.locator("aside button", { hasText: "Users" }).first();
+    await expect(usersTab).toBeVisible({ timeout: LIVE_TIMEOUT });
+    await usersTab.click();
+    await expect(page.getByText("Create Sub-Account")).toBeVisible({ timeout: LIVE_TIMEOUT });
+    await expect(page.getByText("Allowed Emails")).toBeVisible({ timeout: LIVE_TIMEOUT });
+    await expectNoRuntimeOverlay(page);
+
+    await page.locator("aside button", { hasText: "System" }).first().click();
+    await expect(page.getByText("Operator Overview")).toBeVisible({ timeout: LIVE_TIMEOUT });
+    await expect(page.getByText("Live Logs")).toBeVisible({ timeout: LIVE_TIMEOUT });
+    await expectNoRuntimeOverlay(page);
+
+    await page.locator("aside button", { hasText: "Server" }).first().click();
+    await expect(page.getByText("Deployment Mode")).toBeVisible({ timeout: LIVE_TIMEOUT });
+    await expect(page.getByText("Admin Token Status")).toBeVisible({ timeout: LIVE_TIMEOUT });
+    await expectNoRuntimeOverlay(page);
+
+    await page.locator("aside button", { hasText: "OminiX" }).first().click();
+    await expect(page.getByRole("heading", { name: "OminiX API" })).toBeVisible({ timeout: LIVE_TIMEOUT });
+    await expect(page.getByRole("heading", { name: "Enabled Platform Models" })).toBeVisible({ timeout: LIVE_TIMEOUT });
+    await expect(page.getByRole("heading", { name: "Available Catalog" })).toBeVisible({ timeout: LIVE_TIMEOUT });
+    await expect(page.getByRole("heading", { name: "Logs" })).toBeVisible({ timeout: LIVE_TIMEOUT });
+    const enabledModels = page.locator("section", { hasText: "Enabled Platform Models" });
+    await expect(
+      enabledModels.getByText("qwen3-asr-1.7b").first(),
+    ).toBeVisible({ timeout: LIVE_TIMEOUT });
+    await expect(
+      page.getByText("available models:", { exact: false }).first(),
+    ).toBeVisible({ timeout: LIVE_TIMEOUT });
+    await expect(page.getByText("No catalog models returned")).toBeVisible({
+      timeout: LIVE_TIMEOUT,
+    });
+    await expectNoRuntimeOverlay(page);
   });
 
   test("persists Home config through the real profile endpoint", async ({ page }) => {


### PR DESCRIPTION
## Summary
- add live admin Settings coverage for Users, System, Server, and OminiX tabs
- assert OminiX offline/catalog error state renders cleanly without the mocked harness
- add a shared runtime-overlay/no-horizontal-overflow check for the live Settings smoke

## Verification
- `BASE_URL=http://127.0.0.1:5174 OCTOS_LIVE_E2E=1 ./node_modules/.bin/playwright test tests/live-settings-profile.spec.ts --workers=1 --reporter=list` -> 3 passed
- `BASE_URL=http://127.0.0.1:5174 ./node_modules/.bin/playwright test --reporter=list` -> 89 passed, 29 skipped, 0 failed

## Notes
- The OminiX live smoke is read-only. It does not start/stop/restart services, rotate tokens, download models, or remove local models.
- On the local live backend, `/api/admin/platform-skills/ominix-api/models` returns offline fallback rows, and `/models/available` returns a visible backend error; the test asserts that this real state renders instead of assuming the catalog is available.
