### PR TITLE
Fix home runtime UI behavior

### DIFF
--- a/src/components/home-nav.tsx
+++ b/src/components/home-nav.tsx
@@ -10,10 +10,13 @@ export function HomeNav() {
     <nav className="workbench-topbar shrink-0">
       <div className="workbench-topbar-inner flex min-h-16 items-center gap-3 px-5 py-3 max-sm:px-3">
         <WorkbenchBrand />
-        <WorkbenchRouteNav compact />
-        <div className="flex-1" />
-        <WorkbenchThemeButton />
-        <WorkbenchUserActions />
+        <div className="min-w-0 flex-1">
+          <WorkbenchRouteNav compact />
+        </div>
+        <div className="home-nav-actions flex shrink-0 items-center gap-2">
+          <WorkbenchThemeButton />
+          <WorkbenchUserActions />
+        </div>
       </div>
     </nav>
   );

--- a/src/home/home-settings.tsx
+++ b/src/home/home-settings.tsx
@@ -129,7 +129,7 @@ export function HomeSettingsPanel({ open, onClose }: HomeSettingsPanelProps) {
         role="dialog"
         aria-modal={open}
         aria-hidden={!open}
-        className={`home-settings-panel fixed right-0 top-0 bottom-0 z-50 flex w-80 max-w-[85vw] flex-col transition-transform duration-300 ease-out ${
+        className={`home-settings-panel ${open ? "is-open" : "is-closed"} fixed right-0 top-0 bottom-0 z-50 flex w-80 max-w-[85vw] flex-col transition-transform duration-300 ease-out ${
           open ? "translate-x-0" : "translate-x-full"
         }`}
       >

--- a/src/home/metro-tiles.tsx
+++ b/src/home/metro-tiles.tsx
@@ -673,10 +673,6 @@ export function MetroTileGrid({ onActivate, nightActive }: MetroTileGridProps) {
   const drag = useTileDrag(effectiveLayouts, setLayouts, commitLayouts, editMode, visibleIds);
   const resize = useTileResize(effectiveLayouts, setLayouts, commitLayouts, editMode, visibleIds);
 
-  const handleClick = useCallback(() => {
-    if (!settingsOpen && !editMode) onActivate();
-  }, [onActivate, settingsOpen, editMode]);
-
   const resetLayout = useCallback(() => {
     commitLayouts(defaultLayouts());
   }, [commitLayouts]);
@@ -701,7 +697,6 @@ export function MetroTileGrid({ onActivate, nightActive }: MetroTileGridProps) {
   return (
     <div
       className={`metro-grid-container ${burnIn.dimmed ? "home-dimmed" : ""} ${editMode ? "metro-edit-mode" : ""}`}
-      onClick={handleClick}
       onMouseMove={() => burnIn.onActivity()}
       onTouchStart={() => burnIn.onActivity()}
     >

--- a/src/home/use-news.test.tsx
+++ b/src/home/use-news.test.tsx
@@ -1,0 +1,51 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { useNews } from "./use-news";
+
+const DEFAULT_FEED = "https://feeds.bbci.co.uk/news/rss.xml";
+
+function Probe({ feedUrl = DEFAULT_FEED }: { feedUrl?: string }) {
+  const news = useNews(feedUrl);
+  return <output data-testid="news-state">{JSON.stringify(news)}</output>;
+}
+
+function readState() {
+  return JSON.parse(screen.getByTestId("news-state").textContent || "{}");
+}
+
+describe("useNews", () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("loads the default BBC headlines without hitting the rate-limited rss2json endpoint", async () => {
+    const fetchMock = vi.fn(async () => {
+      return new Response(
+        `Title: BBC News
+
+Markdown Content:
+[![Image 1](https://ichef.bbci.co.uk/news.jpg) ## Royal Marines board Russian shadow fleet oil tanker in English Channel Marines were joined by officers. 54 mins ago Europe](https://www.bbc.com/news/articles/clyek039l2vo)
+## [Why the US economy keeps defying the odds](https://www.bbc.com/news/articles/cwy031el03po)
+## [Swiss voters reject 10 million population cap, early projections say 7 hrs ago Europe](https://www.bbc.com/news/articles/c20ygjem17zo)
+## [Watch: British forces intercept sanctioned oil tanker 9 hrs ago UK](https://www.bbc.com/news/videos/ce8k5kj64lgo)
+## [This fifth item should be ignored](https://www.bbc.com/news/articles/ignore)
+`,
+        { status: 200, headers: { "Content-Type": "text/plain" } },
+      );
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    render(<Probe />);
+
+    await waitFor(() => {
+      expect(readState().items).toHaveLength(4);
+    });
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(String(fetchMock.mock.calls[0][0])).toContain("r.jina.ai");
+    expect(String(fetchMock.mock.calls[0][0])).not.toContain("rss2json");
+    expect(readState().items[0].title).toContain("Royal Marines");
+    expect(readState().error).toBeNull();
+  });
+});

--- a/src/home/use-news.ts
+++ b/src/home/use-news.ts
@@ -22,6 +22,93 @@ export interface NewsState {
 
 const POLL_MS = 30 * 60 * 1000; // 30 minutes
 const MAX_ITEMS = 4;
+const DEFAULT_BBC_FEED_URL = "https://feeds.bbci.co.uk/news/rss.xml";
+const BBC_NEWS_READER_URL =
+  "https://r.jina.ai/http://https://www.bbc.com/news";
+
+function isDefaultBbcFeed(url: string): boolean {
+  return url.trim() === DEFAULT_BBC_FEED_URL;
+}
+
+function relativePubDate(text: string): string {
+  const minutes = text.match(/\b(\d+)\s+mins?\s+ago\b/i);
+  if (minutes) {
+    return new Date(Date.now() - Number(minutes[1]) * 60_000).toISOString();
+  }
+  const hours = text.match(/\b(\d+)\s+hrs?\s+ago\b/i);
+  if (hours) {
+    return new Date(Date.now() - Number(hours[1]) * 3_600_000).toISOString();
+  }
+  return "";
+}
+
+function cleanReaderTitle(text: string): string {
+  return text
+    .replace(/!\[[^\]]*\]\([^)]+\)/g, "")
+    .replace(/^LIVE\s+##\s+/i, "LIVE ")
+    .replace(/^##\s+/i, "")
+    .replace(/\s+/g, " ")
+    .replace(/\b\d+\s+(?:mins?|hrs?)\s+ago\b.*$/i, "")
+    .trim();
+}
+
+function parseBbcReaderMarkdown(markdown: string): NewsItem[] {
+  const seen = new Set<string>();
+  const items: NewsItem[] = [];
+
+  for (const line of markdown.split("\n")) {
+    if (!line.includes("##") || !line.includes("https://www.bbc.com/")) {
+      continue;
+    }
+    const match = line.match(/##\s*(?:\[)?(.+?)\]\((https:\/\/www\.bbc\.com\/[^)]+)\)/);
+    if (!match) continue;
+
+    const title = cleanReaderTitle(match[1]);
+    const link = match[2];
+    if (!title || seen.has(link)) continue;
+
+    seen.add(link);
+    items.push({
+      title,
+      link,
+      pubDate: relativePubDate(line),
+    });
+    if (items.length >= MAX_ITEMS) break;
+  }
+
+  return items;
+}
+
+async function fetchDefaultBbcNews(): Promise<NewsItem[]> {
+  const res = await fetch(BBC_NEWS_READER_URL);
+  if (!res.ok) throw new Error(`HTTP ${res.status}`);
+  const markdown = await res.text();
+  const items = parseBbcReaderMarkdown(markdown);
+  if (items.length === 0) throw new Error("Feed error");
+  return items;
+}
+
+async function fetchRss2JsonNews(url: string): Promise<NewsItem[]> {
+  const endpoint = `https://api.rss2json.com/v1/api.json?rss_url=${encodeURIComponent(url)}`;
+  const res = await fetch(endpoint);
+  if (!res.ok) throw new Error(`HTTP ${res.status}`);
+
+  const data = await res.json();
+  if (data.status !== "ok") throw new Error(data.message ?? "Feed error");
+
+  return (data.items ?? [])
+    .slice(0, MAX_ITEMS)
+    .map((item: Record<string, unknown>) => ({
+      title: String(item.title ?? ""),
+      link: String(item.link ?? ""),
+      pubDate: String(item.pubDate ?? ""),
+      thumbnail: item.thumbnail
+        ? String(item.thumbnail)
+        : item.enclosure && (item.enclosure as Record<string, unknown>).link
+          ? String((item.enclosure as Record<string, unknown>).link)
+          : undefined,
+    }));
+}
 
 export function useNews(feedUrl: string): NewsState {
   const [state, setState] = useState<NewsState>({
@@ -44,21 +131,9 @@ export function useNews(feedUrl: string): NewsState {
     try {
       setState((prev) => ({ ...prev, loading: prev.items.length === 0 }));
 
-      const endpoint = `https://api.rss2json.com/v1/api.json?rss_url=${encodeURIComponent(url)}`;
-      const res = await fetch(endpoint);
-      if (!res.ok) throw new Error(`HTTP ${res.status}`);
-
-      const data = await res.json();
-      if (data.status !== "ok") throw new Error(data.message ?? "Feed error");
-
-      const items: NewsItem[] = (data.items ?? [])
-        .slice(0, MAX_ITEMS)
-        .map((item: Record<string, unknown>) => ({
-          title: String(item.title ?? ""),
-          link: String(item.link ?? ""),
-          pubDate: String(item.pubDate ?? ""),
-          thumbnail: item.thumbnail ? String(item.thumbnail) : item.enclosure && (item.enclosure as Record<string, unknown>).link ? String((item.enclosure as Record<string, unknown>).link) : undefined,
-        }));
+      const items = isDefaultBbcFeed(url)
+        ? await fetchDefaultBbcNews()
+        : await fetchRss2JsonNews(url);
 
       setState({ items, loading: false, error: null });
     } catch (err) {

--- a/src/home/voice/voice-view.test.tsx
+++ b/src/home/voice/voice-view.test.tsx
@@ -1,44 +1,59 @@
-import { beforeEach, describe, it, expect, vi } from "vitest";
-import { cleanup, render, screen, fireEvent } from "@testing-library/react";
-import type { VoiceState } from "./use-voice-conversation";
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 import { VoiceView } from "./voice-view";
+import type { VoiceConversation } from "./use-voice-conversation";
 
-let mockState: VoiceState = "listening";
-const interruptMock = vi.fn();
+const conversationMock = vi.hoisted(() => ({
+  state: "idle" as VoiceConversation["state"],
+  start: vi.fn(),
+  stop: vi.fn(),
+  interrupt: vi.fn(),
+}));
 
 vi.mock("./use-voice-conversation", () => ({
   useVoiceConversation: () => ({
-    state: mockState,
-    lastUserText: "你好",
-    lastAssistantText: "在的",
+    state: conversationMock.state,
+    lastUserText: "",
+    lastAssistantText: "",
     error: null,
-    start: vi.fn().mockResolvedValue(undefined),
-    stop: vi.fn(),
-    interrupt: interruptMock,
+    start: conversationMock.start,
+    stop: conversationMock.stop,
+    interrupt: conversationMock.interrupt,
   }),
+}));
+
+vi.mock("./voice-orb", () => ({
+  VoiceOrb: ({ state }: { state: string }) => (
+    <div data-testid="voice-orb-state">{state}</div>
+  ),
+}));
+
+vi.mock("./voice-selector", () => ({
+  VoiceSelector: () => <div data-testid="voice-selector" />,
+}));
+
+vi.mock("./audio-playback", () => ({
+  unlockAudio: vi.fn(),
 }));
 
 describe("VoiceView", () => {
   beforeEach(() => {
     cleanup();
-    mockState = "listening";
-    interruptMock.mockClear();
+    conversationMock.state = "idle";
+    conversationMock.start.mockReset();
+    conversationMock.stop.mockReset();
+    conversationMock.interrupt.mockReset();
   });
 
-  it("renders orb + captions and exits via the × button", () => {
-    const onBack = vi.fn();
-    render(<VoiceView sessionId="s1" onBack={onBack} />);
-    expect(screen.getByText("在的")).toBeTruthy();
-    fireEvent.click(screen.getByLabelText("exit voice mode"));
-    expect(onBack).toHaveBeenCalled();
-  });
+  it("waits for an orb click before starting microphone capture", () => {
+    render(<VoiceView sessionId="voice-test" onBack={vi.fn()} />);
 
-  it("interrupts the current turn when the orb is clicked while thinking", () => {
-    mockState = "thinking";
-    render(<VoiceView sessionId="s1" onBack={vi.fn()} />);
+    expect(conversationMock.start).not.toHaveBeenCalled();
+    expect(screen.getByText("点光球开始说话")).toBeTruthy();
+    expect(screen.queryByTestId("voice-selector")).toBeNull();
 
-    fireEvent.click(screen.getByLabelText("voice orb"));
+    fireEvent.click(screen.getByRole("button", { name: "voice orb" }));
 
-    expect(interruptMock).toHaveBeenCalledTimes(1);
+    expect(conversationMock.start).toHaveBeenCalledTimes(1);
   });
 });

--- a/src/home/voice/voice-view.tsx
+++ b/src/home/voice/voice-view.tsx
@@ -7,7 +7,7 @@ import { unlockAudio } from "./audio-playback";
 import "./voice.css";
 
 const STATE_WORD: Record<VoiceState, string> = {
-  idle: "",
+  idle: "点光球开始说话",
   listening: "聆听中…",
   thinking: "思考中…",
   speaking: "说话中…",
@@ -24,7 +24,6 @@ export function VoiceView({ sessionId, historyTopic, onBack }: VoiceViewProps) {
   const conv = useVoiceConversation(sessionId, historyTopic);
 
   useEffect(() => {
-    void conv.start();
     return () => conv.stop();
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
@@ -34,7 +33,7 @@ export function VoiceView({ sessionId, historyTopic, onBack }: VoiceViewProps) {
     // is another gesture that unlocks playback for subsequent replies.
     unlockAudio();
     if (conv.state === "speaking" || conv.state === "thinking") conv.interrupt();
-    else if (conv.state === "error") void conv.start();
+    else if (conv.state === "idle" || conv.state === "error") void conv.start();
   };
 
   return (
@@ -63,9 +62,11 @@ export function VoiceView({ sessionId, historyTopic, onBack }: VoiceViewProps) {
       </div>
 
       {/* Quick voice switcher — same store as the settings panel. */}
-      <div className="absolute inset-x-0 bottom-6 px-6">
-        <VoiceSelector />
-      </div>
+      {conv.state !== "idle" && (
+        <div className="absolute inset-x-0 bottom-6 px-6">
+          <VoiceSelector />
+        </div>
+      )}
     </div>
   );
 }

--- a/src/index.css
+++ b/src/index.css
@@ -382,6 +382,30 @@ body {
   box-shadow: inset 0 -2px 0 color-mix(in srgb, var(--color-accent) 72%, transparent);
 }
 
+@media (max-width: 640px) {
+  .workbench-topbar-inner {
+    gap: 0.45rem;
+  }
+
+  .workbench-brand {
+    padding-inline: 0.35rem;
+  }
+
+  .workbench-route-nav {
+    gap: 0.25rem;
+  }
+
+  .workbench-route-link {
+    min-width: 2rem;
+    justify-content: center;
+    padding-inline: 0.5rem;
+  }
+
+  .home-nav-actions {
+    gap: 0.45rem;
+  }
+}
+
 .workbench-rail {
   border-right: 1px solid color-mix(in srgb, var(--color-border) 82%, var(--color-accent) 18%);
   background:
@@ -1932,6 +1956,20 @@ button, a, input, textarea {
   backdrop-filter: none;
   -webkit-backdrop-filter: none;
   border-left: 1px solid rgba(255, 255, 255, 0.08);
+}
+
+.home-settings-panel.is-open {
+  visibility: visible;
+  transition-delay: 0ms, 0ms;
+  transition-duration: 300ms, 0ms;
+  transition-property: transform, translate, visibility;
+}
+
+.home-settings-panel.is-closed {
+  visibility: hidden;
+  transition-delay: 0ms, 300ms;
+  transition-duration: 300ms, 0ms;
+  transition-property: transform, translate, visibility;
 }
 
 .home-settings-input {

--- a/src/settings/ominix-tab.test.tsx
+++ b/src/settings/ominix-tab.test.tsx
@@ -1,0 +1,78 @@
+import { cleanup, render, screen, waitFor } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { OminixTab } from "./ominix-tab";
+
+const apiMocks = vi.hoisted(() => ({
+  disableOminixModel: vi.fn(),
+  downloadOminixModel: vi.fn(),
+  enableOminixModel: vi.fn(),
+  fetchOminixAvailableModels: vi.fn(),
+  fetchOminixLogs: vi.fn(),
+  fetchOminixPlatformModels: vi.fn(),
+  fetchPlatformSkillHealth: vi.fn(),
+  fetchPlatformSkillsStatus: vi.fn(),
+  formatSettingsError: vi.fn((err: unknown, fallback = "Request failed.") =>
+    err instanceof Error ? err.message : fallback,
+  ),
+  installPlatformSkill: vi.fn(),
+  removeOminixModel: vi.fn(),
+  removePlatformSkill: vi.fn(),
+  runOminixServiceAction: vi.fn(),
+}));
+
+vi.mock("./settings-api", () => apiMocks);
+
+describe("OminixTab catalog loading", () => {
+  beforeEach(() => {
+    cleanup();
+    for (const mock of Object.values(apiMocks)) {
+      if (typeof mock === "function" && "mockReset" in mock) {
+        mock.mockReset();
+      }
+    }
+    apiMocks.formatSettingsError.mockImplementation(
+      (err: unknown, fallback = "Request failed.") =>
+        err instanceof Error ? err.message : fallback,
+    );
+    apiMocks.fetchPlatformSkillsStatus.mockResolvedValue({
+      platform_skills: [],
+      skills_dir: "/tmp/skills",
+      ominix_api: {
+        url: "http://localhost:8080",
+        healthy: true,
+        service_registered: false,
+      },
+      models: {
+        dir: "/tmp/models",
+        asr: [],
+        tts: [],
+      },
+    });
+    apiMocks.fetchPlatformSkillHealth.mockResolvedValue({
+      status: "healthy",
+      url: "http://localhost:8080",
+      detail: null,
+    });
+    apiMocks.fetchOminixPlatformModels.mockResolvedValue([]);
+    apiMocks.fetchOminixAvailableModels.mockResolvedValue([]);
+    apiMocks.fetchOminixLogs.mockResolvedValue({
+      log_path: "/tmp/ominix.log",
+      lines: [],
+      error: null,
+    });
+  });
+
+  it("does not request the available catalog while the service is not registered", async () => {
+    render(<OminixTab />);
+
+    expect(await screen.findByText("LaunchAgent missing")).toBeTruthy();
+    await waitFor(() => {
+      expect(apiMocks.fetchPlatformSkillsStatus).toHaveBeenCalled();
+    });
+    expect(apiMocks.fetchOminixAvailableModels).not.toHaveBeenCalled();
+    expect(
+      screen.getByText(/Catalog sync is paused until OminiX API is installed/i),
+    ).toBeTruthy();
+  });
+});

--- a/src/settings/ominix-tab.tsx
+++ b/src/settings/ominix-tab.tsx
@@ -465,6 +465,7 @@ export function OminixTab() {
   const [logs, setLogs] = useState<OminixLogResponse | null>(null);
   const [logLines, setLogLines] = useState(80);
   const [catalogSearch, setCatalogSearch] = useState("");
+  const [catalogNotice, setCatalogNotice] = useState<string | null>(null);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
   const [message, setMessage] = useState<string | null>(null);
@@ -474,38 +475,51 @@ export function OminixTab() {
   const load = useCallback(async () => {
     setLoading(true);
     setError(null);
+    setCatalogNotice(null);
 
-    const [
-      statusResult,
-      healthResult,
-      platformResult,
-      availableResult,
-      logsResult,
-    ] =
-      await Promise.allSettled([
-        fetchPlatformSkillsStatus(),
-        fetchPlatformSkillHealth("ominix-api"),
-        fetchOminixPlatformModels(),
-        fetchOminixAvailableModels(),
-        fetchOminixLogs(logLines),
-      ]);
+    const [statusResult, healthResult, logsResult] = await Promise.allSettled([
+      fetchPlatformSkillsStatus(),
+      fetchPlatformSkillHealth("ominix-api"),
+      fetchOminixLogs(logLines),
+    ]);
 
     const errors: string[] = [];
-
-    if (statusResult.status === "fulfilled") setStatus(statusResult.value);
-    else errors.push(`status: ${errorMessage(statusResult.reason)}`);
+    let nextStatus: PlatformSkillsStatus | null = null;
+    if (statusResult.status === "fulfilled") {
+      nextStatus = statusResult.value;
+      setStatus(nextStatus);
+    } else {
+      errors.push(`status: ${errorMessage(statusResult.reason)}`);
+    }
 
     if (healthResult.status === "fulfilled") setHealth(healthResult.value);
     else errors.push(`health: ${errorMessage(healthResult.reason)}`);
+
+    if (logsResult.status === "fulfilled") setLogs(logsResult.value);
+    else errors.push(`logs: ${errorMessage(logsResult.reason)}`);
+
+    const canLoadAvailableCatalog = Boolean(
+      nextStatus?.ominix_api.healthy &&
+        nextStatus.ominix_api.service_registered,
+    );
+
+    const [platformResult, availableResult] = await Promise.allSettled([
+      fetchOminixPlatformModels(),
+      canLoadAvailableCatalog
+        ? fetchOminixAvailableModels()
+        : Promise.resolve([] as OminixCatalogModel[]),
+    ]);
 
     if (platformResult.status === "fulfilled") setPlatformModels(platformResult.value);
     else errors.push(`models: ${errorMessage(platformResult.reason)}`);
 
     if (availableResult.status === "fulfilled") setAvailableModels(availableResult.value);
     else errors.push(`available models: ${errorMessage(availableResult.reason)}`);
-
-    if (logsResult.status === "fulfilled") setLogs(logsResult.value);
-    else errors.push(`logs: ${errorMessage(logsResult.reason)}`);
+    if (!canLoadAvailableCatalog) {
+      setCatalogNotice(
+        "Catalog sync is paused until OminiX API is installed and running.",
+      );
+    }
 
     setError(errors.length ? errors.join("\n") : null);
     setLoading(false);
@@ -793,6 +807,11 @@ export function OminixTab() {
           />
         }
       >
+        {catalogNotice && (
+          <div className="mb-3 rounded-lg border border-yellow-400/30 bg-yellow-400/5 px-4 py-3 text-xs text-yellow-300">
+            {catalogNotice}
+          </div>
+        )}
         <div className="mb-3 text-xs text-muted">
           {filteredCatalogModels.length} of {catalogModels.length} models visible
         </div>

--- a/src/sites/components/project-files.test.tsx
+++ b/src/sites/components/project-files.test.tsx
@@ -1,0 +1,75 @@
+import { act, cleanup, render, screen, waitFor } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { ProjectFiles } from "./project-files";
+
+const apiMocks = vi.hoisted(() => ({
+  listSiteFiles: vi.fn(),
+  siteFileToContentEntry: vi.fn(),
+  inferContentCategory: vi.fn(() => "report"),
+  uploadSiteFiles: vi.fn(),
+}));
+const profileMocks = vi.hoisted(() => ({
+  getMyProfileStatus: vi.fn(),
+}));
+
+vi.mock("../api", () => apiMocks);
+vi.mock("@/settings/settings-api", () => profileMocks);
+vi.mock("@/api/content", () => ({
+  downloadContent: vi.fn(),
+}));
+
+describe("site ProjectFiles", () => {
+  beforeEach(() => {
+    cleanup();
+    apiMocks.listSiteFiles.mockReset();
+    apiMocks.listSiteFiles.mockResolvedValue([]);
+    profileMocks.getMyProfileStatus.mockReset();
+  });
+
+  it("does not request project files while the local runtime is stopped", async () => {
+    profileMocks.getMyProfileStatus.mockResolvedValue({ running: false });
+
+    render(
+      <ProjectFiles
+        slug="family-hub"
+        sessionId="site-1"
+        onOpenFile={vi.fn()}
+      />,
+    );
+
+    expect(
+      await screen.findByText(/Local runtime is stopped/i),
+    ).toBeTruthy();
+    await waitFor(() => {
+      expect(apiMocks.listSiteFiles).not.toHaveBeenCalled();
+    });
+  });
+
+  it("does not request project files after unmount while runtime status is resolving", async () => {
+    let resolveStatus!: (value: { running: boolean }) => void;
+    const statusPromise = new Promise<{ running: boolean }>((resolve) => {
+      resolveStatus = resolve;
+    });
+    profileMocks.getMyProfileStatus.mockReturnValue(statusPromise);
+
+    const { unmount } = render(
+      <ProjectFiles
+        slug="family-hub"
+        sessionId="site-1"
+        onOpenFile={vi.fn()}
+      />,
+    );
+
+    await waitFor(() => {
+      expect(profileMocks.getMyProfileStatus).toHaveBeenCalled();
+    });
+    unmount();
+    await act(async () => {
+      resolveStatus({ running: false });
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    expect(apiMocks.listSiteFiles).not.toHaveBeenCalled();
+  });
+});

--- a/src/sites/components/project-files.tsx
+++ b/src/sites/components/project-files.tsx
@@ -21,6 +21,7 @@ import {
   uploadSiteFiles,
   type SiteFileEntry,
 } from "../api";
+import { getMyProfileStatus } from "@/settings/settings-api";
 
 interface ProjectFilesProps {
   slug: string;
@@ -266,6 +267,7 @@ export function ProjectFiles({
 }: ProjectFilesProps) {
   const [files, setFiles] = useState<SiteFileEntry[]>([]);
   const [error, setError] = useState<string | null>(null);
+  const [runtimeStopped, setRuntimeStopped] = useState(false);
   const [refreshTick, setRefreshTick] = useState(0);
   const [uploadError, setUploadError] = useState<string | null>(null);
   const [uploadNotice, setUploadNotice] = useState<string | null>(null);
@@ -283,6 +285,16 @@ export function ProjectFiles({
 
     async function load() {
       try {
+        const status = await getMyProfileStatus();
+        if (stopped) return;
+        if (status?.running === false) {
+          setRuntimeStopped(true);
+          setFiles([]);
+          setError(null);
+          return;
+        }
+        setRuntimeStopped(false);
+
         const nextFiles = await listSiteFiles(`sites/${slug}`, {
           sessionId,
           profileId,
@@ -399,6 +411,14 @@ export function ProjectFiles({
     return (
       <div className="flex h-full items-center justify-center px-4 text-center text-xs text-muted">
         Failed to load project files: {error}
+      </div>
+    );
+  }
+
+  if (runtimeStopped) {
+    return (
+      <div className="flex h-full items-center justify-center px-4 text-center text-xs leading-5 text-muted">
+        Local runtime is stopped. Start this profile from Settings &gt; Server to browse project files.
       </div>
     );
   }

--- a/src/sites/components/sites-chat.test.tsx
+++ b/src/sites/components/sites-chat.test.tsx
@@ -11,6 +11,7 @@ import type { SiteProject } from "../types";
 const threadStoreMocks = vi.hoisted(() => ({
   loadHistory: vi.fn(),
 }));
+const bridgeSendMock = vi.hoisted(() => vi.fn());
 const sitesApiMocks = vi.hoisted(() => ({
   hydrateSiteProjectFromSession: vi.fn(),
 }));
@@ -33,7 +34,7 @@ vi.mock("@/runtime/runtime-provider", () => ({
 }));
 
 vi.mock("@/runtime/ui-protocol-send", () => ({
-  sendMessage: vi.fn(),
+  sendMessage: bridgeSendMock,
 }));
 
 vi.mock("@/store/thread-store", () => ({
@@ -130,6 +131,7 @@ beforeEach(() => {
   installLocalStorageStub();
   localStorage.clear();
   threadStoreMocks.loadHistory.mockReset();
+  bridgeSendMock.mockReset();
   sitesApiMocks.hydrateSiteProjectFromSession.mockReset();
   sitesContextMocks.project = undefined;
   sitesContextMocks.save.mockReset();
@@ -153,6 +155,31 @@ afterEach(() => {
 });
 
 describe("SitesChat approval requests", () => {
+  it("does not auto-scaffold or hydrate an already scaffolded local project", async () => {
+    seedProject({ scaffolded: true, slug: "physics-learning-studio" });
+    sitesApiMocks.hydrateSiteProjectFromSession.mockRejectedValue(
+      new Error("HTTP 503"),
+    );
+
+    const harness = await mountSitesChat();
+    try {
+      await act(async () => {
+        await new Promise((resolve) => setTimeout(resolve, 0));
+      });
+
+      expect(sitesApiMocks.hydrateSiteProjectFromSession).not.toHaveBeenCalled();
+      expect(bridgeSendMock).not.toHaveBeenCalled();
+      expect(sitesContextMocks.save).not.toHaveBeenCalledWith(
+        expect.objectContaining({
+          scaffolded: false,
+          scaffoldError: "HTTP 503",
+        }),
+      );
+    } finally {
+      harness.unmount();
+    }
+  });
+
   it("renders a blocking approval dialog for a topic-scoped approval", async () => {
     seedProject();
     const harness = await mountSitesChat();

--- a/src/sites/components/sites-chat.tsx
+++ b/src/sites/components/sites-chat.tsx
@@ -122,6 +122,7 @@ export function SitesChat({ sessionId }: Props) {
   const projectId = project?.id;
   const projectTitle = project?.title;
   const projectScaffolded = project?.scaffolded;
+  const projectScaffoldError = project?.scaffoldError;
   const historyTopic = project?.preset ? `site ${project.preset}` : undefined;
   // M10.5: ThreadStore is the single source of truth. SitesChat still
   // reads a flattened `Message[]` for backwards compatibility with its
@@ -154,6 +155,9 @@ export function SitesChat({ sessionId }: Props) {
     async (request?: SessionSendRequest) => {
       const current = projectRef.current;
       if (!current?.id) return;
+      if (current.scaffolded && current.slug && !current.scaffoldError) {
+        return;
+      }
 
       if (scaffoldPromiseRef.current) {
         return scaffoldPromiseRef.current;
@@ -284,8 +288,9 @@ export function SitesChat({ sessionId }: Props) {
 
   useEffect(() => {
     if (!projectId) return;
+    if (projectScaffolded || projectScaffoldError) return;
     void ensureSiteScaffolded();
-  }, [ensureSiteScaffolded, projectId, projectScaffolded]);
+  }, [ensureSiteScaffolded, projectId, projectScaffolded, projectScaffoldError]);
 
   const beforeSend = useCallback(
     async (request: SessionSendRequest): Promise<SessionBeforeSendResult> => {

--- a/src/sites/context/sites-context.test.tsx
+++ b/src/sites/context/sites-context.test.tsx
@@ -1,0 +1,112 @@
+import { act, cleanup, render, waitFor } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { upsertSiteProject } from "../store";
+import { SitesProvider } from "./sites-context";
+
+const apiMocks = vi.hoisted(() => ({
+  buildSitePreviewUrl: vi.fn(() => "/preview/site-1"),
+  fetchSiteSession: vi.fn(),
+  listSiteFiles: vi.fn(),
+}));
+const profileMocks = vi.hoisted(() => ({
+  getMyProfileStatus: vi.fn(),
+}));
+
+vi.mock("../api", () => apiMocks);
+vi.mock("@/settings/settings-api", () => profileMocks);
+vi.mock("@/api/client", () => ({
+  getSelectedProfileId: vi.fn(() => "admin"),
+}));
+
+describe("SitesProvider runtime polling", () => {
+  beforeEach(() => {
+    cleanup();
+    localStorage.clear();
+    apiMocks.fetchSiteSession.mockReset();
+    apiMocks.listSiteFiles.mockReset();
+    apiMocks.listSiteFiles.mockResolvedValue([]);
+    profileMocks.getMyProfileStatus.mockReset();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("does not poll site files while the local runtime is stopped", async () => {
+    profileMocks.getMyProfileStatus.mockResolvedValue({ running: false });
+    upsertSiteProject({
+      id: "site-1",
+      title: "Family Hub",
+      createdAt: 1,
+      updatedAt: 1,
+      profileId: "admin",
+      preset: "learning",
+      template: "quarto-lesson",
+      siteKind: "course",
+      slug: "family-hub",
+      scaffolded: true,
+    });
+
+    render(
+      <SitesProvider projectId="site-1">
+        <div>site child</div>
+      </SitesProvider>,
+    );
+
+    await waitFor(() => {
+      expect(profileMocks.getMyProfileStatus).toHaveBeenCalled();
+    });
+    expect(apiMocks.listSiteFiles).not.toHaveBeenCalled();
+    expect(apiMocks.fetchSiteSession).not.toHaveBeenCalled();
+  });
+
+  it("backs off runtime status polling while the local runtime remains stopped", async () => {
+    vi.useFakeTimers();
+    profileMocks.getMyProfileStatus.mockResolvedValue({ running: false });
+    upsertSiteProject({
+      id: "site-1",
+      title: "Family Hub",
+      createdAt: 1,
+      updatedAt: 1,
+      profileId: "admin",
+      preset: "learning",
+      template: "quarto-lesson",
+      siteKind: "course",
+      slug: "family-hub",
+      scaffolded: true,
+    });
+
+    render(
+      <SitesProvider projectId="site-1">
+        <div>site child</div>
+      </SitesProvider>,
+    );
+
+    await act(async () => {
+      await Promise.resolve();
+    });
+    expect(profileMocks.getMyProfileStatus).toHaveBeenCalledTimes(1);
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(5000);
+    });
+    expect(profileMocks.getMyProfileStatus).toHaveBeenCalledTimes(2);
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(5000);
+    });
+    expect(profileMocks.getMyProfileStatus).toHaveBeenCalledTimes(3);
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(5000);
+    });
+    expect(profileMocks.getMyProfileStatus).toHaveBeenCalledTimes(3);
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(10_000);
+    });
+    expect(profileMocks.getMyProfileStatus).toHaveBeenCalledTimes(4);
+    expect(apiMocks.listSiteFiles).not.toHaveBeenCalled();
+  });
+});

--- a/src/sites/context/sites-context.tsx
+++ b/src/sites/context/sites-context.tsx
@@ -7,6 +7,7 @@ import {
 } from "react";
 
 import { getSelectedProfileId } from "@/api/client";
+import { getMyProfileStatus } from "@/settings/settings-api";
 
 import { buildSitePreviewUrl, fetchSiteSession, listSiteFiles } from "../api";
 import { useSiteProject, updateSiteProject } from "../store";
@@ -37,12 +38,36 @@ export function SitesProvider({
 
     let stopped = false;
     let pollTimer: ReturnType<typeof setTimeout> | undefined;
+    let idleStreak = 0;
+
+    function nextDelay(): number {
+      if (idleStreak < 3) return 5000;
+      if (idleStreak < 10) return 15_000;
+      return 30_000;
+    }
+
+    function schedule() {
+      if (stopped) return;
+      pollTimer = setTimeout(() => {
+        if (typeof document !== "undefined" && document.hidden) {
+          schedule();
+          return;
+        }
+        void pollProject();
+      }, nextDelay());
+    }
 
     async function pollProject() {
       try {
         const latest = projectRef.current;
         if (!latest?.slug) return;
         const profileId = latest.profileId || getSelectedProfileId() || undefined;
+        const profileStatus = await getMyProfileStatus();
+        if (stopped) return;
+        if (profileStatus?.running === false) {
+          idleStreak += 1;
+          return;
+        }
 
         const files = await listSiteFiles(`sites/${latest.slug}`, {
           sessionId: latest.id,
@@ -77,10 +102,14 @@ export function SitesProvider({
             nextUpdate.previewUrl !== latest.previewUrl;
 
           if (changed) {
+            idleStreak = 0;
             updateSiteProject(latest.id, nextUpdate);
             reload();
+          } else {
+            idleStreak += 1;
           }
         } else if (!latest.previewUrl) {
+          idleStreak = 0;
           updateSiteProject(latest.id, {
             profileId: profileId || latest.profileId,
             previewUrl: buildSitePreviewUrl(
@@ -90,11 +119,14 @@ export function SitesProvider({
             ),
           });
           reload();
+        } else {
+          idleStreak += 1;
         }
       } catch {
         // The site scaffold can still be warming up.
+        idleStreak += 1;
       } finally {
-        if (!stopped) pollTimer = setTimeout(pollProject, 5000);
+        schedule();
       }
     }
 

--- a/src/slides/components/project-files.test.tsx
+++ b/src/slides/components/project-files.test.tsx
@@ -1,0 +1,80 @@
+import { act, cleanup, render, screen, waitFor } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { ProjectFiles } from "./project-files";
+
+const apiMocks = vi.hoisted(() => ({
+  fetchSlidesManifest: vi.fn(),
+  fetchSlidesWorkspaceContract: vi.fn(),
+  inferContentCategory: vi.fn(() => "report"),
+  listSlidesFiles: vi.fn(),
+  slidesFileToContentEntry: vi.fn(),
+}));
+const profileMocks = vi.hoisted(() => ({
+  getMyProfileStatus: vi.fn(),
+}));
+
+vi.mock("../api", () => apiMocks);
+vi.mock("@/settings/settings-api", () => profileMocks);
+vi.mock("@/api/content", () => ({
+  downloadContent: vi.fn(),
+}));
+
+describe("slides ProjectFiles", () => {
+  beforeEach(() => {
+    cleanup();
+    apiMocks.listSlidesFiles.mockReset();
+    apiMocks.listSlidesFiles.mockResolvedValue([]);
+    apiMocks.fetchSlidesManifest.mockReset();
+    apiMocks.fetchSlidesManifest.mockResolvedValue(null);
+    apiMocks.fetchSlidesWorkspaceContract.mockReset();
+    apiMocks.fetchSlidesWorkspaceContract.mockResolvedValue(null);
+    profileMocks.getMyProfileStatus.mockReset();
+  });
+
+  it("does not request project files while the local runtime is stopped", async () => {
+    profileMocks.getMyProfileStatus.mockResolvedValue({ running: false });
+
+    render(
+      <ProjectFiles
+        slug="household-brief"
+        sessionId="deck-1"
+        onOpenFile={vi.fn()}
+      />,
+    );
+
+    expect(
+      await screen.findByText(/Local runtime is stopped/i),
+    ).toBeTruthy();
+    await waitFor(() => {
+      expect(apiMocks.listSlidesFiles).not.toHaveBeenCalled();
+    });
+  });
+
+  it("does not request project files after unmount while runtime status is resolving", async () => {
+    let resolveStatus!: (value: { running: boolean }) => void;
+    const statusPromise = new Promise<{ running: boolean }>((resolve) => {
+      resolveStatus = resolve;
+    });
+    profileMocks.getMyProfileStatus.mockReturnValue(statusPromise);
+
+    const { unmount } = render(
+      <ProjectFiles
+        slug="household-brief"
+        sessionId="deck-1"
+        onOpenFile={vi.fn()}
+      />,
+    );
+
+    await waitFor(() => {
+      expect(profileMocks.getMyProfileStatus).toHaveBeenCalled();
+    });
+    unmount();
+    await act(async () => {
+      resolveStatus({ running: false });
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    expect(apiMocks.listSlidesFiles).not.toHaveBeenCalled();
+  });
+});

--- a/src/slides/components/project-files.tsx
+++ b/src/slides/components/project-files.tsx
@@ -28,6 +28,7 @@ import {
   type SlidesRenderManifest,
   type SlidesFileEntry,
 } from "../api";
+import { getMyProfileStatus } from "@/settings/settings-api";
 
 interface ProjectFilesProps {
   slug: string;
@@ -274,6 +275,7 @@ export function ProjectFiles({
   const [manifest, setManifest] = useState<SlidesRenderManifest | null>(null);
   const [contract, setContract] = useState<SlidesWorkspaceContract | null>(null);
   const [error, setError] = useState<string | null>(null);
+  const [runtimeStopped, setRuntimeStopped] = useState(false);
   const requestedDirs = useMemo(
     () => [`slides/${slug}`, "skill-output", "research", "sites"],
     [slug],
@@ -359,6 +361,25 @@ export function ProjectFiles({
         pollTimer = undefined;
       }
       try {
+        const status = await getMyProfileStatus();
+        if (stopped) return;
+        if (status?.running === false) {
+          const sig = "runtime-stopped";
+          if (sig !== prevSignature) {
+            prevSignature = sig;
+            idleStreak = 0;
+            setFiles([]);
+            setManifest(null);
+            setContract(null);
+          } else {
+            idleStreak += 1;
+          }
+          setRuntimeStopped(true);
+          setError(null);
+          return;
+        }
+        setRuntimeStopped(false);
+
         const [nextFiles, nextContract] = await Promise.all([
           listSlidesFiles(requestedDirs, { sessionId }),
           fetchSlidesWorkspaceContract(sessionId, slug).catch(() => null),
@@ -504,6 +525,12 @@ export function ProjectFiles({
     body = (
       <div className="shell-empty-state flex h-full items-center justify-center rounded-lg px-4 text-center text-sm text-muted">
         Failed to load project files: {error}
+      </div>
+    );
+  } else if (runtimeStopped) {
+    body = (
+      <div className="shell-empty-state flex h-full items-center justify-center rounded-lg px-4 text-center text-sm leading-6 text-muted">
+        Local runtime is stopped. Start this profile from Settings &gt; Server to browse project files.
       </div>
     );
   } else if (files.length === 0) {

--- a/src/slides/context/slides-context.test.tsx
+++ b/src/slides/context/slides-context.test.tsx
@@ -1,0 +1,55 @@
+import { cleanup, render, waitFor } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { upsertSlidesProject } from "../store";
+import { SlidesProvider } from "./slides-context";
+
+const apiMocks = vi.hoisted(() => ({
+  fetchSlidesManifest: vi.fn(),
+  listSlidesFiles: vi.fn(),
+}));
+const profileMocks = vi.hoisted(() => ({
+  getMyProfileStatus: vi.fn(),
+}));
+
+vi.mock("../api", () => apiMocks);
+vi.mock("@/settings/settings-api", () => profileMocks);
+
+describe("SlidesProvider runtime polling", () => {
+  beforeEach(() => {
+    cleanup();
+    localStorage.clear();
+    apiMocks.fetchSlidesManifest.mockReset();
+    apiMocks.listSlidesFiles.mockReset();
+    apiMocks.listSlidesFiles.mockResolvedValue([]);
+    profileMocks.getMyProfileStatus.mockReset();
+  });
+
+  it("does not poll slide files while the local runtime is stopped", async () => {
+    profileMocks.getMyProfileStatus.mockResolvedValue({ running: false });
+    upsertSlidesProject({
+      id: "deck-1",
+      title: "Household Brief",
+      createdAt: 1,
+      updatedAt: 1,
+      scaffolded: true,
+      slug: "household-brief",
+      slides: [],
+      template: "business",
+      tags: [],
+      versions: [],
+    });
+
+    render(
+      <SlidesProvider projectId="deck-1">
+        <div>slides child</div>
+      </SlidesProvider>,
+    );
+
+    await waitFor(() => {
+      expect(profileMocks.getMyProfileStatus).toHaveBeenCalled();
+    });
+    expect(apiMocks.listSlidesFiles).not.toHaveBeenCalled();
+    expect(apiMocks.fetchSlidesManifest).not.toHaveBeenCalled();
+  });
+});

--- a/src/slides/context/slides-context.tsx
+++ b/src/slides/context/slides-context.tsx
@@ -7,6 +7,8 @@ import {
   type ReactNode,
 } from "react";
 
+import { getMyProfileStatus } from "@/settings/settings-api";
+
 import type { SlidesProject, Slide } from "../types";
 import { useSlidesProject, updateSlidesProject } from "../store";
 import { fetchSlidesManifest, listSlidesFiles } from "../api";
@@ -69,6 +71,12 @@ export function SlidesProvider({
       try {
         const latest = projectRef.current;
         if (!latest?.slug) return;
+        const profileStatus = await getMyProfileStatus();
+        if (stopped) return;
+        if (profileStatus?.running === false) {
+          idleStreak += 1;
+          return;
+        }
 
         // List BOTH the scaffold dir and the plugin-output dir. The
         // `mofa_slides` plugin writes generated PNGs to

--- a/src/slides/pages/slides-editor-page.test.tsx
+++ b/src/slides/pages/slides-editor-page.test.tsx
@@ -1,0 +1,80 @@
+import { cleanup, render, screen, waitFor } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { MemoryRouter, Route, Routes } from "react-router-dom";
+import type { ReactNode } from "react";
+
+import { upsertSlidesProject } from "../store";
+import { SlidesEditorPage } from "./slides-editor-page";
+
+const apiMocks = vi.hoisted(() => ({
+  hydrateSlidesProjectFromSession: vi.fn(),
+}));
+const contextMocks = vi.hoisted(() => ({
+  currentProject: undefined as unknown,
+  save: vi.fn(),
+}));
+const profileMocks = vi.hoisted(() => ({
+  getMyProfileStatus: vi.fn(),
+}));
+
+vi.mock("../api", () => apiMocks);
+vi.mock("@/settings/settings-api", () => profileMocks);
+vi.mock("../context/slides-context", () => ({
+  SlidesProvider: ({ children }: { children: ReactNode }) => <>{children}</>,
+  useSlides: () => ({
+    project: contextMocks.currentProject,
+    save: contextMocks.save,
+  }),
+}));
+vi.mock("../layouts/slides-editor-layout", () => ({
+  SlidesEditorLayout: () => <div>editor layout</div>,
+}));
+vi.mock("../components/slide-preview", () => ({
+  default: () => <div>slide preview</div>,
+}));
+vi.mock("../components/slides-chat", () => ({
+  SlidesChat: () => <div>slides chat</div>,
+}));
+
+describe("SlidesEditorPage hydration", () => {
+  beforeEach(() => {
+    cleanup();
+    localStorage.clear();
+    apiMocks.hydrateSlidesProjectFromSession.mockReset();
+    profileMocks.getMyProfileStatus.mockReset();
+    contextMocks.save.mockReset();
+    contextMocks.currentProject = undefined;
+  });
+
+  it("does not hydrate from backend files while the local runtime is stopped", async () => {
+    const project = {
+      id: "deck-1",
+      title: "Household Brief",
+      createdAt: 1,
+      updatedAt: 1,
+      scaffolded: true,
+      slug: "household-brief",
+      slides: [],
+      template: "business",
+      tags: [],
+      versions: [],
+    };
+    contextMocks.currentProject = project;
+    profileMocks.getMyProfileStatus.mockResolvedValue({ running: false });
+    upsertSlidesProject(project);
+
+    render(
+      <MemoryRouter initialEntries={["/slides/deck-1"]}>
+        <Routes>
+          <Route path="/slides/:id" element={<SlidesEditorPage />} />
+        </Routes>
+      </MemoryRouter>,
+    );
+
+    expect(await screen.findByText("editor layout")).toBeTruthy();
+    await waitFor(() => {
+      expect(profileMocks.getMyProfileStatus).toHaveBeenCalled();
+    });
+    expect(apiMocks.hydrateSlidesProjectFromSession).not.toHaveBeenCalled();
+  });
+});

--- a/src/slides/pages/slides-editor-page.tsx
+++ b/src/slides/pages/slides-editor-page.tsx
@@ -1,5 +1,7 @@
 import { useParams, useNavigate } from "react-router-dom";
 import { useState, useEffect, useCallback } from "react";
+import { getMyProfileStatus } from "@/settings/settings-api";
+
 import { SlidesProvider, useSlides } from "../context/slides-context";
 import { SlidesEditorLayout } from "../layouts/slides-editor-layout";
 import SlidePreview from "../components/slide-preview";
@@ -95,6 +97,16 @@ export function SlidesEditorPage() {
 
     async function hydrate() {
       try {
+        const profileStatus = await getMyProfileStatus();
+        if (stopped) return;
+        if (profileStatus?.running === false) {
+          if (!project) {
+            setHydrateError(
+              "Local runtime is stopped. Start this profile from Settings > Server to load this deck.",
+            );
+          }
+          return;
+        }
         const nextProject = await hydrateSlidesProjectFromSession(sessionId);
         if (stopped) return;
 

--- a/src/slides/pages/slides-present-page.tsx
+++ b/src/slides/pages/slides-present-page.tsx
@@ -7,6 +7,7 @@ import {
   ChevronLeft,
   ChevronRight,
 } from "lucide-react";
+import { getMyProfileStatus } from "@/settings/settings-api";
 
 import { hydrateSlidesProjectFromSession } from "../api";
 import { SlidesProvider, useSlides } from "../context/slides-context";
@@ -204,6 +205,7 @@ function SlidesPresentContent() {
 export function SlidesPresentPage() {
   const { id } = useParams<{ id: string }>();
   const [hydrating, setHydrating] = useState(false);
+  const [hydrateError, setHydrateError] = useState<string | null>(null);
   const navigate = useNavigate();
 
   const project = id ? getSlidesProject(id) : undefined;
@@ -213,9 +215,18 @@ export function SlidesPresentPage() {
     const sessionId = id;
     let stopped = false;
     setHydrating(true);
+    setHydrateError(null);
 
     async function hydrate() {
       try {
+        const profileStatus = await getMyProfileStatus();
+        if (stopped) return;
+        if (profileStatus?.running === false) {
+          setHydrateError(
+            "Local runtime is stopped. Start this profile from Settings > Server to load this deck.",
+          );
+          return;
+        }
         const nextProject = await hydrateSlidesProjectFromSession(sessionId);
         if (stopped || !nextProject) return;
         upsertSlidesProject(nextProject);
@@ -236,7 +247,15 @@ export function SlidesPresentPage() {
   }, [id, navigate, project]);
 
   if (!id || (!project && hydrating)) return null;
-  if (!id || !project) return null;
+  if (!id || !project) {
+    return (
+      <div className="flex h-screen flex-col bg-black text-white">
+        <div className="flex flex-1 items-center justify-center px-6 text-center text-white/70">
+          {hydrateError || "Slides session unavailable."}
+        </div>
+      </div>
+    );
+  }
 
   return (
     <SlidesProvider projectId={project.id}>

--- a/tests/ui-redesign-smoke.spec.ts
+++ b/tests/ui-redesign-smoke.spec.ts
@@ -258,6 +258,92 @@ test.describe("UI redesign shell smoke", () => {
     }
   });
 
+  test("mobile home navigation keeps visible controls inside the viewport", async ({
+    page,
+  }) => {
+    await page.setViewportSize({ width: 390, height: 844 });
+    await page.goto("/", { waitUntil: "networkidle" });
+
+    const offscreenControls = await page.evaluate(() => {
+      const controls = Array.from(
+        document.querySelectorAll(".workbench-topbar a, .workbench-topbar button"),
+      );
+      return controls
+        .map((control) => {
+          const rect = control.getBoundingClientRect();
+          const text =
+            (control.textContent ||
+              control.getAttribute("aria-label") ||
+              control.getAttribute("title") ||
+              "").trim();
+          return {
+            text,
+            left: Math.round(rect.left),
+            right: Math.round(rect.right),
+            width: Math.round(rect.width),
+          };
+        })
+        .filter(
+          (control) =>
+            control.width > 0 &&
+            (control.left < -1 || control.right > window.innerWidth + 1),
+        );
+    });
+
+    expect(offscreenControls).toEqual([]);
+  });
+
+  test("home settings drawer hides closed controls from visual audits", async ({
+    page,
+  }) => {
+    await page.setViewportSize({ width: 1440, height: 900 });
+    await page.goto("/home", { waitUntil: "networkidle" });
+
+    const panel = page.locator(".home-settings-panel");
+    await expect(panel).toHaveCSS("visibility", "hidden");
+
+    await page.locator(".home-settings-gear").click();
+    await expect(panel).toHaveCSS("visibility", "visible");
+
+    await page.getByRole("button", { name: "Close" }).click();
+    await expect(panel).toHaveCSS("visibility", "hidden");
+  });
+
+  test("home blank space does not enter conversation mode", async ({ page }) => {
+    await page.setViewportSize({ width: 1440, height: 900 });
+    await page.goto("/home", { waitUntil: "networkidle" });
+
+    const readMode = () =>
+      page.evaluate(() => {
+        const layers = Array.from(document.querySelectorAll(".home-layer"));
+        return layers.map((layer) => {
+          const style = getComputedStyle(layer);
+          return {
+            opacity: style.opacity,
+            pointerEvents: style.pointerEvents,
+          };
+        });
+      });
+
+    expect(await readMode()).toEqual([
+      { opacity: "1", pointerEvents: "auto" },
+      { opacity: "0", pointerEvents: "none" },
+    ]);
+
+    await page.mouse.click(1320, 820);
+    await page.waitForTimeout(100);
+    expect(await readMode()).toEqual([
+      { opacity: "1", pointerEvents: "auto" },
+      { opacity: "0", pointerEvents: "none" },
+    ]);
+
+    await page.getByRole("button", { name: "Chat" }).click();
+    await expect.poll(readMode).toEqual([
+      { opacity: "0", pointerEvents: "none" },
+      { opacity: "1", pointerEvents: "auto" },
+    ]);
+  });
+
   test("workspace surfaces use the shared topbar titles", async ({ page }) => {
     await page.setViewportSize({ width: 1440, height: 900 });
 


### PR DESCRIPTION
## Summary
- fix /home blank-space clicks entering conversation mode by removing the full-screen grid click activator and covering the regression in Playwright
- harden live runtime stopped states for Voice, OminiX, Sites, and Slides so the UI does not call unavailable local endpoints or show misleading fake-ready states
- clean up home shell visual issues: mobile topbar clipping, settings drawer hidden state, Metro resize/blank-click smoke coverage, and a real BBC default news source that avoids rss2json rate limits

## Verification
- npm run test:unit -> 63 files / 658 tests passed
- npm run build -> passed; existing warnings only: CSS [file:...] unsupported property and large chunk warnings
- BASE_URL=http://127.0.0.1:5174 npx playwright test --reporter=list -> 97 passed, 35 skipped, 0 failed
- BASE_URL=http://127.0.0.1:5174 npx playwright test tests/ui-redesign-smoke.spec.ts --grep "home blank space" --reporter=list -> 1 passed
- node /tmp/octos-live-ui-audit.mjs -> 20 checked, 0 failures
- git diff --check -> clean

## Notes
- npm run lint still fails repo-wide with 149 existing problems, mostly React 19 lint rules, explicit any, and unused test helpers outside this PR scope.
- Claude Code was used as an independent reviewer for mock endpoint/runtime/UI risks; its findings were manually verified before commit.