### PR TITLE
Add classic Home UI option

### DIFF
--- a/src/home/classic-standby-view.tsx
+++ b/src/home/classic-standby-view.tsx
@@ -1,0 +1,371 @@
+import { useCallback, useMemo, useState } from "react";
+import {
+  CalendarDays,
+  Home,
+  MessageSquare,
+  Music,
+  Newspaper,
+} from "lucide-react";
+
+import { SettingsGearButton, HomeSettingsPanel } from "./home-settings";
+import { useBurnInProtection } from "./use-burn-in-protection";
+import { useClock } from "./use-clock";
+import { useEvents } from "./use-events";
+import { useHomeSettings } from "./home-settings-context";
+import { useNews, timeAgo } from "./use-news";
+import { PhotoFrame } from "./photo-frame";
+import { TimerWidget } from "./timer-widget";
+import { useVoiceInput } from "./use-voice-input";
+import { useWeather } from "./use-weather";
+import { VoiceOrb } from "./voice-orb";
+import type { WidgetConfig, WidgetType } from "./widget-registry";
+
+interface ClassicStandbyViewProps {
+  onActivate: (prefill?: string) => void;
+  nightActive: boolean;
+}
+
+function isWidgetOn(widgets: WidgetConfig[], type: WidgetType): boolean {
+  const widget = widgets.find((entry) => entry.type === type);
+  return widget ? widget.enabled : true;
+}
+
+export function ClassicStandbyView({
+  onActivate,
+  nightActive,
+}: ClassicStandbyViewProps) {
+  const clock = useClock();
+  const weather = useWeather();
+  const { strings, tempUnit, clockFormat, widgets, newsFeedUrl, lang } =
+    useHomeSettings();
+  const burnIn = useBurnInProtection();
+  const [settingsOpen, setSettingsOpen] = useState(false);
+  const news = useNews(newsFeedUrl);
+  const events = useEvents();
+
+  const voice = useVoiceInput({
+    onResult: (text) => onActivate(text),
+    lang: lang === "zh" ? "zh-CN" : "en-US",
+  });
+
+  const handleOrbClick = useCallback(() => {
+    if (!voice.isSupported) {
+      onActivate();
+      return;
+    }
+    if (voice.orbState === "listening") {
+      voice.stop();
+    } else if (voice.orbState === "idle") {
+      voice.start();
+    }
+  }, [voice, onActivate]);
+
+  const dateStr = `${strings.weekdays[clock.date.getDay()]}, ${
+    strings.months[clock.date.getMonth()]
+  } ${clock.date.getDate()}`;
+
+  const greeting = useMemo(() => {
+    const hour = clock.date.getHours();
+    if (hour >= 5 && hour < 12) return strings.greetingMorning;
+    if (hour >= 12 && hour < 17) return strings.greetingAfternoon;
+    if (hour >= 17 && hour < 21) return strings.greetingEvening;
+    return strings.greetingNight;
+  }, [clock.date, strings]);
+
+  const displayHours = (() => {
+    const hour = clock.date.getHours();
+    if (clockFormat === "12h") return String(hour % 12 || 12).padStart(2, "0");
+    return clock.hours;
+  })();
+
+  const ampm =
+    clockFormat === "12h" ? (clock.date.getHours() >= 12 ? "PM" : "AM") : null;
+
+  const formatTemp = useCallback(
+    (tempC: number) =>
+      tempUnit === "F" ? Math.round((tempC * 9) / 5 + 32) : tempC,
+    [tempUnit],
+  );
+
+  const quickActions = [
+    {
+      id: "chat",
+      icon: MessageSquare,
+      label: strings.cardChat,
+      color: "text-blue-400",
+      prefill: strings.cardChatPrefill,
+    },
+    {
+      id: "news",
+      icon: Newspaper,
+      label: strings.cardNews,
+      color: "text-amber-400",
+      prefill: strings.cardNewsPrefill,
+    },
+    {
+      id: "music",
+      icon: Music,
+      label: strings.cardMusic,
+      color: "text-emerald-400",
+      prefill: strings.cardMusicPrefill,
+    },
+    {
+      id: "home",
+      icon: Home,
+      label: strings.cardHome,
+      color: "text-purple-400",
+      prefill: strings.cardHomePrefill,
+    },
+  ] as const;
+
+  return (
+    <div
+      className={`classic-home-standby home-standby flex h-full w-full flex-col items-center select-none overflow-y-auto py-8 ${
+        burnIn.dimmed ? "home-dimmed" : ""
+      }`}
+      onMouseMove={() => burnIn.onActivity()}
+      onTouchStart={() => burnIn.onActivity()}
+    >
+      <div className="home-top-bar absolute left-0 right-0 top-0 z-20 flex items-center justify-between px-6 pt-5">
+        {!nightActive && isWidgetOn(widgets, "greeting") ? (
+          <span className="home-greeting home-greeting-fadein text-2xl font-light text-white/40">
+            {greeting}
+          </span>
+        ) : (
+          <span />
+        )}
+        <SettingsGearButton onClick={() => setSettingsOpen(true)} />
+      </div>
+
+      {isWidgetOn(widgets, "clock") && (
+        <>
+          <div
+            className={`home-clock tabular-nums ${
+              nightActive ? "home-clock-night" : "text-white"
+            }`}
+            aria-live="polite"
+            style={{
+              transform: `translate(${burnIn.offset.x}px, ${burnIn.offset.y}px)`,
+              transition: "transform 2s ease-in-out",
+            }}
+          >
+            <span>{displayHours}</span>
+            <span className="home-clock-colon">:</span>
+            <span>{clock.minutes}</span>
+            {ampm && (
+              <span className="home-clock-ampm ml-3 text-[0.3em] font-normal text-white/40">
+                {ampm}
+              </span>
+            )}
+          </div>
+
+          <div
+            className="home-date mt-2 text-white/50"
+            style={{
+              transform: `translate(${burnIn.offset.x}px, ${burnIn.offset.y}px)`,
+              transition: "transform 2s ease-in-out",
+            }}
+          >
+            {dateStr}
+          </div>
+        </>
+      )}
+
+      {!nightActive && isWidgetOn(widgets, "voice-orb") && (
+        <div
+          className="mt-6"
+          style={{
+            transform: `translate(${burnIn.offset.x}px, ${burnIn.offset.y}px)`,
+            transition: "transform 2s ease-in-out",
+          }}
+        >
+          <VoiceOrb state={voice.orbState} onClick={handleOrbClick} />
+          {voice.orbState === "listening" && voice.transcript && (
+            <p className="mt-2 max-w-[200px] truncate text-center text-sm text-white/40">
+              {voice.transcript}
+            </p>
+          )}
+        </div>
+      )}
+
+      {!nightActive && isWidgetOn(widgets, "weather") && (
+        <div className="home-widget home-weather-widget mx-4 mt-8 px-6 py-4">
+          {weather.loading ? (
+            <div className="flex items-center gap-3">
+              <div className="h-10 w-20 animate-pulse rounded-xl bg-white/10" />
+              <div className="h-6 w-40 animate-pulse rounded-lg bg-white/10" />
+            </div>
+          ) : weather.error ? (
+            <span className="text-lg text-white/40">
+              {strings.weatherUnavailable}
+            </span>
+          ) : (
+            <div className="home-weather-layout flex items-center gap-6">
+              <div className="home-weather-current flex shrink-0 items-center gap-3">
+                <span className="text-4xl leading-none">{weather.emoji}</span>
+                <div className="flex flex-col">
+                  <span className="text-3xl font-semibold leading-tight tabular-nums text-white/95">
+                    {formatTemp(weather.temperature)}&deg;{tempUnit}
+                  </span>
+                  <span className="mt-0.5 text-sm leading-tight text-white/50">
+                    {weather.label}
+                    {weather.city && <span> &middot; {weather.city}</span>}
+                  </span>
+                </div>
+              </div>
+
+              {weather.hourly.length > 0 && (
+                <div className="home-weather-divider h-12 w-px shrink-0 bg-white/10" />
+              )}
+
+              {weather.hourly.length > 0 && (
+                <div className="home-forecast-strip flex gap-4 overflow-x-auto">
+                  {weather.hourly.map((item, index) => (
+                    <div
+                      key={`${item.hour}-${index}`}
+                      className="home-forecast-item flex shrink-0 flex-col items-center gap-1"
+                    >
+                      <span className="text-xs tabular-nums text-white/40">
+                        {item.hour}
+                      </span>
+                      <span className="text-lg leading-none">{item.emoji}</span>
+                      <span className="text-sm font-medium tabular-nums text-white/70">
+                        {formatTemp(item.temp)}&deg;
+                      </span>
+                    </div>
+                  ))}
+                </div>
+              )}
+            </div>
+          )}
+        </div>
+      )}
+
+      {!nightActive && isWidgetOn(widgets, "quick-actions") && (
+        <div className="home-quick-actions mt-8">
+          {quickActions.map(({ id, icon: Icon, label, color, prefill }) => (
+            <button
+              key={id}
+              onClick={() => onActivate(prefill || undefined)}
+              className="home-quick-card group flex flex-col items-center justify-center gap-2"
+              aria-label={label}
+            >
+              <div className="home-quick-card-icon flex items-center justify-center rounded-2xl">
+                <Icon
+                  size={28}
+                  className={`${color} transition-transform group-hover:scale-110`}
+                />
+              </div>
+              <span className="text-sm font-medium text-white/60 transition-colors group-hover:text-white/90">
+                {label}
+              </span>
+            </button>
+          ))}
+        </div>
+      )}
+
+      {!nightActive && isWidgetOn(widgets, "news") && (
+        <div className="home-widget home-news-widget mx-4 mt-8 px-5 py-4">
+          <div className="mb-3 flex items-center gap-2">
+            <Newspaper size={16} className="text-amber-400/70" />
+            <span className="text-sm font-medium text-white/50">
+              {strings.newsHeadlines}
+            </span>
+          </div>
+
+          {news.loading && news.items.length === 0 ? (
+            <div className="flex gap-4 overflow-hidden">
+              {[0, 1, 2].map((index) => (
+                <div
+                  key={index}
+                  className="home-news-card shrink-0 animate-pulse"
+                >
+                  <div className="mb-2 h-4 w-36 rounded bg-white/10" />
+                  <div className="h-3 w-20 rounded bg-white/5" />
+                </div>
+              ))}
+            </div>
+          ) : news.error ? (
+            <span className="text-sm text-white/30">{news.error}</span>
+          ) : (
+            <div className="home-news-strip flex gap-3 overflow-x-auto pb-1">
+              {news.items.map((item, index) => (
+                <button
+                  key={`${item.link}-${index}`}
+                  className="home-news-card shrink-0"
+                  onClick={() => onActivate(`Tell me more about: ${item.title}`)}
+                  aria-label={item.title}
+                >
+                  <p className="home-news-title text-sm font-medium leading-snug text-white/80">
+                    {item.title}
+                  </p>
+                  <span className="mt-auto pt-1 text-xs text-white/30">
+                    {timeAgo(item.pubDate)}
+                  </span>
+                </button>
+              ))}
+            </div>
+          )}
+        </div>
+      )}
+
+      {!nightActive && isWidgetOn(widgets, "calendar") && (
+        <div className="home-widget home-calendar-widget mx-4 mt-4 px-5 py-4">
+          <div className="mb-3 flex items-center gap-2">
+            <CalendarDays size={16} className="text-blue-400/70" />
+            <span className="text-sm font-medium text-white/50">
+              {strings.calendarToday}
+            </span>
+          </div>
+
+          {events.todayEvents.length === 0 ? (
+            <span className="text-sm text-white/25">
+              {strings.calendarNoEvents}
+            </span>
+          ) : (
+            <div className="home-calendar-list max-h-[180px] space-y-1.5 overflow-y-auto">
+              {events.todayEvents.slice(0, 4).map((event) => {
+                const [eventHour, eventMinute] = event.time.split(":").map(Number);
+                const eventMinutes = eventHour * 60 + eventMinute;
+                const nowMinutes =
+                  clock.date.getHours() * 60 + clock.date.getMinutes();
+                const isUpcoming =
+                  eventMinutes >= nowMinutes && eventMinutes - nowMinutes <= 120;
+                const isPast = eventMinutes < nowMinutes;
+
+                return (
+                  <div
+                    key={event.id}
+                    className={`home-event-item flex items-center gap-3 rounded-lg px-3 py-2 ${
+                      isUpcoming
+                        ? "border border-blue-500/20 bg-blue-500/10"
+                        : isPast
+                          ? "opacity-40"
+                          : "bg-white/[0.03]"
+                    }`}
+                  >
+                    <span className="shrink-0 text-sm font-medium tabular-nums text-white/50">
+                      {event.time}
+                    </span>
+                    <span className="truncate text-sm text-white/75">
+                      {event.title}
+                    </span>
+                  </div>
+                );
+              })}
+            </div>
+          )}
+        </div>
+      )}
+
+      {!nightActive && isWidgetOn(widgets, "timer") && <TimerWidget />}
+
+      {!nightActive && isWidgetOn(widgets, "photo-frame") && <PhotoFrame />}
+
+      <HomeSettingsPanel
+        open={settingsOpen}
+        onClose={() => setSettingsOpen(false)}
+      />
+    </div>
+  );
+}

