### PR TITLE
Expand live Settings smoke and warm UI polish

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -985,7 +985,7 @@ body {
 .prose pre {
   background: var(--color-code-block-bg);
   border: none;
-  border-radius: 12px;
+  border-radius: 8px;
   font-size: 0.8rem;
   color: var(--color-code-text);
   white-space: pre-wrap;
@@ -1022,7 +1022,7 @@ body {
   font-size: 0.85em;
   border-collapse: separate;
   border-spacing: 0;
-  border-radius: 12px;
+  border-radius: 8px;
   overflow: hidden;
 }
 .prose th {
@@ -1242,7 +1242,7 @@ button, a, input, textarea {
 }
 .reader-prose pre {
   background: var(--reader-code-block-bg) !important;
-  border-radius: 12px;
+  border-radius: 8px;
   padding: 1em 1.15em;
   font-size: 0.9rem;
   line-height: 1.55;
@@ -1254,7 +1254,7 @@ button, a, input, textarea {
   margin: 1.3em 0;
   border-collapse: separate;
   border-spacing: 0;
-  border-radius: 12px;
+  border-radius: 8px;
   overflow: hidden;
   font-size: 0.95em;
 }
@@ -1272,7 +1272,7 @@ button, a, input, textarea {
 .reader-prose img {
   max-width: 100%;
   height: auto;
-  border-radius: 10px;
+  border-radius: 8px;
   margin: 1.2em 0;
 }
 
@@ -1487,7 +1487,7 @@ button, a, input, textarea {
   min-height: 44px;
   background: rgba(255, 255, 255, 0.06);
   border: 1px solid rgba(255, 255, 255, 0.08);
-  border-radius: 12px;
+  border-radius: 8px;
   cursor: pointer;
   transition: background 0.2s ease;
 }
@@ -1570,7 +1570,7 @@ button, a, input, textarea {
   background: #dc2626;
   border: none;
   cursor: pointer;
-  border-radius: 12px;
+  border-radius: 8px;
   transition: background 0.2s ease, transform 0.1s ease;
 }
 
@@ -1646,7 +1646,7 @@ button, a, input, textarea {
 .home-audio-player {
   max-width: 100%;
   height: 44px;
-  border-radius: 10px;
+  border-radius: 8px;
   filter: invert(1) hue-rotate(180deg);
   opacity: 0.85;
 }
@@ -1708,7 +1708,7 @@ button, a, input, textarea {
 }
 .home-bubble-markdown pre {
   background: rgba(0, 0, 0, 0.3);
-  border-radius: 10px;
+  border-radius: 8px;
   padding: 0.75em 1em;
   margin: 0.6em 0;
   overflow-x: auto;
@@ -1916,7 +1916,7 @@ button, a, input, textarea {
   border: none;
   cursor: pointer;
   transition: background 0.2s ease;
-  border-radius: 12px;
+  border-radius: 8px;
 }
 
 .home-settings-gear:hover {
@@ -1942,7 +1942,7 @@ button, a, input, textarea {
   color: #f0f4f8;
   background: rgba(255, 255, 255, 0.06);
   border: 1px solid rgba(255, 255, 255, 0.1);
-  border-radius: 10px;
+  border-radius: 8px;
   outline: none;
   transition: border-color 0.2s ease;
 }
@@ -1957,7 +1957,7 @@ button, a, input, textarea {
 
 .home-settings-segmented {
   border: 1px solid rgba(255, 255, 255, 0.08);
-  border-radius: 10px;
+  border-radius: 8px;
   overflow: hidden;
 }
 
@@ -2012,7 +2012,7 @@ button, a, input, textarea {
   backdrop-filter: none;
   -webkit-backdrop-filter: none;
   border: 1px solid rgba(255, 255, 255, 0.07);
-  border-radius: 14px;
+  border-radius: 8px;
   cursor: pointer;
   text-align: left;
   outline: none;
@@ -2074,7 +2074,7 @@ button, a, input, textarea {
 .home-timer-preset {
   background: rgba(255, 255, 255, 0.06);
   border: 1px solid rgba(255, 255, 255, 0.12);
-  border-radius: 12px;
+  border-radius: 8px;
   padding: 10px 20px;
   color: rgba(255, 255, 255, 0.75);
   font-size: 1rem;
@@ -2099,7 +2099,7 @@ button, a, input, textarea {
   justify-content: center;
   width: 44px;
   height: 44px;
-  border-radius: 12px;
+  border-radius: 8px;
   background: rgba(255, 255, 255, 0.06);
   border: 1px solid rgba(255, 255, 255, 0.1);
   color: rgba(255, 255, 255, 0.7);
@@ -2117,7 +2117,7 @@ button, a, input, textarea {
   max-width: 480px;
   width: 100%;
   aspect-ratio: 16 / 9;
-  border-radius: 16px;
+  border-radius: 8px;
   overflow: hidden;
   border: 1px solid rgba(255, 255, 255, 0.08);
   background: rgba(255, 255, 255, 0.03);
@@ -2129,7 +2129,7 @@ button, a, input, textarea {
   width: 100%;
   height: 100%;
   object-fit: cover;
-  border-radius: 16px;
+  border-radius: 8px;
   transition: opacity 0.6s ease-in-out;
 }
 
@@ -2259,19 +2259,19 @@ button, a, input, textarea {
   }
   .home-quick-card {
     padding: 0.625rem 0.375rem;
-    border-radius: 14px;
+    border-radius: 8px;
   }
   .home-quick-card-icon {
     width: 40px;
     height: 40px;
     min-width: 40px;
     min-height: 40px;
-    border-radius: 12px;
+    border-radius: 8px;
   }
   .home-standby .home-weather-widget {
     margin-top: 0.75rem;
     padding: 0.375rem 0.75rem;
-    border-radius: 14px;
+    border-radius: 8px;
     max-width: 420px;
   }
   .home-weather-current .text-3xl {
@@ -2281,7 +2281,7 @@ button, a, input, textarea {
     font-size: 1.75rem;
   }
   .home-widget {
-    border-radius: 14px;
+    border-radius: 8px;
   }
   .home-bubble-text {
     font-size: 0.95rem;
@@ -2289,7 +2289,7 @@ button, a, input, textarea {
   }
   .home-composer {
     padding: 0.25rem 0.375rem;
-    border-radius: 1rem;
+    border-radius: 8px;
   }
   .home-composer-input {
     font-size: 0.95rem;

--- a/src/settings/ominix-tab.tsx
+++ b/src/settings/ominix-tab.tsx
@@ -154,7 +154,7 @@ function Section({
     <section className="glass-section rounded-lg p-4 sm:p-6">
       <div className="mb-5 flex flex-wrap items-center justify-between gap-4">
         <div className="flex items-center gap-3">
-          <div className="flex h-10 w-10 items-center justify-center rounded-xl bg-accent/10 text-accent">
+          <div className="flex h-10 w-10 items-center justify-center rounded-lg bg-accent/10 text-accent">
             {icon}
           </div>
           <h3 className="text-sm font-semibold text-text-strong">{title}</h3>
@@ -236,7 +236,7 @@ function PlatformModelRow({
 }) {
   const ready = isModelReady(model);
   return (
-    <div className="flex flex-col gap-3 rounded-xl border border-border/30 bg-surface-container/50 px-4 py-3 sm:flex-row sm:items-start sm:justify-between">
+    <div className="flex flex-col gap-3 rounded-lg border border-border/30 bg-surface-container/50 px-4 py-3 sm:flex-row sm:items-start sm:justify-between">
       <div className="min-w-0">
         <div className="flex flex-wrap items-center gap-2">
           <span className="truncate text-sm font-medium text-text-strong">
@@ -296,7 +296,7 @@ function AvailableModelRow({
   const roleOptions = roleOptionsForModel(model);
 
   return (
-    <div className="flex flex-col gap-3 rounded-xl border border-border/30 bg-surface-container/50 px-4 py-3 sm:flex-row sm:items-start sm:justify-between">
+    <div className="flex flex-col gap-3 rounded-lg border border-border/30 bg-surface-container/50 px-4 py-3 sm:flex-row sm:items-start sm:justify-between">
       <div className="min-w-0">
         <div className="flex flex-wrap items-center gap-2">
           <span className="truncate text-sm font-medium text-text-strong">
@@ -380,7 +380,7 @@ function SkillRow({
   onRemove: (name: string) => void;
 }) {
   return (
-    <div className="flex flex-col gap-3 rounded-xl border border-border/30 bg-surface-container/50 px-4 py-3 sm:flex-row sm:items-center sm:justify-between">
+    <div className="flex flex-col gap-3 rounded-lg border border-border/30 bg-surface-container/50 px-4 py-3 sm:flex-row sm:items-center sm:justify-between">
       <div>
         <div className="text-sm font-medium text-text-strong">{skill.name}</div>
         <div className="mt-0.5 text-xs text-muted">
@@ -436,7 +436,7 @@ function ConfirmBar({
             : `Remove platform skill ${pending.name}?`;
 
   return (
-    <div className="flex items-center gap-3 rounded-xl border border-yellow-400/30 bg-yellow-400/5 px-4 py-3">
+    <div className="flex items-center gap-3 rounded-lg border border-yellow-400/30 bg-yellow-400/5 px-4 py-3">
       <AlertCircle size={16} className="shrink-0 text-yellow-400" />
       <span className="flex-1 text-xs font-medium text-yellow-400">{label}</span>
       <button
@@ -636,18 +636,18 @@ export function OminixTab() {
               />
             )}
             {error && (
-              <div className="whitespace-pre-wrap rounded-xl border border-red-400/30 bg-red-400/5 px-4 py-3 text-xs text-red-300">
+              <div className="whitespace-pre-wrap rounded-lg border border-red-400/30 bg-red-400/5 px-4 py-3 text-xs text-red-300">
                 {error}
               </div>
             )}
             {message && (
-              <div className="rounded-xl border border-green-400/30 bg-green-400/5 px-4 py-3 text-xs text-green-300">
+              <div className="rounded-lg border border-green-400/30 bg-green-400/5 px-4 py-3 text-xs text-green-300">
                 {message}
               </div>
             )}
 
             <div className="grid grid-cols-1 gap-3 sm:grid-cols-3">
-              <div className={`rounded-xl border px-4 py-3 ${statusClass(Boolean(status?.ominix_api.healthy))}`}>
+              <div className={`rounded-lg border px-4 py-3 ${statusClass(Boolean(status?.ominix_api.healthy))}`}>
                 <div className="flex items-center gap-2 text-sm font-semibold">
                   {status?.ominix_api.healthy ? <CheckCircle size={14} /> : <AlertCircle size={14} />}
                   {runningLabel}
@@ -656,11 +656,11 @@ export function OminixTab() {
                   {compactText(status?.ominix_api.url)}
                 </div>
               </div>
-              <div className={`rounded-xl border px-4 py-3 ${statusClass(Boolean(status?.ominix_api.service_registered))}`}>
+              <div className={`rounded-lg border px-4 py-3 ${statusClass(Boolean(status?.ominix_api.service_registered))}`}>
                 <div className="text-sm font-semibold">{registeredLabel}</div>
                 <div className="mt-1 text-[11px] opacity-80">io.ominix.ominix-api</div>
               </div>
-              <div className="rounded-xl border border-border/30 bg-surface-container/50 px-4 py-3">
+              <div className="rounded-lg border border-border/30 bg-surface-container/50 px-4 py-3">
                 <div className="text-sm font-semibold text-text-strong">
                   {status?.models.asr.length ?? 0} ASR / {status?.models.tts.length ?? 0} TTS
                 </div>
@@ -670,7 +670,7 @@ export function OminixTab() {
               </div>
             </div>
 
-            <div className={`rounded-xl border px-4 py-3 ${statusClass(health?.status === "healthy")}`}>
+            <div className={`rounded-lg border px-4 py-3 ${statusClass(health?.status === "healthy")}`}>
               <div className="flex flex-wrap items-start justify-between gap-3">
                 <div>
                   <div className="text-xs font-semibold uppercase text-muted">
@@ -737,7 +737,7 @@ export function OminixTab() {
       <Section title="Platform Skills" icon={<Activity size={20} />}>
         <div className="space-y-3">
           {(status?.platform_skills ?? []).length === 0 ? (
-            <div className="rounded-xl bg-surface-container/50 px-4 py-6 text-center text-sm text-muted">
+            <div className="rounded-lg bg-surface-container/50 px-4 py-6 text-center text-sm text-muted">
               No platform skills returned
             </div>
           ) : (
@@ -762,7 +762,7 @@ export function OminixTab() {
       <Section title="Enabled Platform Models" icon={<Download size={20} />}>
         <div className="space-y-3">
           {platformModels.length === 0 ? (
-            <div className="rounded-xl bg-surface-container/50 px-4 py-6 text-center text-sm text-muted">
+            <div className="rounded-lg bg-surface-container/50 px-4 py-6 text-center text-sm text-muted">
               No models are enabled for Octos
             </div>
           ) : (
@@ -798,7 +798,7 @@ export function OminixTab() {
         </div>
         <div className="max-h-[28rem] space-y-3 overflow-y-auto pr-1">
           {filteredCatalogModels.length === 0 ? (
-            <div className="rounded-xl bg-surface-container/50 px-4 py-6 text-center text-sm text-muted">
+            <div className="rounded-lg bg-surface-container/50 px-4 py-6 text-center text-sm text-muted">
               {catalogSearch.trim()
                 ? "No catalog models match the current search"
                 : "No catalog models returned"}
@@ -855,11 +855,11 @@ export function OminixTab() {
           {compactText(logs?.log_path)}
         </div>
         {logs?.error && (
-          <div className="mb-3 rounded-xl border border-yellow-400/30 bg-yellow-400/5 px-4 py-3 text-xs text-yellow-300">
+          <div className="mb-3 rounded-lg border border-yellow-400/30 bg-yellow-400/5 px-4 py-3 text-xs text-yellow-300">
             {logs.error}
           </div>
         )}
-        <pre className="max-h-80 overflow-auto rounded-xl bg-black/30 p-4 font-mono text-[11px] leading-5 text-text/80">
+        <pre className="max-h-80 overflow-auto rounded-lg bg-black/30 p-4 font-mono text-[11px] leading-5 text-text/80">
           {(logs?.lines ?? []).join("\n") || "No logs"}
         </pre>
       </Section>

--- a/src/settings/sandbox-tab.tsx
+++ b/src/settings/sandbox-tab.tsx
@@ -24,9 +24,9 @@ interface SandboxTabProps {
 const SANDBOX_MODES = [
   { value: "auto", label: "Auto", description: "Automatically select the best isolation method" },
   { value: "docker", label: "Docker", description: "Docker container isolation" },
-  { value: "sandbox-exec", label: "sandbox-exec", description: "macOS sandbox" },
-  { value: "bubblewrap", label: "Bubblewrap", description: "Linux namespace isolation" },
-  { value: "appcontainer", label: "AppContainer", description: "Windows AppContainer" },
+  { value: "sandbox-exec", label: "macOS Sandbox", description: "Use native macOS sandbox rules" },
+  { value: "bubblewrap", label: "Linux Sandbox", description: "Use Linux namespace isolation" },
+  { value: "appcontainer", label: "Windows Sandbox", description: "Use Windows AppContainer isolation" },
   { value: "host", label: "Host", description: "No isolation (runs directly on host)" },
 ] as const;
 
@@ -107,7 +107,7 @@ function StringListEditor({
             value={item}
             onChange={(e) => updateItem(idx, e.target.value)}
             placeholder={placeholder}
-            className="flex-1 rounded-xl bg-surface-container px-4 py-2.5 text-sm text-text placeholder-muted/50 outline-none border border-transparent focus:border-accent/30 transition font-mono"
+            className="flex-1 rounded-xl bg-surface-container px-4 py-2.5 text-sm text-text placeholder-muted/50 outline-none border border-transparent focus:border-accent/30 transition"
           />
           <button
             type="button"
@@ -315,7 +315,7 @@ export function SandboxTab({ profile, onProfileUpdated }: SandboxTabProps) {
                   value={form.docker_cpu_limit}
                   onChange={(e) => setForm((f) => ({ ...f, docker_cpu_limit: e.target.value }))}
                   placeholder="1.0"
-                  className="w-full rounded-xl bg-surface-container px-4 py-3 text-sm text-text placeholder-muted/50 outline-none border border-transparent focus:border-accent/30 transition font-mono"
+                  className="w-full rounded-xl bg-surface-container px-4 py-3 text-sm text-text placeholder-muted/50 outline-none border border-transparent focus:border-accent/30 transition tabular-nums"
                 />
               </div>
               <div>
@@ -327,7 +327,7 @@ export function SandboxTab({ profile, onProfileUpdated }: SandboxTabProps) {
                   value={form.docker_memory_limit}
                   onChange={(e) => setForm((f) => ({ ...f, docker_memory_limit: e.target.value }))}
                   placeholder="512m"
-                  className="w-full rounded-xl bg-surface-container px-4 py-3 text-sm text-text placeholder-muted/50 outline-none border border-transparent focus:border-accent/30 transition font-mono"
+                  className="w-full rounded-xl bg-surface-container px-4 py-3 text-sm text-text placeholder-muted/50 outline-none border border-transparent focus:border-accent/30 transition tabular-nums"
                 />
               </div>
               <div>
@@ -340,7 +340,7 @@ export function SandboxTab({ profile, onProfileUpdated }: SandboxTabProps) {
                   onChange={(e) => setForm((f) => ({ ...f, docker_pids_limit: e.target.value }))}
                   placeholder="256"
                   min={1}
-                  className="w-full rounded-xl bg-surface-container px-4 py-3 text-sm text-text placeholder-muted/50 outline-none border border-transparent focus:border-accent/30 transition font-mono"
+                  className="w-full rounded-xl bg-surface-container px-4 py-3 text-sm text-text placeholder-muted/50 outline-none border border-transparent focus:border-accent/30 transition tabular-nums"
                 />
               </div>
             </div>

--- a/src/settings/server-tab.tsx
+++ b/src/settings/server-tab.tsx
@@ -519,7 +519,7 @@ export function ServerTab() {
             </div>
             {/* Version */}
             <div className="rounded-xl border border-border/30 px-4 py-3">
-              <div className="text-lg font-bold tabular-nums text-text-strong font-mono">
+              <div className="text-lg font-bold tabular-nums text-text-strong">
                 {resources.version || "—"}
               </div>
               <div className="mt-0.5 text-xs text-muted">Octos Version</div>
@@ -532,7 +532,7 @@ export function ServerTab() {
               Resource metrics unavailable
             </p>
             <p className="mt-0.5 text-[10px] text-muted/60">
-              Could not read <code className="font-mono">GET /api/admin/system/metrics</code>
+              Could not read system metrics.
             </p>
           </div>
         )}
@@ -599,9 +599,7 @@ export function ServerTab() {
         </div>
 
         <p className="mt-3 text-[10px] text-muted/50">
-          Settings use <code className="font-mono">/api/admin/monitor/status</code>,{" "}
-          <code className="font-mono">/watchdog</code>, and{" "}
-          <code className="font-mono">/alerts</code>.
+          Changes apply to gateway monitoring immediately.
         </p>
       </div>
 
@@ -666,8 +664,7 @@ export function ServerTab() {
         </div>
 
         <p className="mt-3 text-[10px] text-muted/50">
-          Mode is read from <code className="font-mono">GET /api/admin/deployment-mode</code> and saved via{" "}
-          <code className="font-mono">POST /api/admin/deployment-mode</code>.
+          This setting controls deployment-aware defaults across the dashboard.
         </p>
       </div>
 
@@ -779,9 +776,7 @@ export function ServerTab() {
         </button>
 
         <p className="mt-3 text-[10px] text-muted/50">
-          Token rotation sends your chosen value to{" "}
-          <code className="font-mono">POST /api/admin/token/rotate</code>; the server returns{" "}
-          <code className="font-mono">204</code> on success.
+          Token rotation applies immediately. Keep the new token somewhere private.
         </p>
       </div>
 

--- a/src/settings/skills-tab.tsx
+++ b/src/settings/skills-tab.tsx
@@ -243,7 +243,7 @@ export function SkillsTab() {
                       {skill.name}
                     </span>
                     {skill.version && (
-                      <span className="shrink-0 rounded-md bg-surface-dark/60 px-1.5 py-0.5 text-[10px] font-mono text-muted">
+                      <span className="shrink-0 rounded-md bg-surface-dark/60 px-1.5 py-0.5 text-[10px] tabular-nums text-muted">
                         v{skill.version}
                       </span>
                     )}
@@ -378,7 +378,7 @@ export function SkillsTab() {
                           {pkg.name}
                         </span>
                         {pkg.version && (
-                          <span className="shrink-0 rounded-md bg-surface-dark/60 px-1.5 py-0.5 text-[10px] font-mono text-muted">
+                          <span className="shrink-0 rounded-md bg-surface-dark/60 px-1.5 py-0.5 text-[10px] tabular-nums text-muted">
                             v{pkg.version}
                           </span>
                         )}
@@ -426,7 +426,7 @@ export function SkillsTab() {
                       {pkg.skills.map((s) => (
                         <span
                           key={s}
-                          className={`rounded-md px-1.5 py-0.5 text-[10px] font-mono transition ${
+                          className={`rounded-md px-1.5 py-0.5 text-[10px] tabular-nums transition ${
                             installedNames.has(s)
                               ? "bg-accent/15 text-accent"
                               : "bg-surface-dark/60 text-muted"

--- a/src/settings/tools-tab.tsx
+++ b/src/settings/tools-tab.tsx
@@ -381,7 +381,7 @@ function EmailToolSection({
                     value={config.smtp_host}
                     onChange={(e) => set({ smtp_host: e.target.value })}
                     placeholder="smtp.example.com"
-                    className="w-full rounded-xl bg-surface-dark/50 px-4 py-2.5 text-sm text-text placeholder-muted/50 outline-none border border-transparent focus:border-accent/30 transition font-mono"
+                    className="w-full rounded-xl bg-surface-dark/50 px-4 py-2.5 text-sm text-text placeholder-muted/50 outline-none border border-transparent focus:border-accent/30 transition"
                   />
                 </div>
                 <div>
@@ -393,7 +393,7 @@ function EmailToolSection({
                     placeholder="587"
                     min={1}
                     max={65535}
-                    className="w-full rounded-xl bg-surface-dark/50 px-4 py-2.5 text-sm text-text placeholder-muted/50 outline-none border border-transparent focus:border-accent/30 transition font-mono"
+                    className="w-full rounded-xl bg-surface-dark/50 px-4 py-2.5 text-sm text-text placeholder-muted/50 outline-none border border-transparent focus:border-accent/30 transition tabular-nums"
                   />
                 </div>
               </div>
@@ -406,7 +406,7 @@ function EmailToolSection({
                     value={config.smtp_username}
                     onChange={(e) => set({ smtp_username: e.target.value })}
                     placeholder="user@example.com"
-                    className="w-full rounded-xl bg-surface-dark/50 px-4 py-2.5 text-sm text-text placeholder-muted/50 outline-none border border-transparent focus:border-accent/30 transition font-mono"
+                    className="w-full rounded-xl bg-surface-dark/50 px-4 py-2.5 text-sm text-text placeholder-muted/50 outline-none border border-transparent focus:border-accent/30 transition"
                   />
                 </div>
                 <div>
@@ -416,7 +416,7 @@ function EmailToolSection({
                     value={config.smtp_password}
                     onChange={(e) => set({ smtp_password: e.target.value })}
                     placeholder="App password"
-                    className="w-full rounded-xl bg-surface-dark/50 px-4 py-2.5 text-sm text-text placeholder-muted/50 outline-none border border-transparent focus:border-accent/30 transition font-mono"
+                    className="w-full rounded-xl bg-surface-dark/50 px-4 py-2.5 text-sm text-text placeholder-muted/50 outline-none border border-transparent focus:border-accent/30 transition"
                   />
                 </div>
               </div>
@@ -428,7 +428,7 @@ function EmailToolSection({
                   value={config.smtp_from}
                   onChange={(e) => set({ smtp_from: e.target.value })}
                   placeholder="noreply@example.com"
-                  className="w-full rounded-xl bg-surface-dark/50 px-4 py-2.5 text-sm text-text placeholder-muted/50 outline-none border border-transparent focus:border-accent/30 transition font-mono"
+                  className="w-full rounded-xl bg-surface-dark/50 px-4 py-2.5 text-sm text-text placeholder-muted/50 outline-none border border-transparent focus:border-accent/30 transition"
                 />
               </div>
 
@@ -616,7 +616,7 @@ export function ToolsTab({ profile, onProfileUpdated }: ToolsTabProps) {
               value={form.crawl.max_depth}
               onChange={(e) => setForm((f) => ({ ...f, crawl: { ...f.crawl, max_depth: e.target.value } }))}
               placeholder="3"
-              className="w-full rounded-xl bg-surface-container px-4 py-3 text-sm text-text placeholder-muted/50 outline-none border border-transparent focus:border-accent/30 transition font-mono"
+              className="w-full rounded-xl bg-surface-container px-4 py-3 text-sm text-text placeholder-muted/50 outline-none border border-transparent focus:border-accent/30 transition tabular-nums"
             />
           </div>
           <div>
@@ -630,7 +630,7 @@ export function ToolsTab({ profile, onProfileUpdated }: ToolsTabProps) {
               value={form.crawl.max_pages}
               onChange={(e) => setForm((f) => ({ ...f, crawl: { ...f.crawl, max_pages: e.target.value } }))}
               placeholder="50"
-              className="w-full rounded-xl bg-surface-container px-4 py-3 text-sm text-text placeholder-muted/50 outline-none border border-transparent focus:border-accent/30 transition font-mono"
+              className="w-full rounded-xl bg-surface-container px-4 py-3 text-sm text-text placeholder-muted/50 outline-none border border-transparent focus:border-accent/30 transition tabular-nums"
             />
           </div>
           <div>
@@ -644,7 +644,7 @@ export function ToolsTab({ profile, onProfileUpdated }: ToolsTabProps) {
               value={form.crawl.timeout_secs}
               onChange={(e) => setForm((f) => ({ ...f, crawl: { ...f.crawl, timeout_secs: e.target.value } }))}
               placeholder="30"
-              className="w-full rounded-xl bg-surface-container px-4 py-3 text-sm text-text placeholder-muted/50 outline-none border border-transparent focus:border-accent/30 transition font-mono"
+              className="w-full rounded-xl bg-surface-container px-4 py-3 text-sm text-text placeholder-muted/50 outline-none border border-transparent focus:border-accent/30 transition tabular-nums"
             />
           </div>
         </div>
@@ -679,7 +679,7 @@ export function ToolsTab({ profile, onProfileUpdated }: ToolsTabProps) {
                 }))
               }
               placeholder="30"
-              className="w-full rounded-xl bg-surface-container px-4 py-3 text-sm text-text placeholder-muted/50 outline-none border border-transparent focus:border-accent/30 transition font-mono"
+              className="w-full rounded-xl bg-surface-container px-4 py-3 text-sm text-text placeholder-muted/50 outline-none border border-transparent focus:border-accent/30 transition tabular-nums"
             />
             <p className="mt-1.5 text-xs text-muted/70">
               Maximum time to wait for browser-based tools to complete

--- a/tests/live-settings-profile.spec.ts
+++ b/tests/live-settings-profile.spec.ts
@@ -219,6 +219,120 @@ test.describe("live Settings and profile smoke", () => {
     await expectNoRuntimeOverlay(page);
   });
 
+  test("binds live LLM and Tools controls without the mocked harness", async ({ page }) => {
+    await ensureSoloSession(page);
+    await page.goto("/settings", { waitUntil: "networkidle" });
+    await expect(page.locator(".animate-spin")).toBeHidden({ timeout: LIVE_TIMEOUT });
+
+    await clickSettingsTab(page, "LLM");
+    const llmSection = page.locator(".glass-section", { hasText: "LLM Configuration" });
+    await expect(llmSection).toBeVisible({ timeout: LIVE_TIMEOUT });
+    const llmSelects = llmSection.locator("select");
+    const providerSelect = llmSelects.first();
+    await expect(providerSelect).toBeVisible({ timeout: LIVE_TIMEOUT });
+    expect(await providerSelect.locator("option").count()).toBeGreaterThan(1);
+    await providerSelect.selectOption("openai");
+    await expect(llmSection.getByText("Model", { exact: true })).toBeVisible({
+      timeout: LIVE_TIMEOUT,
+    });
+    expect(await llmSelects.nth(1).locator("option").count()).toBeGreaterThan(1);
+    await expect(llmSection.getByText("OPENAI_API_KEY")).toBeVisible({
+      timeout: LIVE_TIMEOUT,
+    });
+    await expect(llmSection.getByRole("button", { name: "Test Connection" })).toBeVisible({
+      timeout: LIVE_TIMEOUT,
+    });
+    await expect(page.getByRole("heading", { name: "Fallback Models" })).toBeVisible({
+      timeout: LIVE_TIMEOUT,
+    });
+    await expectNoRuntimeOverlay(page);
+
+    await clickSettingsTab(page, "Tools");
+    for (const heading of [
+      "Web Search APIs",
+      "Email Tool",
+      "Deep Crawl",
+      "Gateway Settings",
+    ]) {
+      await expect(page.getByRole("heading", { name: heading })).toBeVisible({
+        timeout: LIVE_TIMEOUT,
+      });
+    }
+    for (const engine of [
+      "Serper (Google)",
+      "Tavily",
+      "Perplexity",
+      "You.com",
+      "Brave Search",
+    ]) {
+      await expect(page.getByRole("heading", { name: engine, exact: true })).toBeVisible({
+        timeout: LIVE_TIMEOUT,
+      });
+    }
+    await expectNoRuntimeOverlay(page);
+  });
+
+  test("binds live Profile, Skills, Channels, and Sandbox controls without writes", async ({ page }) => {
+    await ensureSoloSession(page);
+    await page.goto("/settings", { waitUntil: "networkidle" });
+    await expect(page.locator(".animate-spin")).toBeHidden({ timeout: LIVE_TIMEOUT });
+
+    await clickSettingsTab(page, "Profile");
+    await expect(page.getByPlaceholder("Enter display name")).toBeVisible({
+      timeout: LIVE_TIMEOUT,
+    });
+    await expect(page.getByText("Profile ID")).toBeVisible({ timeout: LIVE_TIMEOUT });
+    await expect(page.getByRole("heading", { name: "Environment Variables" })).toBeVisible({
+      timeout: LIVE_TIMEOUT,
+    });
+    await expect(page.getByRole("button", { name: "Add Variable" })).toBeVisible({
+      timeout: LIVE_TIMEOUT,
+    });
+    await expectNoRuntimeOverlay(page);
+
+    await clickSettingsTab(page, "Skills");
+    await expect(page.getByRole("heading", { name: "Install Skill" })).toBeVisible({
+      timeout: LIVE_TIMEOUT,
+    });
+    await expect(
+      page.getByPlaceholder("octos-org/system-skills, https://host/org/repo.git, or ./skills/my-skill"),
+    ).toBeVisible({ timeout: LIVE_TIMEOUT });
+    await expect(page.getByRole("button", { name: "Install" }).first()).toBeDisabled({
+      timeout: LIVE_TIMEOUT,
+    });
+    await expectNoRuntimeOverlay(page);
+
+    await clickSettingsTab(page, "Channels");
+    await page.getByRole("button", { name: /^Add Channel$/ }).first().click();
+    const channelForm = page.locator(".glass-section", { hasText: "New Channel" });
+    await expect(channelForm).toBeVisible({ timeout: LIVE_TIMEOUT });
+    await channelForm.locator("select").selectOption("twilio");
+    await expect(channelForm.locator("input[readonly]")).toHaveValue(/\/webhook\/twilio\//, {
+      timeout: LIVE_TIMEOUT,
+    });
+    await expect(channelForm.getByPlaceholder("TWILIO_ACCOUNT_SID")).toBeVisible({
+      timeout: LIVE_TIMEOUT,
+    });
+    await expect(channelForm.getByRole("button", { name: /^Add Channel$/ })).toBeVisible({
+      timeout: LIVE_TIMEOUT,
+    });
+    await channelForm.getByText("Cancel", { exact: true }).click();
+    await expect(channelForm).toHaveCount(0);
+    await expectNoRuntimeOverlay(page);
+
+    await clickSettingsTab(page, "Sandbox");
+    const sandboxSection = page.locator(".glass-section", { hasText: "Sandbox Configuration" });
+    await sandboxSection.locator("select").first().selectOption("docker");
+    await expect(page.getByRole("heading", { name: "Docker Settings" })).toBeVisible({
+      timeout: LIVE_TIMEOUT,
+    });
+    await expect(page.getByPlaceholder("ubuntu:24.04")).toBeVisible({ timeout: LIVE_TIMEOUT });
+    await expect(page.getByRole("button", { name: "Save Changes" })).toBeEnabled({
+      timeout: LIVE_TIMEOUT,
+    });
+    await expectNoRuntimeOverlay(page);
+  });
+
   test("loads admin Settings tabs and OminiX offline state without mocks", async ({ page }) => {
     await ensureSoloSession(page);
     await page.goto("/settings", { waitUntil: "networkidle" });
@@ -419,6 +533,33 @@ test.describe("live Settings and profile smoke", () => {
     await expectNoRuntimeOverlay(page);
   });
 
+  test("OminiX live log controls use the read-only logs endpoint", async ({ page }) => {
+    await ensureSoloSession(page);
+    await page.goto("/settings", { waitUntil: "networkidle" });
+    await expect(page.locator(".animate-spin")).toBeHidden({ timeout: LIVE_TIMEOUT });
+
+    await clickSettingsTab(page, "OminiX");
+    await expect(page.getByRole("heading", { name: "Logs" })).toBeVisible({
+      timeout: LIVE_TIMEOUT,
+    });
+
+    const logsResponsePromise = page.waitForResponse((response) => {
+      const url = new URL(response.url());
+      return (
+        url.pathname === "/api/admin/platform-skills/ominix-api/logs" &&
+        url.searchParams.get("lines") === "200"
+      );
+    }, { timeout: LIVE_TIMEOUT });
+
+    await page.getByRole("button", { name: "200 lines" }).click();
+    const logsResponse = await logsResponsePromise;
+    expect(logsResponse.status()).toBe(200);
+    const logsJson = await logsResponse.json();
+    expectObject(logsJson, "OminiX logs");
+    expect(Array.isArray(logsJson.lines)).toBe(true);
+    await expectNoRuntimeOverlay(page);
+  });
+
   test("read-only Settings APIs return live contract-shaped data", async ({ page }) => {
     await ensureSoloSession(page);
     await page.goto("/settings", { waitUntil: "networkidle" });
@@ -434,6 +575,12 @@ test.describe("live Settings and profile smoke", () => {
     const profileSkillsJson = profileSkills.json;
     expectObject(profileSkillsJson, "profile skills");
     expect(Array.isArray(profileSkillsJson.skills)).toBe(true);
+
+    const skillRegistry = await liveApiRaw(page, "/api/my/profile/skills/registry");
+    expect(skillRegistry.status).toBe(200);
+    const skillRegistryJson = skillRegistry.json;
+    expectObject(skillRegistryJson, "skill registry");
+    expect(Array.isArray(skillRegistryJson.packages)).toBe(true);
 
     const users = await liveApiRaw(page, "/api/admin/users");
     expect(users.status).toBe(200);


### PR DESCRIPTION
## Summary
- expand live Settings smoke coverage for LLM, Tools, Profile, Skills, Channels, Sandbox, OminiX logs, and the live skill registry contract
- reduce Settings/Home UI rough edges: OminiX 8px rows, global hard-coded radii capped at 8px, warmer less terminal-like Settings inputs and copy
- keep mutation live smoke guarded; new live controls test exercises UI without writing profile changes

## Verification
- pnpm exec eslint src/settings/sandbox-tab.tsx src/settings/tools-tab.tsx src/settings/server-tab.tsx src/settings/skills-tab.tsx src/settings/ominix-tab.tsx tests/live-settings-profile.spec.ts
- BASE_URL=http://127.0.0.1:5174 OCTOS_LIVE_E2E=1 ./node_modules/.bin/playwright test tests/live-settings-profile.spec.ts --workers=1 --reporter=list (8 passed, 1 skipped)
- BASE_URL=http://127.0.0.1:5174 ./node_modules/.bin/playwright test tests/settings-tabs.spec.ts --reporter=list (24 passed)
- Browser QA on /settings: no console errors/warnings, no framework overlay, horizontal overflow 0, Settings max radius 8px
- pnpm exec tsc -b --pretty false
- npm run build
- npm run test:unit (56 files, 648 tests passed)
- BASE_URL=http://127.0.0.1:5174 ./node_modules/.bin/playwright test --reporter=list (91 passed, 35 skipped)