### PR TITLE
fix(voice): stop first-sentence playback stutter (VAD teardown before reply)

### DIFF
--- a/src/home/voice/use-voice-capture.ts
+++ b/src/home/voice/use-voice-capture.ts
@@ -8,7 +8,10 @@ export interface VoiceCapture {
     onUtterance: (wav: Blob) => void,
     options?: VoiceCaptureStartOptions,
   ) => Promise<void>;
-  stop: () => void;
+  /** Resolves once the VAD is fully torn down. Await before starting reply
+   *  playback so the Silero ONNX/WASM + mic AudioContext shutdown doesn't
+   *  contend with the playback render thread. */
+  stop: () => Promise<void>;
   error: string | null;
 }
 
@@ -53,15 +56,28 @@ export function useVoiceCapture(): VoiceCapture {
   const [capturing, setCapturing] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
-  const stop = useCallback(() => {
+  const stop = useCallback((): Promise<void> => {
     startGenRef.current++;
     const vad = vadRef.current;
     vadRef.current = null;
-    if (vad) {
-      void vad.pause();
-      void vad.destroy();
-    }
     setCapturing(false);
+    if (!vad) return Promise.resolve();
+    // Return a promise that resolves once teardown finishes so callers can
+    // await it BEFORE starting reply playback — otherwise the ONNX/WASM + mic
+    // AudioContext shutdown spikes CPU exactly as the reply's Web Audio render
+    // thread starts, glitching the first sentence.
+    return (async () => {
+      try {
+        await vad.pause();
+      } catch {
+        // already paused / destroyed
+      }
+      try {
+        await vad.destroy();
+      } catch {
+        // already destroyed
+      }
+    })();
   }, []);
 
   const start = useCallback(async (
@@ -120,7 +136,7 @@ export function useVoiceCapture(): VoiceCapture {
     }
   }, []);
 
-  useEffect(() => () => stop(), [stop]);
+  useEffect(() => () => void stop(), [stop]);
 
   return { capturing, start, stop, error };
 }

--- a/src/home/voice/use-voice-conversation.ts
+++ b/src/home/voice/use-voice-conversation.ts
@@ -208,7 +208,7 @@ export function useVoiceConversation(
     await captureStart(
       (wav: Blob) => {
         if (!speechInterruptArmedRef.current) return;
-        captureStop();
+        void captureStop();
         void sendUtteranceRef.current(wav);
       },
       {
@@ -239,7 +239,7 @@ export function useVoiceConversation(
       (wav: Blob) => {
         // Ignore late utterances that land after we've left listening.
         if (stateRef.current !== "listening") return;
-        captureStop();
+        void captureStop();
         void sendUtteranceRef.current(wav);
       },
       LISTENING_VAD_OPTIONS,
@@ -357,7 +357,7 @@ export function useVoiceConversation(
     speechInterruptArmedRef.current = false;
     audioQueueRef.current = [];
     playingRef.current = false;
-    captureStop();
+    void captureStop();
     releaseAudio();
     stateRef.current = "idle";
     setState("idle");
@@ -375,7 +375,7 @@ export function useVoiceConversation(
       audioQueueRef.current = [];
       speechInterruptArmedRef.current = false;
       requestTurnInterrupt("user tapped orb while thinking");
-      captureStop();
+      void captureStop();
       void beginListeningRef.current();
     }
   }, [captureStop, releaseAudio, requestTurnInterrupt]);
@@ -395,17 +395,25 @@ export function useVoiceConversation(
       ignoredTurnIdsRef.current,
     );
     if (fresh.length === 0) return;
-    captureStop();
     speechInterruptArmedRef.current = false;
     activeTurnIdRef.current = null;
     clearTimeout(replyTimerRef.current);
     clearTimeout(graceTimerRef.current);
+    // Mark + enqueue synchronously so a re-render mid-teardown doesn't
+    // re-collect the same audio.
     for (const f of fresh) {
       playedPathsRef.current.add(f.path);
       audioQueueRef.current.push(f.path);
       setLastAssistantText(f.text);
     }
-    void drainQueueRef.current();
+    // Tear the barge-in VAD down and WAIT for it to finish BEFORE playback, so
+    // its Silero ONNX/WASM + mic AudioContext shutdown doesn't contend with the
+    // reply's Web Audio render thread (that contention glitched the first
+    // sentence). drainQueue is guarded by playingRef against concurrent runs.
+    void (async () => {
+      await captureStop();
+      await drainQueueRef.current();
+    })();
   }, [captureStop, threads, state]);
 
   // Stop ONLY on real unmount. Use a ref so identity churn of `stop` across

--- a/src/home/voice/voice-view.tsx
+++ b/src/home/voice/voice-view.tsx
@@ -38,7 +38,7 @@ export function VoiceView({ sessionId, historyTopic, onBack }: VoiceViewProps) {
   };
 
   return (
-    <div className="voice-view relative flex h-full w-full flex-col items-center justify-center">
+    <div className="voice-view relative flex h-full w-full flex-col items-center justify-center bg-black">
       <button
         onClick={onBack}
         aria-label="exit voice mode"


### PR DESCRIPTION
## Problem
Voice replies intermittently stuttered during browser playback — usually mid first sentence. The generated WAV was always intact (plays fine standalone); only live playback glitched.

## Root cause
The thinking-phase barge-in VAD (Silero ONNX/WASM + its own mic `AudioContext`) was torn down with a fire-and-forget `void vad.destroy()` at the exact moment reply playback started. That teardown spiked CPU and underran the Web Audio render thread → stutter. It's the *first* sentence because the teardown↔playback-start overlap lands there; intermittent because it depends on momentary load.

## Fix
- `use-voice-capture`: `stop()` now returns a promise that resolves once the VAD is fully paused + destroyed.
- `use-voice-conversation`: `await captureStop()` before draining the playback queue, so the VAD-teardown CPU spike completes *before* the reply starts.

Barge-in-while-thinking is retained; only playback start is delayed by the sub-100ms teardown (imperceptible).

Also: `voice-view` gets a solid black background.

## Test plan
- Run voice conversations: first sentence plays smoothly, no stutter. (Confirmed via isolation experiment — disabling the barge-in VAD removed the stutter; this fix reproduces that by tearing it down *before* playback.)
- Voice barge-in while "thinking" still interrupts the turn.

🤖 Generated with [Claude Code](https://claude.com/claude-code)