--- a/src/home/constants.ts
+++ b/src/home/constants.ts
@@ -52,6 +52,9 @@ export interface HomeStrings {
   settingsNightOn: string;
   settingsNightOff: string;
   settingsLanguage: string;
+  settingsHomeUi: string;
+  settingsHomeUiMetro: string;
+  settingsHomeUiClassic: string;
   settingsClose: string;
 
   // Voice
@@ -152,6 +155,9 @@ export const HOME_I18N: Record<string, HomeStrings> = {
     settingsNightOn: "On",
     settingsNightOff: "Off",
     settingsLanguage: "Language",
+    settingsHomeUi: "Home UI",
+    settingsHomeUiMetro: "Metro",
+    settingsHomeUiClassic: "Classic",
     settingsClose: "Close",
 
     voiceListening: "Listening...",
@@ -249,6 +255,9 @@ export const HOME_I18N: Record<string, HomeStrings> = {
     settingsNightOn: "\u5F00\u542F",
     settingsNightOff: "\u5173\u95ED",
     settingsLanguage: "\u8BED\u8A00",
+    settingsHomeUi: "\u9996\u9875 UI",
+    settingsHomeUiMetro: "Metro",
+    settingsHomeUiClassic: "\u7ECF\u5178",
     settingsClose: "\u5173\u95ED",
 
     voiceListening: "\u6B63\u5728\u542C...",

--- a/src/home/home-settings-context.test.tsx
+++ b/src/home/home-settings-context.test.tsx
@@ -72,9 +72,11 @@ function Probe({ onValue }: { onValue?: (value: HomeSettingsContextValue) => voi
   return (
     <div>
       <span data-testid="city">{home.city}</span>
+      <span data-testid="ui-style">{home.uiStyle}</span>
       <span data-testid="photos">{home.photos.join("|")}</span>
       <span data-testid="events">{home.events.map((event) => event.title).join("|")}</span>
       <button onClick={() => home.update({ city: "Kyoto" })}>Set city</button>
+      <button onClick={() => home.update({ uiStyle: "classic" })}>Set classic</button>
       <button
         onClick={() =>
           home.addEvent({
@@ -120,6 +122,7 @@ describe("HomeSettingsProvider", () => {
           night_mode: "on",
           lang: "zh",
           news_feed_url: "https://example.test/feed.xml",
+          ui_style: "classic",
         },
         events: [
           {
@@ -142,6 +145,7 @@ describe("HomeSettingsProvider", () => {
     );
 
     await waitFor(() => expect(screen.getByTestId("city").textContent).toBe("Tokyo"));
+    expect(screen.getByTestId("ui-style").textContent).toBe("classic");
     expect(screen.getByTestId("events").textContent).toBe("Breakfast");
     expect(screen.getByTestId("photos").textContent).toBe("https://example.test/home.jpg");
   });
@@ -166,6 +170,7 @@ describe("HomeSettingsProvider", () => {
 
     await act(async () => {
       screen.getByText("Set city").click();
+      screen.getByText("Set classic").click();
       screen.getByText("Add event").click();
       screen.getByText("Add photo").click();
       screen.getByText("Set layout").click();
@@ -176,7 +181,7 @@ describe("HomeSettingsProvider", () => {
     expect(lastCall?.[0]).toMatchObject({ id: "admin" });
     expect(lastCall?.[1]).toMatchObject({
       home: {
-        settings: { city: "Kyoto" },
+        settings: { city: "Kyoto", ui_style: "classic" },
         events: [expect.objectContaining({ title: "Dinner" })],
         photos: ["https://example.test/family.jpg"],
         metro_layout: { clock: { col: 1, row: 1, w: 4, h: 2 } },
@@ -186,6 +191,7 @@ describe("HomeSettingsProvider", () => {
 
   it("migrates legacy localStorage Home data into the profile once", async () => {
     localStorage.setItem("octos_home_city", "Osaka");
+    localStorage.setItem("octos_home_ui_style", "classic");
     localStorage.setItem(
       "octos_home_events",
       JSON.stringify([
@@ -212,7 +218,10 @@ describe("HomeSettingsProvider", () => {
         expect.objectContaining({ id: "admin" }),
         expect.objectContaining({
           home: expect.objectContaining({
-            settings: expect.objectContaining({ city: "Osaka" }),
+            settings: expect.objectContaining({
+              city: "Osaka",
+              ui_style: "classic",
+            }),
             events: [expect.objectContaining({ title: "Lunch" })],
             photos: ["https://example.test/legacy.jpg"],
           }),

--- a/src/home/home-settings-context.tsx
+++ b/src/home/home-settings-context.tsx
@@ -34,6 +34,7 @@ export type TempUnit = "C" | "F";
 export type ClockFormat = "12h" | "24h";
 export type NightMode = "auto" | "on" | "off";
 export type Lang = "en" | "zh";
+export type HomeUiStyle = "metro" | "classic";
 
 export interface HomeSettings {
   city: string;
@@ -43,6 +44,7 @@ export interface HomeSettings {
   nightMode: NightMode;
   lang: Lang;
   newsFeedUrl: string;
+  uiStyle: HomeUiStyle;
 }
 
 export interface CalendarEvent {
@@ -98,6 +100,7 @@ const SETTINGS_KEYS = {
   nightMode: "octos_home_night_mode",
   lang: "octos_home_lang",
   newsFeedUrl: "octos_home_news_feed_url",
+  uiStyle: "octos_home_ui_style",
 } as const;
 
 const EVENTS_KEY = "octos_home_events";
@@ -112,6 +115,7 @@ const DEFAULT_SETTINGS: HomeSettings = {
   nightMode: "auto",
   lang: "en",
   newsFeedUrl: DEFAULT_FEED_URL,
+  uiStyle: "metro",
 };
 
 function storageGet(key: string): string | null {
@@ -150,6 +154,10 @@ function asLang(value: unknown, fallback: Lang): Lang {
   return value === "en" || value === "zh" ? value : fallback;
 }
 
+function asHomeUiStyle(value: unknown, fallback: HomeUiStyle): HomeUiStyle {
+  return value === "metro" || value === "classic" ? value : fallback;
+}
+
 function readLegacySettings(): HomeSettings {
   return {
     city: storageGet(SETTINGS_KEYS.city) ?? DEFAULT_SETTINGS.city,
@@ -164,6 +172,7 @@ function readLegacySettings(): HomeSettings {
     nightMode: asNightMode(storageGet(SETTINGS_KEYS.nightMode), DEFAULT_SETTINGS.nightMode),
     lang: asLang(storageGet(SETTINGS_KEYS.lang), DEFAULT_SETTINGS.lang),
     newsFeedUrl: storageGet(SETTINGS_KEYS.newsFeedUrl) ?? DEFAULT_SETTINGS.newsFeedUrl,
+    uiStyle: asHomeUiStyle(storageGet(SETTINGS_KEYS.uiStyle), DEFAULT_SETTINGS.uiStyle),
   };
 }
 
@@ -175,6 +184,7 @@ function writeLegacySettings(settings: HomeSettings): void {
   storageSet(SETTINGS_KEYS.nightMode, settings.nightMode);
   storageSet(SETTINGS_KEYS.lang, settings.lang);
   storageSet(SETTINGS_KEYS.newsFeedUrl, settings.newsFeedUrl);
+  storageSet(SETTINGS_KEYS.uiStyle, settings.uiStyle);
 }
 
 function readJsonArray<T>(key: string, guard: (value: unknown) => value is T): T[] {
@@ -334,6 +344,7 @@ function mergeProfileHome(
         typeof settings.news_feed_url === "string" && settings.news_feed_url.trim()
           ? settings.news_feed_url
           : legacy.settings.newsFeedUrl,
+      uiStyle: asHomeUiStyle(settings.ui_style, legacy.settings.uiStyle),
     },
     widgets: normalizeWidgets(home?.widgets, legacy.widgets),
     events: normalizeEvents(home?.events, legacy.events),
@@ -363,6 +374,7 @@ function serializeHome(data: HomeData): HomeProfileConfig {
       night_mode: data.settings.nightMode,
       lang: data.settings.lang,
       news_feed_url: data.settings.newsFeedUrl,
+      ui_style: data.settings.uiStyle,
     },
     events: data.events,
     photos: data.photos,

--- a/src/home/home-settings.tsx
+++ b/src/home/home-settings.tsx
@@ -12,6 +12,7 @@ import {
   useHomeSettings,
   DEFAULT_FEED_URL,
   type ClockFormat,
+  type HomeUiStyle,
   type Lang,
   type NightMode,
   type TempUnit,
@@ -212,6 +213,16 @@ export function HomeSettingsPanel({ open, onClose }: HomeSettingsPanelProps) {
               labels={["EN", "\u4E2D\u6587"]}
               value={s.lang}
               onChange={(v) => s.update({ lang: v })}
+            />
+          </SettingsField>
+
+          {/* Home UI style */}
+          <SettingsField label={t.settingsHomeUi}>
+            <SegmentedPicker
+              options={["metro", "classic"] as HomeUiStyle[]}
+              labels={[t.settingsHomeUiMetro, t.settingsHomeUiClassic]}
+              value={s.uiStyle}
+              onChange={(v) => s.update({ uiStyle: v })}
             />
           </SettingsField>
 

--- a/src/home/standby-view.tsx
+++ b/src/home/standby-view.tsx
@@ -1,3 +1,5 @@
+import { ClassicStandbyView } from "./classic-standby-view";
+import { useHomeSettings } from "./home-settings-context";
 import { MetroTileGrid } from "./metro-tiles";
 
 interface StandbyViewProps {
@@ -6,5 +8,11 @@ interface StandbyViewProps {
 }
 
 export function StandbyView({ onActivate, nightActive }: StandbyViewProps) {
+  const { uiStyle } = useHomeSettings();
+  if (uiStyle === "classic") {
+    return (
+      <ClassicStandbyView onActivate={onActivate} nightActive={nightActive} />
+    );
+  }
   return <MetroTileGrid onActivate={onActivate} nightActive={nightActive} />;
 }

--- a/src/settings/settings-api.ts
+++ b/src/settings/settings-api.ts
@@ -92,6 +92,7 @@ export interface HomeProfileSettings {
   night_mode?: string | null;
   lang?: string | null;
   news_feed_url?: string | null;
+  ui_style?: string | null;
 }
 
 export interface HomeProfileEvent {

--- a/tests/ui-redesign-smoke.spec.ts
+++ b/tests/ui-redesign-smoke.spec.ts
@@ -344,6 +344,28 @@ test.describe("UI redesign shell smoke", () => {
     ]);
   });
 
+  test("home settings can switch back to the classic dashboard UI", async ({
+    page,
+  }) => {
+    await page.setViewportSize({ width: 1440, height: 900 });
+    await page.goto("/home", { waitUntil: "networkidle" });
+
+    await expect(page.locator(".metro-grid")).toBeVisible();
+
+    await page.locator(".home-settings-gear").click();
+    await page.getByRole("button", { name: "Classic" }).click();
+    await expect(page.locator(".classic-home-standby")).toBeVisible();
+    await expect(page.locator(".metro-grid")).toHaveCount(0);
+
+    await page.reload({ waitUntil: "networkidle" });
+    await expect(page.locator(".classic-home-standby")).toBeVisible();
+    await expect(page.locator(".metro-grid")).toHaveCount(0);
+
+    await page.locator(".home-settings-gear").click();
+    await page.getByRole("button", { name: "Metro" }).click();
+    await expect(page.locator(".metro-grid")).toBeVisible();
+  });
+
   test("workspace surfaces use the shared topbar titles", async ({ page }) => {
     await page.setViewportSize({ width: 1440, height: 900 });
 


### PR DESCRIPTION
## Summary
- Add a Home UI segmented setting so users can switch between Metro and Classic dashboards.
- Restore the original card-style Home dashboard as a separate Classic view without reintroducing blank-space click-to-chat behavior.
- Persist the choice through profile config (`home.settings.ui_style`) and legacy localStorage.

## Validation
- `npx vitest run src/home/home-settings-context.test.tsx` -> 3 passed
- `npm run test:unit` -> 658 passed
- `npm run build` -> passed
- `BASE_URL=http://127.0.0.1:5174 npx playwright test tests/ui-redesign-smoke.spec.ts --grep "classic dashboard" --reporter=list` -> 1 passed
- `BASE_URL=http://127.0.0.1:5174 npx playwright test tests/ui-redesign-smoke.spec.ts --grep "home (blank space|settings can switch back|settings drawer)" --reporter=list` -> 3 passed
- `BASE_URL=http://127.0.0.1:5174 npx playwright test tests/metro-tiles.spec.ts --reporter=list` -> 10 passed
- `BASE_URL=http://127.0.0.1:5174 npx playwright test --reporter=list` -> 98 passed, 35 skipped

## Notes
- `npm run lint` still fails on existing repo-wide lint debt: 149 problems (147 errors, 2 warnings); no new lint command was made green by this PR.
- Live browser audit against the local Vite app is blocked unless the real backend proxy target is running; Playwright harness E2E passed.
