### PR TITLE
[codex] Warm file panels and stabilize Metro tests

### DIFF
--- a/src/components/content-browser.tsx
+++ b/src/components/content-browser.tsx
@@ -335,16 +335,16 @@ export function ContentBrowser({
   };
 
   return (
-    <div className="glass-panel flex h-full flex-col overflow-hidden rounded-[16px]">
+    <div className="glass-panel flex h-full flex-col overflow-hidden rounded-lg">
       <div className="px-3 pt-3">
-        <div className="glass-toolbar flex flex-wrap items-start justify-between gap-3 rounded-[14px] px-4 py-4">
+        <div className="glass-toolbar flex flex-wrap items-start justify-between gap-3 rounded-lg px-4 py-4">
           <div className="min-w-0 flex-1">
             <div className="shell-kicker">Session Files</div>
             <SessionTitleEditor
               value={sessionTitle}
               onSave={onRenameTitle}
               buttonClassName="mt-2 w-full text-left text-[1.24rem] font-semibold tracking-tight text-text-strong transition hover:text-accent"
-              inputClassName="mt-2 w-full rounded-[12px] border border-accent/40 bg-surface-container px-3 py-2.5 text-[1.08rem] font-semibold tracking-tight text-text outline-none"
+              inputClassName="workbench-input mt-2 w-full px-3 py-2.5 text-[1.08rem] font-semibold tracking-tight text-text"
               testId="content-session-title"
             />
             <div className="mt-2 text-xs text-muted">
@@ -354,7 +354,7 @@ export function ContentBrowser({
           <div className="flex items-center gap-2">
             <button
               onClick={onToggleMaximize}
-              className="glass-icon-button rounded-[10px] p-2"
+              className="glass-icon-button p-2"
               title={isMaximized ? "Restore" : "Maximize"}
               aria-label={isMaximized ? "Restore files panel" : "Maximize files panel"}
             >
@@ -366,7 +366,7 @@ export function ContentBrowser({
             </button>
             <button
               onClick={onClose}
-              className="glass-icon-button rounded-[10px] p-2"
+              className="glass-icon-button p-2"
               title="Close"
               aria-label="Close files panel"
             >
@@ -376,7 +376,7 @@ export function ContentBrowser({
         </div>
 
         <div className="mt-2 grid gap-2 xl:grid-cols-[minmax(180px,1fr)_auto_auto]">
-          <label className="glass-section flex min-w-0 items-center gap-2 rounded-[12px] px-3 py-2">
+          <label className="workbench-input flex min-w-0 items-center gap-2 px-3 py-2">
             <Search size={14} className="shrink-0 text-muted" />
             <input
               value={search}
@@ -389,7 +389,7 @@ export function ContentBrowser({
             <select
               value={category}
               onChange={(event) => setCategory(event.target.value as CategoryFilter)}
-              className="glass-section rounded-[12px] px-3 py-2 text-sm text-text outline-none"
+              className="workbench-input px-3 py-2 text-sm"
               aria-label="Filter by type"
             >
               {CATEGORY_OPTIONS.map((option) => (
@@ -401,7 +401,7 @@ export function ContentBrowser({
             <select
               value={dateFilter}
               onChange={(event) => setDateFilter(event.target.value as DateFilter)}
-              className="glass-section rounded-[12px] px-3 py-2 text-sm text-text outline-none"
+              className="workbench-input px-3 py-2 text-sm"
               aria-label="Filter by date"
             >
               {DATE_OPTIONS.map((option) => (
@@ -411,7 +411,7 @@ export function ContentBrowser({
               ))}
             </select>
           </div>
-          <div className="glass-section flex items-center gap-1 rounded-[12px] p-1">
+          <div className="glass-section flex items-center gap-1 rounded-lg p-1">
             <ModeButton active={viewMode === "timeline"} onClick={() => setViewMode("timeline")}>
               <Clock3 size={14} />
               <span>Timeline</span>
@@ -428,27 +428,27 @@ export function ContentBrowser({
         </div>
 
         {selectedEntries.length > 0 && (
-          <div className="glass-section mt-2 flex flex-wrap items-center gap-2 rounded-[12px] px-3 py-2 text-xs text-muted">
+          <div className="glass-section mt-2 flex flex-wrap items-center gap-2 rounded-lg px-3 py-2 text-xs text-muted">
             <span className="font-medium text-text">
               {selectedEntries.length} selected
             </span>
             <button
               onClick={downloadSelected}
-              className="glass-icon-button rounded-[9px] px-2 py-1.5 hover:text-accent"
+              className="glass-icon-button px-2 py-1.5 hover:text-accent"
             >
               <Download size={13} />
               <span>Download</span>
             </button>
             <button
               onClick={() => deleteEntries(selectedEntries.map((entry) => entry.id))}
-              className="glass-icon-button rounded-[9px] px-2 py-1.5 hover:text-red-300"
+              className="glass-icon-button px-2 py-1.5 hover:text-red-300"
             >
               <Trash2 size={13} />
               <span>Delete</span>
             </button>
             <button
               onClick={() => setSelectedIds(new Set())}
-              className="ml-auto rounded-[9px] px-2 py-1.5 text-muted hover:bg-surface-elevated hover:text-text"
+              className="ml-auto rounded-lg px-2 py-1.5 text-muted hover:bg-surface-elevated hover:text-text"
             >
               Clear
             </button>
@@ -462,11 +462,11 @@ export function ContentBrowser({
 
       <div className="flex-1 overflow-y-auto px-3 pb-3 pt-2">
         {entries.length === 0 ? (
-          <div className="shell-empty-state flex h-full items-center justify-center rounded-[12px] px-5 text-center text-sm text-muted">
+          <div className="shell-empty-state flex h-full items-center justify-center rounded-lg px-5 text-center text-sm text-muted">
             Files generated in your sessions will appear here.
           </div>
         ) : filteredEntries.length === 0 ? (
-          <div className="shell-empty-state flex h-full items-center justify-center rounded-[12px] px-5 text-center text-sm text-muted">
+          <div className="shell-empty-state flex h-full items-center justify-center rounded-lg px-5 text-center text-sm text-muted">
             No files match the current filters.
           </div>
         ) : (
@@ -474,7 +474,7 @@ export function ContentBrowser({
             <div className="mb-2 flex items-center justify-between gap-3 text-xs text-muted">
               <button
                 onClick={selectVisible}
-                className="rounded-[9px] px-2 py-1.5 hover:bg-surface-elevated hover:text-text"
+                className="rounded-lg px-2 py-1.5 hover:bg-surface-elevated hover:text-text"
               >
                 Select visible
               </button>
@@ -553,9 +553,8 @@ function ModeButton({
     <button
       type="button"
       onClick={onClick}
-      className={`flex items-center gap-1.5 rounded-[9px] px-2.5 py-1.5 text-xs font-medium ${
-        active ? "bg-accent text-white" : "text-muted hover:bg-surface-elevated hover:text-text"
-      }`}
+      data-active={active ? "true" : undefined}
+      className="workbench-button flex items-center gap-1.5 px-2.5 py-1.5 text-xs font-medium"
     >
       {children}
     </button>
@@ -591,7 +590,7 @@ function EntryActions({
           event.stopPropagation();
           onToggleSelected(entry.id);
         }}
-        className={`flex h-7 w-7 items-center justify-center rounded-[9px] border ${
+        className={`flex h-7 w-7 items-center justify-center rounded-lg border ${
           selected
             ? "border-accent bg-accent text-white"
             : "border-border text-transparent hover:text-muted"
@@ -606,7 +605,7 @@ function EntryActions({
           event.stopPropagation();
           void downloadContent(entry);
         }}
-        className="glass-icon-button rounded-[9px] p-1.5 hover:text-accent"
+        className="glass-icon-button p-1.5 hover:text-accent"
         title="Download"
         aria-label={`Download ${entry.filename}`}
       >
@@ -617,7 +616,7 @@ function EntryActions({
           event.stopPropagation();
           onStartRename(entry);
         }}
-        className="glass-icon-button rounded-[9px] p-1.5 hover:text-accent"
+        className="glass-icon-button p-1.5 hover:text-accent"
         title="Rename"
         aria-label={`Rename ${entry.filename}`}
       >
@@ -628,7 +627,7 @@ function EntryActions({
           event.stopPropagation();
           onDelete(entry);
         }}
-        className="glass-icon-button rounded-[9px] p-1.5 hover:text-red-300"
+        className="glass-icon-button p-1.5 hover:text-red-300"
         title="Delete"
         aria-label={`Delete ${entry.filename}`}
       >
@@ -659,18 +658,18 @@ function RenameField({
           if (event.key === "Enter") onCommit();
           if (event.key === "Escape") onCancel();
         }}
-        className="min-w-0 flex-1 rounded-[9px] border border-accent/40 bg-surface-container px-2 py-1.5 text-sm text-text outline-none"
+        className="workbench-input min-w-0 flex-1 px-2 py-1.5 text-sm"
       />
       <button
         onClick={onCommit}
-        className="glass-icon-button rounded-[9px] p-1.5 text-emerald-300"
+        className="glass-icon-button p-1.5 text-emerald-300"
         title="Save rename"
       >
         <Check size={13} />
       </button>
       <button
         onClick={onCancel}
-        className="glass-icon-button rounded-[9px] p-1.5 text-muted"
+        className="glass-icon-button p-1.5 text-muted"
         title="Cancel rename"
       >
         <X size={13} />
@@ -720,11 +719,11 @@ function EntryPreview({ entry }: { entry: ContentEntry }) {
 function EntryRow(props: EntryActionProps) {
   return (
     <div
-      className="glass-file-row flex items-start gap-3 rounded-[12px] px-3 py-3 transition-colors hover:bg-surface-elevated/70"
+      className="glass-file-row flex items-start gap-3 rounded-lg px-3 py-3 transition-colors hover:bg-surface-elevated/70"
       onClick={() => props.onOpen(props.entry)}
       data-testid="content-file-row"
     >
-      <div className="glass-pill mt-0.5 flex h-9 w-9 shrink-0 items-center justify-center rounded-[10px] text-muted">
+      <div className="glass-pill mt-0.5 flex h-9 w-9 shrink-0 items-center justify-center rounded-lg text-muted">
         {renderFileIcon(props.entry, 15)}
       </div>
       <div className="min-w-0 flex-1">
@@ -759,7 +758,7 @@ function TimelineView(props: Omit<EntryActionProps, "entry" | "selected" | "rena
     <div className="space-y-3">
       {groupByDay(props.entries).map(([key, entries]) => (
         <section key={key} className="space-y-2">
-          <div className="sticky top-0 z-10 glass-toolbar rounded-[10px] px-3 py-2 text-xs font-semibold text-text-strong">
+          <div className="sticky top-0 z-10 glass-toolbar rounded-lg px-3 py-2 text-xs font-semibold text-text-strong">
             {dayLabel(key)}
           </div>
           <div className="space-y-2">
@@ -809,7 +808,7 @@ function GridView(props: Omit<EntryActionProps, "entry" | "selected" | "renaming
 function EntryCard(props: EntryActionProps) {
   return (
     <div
-      className="group overflow-hidden rounded-[12px] border border-border bg-surface-container transition-colors hover:bg-surface-elevated"
+      className="group overflow-hidden rounded-lg border border-border bg-surface-container transition-colors hover:bg-surface-elevated"
       onClick={() => props.onOpen(props.entry)}
       data-testid="content-file-card"
     >
@@ -821,7 +820,7 @@ function EntryCard(props: EntryActionProps) {
               event.stopPropagation();
               props.onToggleSelected(props.entry.id);
             }}
-            className={`flex h-7 w-7 items-center justify-center rounded-[9px] border ${
+            className={`flex h-7 w-7 items-center justify-center rounded-lg border ${
               props.selected
                 ? "border-accent bg-accent text-white"
                 : "border-white/40 bg-black/30 text-transparent group-hover:text-white"

--- a/src/sites/components/project-files.tsx
+++ b/src/sites/components/project-files.tsx
@@ -57,7 +57,7 @@ function EditableTitle({ value, onSave }: { value: string; onSave?: (value: stri
     return (
       <input
         defaultValue={value}
-        className="mt-1 w-full rounded border border-accent/50 bg-surface-container px-1 py-0.5 text-[11px] text-muted outline-none"
+        className="workbench-input mt-1 w-full px-1 py-0.5 text-[11px]"
         autoFocus
         onBlur={(event) => {
           const next = event.target.value.trim();
@@ -99,11 +99,11 @@ function formatTime(value: string): string {
   });
 }
 
-function fileIcon(file: SiteFileEntry) {
+function FileIconView({ file }: { file: SiteFileEntry }) {
   const category = inferContentCategory(file);
-  if (category === "image") return ImageIcon;
-  if (isViewerFile(file.filename)) return FileText;
-  return File;
+  if (category === "image") return <ImageIcon size={14} />;
+  if (isViewerFile(file.filename)) return <FileText size={14} />;
+  return <File size={14} />;
 }
 
 function isViewerFile(filename: string) {
@@ -413,7 +413,7 @@ export function ProjectFiles({
 
   return (
     <div className="flex h-full flex-col">
-      <div className="border-b border-border px-3 py-2">
+      <div className="glass-toolbar m-3 mb-0 rounded-lg px-3 py-2">
         <div className="flex items-start justify-between gap-3">
           <div className="min-w-0 flex-1">
             <div className="text-xs font-semibold uppercase tracking-normal text-muted">
@@ -434,7 +434,7 @@ export function ProjectFiles({
             />
             <button
               onClick={() => fileInputRef.current?.click()}
-              className="rounded-lg p-2 text-muted transition hover:bg-surface-container hover:text-text disabled:cursor-not-allowed disabled:opacity-50"
+              className="glass-icon-button p-2 disabled:cursor-not-allowed disabled:opacity-50"
               title={`Upload assets into ${uploadTarget}`}
               disabled={uploading}
             >
@@ -442,7 +442,7 @@ export function ProjectFiles({
             </button>
             <button
               onClick={triggerRefresh}
-              className="rounded-lg p-2 text-muted transition hover:bg-surface-container hover:text-text"
+              className="glass-icon-button p-2"
               title="Refresh files"
             >
               <RefreshCw size={15} className={uploading ? "animate-spin" : ""} />
@@ -532,7 +532,6 @@ function FileNodeView({
 }) {
   const file = node.file;
   const entry = entryMap.get(file.path) ?? siteFileToContentEntry(file, sessionId);
-  const Icon = fileIcon(file);
   const category = inferContentCategory(file);
   const opensViewer = category === "image" || isViewerFile(file.filename);
 
@@ -545,11 +544,11 @@ function FileNodeView({
           void downloadContent(entry);
         }
       }}
-      className="flex w-full items-start gap-2 rounded-xl px-2 py-2 text-left transition-colors hover:bg-surface-container"
+      className="glass-file-row flex w-full items-start gap-2 rounded-lg px-2 py-2 text-left transition-colors hover:bg-surface-elevated/70"
       style={{ paddingLeft: `${10 + depth * 16}px` }}
     >
       <div className="mt-0.5 shrink-0 text-muted">
-        <Icon size={14} />
+        <FileIconView file={file} />
       </div>
       <div className="min-w-0 flex-1">
         <div className="truncate text-sm text-text-strong">{file.filename}</div>

--- a/src/slides/components/project-files.tsx
+++ b/src/slides/components/project-files.tsx
@@ -63,7 +63,7 @@ function EditableTitle({ value, onSave }: { value: string; onSave?: (v: string) 
     return (
       <input
         defaultValue={value}
-        className="mt-2 w-full rounded-[12px] border border-accent/50 bg-surface-container px-3 py-2 text-lg font-semibold tracking-tight text-text outline-none"
+        className="workbench-input mt-2 w-full px-3 py-2 text-lg font-semibold tracking-tight"
         autoFocus
         onBlur={(e) => {
           const v = e.target.value.trim();
@@ -252,14 +252,14 @@ function isViewerFile(filename: string) {
   return /\.(md|markdown|txt|js|jsx|ts|tsx|json)$/i.test(filename);
 }
 
-function fileIcon(file: SlidesFileEntry) {
+function FileIconView({ file }: { file: SlidesFileEntry }) {
   const category = inferContentCategory(file);
-  if (category === "slides") return Presentation;
-  if (category === "image") return ImageIcon;
-  if (category === "audio") return Music;
-  if (category === "video") return VideoIcon;
-  if (isViewerFile(file.filename)) return FileText;
-  return File;
+  if (category === "slides") return <Presentation size={14} />;
+  if (category === "image") return <ImageIcon size={14} />;
+  if (category === "audio") return <Music size={14} />;
+  if (category === "video") return <VideoIcon size={14} />;
+  if (isViewerFile(file.filename)) return <FileText size={14} />;
+  return <File size={14} />;
 }
 
 export function ProjectFiles({
@@ -502,13 +502,13 @@ export function ProjectFiles({
   let body: ReactNode;
   if (error) {
     body = (
-      <div className="shell-empty-state flex h-full items-center justify-center rounded-[12px] px-4 text-center text-sm text-muted">
+      <div className="shell-empty-state flex h-full items-center justify-center rounded-lg px-4 text-center text-sm text-muted">
         Failed to load project files: {error}
       </div>
     );
   } else if (files.length === 0) {
     body = (
-      <div className="shell-empty-state flex h-full items-center justify-center rounded-[12px] px-4 text-center text-sm text-muted">
+      <div className="shell-empty-state flex h-full items-center justify-center rounded-lg px-4 text-center text-sm text-muted">
         Project files will appear here after the backend scaffold finishes.
       </div>
     );
@@ -531,9 +531,9 @@ export function ProjectFiles({
   }
 
   return (
-    <div className="glass-panel flex h-full flex-col overflow-hidden rounded-[16px]">
+    <div className="glass-panel flex h-full flex-col overflow-hidden rounded-lg">
       <div className="px-3 pt-3">
-        <div className="glass-toolbar rounded-[14px] px-4 py-4">
+        <div className="glass-toolbar rounded-lg px-4 py-4">
           <div className="shell-kicker">Project Files</div>
           <EditableTitle value={title || slug} onSave={onRename} />
           <WorkspaceContractCard contract={contract} />
@@ -553,7 +553,7 @@ function WorkspaceContractCard({
 }) {
   if (!contract) {
     return (
-      <div className="mt-3 rounded-[12px] border border-border/60 bg-surface-container/70 px-3 py-3 text-xs text-muted">
+      <div className="glass-section mt-3 rounded-lg px-3 py-3 text-xs text-muted">
         Workspace contract status is loading.
       </div>
     );
@@ -570,7 +570,7 @@ function WorkspaceContractCard({
   const StatusIcon = contract.error || !contract.ready ? AlertTriangle : CheckCircle2;
 
   return (
-    <div className={`mt-3 rounded-[12px] border px-3 py-3 text-xs ${statusTone}`}>
+    <div className={`glass-section mt-3 rounded-lg px-3 py-3 text-xs ${statusTone}`}>
       <div className="flex items-center justify-between gap-3">
         <div className="flex items-center gap-2">
           <StatusIcon size={14} className="shrink-0" />
@@ -603,14 +603,14 @@ function WorkspaceContractCard({
       {failedChecks.length > 0 ? (
         <div className="mt-3 space-y-1 text-[11px] text-amber-100">
           {failedChecks.slice(0, 4).map((check) => (
-            <div key={check.spec} className="rounded-[10px] bg-black/15 px-2 py-1.5">
+            <div key={check.spec} className="rounded-lg bg-black/15 px-2 py-1.5">
               <div className="font-medium">{check.spec}</div>
               <div className="mt-0.5 text-amber-100/80">{check.reason || "validation failed"}</div>
             </div>
           ))}
         </div>
       ) : contract.error ? (
-        <div className="mt-3 rounded-[10px] bg-black/15 px-2 py-1.5 text-[11px] text-amber-100/85">
+        <div className="mt-3 rounded-lg bg-black/15 px-2 py-1.5 text-[11px] text-amber-100/85">
           {contract.error}
         </div>
       ) : null}
@@ -634,47 +634,100 @@ function TreeNodeView({
   onOpenFile: (entry: ContentEntry, allEntries: ContentEntry[]) => void;
 }) {
   if (node.kind === "file") {
-    const file = node.file;
-    const entry = entryMap.get(file.path) ?? slidesFileToContentEntry(file);
-    const Icon = fileIcon(file);
-    const category = inferContentCategory(file);
-    const opensViewer = category === "image" || isViewerFile(file.filename);
-
     return (
-      <button
-        onClick={() => {
-          if (opensViewer) {
-            onOpenFile(
-              entry,
-              category === "image" && manifestImagePaths.has(entry.path)
-                ? manifestImageEntries
-                : [entry],
-            );
-          } else {
-            void downloadContent(entry);
-          }
-        }}
-        className="glass-file-row flex w-full items-start gap-2 rounded-[12px] px-2 py-2 text-left transition-colors hover:bg-surface-elevated/70"
-        style={{ paddingLeft: `${10 + depth * 16}px` }}
-      >
-        <div className="glass-pill mt-0.5 flex h-8 w-8 shrink-0 items-center justify-center rounded-[10px] text-muted">
-          <Icon size={14} />
-        </div>
-        <div className="min-w-0 flex-1">
-          <div className="truncate text-sm font-medium text-text-strong">
-            {file.filename}
-          </div>
-          <div className="truncate text-[10px] text-muted/65">{node.relativePath}</div>
-          <div className="mt-1 flex flex-wrap gap-x-2 gap-y-0.5 text-[10px] text-muted">
-            <span>{formatSize(file.size)}</span>
-            <span>{formatTime(file.modified)}</span>
-            <span className="uppercase tracking-[0.14em] text-muted/60">{category}</span>
-          </div>
-        </div>
-      </button>
+      <FileNodeView
+        node={node}
+        depth={depth}
+        entryMap={entryMap}
+        manifestImageEntries={manifestImageEntries}
+        manifestImagePaths={manifestImagePaths}
+        onOpenFile={onOpenFile}
+      />
     );
   }
 
+  return (
+    <FolderNodeView
+      node={node}
+      depth={depth}
+      entryMap={entryMap}
+      manifestImageEntries={manifestImageEntries}
+      manifestImagePaths={manifestImagePaths}
+      onOpenFile={onOpenFile}
+    />
+  );
+}
+
+function FileNodeView({
+  node,
+  depth,
+  entryMap,
+  manifestImageEntries,
+  manifestImagePaths,
+  onOpenFile,
+}: {
+  node: FileNode;
+  depth: number;
+  entryMap: Map<string, ContentEntry>;
+  manifestImageEntries: ContentEntry[];
+  manifestImagePaths: Set<string>;
+  onOpenFile: (entry: ContentEntry, allEntries: ContentEntry[]) => void;
+}) {
+  const file = node.file;
+  const entry = entryMap.get(file.path) ?? slidesFileToContentEntry(file);
+  const category = inferContentCategory(file);
+  const opensViewer = category === "image" || isViewerFile(file.filename);
+
+  return (
+    <button
+      onClick={() => {
+        if (opensViewer) {
+          onOpenFile(
+            entry,
+            category === "image" && manifestImagePaths.has(entry.path)
+              ? manifestImageEntries
+              : [entry],
+          );
+        } else {
+          void downloadContent(entry);
+        }
+      }}
+      className="glass-file-row flex w-full items-start gap-2 rounded-lg px-2 py-2 text-left transition-colors hover:bg-surface-elevated/70"
+      style={{ paddingLeft: `${10 + depth * 16}px` }}
+    >
+      <div className="glass-pill mt-0.5 flex h-8 w-8 shrink-0 items-center justify-center rounded-lg text-muted">
+        <FileIconView file={file} />
+      </div>
+      <div className="min-w-0 flex-1">
+        <div className="truncate text-sm font-medium text-text-strong">
+          {file.filename}
+        </div>
+        <div className="truncate text-[10px] text-muted/65">{node.relativePath}</div>
+        <div className="mt-1 flex flex-wrap gap-x-2 gap-y-0.5 text-[10px] text-muted">
+          <span>{formatSize(file.size)}</span>
+          <span>{formatTime(file.modified)}</span>
+          <span className="uppercase tracking-[0.14em] text-muted/60">{category}</span>
+        </div>
+      </div>
+    </button>
+  );
+}
+
+function FolderNodeView({
+  node,
+  depth,
+  entryMap,
+  manifestImageEntries,
+  manifestImagePaths,
+  onOpenFile,
+}: {
+  node: FolderNode;
+  depth: number;
+  entryMap: Map<string, ContentEntry>;
+  manifestImageEntries: ContentEntry[];
+  manifestImagePaths: Set<string>;
+  onOpenFile: (entry: ContentEntry, allEntries: ContentEntry[]) => void;
+}) {
   const [open, setOpen] = useState(() => defaultFolderOpen(node.name, depth));
   return (
     <div>

--- a/tests/metro-tiles.spec.ts
+++ b/tests/metro-tiles.spec.ts
@@ -4,7 +4,10 @@ import { login } from "./helpers";
 test.describe("Metro tiles", () => {
   test.beforeEach(async ({ page }) => {
     await login(page);
-    await page.evaluate(() => localStorage.removeItem("octos_home_metro_layout"));
+    await page.evaluate(() => {
+      localStorage.removeItem("octos_home_metro_layout");
+      localStorage.setItem("octos_home_night_mode", "off");
+    });
     await page.goto("/home", { waitUntil: "networkidle" });
     await expect(page.locator(".metro-grid")).toBeVisible();
   });
@@ -201,7 +204,7 @@ test.describe("Metro tiles", () => {
       { type: "photo-frame", enabled: false, order: 7 },
       { type: "greeting", enabled: true, order: 8 },
     ];
-    let profile = {
+    const profile = {
       id: "admin",
       name: "Admin",
       enabled: true,
@@ -216,24 +219,18 @@ test.describe("Metro tiles", () => {
       },
       config: {
         home: {
+          settings: {
+            night_mode: "off",
+          },
           widgets,
           metro_layout: {},
         },
       },
     };
-    await page.route("**/api/my/profile", async (route) => {
-      if (route.request().method() === "PUT") {
-        const body = route.request().postDataJSON() as {
-          config?: Record<string, unknown>;
-        };
-        profile = {
-          ...profile,
-          config: {
-            ...profile.config,
-            ...(body.config ?? {}),
-          },
-        };
-      }
+    let profileHits = 0;
+    await page.unroute(/\/api\/my\/profile$/);
+    await page.route(/\/api\/my\/profile$/, async (route) => {
+      profileHits += 1;
       await route.fulfill({
         status: 200,
         contentType: "application/json",
@@ -256,11 +253,13 @@ test.describe("Metro tiles", () => {
           { type: "greeting", enabled: true, order: 8 },
         ]),
       );
+      localStorage.setItem("octos_home_night_mode", "off");
       localStorage.removeItem("octos_home_metro_layout");
     });
 
     await page.reload({ waitUntil: "networkidle" });
     await expect(page.locator(".metro-grid")).toBeVisible();
+    expect(profileHits).toBeGreaterThan(0);
 
     await expect(page.locator(".metro-tile").first()).toHaveAttribute(
       "data-tile-id",

--- a/tests/ui-redesign-smoke.spec.ts
+++ b/tests/ui-redesign-smoke.spec.ts
@@ -35,6 +35,25 @@ async function fulfillJson(route: Route, body: unknown) {
 }
 
 async function installWorkbenchMocks(page: Page) {
+  const contentEntry = {
+    id: "content-1",
+    filename: "family-plan.md",
+    path: "pf/mock/family-plan.md",
+    category: "report",
+    size_bytes: 128,
+    created_at: "2026-01-01T00:00:00Z",
+    thumbnail_path: null,
+    session_id: "web-ui-smoke",
+    tool_name: "write_file",
+    caption: "Shared household notes",
+  };
+  const sessionFile = {
+    filename: contentEntry.filename,
+    path: contentEntry.path,
+    size_bytes: contentEntry.size_bytes,
+    modified_at: contentEntry.created_at,
+  };
+
   await page.addInitScript(() => {
     localStorage.setItem("octos_session_token", "ui-smoke-token");
     localStorage.setItem("octos_auth_token", "ui-smoke-token");
@@ -119,6 +138,23 @@ async function installWorkbenchMocks(page: Page) {
       });
       return;
     }
+    if (path === "/api/my/content") {
+      await fulfillJson(route, { entries: [contentEntry], total: 1 });
+      return;
+    }
+    if (path === "/api/files/list") {
+      await fulfillJson(route, [
+        {
+          filename: contentEntry.filename,
+          path: contentEntry.path,
+          size: contentEntry.size_bytes,
+          modified: contentEntry.created_at,
+          category: "report",
+          group: "Shared household notes",
+        },
+      ]);
+      return;
+    }
     if (path.startsWith("/api/sessions")) {
       await fulfillJson(route, {
         sessions: [{ id: "web-ui-smoke", title: "Visual review", message_count: 0 }],
@@ -165,8 +201,10 @@ async function installWorkbenchMocks(page: Page) {
                   : message.method === "session/tasks.list"
                     ? { tasks: [] }
                     : message.method === "session/files.list"
-                      ? { files: [] }
-                      : { ok: true, replayed_envelopes: [] };
+                      ? { files: [sessionFile] }
+                      : message.method === "content/list"
+                        ? { entries: [contentEntry], total: 1 }
+                        : { ok: true, replayed_envelopes: [] };
       ws.send(JSON.stringify({ jsonrpc: "2.0", id: message.id, result }));
     });
   });
@@ -255,5 +293,53 @@ test.describe("UI redesign shell smoke", () => {
     expect(styling.link.toLowerCase()).not.toMatch(/7ca8b8|4d7f91|blue|purple/);
     expect(styling.sectionRadius).toBeLessThanOrEqual(8);
     expect(styling.tabRadius).toBeLessThanOrEqual(8);
+  });
+
+  test("content file panel keeps warm restrained control styling", async ({ page }) => {
+    await page.setViewportSize({ width: 1440, height: 900 });
+    await page.goto("/chat", { waitUntil: "networkidle" });
+    await page.evaluate(() => {
+      window.dispatchEvent(
+        new CustomEvent("crew:file", {
+          detail: {
+            fileUrl: "/api/files/pf/mock/family-plan.md",
+            filename: "family-plan.md",
+            caption: "Shared household notes",
+            sessionId: "web-ui-smoke",
+          },
+        }),
+      );
+    });
+
+    await page.getByTitle("Open files panel").click();
+    await expect(page.getByText("Session Files")).toBeVisible();
+    await expect(page.getByTestId("content-file-row")).toBeVisible();
+
+    const styling = await page.evaluate(() => {
+      const parseRadius = (selector: string) => {
+        const element = document.querySelector(selector);
+        return element ? parseFloat(getComputedStyle(element).borderTopLeftRadius) : Number.NaN;
+      };
+      const panel = document.querySelector(".chat-media-panel-wrap .glass-panel");
+      const hasOldRoundedClass = panel
+        ? /rounded-\[(1[0-9]|[2-9][0-9])px\]|rounded-xl|rounded-2xl|rounded-3xl/.test(
+            panel.innerHTML,
+          )
+        : true;
+      return {
+        panelRadius: parseRadius(".chat-media-panel-wrap .glass-panel"),
+        toolbarRadius: parseRadius(".chat-media-panel-wrap .glass-toolbar"),
+        rowRadius: parseRadius("[data-testid='content-file-row']"),
+        inputRadius: parseRadius(".chat-media-panel-wrap .workbench-input"),
+        hasOldRoundedClass,
+      };
+    });
+
+    expect(styling.panelRadius).toBeLessThanOrEqual(8);
+    expect(styling.toolbarRadius).toBeLessThanOrEqual(8);
+    expect(styling.rowRadius).toBeLessThanOrEqual(8);
+    expect(styling.inputRadius).toBeLessThanOrEqual(8);
+    expect(styling.hasOldRoundedClass).toBe(false);
+    await expectNoHorizontalOverflow(page);
   });
 });


### PR DESCRIPTION
## Summary
- Warm the session, Slides, and Sites file panels with the shared workbench controls and 8px-radius surfaces.
- Add a content panel UI smoke with live-style file data so the harness checks row/input/panel styling.
- Stabilize Metro tile tests by disabling night mode in the Metro suite and making the widget-order profile mock deterministic.

## Root cause
The Metro widget-order e2e was time-dependent: after 22:00, Home night mode hides every tile except Clock, so the test could fail while the product behavior was correct. The suite now forces `octos_home_night_mode=off` before loading `/home`.

## Verification
- `pnpm exec eslint src/components/content-browser.tsx src/slides/components/project-files.tsx src/sites/components/project-files.tsx tests/ui-redesign-smoke.spec.ts tests/metro-tiles.spec.ts`
- `pnpm exec tsc -b --pretty false`
- `npm run build`
- `npm run test:unit` -> 56 files passed, 648 tests passed
- `BASE_URL=http://127.0.0.1:5174 ./node_modules/.bin/playwright test tests/content-panel.spec.ts tests/ui-redesign-smoke.spec.ts --reporter=list` -> 8 passed
- `BASE_URL=http://127.0.0.1:5174 ./node_modules/.bin/playwright test tests/metro-tiles.spec.ts --reporter=list` -> 7 passed
- `BASE_URL=http://127.0.0.1:5174 OCTOS_LIVE_E2E=1 ./node_modules/.bin/playwright test tests/live-settings-profile.spec.ts --workers=1 --reporter=list` -> 5 passed, 1 skipped
- `BASE_URL=http://127.0.0.1:5174 ./node_modules/.bin/playwright test --reporter=list` -> 91 passed, 32 skipped
- Browser QA on `http://127.0.0.1:5174/chat`: files panel opened, panel/toolbar/input radius = 8px, horizontal overflow = 0, console errors/warnings = 0
