### PR TITLE
Warm workbench shell and expand live Settings smoke

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -29,7 +29,7 @@
   --color-assistant-bubble: #211d18;
 
   /* Semantic */
-  --color-link: #7ca8b8;
+  --color-link: #94a36f;
   --color-heading: #dbb07a;
   --color-heading-accent: #e8c07f;
   --color-code-inline: #d9a170;
@@ -63,7 +63,7 @@
   --color-user-bubble: rgba(169, 95, 57, 0.09);
   --color-assistant-bubble: #fbfcfa;
 
-  --color-link: #4d7f91;
+  --color-link: #6f8656;
   --color-heading: #9c663d;
   --color-heading-accent: #a77532;
   --color-code-inline: #b87a4a;
@@ -318,15 +318,20 @@ body {
 .workbench-shell {
   min-height: 100vh;
   background:
-    linear-gradient(180deg, color-mix(in srgb, var(--color-surface-dark) 92%, var(--color-link) 8%), var(--color-surface-dark));
+    linear-gradient(
+      180deg,
+      color-mix(in srgb, var(--color-surface-dark) 86%, #5d442b 14%),
+      color-mix(in srgb, var(--color-surface-dark) 94%, #6f7a42 6%) 42%,
+      var(--color-surface-dark)
+    );
   color: var(--color-text);
 }
 
 .workbench-topbar {
-  border-bottom: 1px solid var(--color-border);
-  background: color-mix(in srgb, var(--color-surface) 92%, transparent);
-  backdrop-filter: blur(16px);
-  -webkit-backdrop-filter: blur(16px);
+  border-bottom: 1px solid color-mix(in srgb, var(--color-border) 76%, var(--color-accent) 24%);
+  background: color-mix(in srgb, var(--color-surface-dark) 72%, var(--color-surface) 28%);
+  backdrop-filter: blur(10px);
+  -webkit-backdrop-filter: blur(10px);
   position: relative;
   z-index: 20;
 }
@@ -365,8 +370,8 @@ body {
 }
 
 .workbench-route-link:hover {
-  border-color: var(--color-border);
-  background: var(--color-surface-container);
+  border-color: color-mix(in srgb, var(--color-border) 78%, var(--color-accent) 22%);
+  background: color-mix(in srgb, var(--color-surface-container) 84%, var(--color-accent) 16%);
   color: var(--color-text-strong);
 }
 
@@ -378,8 +383,13 @@ body {
 }
 
 .workbench-rail {
-  border-right: 1px solid var(--color-border);
-  background: color-mix(in srgb, var(--color-surface) 88%, var(--color-surface-container) 12%);
+  border-right: 1px solid color-mix(in srgb, var(--color-border) 82%, var(--color-accent) 18%);
+  background:
+    linear-gradient(
+      180deg,
+      color-mix(in srgb, var(--color-surface) 88%, #5d442b 12%),
+      color-mix(in srgb, var(--color-surface-container) 90%, #53613f 10%)
+    );
 }
 
 .workbench-panel {
@@ -411,7 +421,7 @@ body {
   background: color-mix(in srgb, var(--color-surface-container) 88%, var(--color-accent) 12%);
   box-shadow:
     0 0 0 1px var(--color-accent-container),
-    0 10px 28px color-mix(in srgb, var(--color-accent) 12%, transparent);
+    0 10px 22px color-mix(in srgb, var(--color-accent) 10%, transparent);
 }
 
 .workbench-route-card {
@@ -572,6 +582,88 @@ body {
   color: var(--color-accent);
   box-shadow: inset 3px 0 0 var(--color-accent);
   border-radius: 0 8px 8px 0;
+}
+
+.settings-shell {
+  background:
+    linear-gradient(
+      180deg,
+      color-mix(in srgb, var(--color-surface-dark) 82%, #5a412d 18%),
+      color-mix(in srgb, var(--color-surface-dark) 92%, #6b7344 8%) 44%,
+      var(--color-surface-dark)
+    );
+}
+
+[data-theme="light"] .workbench-shell,
+[data-theme="light"] .settings-shell {
+  background:
+    linear-gradient(
+      180deg,
+      color-mix(in srgb, var(--color-surface) 88%, #d7b47a 12%),
+      color-mix(in srgb, var(--color-surface-dark) 88%, #9dac7c 12%)
+    );
+}
+
+.settings-shell .workbench-topbar {
+  background: color-mix(in srgb, var(--color-surface-dark) 78%, var(--color-surface) 22%);
+}
+
+[data-theme="light"] .settings-shell .workbench-topbar {
+  background: color-mix(in srgb, var(--color-surface-elevated) 86%, #c99a64 14%);
+}
+
+.settings-main {
+  background:
+    linear-gradient(
+      180deg,
+      color-mix(in srgb, var(--color-surface-dark) 92%, transparent),
+      color-mix(in srgb, var(--color-surface) 88%, transparent)
+    );
+}
+
+.settings-shell .settings-rail {
+  background:
+    linear-gradient(
+      180deg,
+      color-mix(in srgb, var(--color-surface) 84%, #5e442e 16%),
+      color-mix(in srgb, var(--color-surface-container) 88%, #657246 12%)
+    );
+}
+
+.settings-shell .glass-section {
+  border-color: color-mix(in srgb, var(--color-border) 74%, var(--color-accent) 26%);
+  background: color-mix(in srgb, var(--color-surface-container) 88%, #4d3a2a 12%);
+  box-shadow: none;
+}
+
+[data-theme="light"] .settings-shell .glass-section {
+  background: color-mix(in srgb, var(--color-surface-elevated) 84%, #e4cfad 16%);
+}
+
+.settings-shell .rounded-xl,
+.settings-shell .rounded-\[12px\] {
+  border-radius: 8px !important;
+}
+
+.settings-shell .bg-surface-dark\/50,
+.settings-shell .bg-surface-container\/50,
+.settings-shell .bg-surface-container\/60,
+.settings-shell .bg-surface-container\/40 {
+  background-color: color-mix(in srgb, var(--color-surface-container) 82%, var(--color-accent) 8%) !important;
+}
+
+.settings-shell .border-border\/30,
+.settings-shell .border-border\/50,
+.settings-shell .border-border\/70 {
+  border-color: color-mix(in srgb, var(--color-border) 78%, var(--color-accent) 22%) !important;
+}
+
+.settings-shell .bg-accent.text-white {
+  color: #17110c !important;
+}
+
+.settings-shell .text-link {
+  color: var(--color-link);
 }
 
 @media (max-width: 768px) {
@@ -1186,9 +1278,10 @@ button, a, input, textarea {
 
 /* ── Home Assistant UI ──────────────────────────────── */
 
-/* Root — deep dark background, no gradient noise */
+/* Root — warm dark background, no decorative noise */
 .home-root {
-  background: #090806;
+  background:
+    linear-gradient(180deg, #17120d 0%, #0f0c08 46%, #080706 100%);
   color: #fbf6ea;
   font-family: "SF Pro Display", "Inter", -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
   -webkit-font-smoothing: antialiased;
@@ -1200,7 +1293,8 @@ button, a, input, textarea {
 
 /* ── Standby view ─────────────────────────────────── */
 .home-standby {
-  background: #090806;
+  background:
+    linear-gradient(180deg, #17120d 0%, #0f0c08 46%, #080706 100%);
   background-size: 100% 200%;
   animation: gradientShift 20s ease-in-out infinite;
   scrollbar-width: none;
@@ -1272,11 +1366,11 @@ button, a, input, textarea {
 
 /* ── Widget card base (glassmorphism) ────────────── */
 .home-widget {
-  background: rgba(255, 255, 255, 0.05);
+  background: rgba(86, 61, 39, 0.22);
   backdrop-filter: none;
   -webkit-backdrop-filter: none;
-  border: 1px solid rgba(255, 255, 255, 0.08);
-  border-radius: 20px;
+  border: 1px solid rgba(226, 180, 127, 0.14);
+  border-radius: 8px;
   transition:
     background 0.2s ease,
     border-color 0.2s ease,
@@ -1284,8 +1378,8 @@ button, a, input, textarea {
 }
 
 .home-widget:hover {
-  background: rgba(255, 255, 255, 0.07);
-  border-color: rgba(255, 255, 255, 0.12);
+  background: rgba(96, 69, 44, 0.28);
+  border-color: rgba(226, 180, 127, 0.2);
 }
 
 /* ── Weather widget ──────────────────────────────── */
@@ -1327,11 +1421,11 @@ button, a, input, textarea {
 
 .home-quick-card {
   border: none;
-  background: rgba(255, 255, 255, 0.05);
+  background: rgba(86, 61, 39, 0.22);
   backdrop-filter: none;
   -webkit-backdrop-filter: none;
-  border-radius: 20px;
-  border: 1px solid rgba(255, 255, 255, 0.08);
+  border-radius: 8px;
+  border: 1px solid rgba(226, 180, 127, 0.14);
   cursor: pointer;
   padding: 1.25rem 0.75rem;
   outline: none;
@@ -1343,8 +1437,8 @@ button, a, input, textarea {
 
 .home-quick-card:hover,
 .home-quick-card:focus-visible {
-  background: rgba(255, 255, 255, 0.09);
-  border-color: rgba(255, 255, 255, 0.16);
+  background: rgba(96, 69, 44, 0.32);
+  border-color: rgba(226, 180, 127, 0.24);
   transform: translateY(-2px);
 }
 
@@ -1357,8 +1451,8 @@ button, a, input, textarea {
   height: 56px;
   min-width: 44px;
   min-height: 44px;
-  background: rgba(255, 255, 255, 0.06);
-  border: 1px solid rgba(255, 255, 255, 0.08);
+  background: rgba(226, 180, 127, 0.08);
+  border: 1px solid rgba(226, 180, 127, 0.14);
   transition:
     background 0.2s ease,
     border-color 0.2s ease,
@@ -1367,17 +1461,23 @@ button, a, input, textarea {
 
 .home-quick-card:hover .home-quick-card-icon,
 .home-quick-card:focus-visible .home-quick-card-icon {
-  background: rgba(255, 255, 255, 0.12);
-  border-color: rgba(255, 255, 255, 0.16);
+  background: rgba(226, 180, 127, 0.13);
+  border-color: rgba(226, 180, 127, 0.24);
 }
 
 .home-quick-card:active .home-quick-card-icon {
   transform: scale(0.95);
 }
 
+.home-root .rounded-xl,
+.home-root .rounded-\[12px\] {
+  border-radius: 8px !important;
+}
+
 /* ── Conversation view ────────────────────────────── */
 .home-conversation {
-  background: #090806;
+  background:
+    linear-gradient(180deg, #17120d 0%, #0f0c08 46%, #080706 100%);
 }
 
 .home-back-button {
@@ -2232,6 +2332,8 @@ button, a, input, textarea {
   position: relative;
   width: 100%;
   height: 100%;
+  background:
+    linear-gradient(180deg, #17120d 0%, #0f0c08 46%, #080706 100%);
   overflow-y: auto;
   overflow-x: hidden;
   scrollbar-width: none;
@@ -2315,13 +2417,15 @@ button, a, input, textarea {
 .metro-tile {
   border-radius: 4px;
   overflow: hidden;
-  transition: box-shadow 0.2s ease, transform 0.15s ease;
+  box-shadow: inset 0 0 0 1px rgba(245, 217, 181, 0.035);
+  transition: box-shadow 0.2s ease, transform 0.15s ease, filter 0.15s ease;
   cursor: pointer;
   position: relative;
   touch-action: manipulation;
 }
 .metro-tile:hover {
-  box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.08);
+  box-shadow: inset 0 0 0 1px rgba(245, 217, 181, 0.12);
+  filter: saturate(1.04);
 }
 .metro-tile:active {
   transform: scale(0.985);

--- a/src/settings/settings-page.tsx
+++ b/src/settings/settings-page.tsx
@@ -82,7 +82,7 @@ export function AdminSettingsPage() {
   const isAdminOnlyTab = activeTab === "system" || activeTab === "server" || activeTab === "users" || activeTab === "ominix";
 
   return (
-    <WorkbenchPage>
+    <WorkbenchPage className="settings-shell">
       <WorkbenchTopbar
         onBack={() => navigate(-1)}
         icon={SettingsIcon}
@@ -142,7 +142,7 @@ export function AdminSettingsPage() {
             </div>
           </aside>
 
-          <main className="min-w-0 flex-1 overflow-y-auto px-8 py-6 max-md:px-4 max-md:py-4">
+          <main className="settings-main min-w-0 flex-1 overflow-y-auto px-8 py-6 max-md:px-4 max-md:py-4">
             <div className={`mx-auto ${isAdminOnlyTab ? "max-w-4xl" : "max-w-3xl"}`}>
               {activeTab === "system" && portal?.can_access_admin_portal && <SystemTab />}
               {activeTab === "server" && portal?.can_access_admin_portal && <ServerTab />}

--- a/tests/live-settings-profile.spec.ts
+++ b/tests/live-settings-profile.spec.ts
@@ -64,6 +64,45 @@ async function liveApi<T>(
   );
 }
 
+async function liveApiRaw(
+  page: Page,
+  path: string,
+  init: { method?: string; body?: unknown } = {},
+): Promise<{ ok: boolean; status: number; text: string; json: unknown | null }> {
+  return await page.evaluate(
+    async ({ path, init }) => {
+      const token =
+        localStorage.getItem("octos_session_token") ||
+        localStorage.getItem("octos_auth_token");
+      const profileId = localStorage.getItem("selected_profile");
+      const resp = await fetch(path, {
+        method: init.method ?? "GET",
+        headers: {
+          "Content-Type": "application/json",
+          ...(token ? { Authorization: `Bearer ${token}` } : {}),
+          ...(profileId ? { "X-Profile-Id": profileId } : {}),
+        },
+        body: init.body === undefined ? undefined : JSON.stringify(init.body),
+      });
+      const text = await resp.text();
+      let json: unknown | null = null;
+      try {
+        json = text ? JSON.parse(text) : null;
+      } catch {
+        json = null;
+      }
+      return { ok: resp.ok, status: resp.status, text, json };
+    },
+    { path, init },
+  );
+}
+
+function expectObject(value: unknown, label: string): asserts value is Record<string, unknown> {
+  expect(value, label).toBeTruthy();
+  expect(Array.isArray(value), label).toBe(false);
+  expect(typeof value, label).toBe("object");
+}
+
 async function expectNoRuntimeOverlay(page: Page) {
   const state = await page.evaluate(() => ({
     hasOverlay: Boolean(
@@ -133,6 +172,104 @@ test.describe("live Settings and profile smoke", () => {
     await expect(page.getByText("No catalog models returned")).toBeVisible({
       timeout: LIVE_TIMEOUT,
     });
+    await expectNoRuntimeOverlay(page);
+  });
+
+  test("read-only Settings APIs return live contract-shaped data", async ({ page }) => {
+    await ensureSoloSession(page);
+    await page.goto("/settings", { waitUntil: "networkidle" });
+    await expect(page.locator(".animate-spin")).toBeHidden({ timeout: LIVE_TIMEOUT });
+
+    const profileStatus = await liveApiRaw(page, "/api/my/profile/status");
+    expect(profileStatus.status).toBe(200);
+    const profileStatusJson = profileStatus.json;
+    expectObject(profileStatusJson, "profile status");
+
+    const profileSkills = await liveApiRaw(page, "/api/my/profile/skills");
+    expect(profileSkills.status).toBe(200);
+    const profileSkillsJson = profileSkills.json;
+    expectObject(profileSkillsJson, "profile skills");
+    expect(Array.isArray(profileSkillsJson.skills)).toBe(true);
+
+    const users = await liveApiRaw(page, "/api/admin/users");
+    expect(users.status).toBe(200);
+    const usersJson = users.json;
+    expectObject(usersJson, "admin users");
+    expect(Array.isArray(usersJson.users)).toBe(true);
+
+    const allowedEmails = await liveApiRaw(page, "/api/admin/allowed-emails");
+    expect(allowedEmails.status).toBe(200);
+    const allowedEmailsJson = allowedEmails.json;
+    expectObject(allowedEmailsJson, "allowed emails");
+    expect(Array.isArray(allowedEmailsJson.entries)).toBe(true);
+
+    const operatorSummary = await liveApiRaw(page, "/api/admin/operator/summary");
+    expect(operatorSummary.status).toBe(200);
+    const operatorSummaryJson = operatorSummary.json;
+    expectObject(operatorSummaryJson, "operator summary");
+
+    const operatorTasks = await liveApiRaw(page, "/api/admin/operator/tasks");
+    expect(operatorTasks.status).toBe(200);
+    const operatorTasksJson = operatorTasks.json;
+    expectObject(operatorTasksJson, "operator tasks");
+    expect(Array.isArray(operatorTasksJson.tasks)).toBe(true);
+
+    const monitorStatus = await liveApiRaw(page, "/api/admin/monitor/status");
+    expect(monitorStatus.status).toBe(200);
+    const monitorStatusJson = monitorStatus.json;
+    expectObject(monitorStatusJson, "monitor status");
+    expect(typeof monitorStatusJson.watchdog_enabled).toBe("boolean");
+
+    const deploymentMode = await liveApiRaw(page, "/api/admin/deployment-mode");
+    expect(deploymentMode.status).toBe(200);
+    const deploymentModeJson = deploymentMode.json;
+    expectObject(deploymentModeJson, "deployment mode");
+    expect(typeof deploymentModeJson.mode).toBe("string");
+
+    const deploymentDetect = await liveApiRaw(page, "/api/admin/deployment-mode/detect");
+    expect(deploymentDetect.status).toBe(200);
+    const deploymentDetectJson = deploymentDetect.json;
+    expectObject(deploymentDetectJson, "deployment detection");
+    expect(typeof deploymentDetectJson.detected).toBe("string");
+
+    const systemMetrics = await liveApiRaw(page, "/api/admin/system/metrics");
+    expect(systemMetrics.status).toBe(200);
+    const systemMetricsJson = systemMetrics.json;
+    expectObject(systemMetricsJson, "system metrics");
+
+    const tokenStatus = await liveApiRaw(page, "/api/admin/token/status");
+    expect(tokenStatus.status).toBe(200);
+    const tokenStatusJson = tokenStatus.json;
+    expectObject(tokenStatusJson, "token status");
+    expect(typeof tokenStatusJson.rotated).toBe("boolean");
+
+    const platformSkills = await liveApiRaw(page, "/api/admin/platform-skills");
+    expect(platformSkills.status).toBe(200);
+    const platformSkillsJson = platformSkills.json;
+    expectObject(platformSkillsJson, "platform skills");
+    expect(Array.isArray(platformSkillsJson.platform_skills)).toBe(true);
+
+    const enabledModels = await liveApiRaw(page, "/api/admin/platform-skills/ominix-api/models");
+    expect(enabledModels.status).toBe(200);
+    const enabledModelsJson = enabledModels.json;
+    expectObject(enabledModelsJson, "enabled OminiX models");
+    expect(Array.isArray(enabledModelsJson.models)).toBe(true);
+    expect(JSON.stringify(enabledModelsJson.models)).toContain("qwen3-asr-1.7b");
+
+    const availableModels = await liveApiRaw(page, "/api/admin/platform-skills/ominix-api/models/available");
+    expect([200, 502]).toContain(availableModels.status);
+    if (availableModels.status === 200) {
+      const availableModelsJson = availableModels.json;
+      if (Array.isArray(availableModelsJson)) {
+        expect(availableModelsJson.length).toBeGreaterThanOrEqual(0);
+      } else {
+        expectObject(availableModelsJson, "available OminiX catalog");
+        expect(Array.isArray(availableModelsJson.models)).toBe(true);
+      }
+    } else {
+      expect(availableModels.text).toContain("ominix-api");
+    }
+
     await expectNoRuntimeOverlay(page);
   });
 

--- a/tests/ui-redesign-smoke.spec.ts
+++ b/tests/ui-redesign-smoke.spec.ts
@@ -234,4 +234,26 @@ test.describe("UI redesign shell smoke", () => {
       await expectNoHorizontalOverflow(page);
     }
   });
+
+  test("settings shell keeps warm restrained control styling", async ({ page }) => {
+    await page.setViewportSize({ width: 1440, height: 900 });
+    await page.goto("/settings", { waitUntil: "networkidle" });
+
+    await expect(page.locator(".settings-shell")).toBeVisible();
+    await expect(page.locator(".settings-shell .glass-section").first()).toBeVisible();
+
+    const styling = await page.evaluate(() => {
+      const root = document.documentElement;
+      const section = document.querySelector(".settings-shell .glass-section");
+      const activeTab = document.querySelector(".settings-shell .settings-tab-button[data-active='true']");
+      const link = getComputedStyle(root).getPropertyValue("--color-link").trim();
+      const sectionRadius = section ? parseFloat(getComputedStyle(section).borderRadius) : Number.NaN;
+      const tabRadius = activeTab ? parseFloat(getComputedStyle(activeTab).borderTopRightRadius) : Number.NaN;
+      return { link, sectionRadius, tabRadius };
+    });
+
+    expect(styling.link.toLowerCase()).not.toMatch(/7ca8b8|4d7f91|blue|purple/);
+    expect(styling.sectionRadius).toBeLessThanOrEqual(8);
+    expect(styling.tabRadius).toBeLessThanOrEqual(8);
+  });
 });


### PR DESCRIPTION
## Summary
- Warm the shared workbench and Settings shell away from cold blue/black styling, with olive/terracotta accents and restrained 8px control radii.
- Add Settings-scoped visual guardrails and warm the Home Metro display background without touching drag/resize logic.
- Expand live Settings smoke coverage with read-only real API contract checks for profile, admin, operator, server, and OminiX endpoints.

## Verification
- npm run build
- npm run test:unit: 56 files passed, 648 tests passed
- BASE_URL=http://127.0.0.1:5174 ./node_modules/.bin/playwright test tests/ui-redesign-smoke.spec.ts --reporter=list: 5 passed
- BASE_URL=http://127.0.0.1:5174 OCTOS_LIVE_E2E=1 ./node_modules/.bin/playwright test tests/live-settings-profile.spec.ts --workers=1 --reporter=list: 4 passed
- BASE_URL=http://127.0.0.1:5174 ./node_modules/.bin/playwright test --reporter=list: 90 passed, 30 skipped
- ./node_modules/.bin/eslint src/settings/settings-page.tsx tests/live-settings-profile.spec.ts tests/ui-redesign-smoke.spec.ts

## Notes
- Full npm run lint still fails on existing repo-wide lint debt outside this PR (auth/slides/tests/markdown), so I verified the files changed here separately.