### PR TITLE
Polish home and settings UI flows

### DIFF
--- a/src/components/workbench-shell.tsx
+++ b/src/components/workbench-shell.tsx
@@ -59,13 +59,13 @@ export function WorkbenchBrand() {
   return (
     <Link
       to="/"
-      className="workbench-brand flex min-w-0 items-center gap-2.5 text-left"
+      className="workbench-brand flex min-w-0 items-center gap-3 text-left"
       aria-label="Octos home"
     >
       <img
         src="/images/octos-logo-color.svg"
         alt="Octos"
-        className="h-7 w-auto shrink-0 select-none"
+        className="workbench-brand-logo h-8 w-8 shrink-0 select-none object-cover"
       />
       <span className="text-base font-semibold text-text-strong max-sm:hidden">
         Octos
@@ -89,10 +89,12 @@ export function WorkbenchRouteNav({ compact = false }: { compact?: boolean }) {
               key={to}
               to={to}
               className="workbench-route-link flex shrink-0 items-center gap-1.5 px-3 py-2 text-sm"
+              aria-label={label}
               aria-current={active ? "page" : undefined}
               data-active={active ? "true" : undefined}
+              title={label}
             >
-              <Icon size={15} />
+              <Icon size={20} strokeWidth={2} />
               <span className={compact ? "max-lg:hidden" : "max-md:hidden"}>
                 {label}
               </span>
@@ -115,7 +117,7 @@ export function WorkbenchThemeButton() {
       title={label}
       aria-label={label}
     >
-      {theme === "dark" ? <Sun size={18} /> : <Moon size={18} />}
+      {theme === "dark" ? <Sun size={20} /> : <Moon size={20} />}
     </button>
   );
 }
@@ -136,7 +138,7 @@ export function WorkbenchUserActions() {
         aria-label="Log out"
         title="Log out"
       >
-        <LogOut size={16} />
+        <LogOut size={18} />
       </button>
     </div>
   );

--- a/src/home/classic-standby-view.tsx
+++ b/src/home/classic-standby-view.tsx
@@ -36,9 +36,9 @@ export function ClassicStandbyView({
 }: ClassicStandbyViewProps) {
   const clock = useClock();
   const weather = useWeather();
-  const { strings, tempUnit, clockFormat, widgets, newsFeedUrl, lang } =
+  const { strings, tempUnit, clockFormat, widgets, newsFeedUrl, lang, burnInProtection } =
     useHomeSettings();
-  const burnIn = useBurnInProtection();
+  const burnIn = useBurnInProtection(burnInProtection);
   const [settingsOpen, setSettingsOpen] = useState(false);
   const news = useNews(newsFeedUrl);
   const events = useEvents();
@@ -50,7 +50,7 @@ export function ClassicStandbyView({
 
   const handleOrbClick = useCallback(() => {
     if (!voice.isSupported) {
-      onActivate();
+      onActivate("");
       return;
     }
     if (voice.orbState === "listening") {
@@ -120,7 +120,7 @@ export function ClassicStandbyView({
 
   return (
     <div
-      className={`classic-home-standby home-standby flex h-full w-full flex-col items-center select-none overflow-y-auto py-8 ${
+      className={`classic-home-standby home-standby h-full w-full select-none overflow-y-auto px-5 pb-6 pt-20 ${
         burnIn.dimmed ? "home-dimmed" : ""
       }`}
       onMouseMove={() => burnIn.onActivity()}
@@ -137,230 +137,233 @@ export function ClassicStandbyView({
         <SettingsGearButton onClick={() => setSettingsOpen(true)} />
       </div>
 
-      {isWidgetOn(widgets, "clock") && (
-        <>
-          <div
-            className={`home-clock tabular-nums ${
-              nightActive ? "home-clock-night" : "text-white"
-            }`}
+      <div className="classic-home-grid">
+        {isWidgetOn(widgets, "clock") && (
+          <section
+            className="classic-home-clock-panel home-widget"
             aria-live="polite"
             style={{
               transform: `translate(${burnIn.offset.x}px, ${burnIn.offset.y}px)`,
               transition: "transform 2s ease-in-out",
             }}
           >
-            <span>{displayHours}</span>
-            <span className="home-clock-colon">:</span>
-            <span>{clock.minutes}</span>
-            {ampm && (
-              <span className="home-clock-ampm ml-3 text-[0.3em] font-normal text-white/40">
-                {ampm}
-              </span>
+            <div
+              className={`home-clock tabular-nums ${
+                nightActive ? "home-clock-night" : "text-white"
+              }`}
+            >
+              <span>{displayHours}</span>
+              <span className="home-clock-colon">:</span>
+              <span>{clock.minutes}</span>
+              {ampm && (
+                <span className="home-clock-ampm ml-3 text-[0.3em] font-normal text-white/40">
+                  {ampm}
+                </span>
+              )}
+            </div>
+
+            <div className="home-date mt-2 text-white/50">{dateStr}</div>
+
+            {isWidgetOn(widgets, "voice-orb") && (
+              <div className="classic-home-voice-panel">
+                <VoiceOrb state={voice.orbState} onClick={handleOrbClick} />
+                {voice.orbState === "listening" && voice.transcript && (
+                  <p className="mt-2 max-w-[200px] truncate text-center text-sm text-white/40">
+                {voice.transcript}
+              </p>
+            )}
+            {(!voice.isSupported || voice.error) && (
+              <p className="mt-2 max-w-[220px] text-center text-xs text-white/35">
+                {voice.error ?? strings.voiceNotSupported}
+              </p>
             )}
           </div>
+        )}
+          </section>
+        )}
 
-          <div
-            className="home-date mt-2 text-white/50"
-            style={{
-              transform: `translate(${burnIn.offset.x}px, ${burnIn.offset.y}px)`,
-              transition: "transform 2s ease-in-out",
-            }}
-          >
-            {dateStr}
-          </div>
-        </>
-      )}
-
-      {!nightActive && isWidgetOn(widgets, "voice-orb") && (
-        <div
-          className="mt-6"
-          style={{
-            transform: `translate(${burnIn.offset.x}px, ${burnIn.offset.y}px)`,
-            transition: "transform 2s ease-in-out",
-          }}
-        >
-          <VoiceOrb state={voice.orbState} onClick={handleOrbClick} />
-          {voice.orbState === "listening" && voice.transcript && (
-            <p className="mt-2 max-w-[200px] truncate text-center text-sm text-white/40">
-              {voice.transcript}
-            </p>
-          )}
-        </div>
-      )}
-
-      {!nightActive && isWidgetOn(widgets, "weather") && (
-        <div className="home-widget home-weather-widget mx-4 mt-8 px-6 py-4">
-          {weather.loading ? (
-            <div className="flex items-center gap-3">
-              <div className="h-10 w-20 animate-pulse rounded-xl bg-white/10" />
-              <div className="h-6 w-40 animate-pulse rounded-lg bg-white/10" />
-            </div>
-          ) : weather.error ? (
-            <span className="text-lg text-white/40">
-              {strings.weatherUnavailable}
-            </span>
-          ) : (
-            <div className="home-weather-layout flex items-center gap-6">
-              <div className="home-weather-current flex shrink-0 items-center gap-3">
-                <span className="text-4xl leading-none">{weather.emoji}</span>
-                <div className="flex flex-col">
-                  <span className="text-3xl font-semibold leading-tight tabular-nums text-white/95">
-                    {formatTemp(weather.temperature)}&deg;{tempUnit}
-                  </span>
-                  <span className="mt-0.5 text-sm leading-tight text-white/50">
-                    {weather.label}
-                    {weather.city && <span> &middot; {weather.city}</span>}
-                  </span>
-                </div>
+        {isWidgetOn(widgets, "weather") && (
+          <section className="home-widget home-weather-widget classic-home-weather-panel px-5 py-4">
+            {weather.loading ? (
+              <div className="flex items-center gap-3">
+                <div className="h-10 w-20 animate-pulse rounded-xl bg-white/10" />
+                <div className="h-6 w-40 animate-pulse rounded-lg bg-white/10" />
               </div>
-
-              {weather.hourly.length > 0 && (
-                <div className="home-weather-divider h-12 w-px shrink-0 bg-white/10" />
-              )}
-
-              {weather.hourly.length > 0 && (
-                <div className="home-forecast-strip flex gap-4 overflow-x-auto">
-                  {weather.hourly.map((item, index) => (
-                    <div
-                      key={`${item.hour}-${index}`}
-                      className="home-forecast-item flex shrink-0 flex-col items-center gap-1"
-                    >
-                      <span className="text-xs tabular-nums text-white/40">
-                        {item.hour}
-                      </span>
-                      <span className="text-lg leading-none">{item.emoji}</span>
-                      <span className="text-sm font-medium tabular-nums text-white/70">
-                        {formatTemp(item.temp)}&deg;
-                      </span>
-                    </div>
-                  ))}
-                </div>
-              )}
-            </div>
-          )}
-        </div>
-      )}
-
-      {!nightActive && isWidgetOn(widgets, "quick-actions") && (
-        <div className="home-quick-actions mt-8">
-          {quickActions.map(({ id, icon: Icon, label, color, prefill }) => (
-            <button
-              key={id}
-              onClick={() => onActivate(prefill || undefined)}
-              className="home-quick-card group flex flex-col items-center justify-center gap-2"
-              aria-label={label}
-            >
-              <div className="home-quick-card-icon flex items-center justify-center rounded-2xl">
-                <Icon
-                  size={28}
-                  className={`${color} transition-transform group-hover:scale-110`}
-                />
-              </div>
-              <span className="text-sm font-medium text-white/60 transition-colors group-hover:text-white/90">
-                {label}
+            ) : weather.error ? (
+              <span className="text-lg text-white/40">
+                {strings.weatherUnavailable}
               </span>
-            </button>
-          ))}
-        </div>
-      )}
-
-      {!nightActive && isWidgetOn(widgets, "news") && (
-        <div className="home-widget home-news-widget mx-4 mt-8 px-5 py-4">
-          <div className="mb-3 flex items-center gap-2">
-            <Newspaper size={16} className="text-amber-400/70" />
-            <span className="text-sm font-medium text-white/50">
-              {strings.newsHeadlines}
-            </span>
-          </div>
-
-          {news.loading && news.items.length === 0 ? (
-            <div className="flex gap-4 overflow-hidden">
-              {[0, 1, 2].map((index) => (
-                <div
-                  key={index}
-                  className="home-news-card shrink-0 animate-pulse"
-                >
-                  <div className="mb-2 h-4 w-36 rounded bg-white/10" />
-                  <div className="h-3 w-20 rounded bg-white/5" />
-                </div>
-              ))}
-            </div>
-          ) : news.error ? (
-            <span className="text-sm text-white/30">{news.error}</span>
-          ) : (
-            <div className="home-news-strip flex gap-3 overflow-x-auto pb-1">
-              {news.items.map((item, index) => (
-                <button
-                  key={`${item.link}-${index}`}
-                  className="home-news-card shrink-0"
-                  onClick={() => onActivate(`Tell me more about: ${item.title}`)}
-                  aria-label={item.title}
-                >
-                  <p className="home-news-title text-sm font-medium leading-snug text-white/80">
-                    {item.title}
-                  </p>
-                  <span className="mt-auto pt-1 text-xs text-white/30">
-                    {timeAgo(item.pubDate)}
-                  </span>
-                </button>
-              ))}
-            </div>
-          )}
-        </div>
-      )}
-
-      {!nightActive && isWidgetOn(widgets, "calendar") && (
-        <div className="home-widget home-calendar-widget mx-4 mt-4 px-5 py-4">
-          <div className="mb-3 flex items-center gap-2">
-            <CalendarDays size={16} className="text-blue-400/70" />
-            <span className="text-sm font-medium text-white/50">
-              {strings.calendarToday}
-            </span>
-          </div>
-
-          {events.todayEvents.length === 0 ? (
-            <span className="text-sm text-white/25">
-              {strings.calendarNoEvents}
-            </span>
-          ) : (
-            <div className="home-calendar-list max-h-[180px] space-y-1.5 overflow-y-auto">
-              {events.todayEvents.slice(0, 4).map((event) => {
-                const [eventHour, eventMinute] = event.time.split(":").map(Number);
-                const eventMinutes = eventHour * 60 + eventMinute;
-                const nowMinutes =
-                  clock.date.getHours() * 60 + clock.date.getMinutes();
-                const isUpcoming =
-                  eventMinutes >= nowMinutes && eventMinutes - nowMinutes <= 120;
-                const isPast = eventMinutes < nowMinutes;
-
-                return (
-                  <div
-                    key={event.id}
-                    className={`home-event-item flex items-center gap-3 rounded-lg px-3 py-2 ${
-                      isUpcoming
-                        ? "border border-blue-500/20 bg-blue-500/10"
-                        : isPast
-                          ? "opacity-40"
-                          : "bg-white/[0.03]"
-                    }`}
-                  >
-                    <span className="shrink-0 text-sm font-medium tabular-nums text-white/50">
-                      {event.time}
+            ) : (
+              <div className="home-weather-layout flex items-center gap-6">
+                <div className="home-weather-current flex shrink-0 items-center gap-3">
+                  <span className="text-4xl leading-none">{weather.emoji}</span>
+                  <div className="flex flex-col">
+                    <span className="text-3xl font-semibold leading-tight tabular-nums text-white/95">
+                      {formatTemp(weather.temperature)}&deg;{tempUnit}
                     </span>
-                    <span className="truncate text-sm text-white/75">
-                      {event.title}
+                    <span className="mt-0.5 text-sm leading-tight text-white/50">
+                      {weather.label}
+                      {weather.city && <span> &middot; {weather.city}</span>}
                     </span>
                   </div>
-                );
-              })}
+                </div>
+
+                {weather.hourly.length > 0 && (
+                  <div className="home-weather-divider h-12 w-px shrink-0 bg-white/10" />
+                )}
+
+                {weather.hourly.length > 0 && (
+                  <div className="home-forecast-strip flex gap-4 overflow-x-auto">
+                    {weather.hourly.map((item, index) => (
+                      <div
+                        key={`${item.hour}-${index}`}
+                        className="home-forecast-item flex shrink-0 flex-col items-center gap-1"
+                      >
+                        <span className="text-xs tabular-nums text-white/40">
+                          {item.hour}
+                        </span>
+                        <span className="text-lg leading-none">{item.emoji}</span>
+                        <span className="text-sm font-medium tabular-nums text-white/70">
+                          {formatTemp(item.temp)}&deg;
+                        </span>
+                      </div>
+                    ))}
+                  </div>
+                )}
+              </div>
+            )}
+          </section>
+        )}
+
+        {isWidgetOn(widgets, "quick-actions") && (
+          <div className="home-quick-actions classic-home-quick-panel">
+            {quickActions.map(({ id, icon: Icon, label, color, prefill }) => (
+              <button
+                key={id}
+                onClick={() => onActivate(prefill || undefined)}
+                className="home-quick-card group flex flex-col items-center justify-center gap-2"
+                aria-label={label}
+              >
+                <div className="home-quick-card-icon flex items-center justify-center rounded-2xl">
+                  <Icon
+                    size={28}
+                    className={`${color} transition-transform group-hover:scale-110`}
+                  />
+                </div>
+                <span className="text-sm font-medium text-white/60 transition-colors group-hover:text-white/90">
+                  {label}
+                </span>
+              </button>
+            ))}
+          </div>
+        )}
+
+        {isWidgetOn(widgets, "news") && (
+          <section className="home-widget home-news-widget classic-home-news-panel px-5 py-4">
+            <div className="mb-3 flex items-center gap-2">
+              <Newspaper size={16} className="text-amber-400/70" />
+              <span className="text-sm font-medium text-white/50">
+                {strings.newsHeadlines}
+              </span>
             </div>
-          )}
-        </div>
-      )}
 
-      {!nightActive && isWidgetOn(widgets, "timer") && <TimerWidget />}
+            {news.loading && news.items.length === 0 ? (
+              <div className="flex gap-4 overflow-hidden">
+                {[0, 1, 2].map((index) => (
+                  <div
+                    key={index}
+                    className="home-news-card shrink-0 animate-pulse"
+                  >
+                    <div className="mb-2 h-4 w-36 rounded bg-white/10" />
+                    <div className="h-3 w-20 rounded bg-white/5" />
+                  </div>
+                ))}
+              </div>
+            ) : news.error ? (
+              <span className="text-sm text-white/30">{news.error}</span>
+            ) : (
+              <div className="home-news-strip flex gap-3 overflow-x-auto pb-1">
+                {news.items.map((item, index) => (
+                  <button
+                    key={`${item.link}-${index}`}
+                    className="home-news-card shrink-0"
+                    onClick={() => onActivate(`Tell me more about: ${item.title}`)}
+                    aria-label={item.title}
+                  >
+                    <p className="home-news-title text-sm font-medium leading-snug text-white/80">
+                      {item.title}
+                    </p>
+                    <span className="mt-auto pt-1 text-xs text-white/30">
+                      {timeAgo(item.pubDate)}
+                    </span>
+                  </button>
+                ))}
+              </div>
+            )}
+          </section>
+        )}
 
-      {!nightActive && isWidgetOn(widgets, "photo-frame") && <PhotoFrame />}
+        {isWidgetOn(widgets, "calendar") && (
+          <section className="home-widget home-calendar-widget classic-home-calendar-panel px-5 py-4">
+            <div className="mb-3 flex items-center gap-2">
+              <CalendarDays size={16} className="text-blue-400/70" />
+              <span className="text-sm font-medium text-white/50">
+                {strings.calendarToday}
+              </span>
+            </div>
+
+            {events.todayEvents.length === 0 ? (
+              <span className="text-sm text-white/25">
+                {strings.calendarNoEvents}
+              </span>
+            ) : (
+              <div className="home-calendar-list max-h-[180px] space-y-1.5 overflow-y-auto">
+                {events.todayEvents.slice(0, 4).map((event) => {
+                  const [eventHour, eventMinute] = event.time.split(":").map(Number);
+                  const eventMinutes = eventHour * 60 + eventMinute;
+                  const nowMinutes =
+                    clock.date.getHours() * 60 + clock.date.getMinutes();
+                  const isUpcoming =
+                    eventMinutes >= nowMinutes && eventMinutes - nowMinutes <= 120;
+                  const isPast = eventMinutes < nowMinutes;
+
+                  return (
+                    <div
+                      key={event.id}
+                      className={`home-event-item flex items-center gap-3 rounded-lg px-3 py-2 ${
+                        isUpcoming
+                          ? "border border-blue-500/20 bg-blue-500/10"
+                          : isPast
+                            ? "opacity-40"
+                            : "bg-white/[0.03]"
+                      }`}
+                    >
+                      <span className="shrink-0 text-sm font-medium tabular-nums text-white/50">
+                        {event.time}
+                      </span>
+                      <span className="truncate text-sm text-white/75">
+                        {event.title}
+                      </span>
+                    </div>
+                  );
+                })}
+              </div>
+            )}
+          </section>
+        )}
+
+        {isWidgetOn(widgets, "timer") && (
+          <div className="classic-home-widget-slot classic-home-timer-panel">
+            <TimerWidget />
+          </div>
+        )}
+
+        {isWidgetOn(widgets, "photo-frame") && (
+          <div className="classic-home-widget-slot classic-home-photo-panel">
+            <PhotoFrame />
+          </div>
+        )}
+      </div>
 
       <HomeSettingsPanel
         open={settingsOpen}

--- a/src/home/constants.ts
+++ b/src/home/constants.ts
@@ -51,6 +51,7 @@ export interface HomeStrings {
   settingsNightAuto: string;
   settingsNightOn: string;
   settingsNightOff: string;
+  settingsBurnInProtection: string;
   settingsLanguage: string;
   settingsHomeUi: string;
   settingsHomeUiMetro: string;
@@ -88,6 +89,7 @@ export interface HomeStrings {
 
   // Settings — News & Events
   settingsNewsFeed: string;
+  settingsCalendarFeed: string;
   settingsEvents: string;
   settingsAddEvent: string;
 
@@ -154,10 +156,11 @@ export const HOME_I18N: Record<string, HomeStrings> = {
     settingsNightAuto: "Auto",
     settingsNightOn: "On",
     settingsNightOff: "Off",
+    settingsBurnInProtection: "Burn-in Protection",
     settingsLanguage: "Language",
     settingsHomeUi: "Home UI",
     settingsHomeUiMetro: "Metro",
-    settingsHomeUiClassic: "Classic",
+    settingsHomeUiClassic: "Grid",
     settingsClose: "Close",
 
     voiceListening: "Listening...",
@@ -185,6 +188,7 @@ export const HOME_I18N: Record<string, HomeStrings> = {
     calendarNoEvents: "No events today",
 
     settingsNewsFeed: "News Feed URL",
+    settingsCalendarFeed: "Calendar Feed URL",
     settingsEvents: "Events",
     settingsAddEvent: "Add Event",
 
@@ -254,10 +258,11 @@ export const HOME_I18N: Record<string, HomeStrings> = {
     settingsNightAuto: "\u81EA\u52A8",
     settingsNightOn: "\u5F00\u542F",
     settingsNightOff: "\u5173\u95ED",
+    settingsBurnInProtection: "\u9632\u70E7\u5C4F",
     settingsLanguage: "\u8BED\u8A00",
     settingsHomeUi: "\u9996\u9875 UI",
     settingsHomeUiMetro: "Metro",
-    settingsHomeUiClassic: "\u7ECF\u5178",
+    settingsHomeUiClassic: "\u7F51\u683C",
     settingsClose: "\u5173\u95ED",
 
     voiceListening: "\u6B63\u5728\u542C...",
@@ -285,6 +290,7 @@ export const HOME_I18N: Record<string, HomeStrings> = {
     calendarNoEvents: "\u4ECA\u5929\u6CA1\u6709\u65E5\u7A0B",
 
     settingsNewsFeed: "\u65B0\u95FB\u6E90",
+    settingsCalendarFeed: "\u65E5\u5386\u6E90",
     settingsEvents: "\u65E5\u7A0B",
     settingsAddEvent: "\u6DFB\u52A0\u65E5\u7A0B",
 

--- a/src/home/conversation-view.test.tsx
+++ b/src/home/conversation-view.test.tsx
@@ -1,0 +1,116 @@
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { ConversationView } from "./conversation-view";
+
+const threadMock = vi.hoisted(() => ({
+  threads: [
+    {
+      id: "thread-1",
+      userMsg: {
+        id: "user-1",
+        role: "user",
+        text: "What happened?",
+        timestamp: Date.UTC(2026, 5, 15, 12, 0),
+        files: [],
+        toolCalls: [],
+      },
+      responses: [
+        {
+          id: "assistant-1",
+          role: "assistant",
+          text: "Here is the short answer.",
+          timestamp: Date.UTC(2026, 5, 15, 12, 1),
+          files: [],
+          toolCalls: [],
+        },
+      ],
+      pendingAssistant: null,
+    },
+  ],
+}));
+
+vi.mock("@/runtime/session-context", () => ({
+  useSession: () => ({
+    currentSessionId: "session-1",
+    historyTopic: null,
+    refreshSessions: vi.fn(),
+    markSessionActive: vi.fn(),
+  }),
+}));
+
+vi.mock("@/store/thread-store", () => ({
+  useThreads: () => threadMock.threads,
+}));
+
+vi.mock("@/runtime/ui-protocol-send", () => ({
+  sendMessage: vi.fn(),
+}));
+
+vi.mock("@/runtime/ui-protocol-runtime", () => ({
+  getActiveBridge: () => null,
+}));
+
+vi.mock("@/api/files", () => ({
+  buildAuthenticatedFileUrl: (path: string) => path,
+}));
+
+vi.mock("./home-settings-context", () => ({
+  useHomeSettings: () => ({
+    idleSeconds: 60,
+    strings: {
+      backToStandby: "Back",
+      inputPlaceholder: "Say something...",
+      send: "Send",
+      suggestions: [],
+    },
+  }),
+}));
+
+vi.mock("./use-smooth", () => ({
+  useSmooth: (text: string) => text,
+}));
+
+describe("ConversationView", () => {
+  beforeEach(() => {
+    cleanup();
+    vi.restoreAllMocks();
+    Object.defineProperty(HTMLElement.prototype, "scrollTo", {
+      configurable: true,
+      value: vi.fn(),
+    });
+  });
+
+  it("can read assistant responses aloud with browser TTS", () => {
+    const speak = vi.fn();
+    const cancel = vi.fn();
+    const utterances: SpeechSynthesisUtterance[] = [];
+
+    vi.stubGlobal("speechSynthesis", {
+      speak: (utterance: SpeechSynthesisUtterance) => {
+        utterances.push(utterance);
+        speak(utterance);
+      },
+      cancel,
+    });
+    vi.stubGlobal(
+      "SpeechSynthesisUtterance",
+      class {
+        text: string;
+        onend: (() => void) | null = null;
+        onerror: (() => void) | null = null;
+
+        constructor(text: string) {
+          this.text = text;
+        }
+      },
+    );
+
+    render(<ConversationView onBack={vi.fn()} />);
+
+    fireEvent.click(screen.getByRole("button", { name: "Read response aloud" }));
+
+    expect(cancel).toHaveBeenCalledTimes(1);
+    expect(speak).toHaveBeenCalledTimes(1);
+    expect(utterances[0].text).toBe("Here is the short answer.");
+  });
+});

--- a/src/home/conversation-view.tsx
+++ b/src/home/conversation-view.tsx
@@ -32,6 +32,8 @@ import {
   Download,
   SendHorizontal,
   Square,
+  Volume2,
+  VolumeX,
   Wrench,
 } from "lucide-react";
 import { useSession } from "@/runtime/session-context";
@@ -57,6 +59,17 @@ function formatBubbleTime(ts: number): string {
   const d = new Date(ts);
   const pad = (n: number) => String(n).padStart(2, "0");
   return `${pad(d.getHours())}:${pad(d.getMinutes())}`;
+}
+
+function speechTextFromMarkdown(text: string): string {
+  return text
+    .replace(/```[\s\S]*?```/g, " ")
+    .replace(/`([^`]+)`/g, "$1")
+    .replace(/!\[[^\]]*]\([^)]*\)/g, " ")
+    .replace(/\[([^\]]+)]\([^)]*\)/g, "$1")
+    .replace(/[#*_>~-]+/g, " ")
+    .replace(/\s+/g, " ")
+    .trim();
 }
 
 // ── File type detection ────────────────────────────────────────────
@@ -187,6 +200,7 @@ export function ConversationView({ onBack, prefill }: ConversationViewProps) {
   const idleTimerRef = useRef<ReturnType<typeof setTimeout> | undefined>(undefined);
   const composingRef = useRef(false);
   const prefillAppliedRef = useRef<string | undefined>(undefined);
+  const [speakingMessageId, setSpeakingMessageId] = useState<string | null>(null);
 
   // ── Scroll state ────────────────────────────────────────────────
   const isAtBottomRef = useRef(true);
@@ -233,6 +247,14 @@ export function ConversationView({ onBack, prefill }: ConversationViewProps) {
     resetIdle();
     return () => clearTimeout(idleTimerRef.current);
   }, [resetIdle]);
+
+  useEffect(() => {
+    return () => {
+      if (typeof window !== "undefined" && "speechSynthesis" in window) {
+        window.speechSynthesis.cancel();
+      }
+    };
+  }, []);
 
   // Any new thread data (assistant reply) resets the idle timer.
   useEffect(() => {
@@ -378,6 +400,45 @@ export function ConversationView({ onBack, prefill }: ConversationViewProps) {
     }
   }, [currentSessionId, historyTopic, threads]);
 
+  const stopSpeaking = useCallback(() => {
+    if (typeof window !== "undefined" && "speechSynthesis" in window) {
+      window.speechSynthesis.cancel();
+    }
+    setSpeakingMessageId(null);
+  }, []);
+
+  const handleSpeak = useCallback(
+    (msg: ThreadMessage) => {
+      resetIdle();
+      if (speakingMessageId === msg.id) {
+        stopSpeaking();
+        return;
+      }
+      if (
+        typeof window === "undefined" ||
+        !("speechSynthesis" in window) ||
+        typeof SpeechSynthesisUtterance === "undefined"
+      ) {
+        return;
+      }
+
+      const textToRead = speechTextFromMarkdown(msg.text);
+      if (!textToRead) return;
+
+      window.speechSynthesis.cancel();
+      const utterance = new SpeechSynthesisUtterance(textToRead);
+      utterance.onend = () => {
+        setSpeakingMessageId((current) => (current === msg.id ? null : current));
+      };
+      utterance.onerror = () => {
+        setSpeakingMessageId((current) => (current === msg.id ? null : current));
+      };
+      setSpeakingMessageId(msg.id);
+      window.speechSynthesis.speak(utterance);
+    },
+    [resetIdle, speakingMessageId, stopSpeaking],
+  );
+
   const handleKeyDown = useCallback(
     (e: React.KeyboardEvent) => {
       if (composingRef.current || e.nativeEvent.isComposing || e.keyCode === 229) return;
@@ -496,8 +557,24 @@ export function ConversationView({ onBack, prefill }: ConversationViewProps) {
                   {msg.toolCalls.length > 0 && (
                     <ToolCallsIndicator toolCalls={msg.toolCalls} />
                   )}
-                  <div className="mt-1 text-xs text-white/30 tabular-nums">
-                    {formatBubbleTime(msg.timestamp)}
+                  <div className="mt-2 flex items-center justify-between gap-3 text-xs text-white/30 tabular-nums">
+                    <button
+                      type="button"
+                      className="home-tts-button"
+                      aria-label={
+                        speakingMessageId === msg.id
+                          ? "Stop reading response"
+                          : "Read response aloud"
+                      }
+                      onClick={() => handleSpeak(msg)}
+                    >
+                      {speakingMessageId === msg.id ? (
+                        <VolumeX size={16} />
+                      ) : (
+                        <Volume2 size={16} />
+                      )}
+                    </button>
+                    <span>{formatBubbleTime(msg.timestamp)}</span>
                   </div>
                 </div>
               </div>

--- a/src/home/home-assistant-page.tsx
+++ b/src/home/home-assistant-page.tsx
@@ -17,9 +17,9 @@
  * Wake Lock is acquired while mounted to prevent screen-off on idle
  * touch devices.
  *
- * Night mode: dims display and hides non-essential UI between 22:00
- * and 06:00 (auto), or always/never based on user setting. Touch/mouse
- * activity temporarily restores normal brightness for 5 seconds.
+ * Night mode: gently dims display between 22:00 and 06:00 (auto), or
+ * always/never based on user setting. Touch/mouse activity temporarily
+ * restores normal brightness.
  */
 
 import { useMemo, useCallback, useEffect, useRef, useState } from "react";
@@ -47,7 +47,7 @@ const HOME_SESSION_KEY = "octos_home_session_id";
 const HOME_HISTORY_TOPIC = "home";
 
 /** Duration in ms to temporarily suppress night mode on interaction. */
-const NIGHT_SUPPRESS_MS = 5000;
+const NIGHT_SUPPRESS_MS = 30 * 60 * 1000;
 
 function generateSessionId(): string {
   return `web-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
@@ -60,7 +60,7 @@ function generateSessionId(): string {
 function useNightMode(): boolean {
   const { nightMode } = useHomeSettings();
   const clock = useClock();
-  const [suppressed, setSuppressed] = useState(false);
+  const [suppressed, setSuppressed] = useState(true);
   const suppressTimerRef = useRef<ReturnType<typeof setTimeout> | undefined>(
     undefined,
   );
@@ -84,6 +84,7 @@ function useNightMode(): boolean {
       );
     };
 
+    handler();
     window.addEventListener("mousemove", handler);
     window.addEventListener("touchstart", handler);
     return () => {

--- a/src/home/home-settings-context.test.tsx
+++ b/src/home/home-settings-context.test.tsx
@@ -73,10 +73,12 @@ function Probe({ onValue }: { onValue?: (value: HomeSettingsContextValue) => voi
     <div>
       <span data-testid="city">{home.city}</span>
       <span data-testid="ui-style">{home.uiStyle}</span>
+      <span data-testid="burn-in">{home.burnInProtection ? "on" : "off"}</span>
       <span data-testid="photos">{home.photos.join("|")}</span>
       <span data-testid="events">{home.events.map((event) => event.title).join("|")}</span>
       <button onClick={() => home.update({ city: "Kyoto" })}>Set city</button>
       <button onClick={() => home.update({ uiStyle: "classic" })}>Set classic</button>
+      <button onClick={() => home.update({ burnInProtection: true })}>Enable burn-in</button>
       <button
         onClick={() =>
           home.addEvent({
@@ -120,6 +122,7 @@ describe("HomeSettingsProvider", () => {
           clock_format: "12h",
           idle_seconds: 60,
           night_mode: "on",
+          burn_in_protection: true,
           lang: "zh",
           news_feed_url: "https://example.test/feed.xml",
           ui_style: "classic",
@@ -146,6 +149,7 @@ describe("HomeSettingsProvider", () => {
 
     await waitFor(() => expect(screen.getByTestId("city").textContent).toBe("Tokyo"));
     expect(screen.getByTestId("ui-style").textContent).toBe("classic");
+    expect(screen.getByTestId("burn-in").textContent).toBe("on");
     expect(screen.getByTestId("events").textContent).toBe("Breakfast");
     expect(screen.getByTestId("photos").textContent).toBe("https://example.test/home.jpg");
   });
@@ -171,6 +175,7 @@ describe("HomeSettingsProvider", () => {
     await act(async () => {
       screen.getByText("Set city").click();
       screen.getByText("Set classic").click();
+      screen.getByText("Enable burn-in").click();
       screen.getByText("Add event").click();
       screen.getByText("Add photo").click();
       screen.getByText("Set layout").click();
@@ -181,7 +186,11 @@ describe("HomeSettingsProvider", () => {
     expect(lastCall?.[0]).toMatchObject({ id: "admin" });
     expect(lastCall?.[1]).toMatchObject({
       home: {
-        settings: { city: "Kyoto", ui_style: "classic" },
+        settings: {
+          city: "Kyoto",
+          ui_style: "classic",
+          burn_in_protection: true,
+        },
         events: [expect.objectContaining({ title: "Dinner" })],
         photos: ["https://example.test/family.jpg"],
         metro_layout: { clock: { col: 1, row: 1, w: 4, h: 2 } },

--- a/src/home/home-settings-context.tsx
+++ b/src/home/home-settings-context.tsx
@@ -42,8 +42,10 @@ export interface HomeSettings {
   clockFormat: ClockFormat;
   idleSeconds: number;
   nightMode: NightMode;
+  burnInProtection: boolean;
   lang: Lang;
   newsFeedUrl: string;
+  calendarFeedUrl: string;
   uiStyle: HomeUiStyle;
 }
 
@@ -98,8 +100,10 @@ const SETTINGS_KEYS = {
   clockFormat: "octos_home_clock_format",
   idleSeconds: "octos_home_idle_seconds",
   nightMode: "octos_home_night_mode",
+  burnInProtection: "octos_home_burn_in_protection",
   lang: "octos_home_lang",
   newsFeedUrl: "octos_home_news_feed_url",
+  calendarFeedUrl: "octos_home_calendar_feed_url",
   uiStyle: "octos_home_ui_style",
 } as const;
 
@@ -113,8 +117,10 @@ const DEFAULT_SETTINGS: HomeSettings = {
   clockFormat: "24h",
   idleSeconds: 30,
   nightMode: "auto",
+  burnInProtection: false,
   lang: "en",
   newsFeedUrl: DEFAULT_FEED_URL,
+  calendarFeedUrl: "",
   uiStyle: "metro",
 };
 
@@ -150,6 +156,12 @@ function asNightMode(value: unknown, fallback: NightMode): NightMode {
   return value === "auto" || value === "on" || value === "off" ? value : fallback;
 }
 
+function asBoolean(value: unknown, fallback: boolean): boolean {
+  if (value === true || value === "true" || value === "1") return true;
+  if (value === false || value === "false" || value === "0") return false;
+  return fallback;
+}
+
 function asLang(value: unknown, fallback: Lang): Lang {
   return value === "en" || value === "zh" ? value : fallback;
 }
@@ -170,8 +182,14 @@ function readLegacySettings(): HomeSettings {
       Number(storageGet(SETTINGS_KEYS.idleSeconds)) || DEFAULT_SETTINGS.idleSeconds,
     ),
     nightMode: asNightMode(storageGet(SETTINGS_KEYS.nightMode), DEFAULT_SETTINGS.nightMode),
+    burnInProtection: asBoolean(
+      storageGet(SETTINGS_KEYS.burnInProtection),
+      DEFAULT_SETTINGS.burnInProtection,
+    ),
     lang: asLang(storageGet(SETTINGS_KEYS.lang), DEFAULT_SETTINGS.lang),
     newsFeedUrl: storageGet(SETTINGS_KEYS.newsFeedUrl) ?? DEFAULT_SETTINGS.newsFeedUrl,
+    calendarFeedUrl:
+      storageGet(SETTINGS_KEYS.calendarFeedUrl) ?? DEFAULT_SETTINGS.calendarFeedUrl,
     uiStyle: asHomeUiStyle(storageGet(SETTINGS_KEYS.uiStyle), DEFAULT_SETTINGS.uiStyle),
   };
 }
@@ -182,8 +200,10 @@ function writeLegacySettings(settings: HomeSettings): void {
   storageSet(SETTINGS_KEYS.clockFormat, settings.clockFormat);
   storageSet(SETTINGS_KEYS.idleSeconds, String(settings.idleSeconds));
   storageSet(SETTINGS_KEYS.nightMode, settings.nightMode);
+  storageSet(SETTINGS_KEYS.burnInProtection, String(settings.burnInProtection));
   storageSet(SETTINGS_KEYS.lang, settings.lang);
   storageSet(SETTINGS_KEYS.newsFeedUrl, settings.newsFeedUrl);
+  storageSet(SETTINGS_KEYS.calendarFeedUrl, settings.calendarFeedUrl);
   storageSet(SETTINGS_KEYS.uiStyle, settings.uiStyle);
 }
 
@@ -339,11 +359,19 @@ function mergeProfileHome(
           ? clampIdle(settings.idle_seconds)
           : legacy.settings.idleSeconds,
       nightMode: asNightMode(settings.night_mode, legacy.settings.nightMode),
+      burnInProtection: asBoolean(
+        settings.burn_in_protection,
+        legacy.settings.burnInProtection,
+      ),
       lang: asLang(settings.lang, legacy.settings.lang),
       newsFeedUrl:
         typeof settings.news_feed_url === "string" && settings.news_feed_url.trim()
           ? settings.news_feed_url
           : legacy.settings.newsFeedUrl,
+      calendarFeedUrl:
+        typeof settings.calendar_feed_url === "string"
+          ? settings.calendar_feed_url
+          : legacy.settings.calendarFeedUrl,
       uiStyle: asHomeUiStyle(settings.ui_style, legacy.settings.uiStyle),
     },
     widgets: normalizeWidgets(home?.widgets, legacy.widgets),
@@ -372,8 +400,10 @@ function serializeHome(data: HomeData): HomeProfileConfig {
       clock_format: data.settings.clockFormat,
       idle_seconds: data.settings.idleSeconds,
       night_mode: data.settings.nightMode,
+      burn_in_protection: data.settings.burnInProtection,
       lang: data.settings.lang,
       news_feed_url: data.settings.newsFeedUrl,
+      calendar_feed_url: data.settings.calendarFeedUrl,
       ui_style: data.settings.uiStyle,
     },
     events: data.events,

--- a/src/home/home-settings.tsx
+++ b/src/home/home-settings.tsx
@@ -59,6 +59,7 @@ export function HomeSettingsPanel({ open, onClose }: HomeSettingsPanelProps) {
   // Reset drafts each time the panel opens so they pick up latest values.
   const [cityDraft, setCityDraft] = useState(s.city);
   const [feedDraft, setFeedDraft] = useState(s.newsFeedUrl);
+  const [calendarFeedDraft, setCalendarFeedDraft] = useState(s.calendarFeedUrl);
 
   // Event add form state
   const [evTitle, setEvTitle] = useState("");
@@ -73,7 +74,8 @@ export function HomeSettingsPanel({ open, onClose }: HomeSettingsPanelProps) {
     if (!open) return;
     setCityDraft(s.city);
     setFeedDraft(s.newsFeedUrl);
-  }, [open, s.city, s.newsFeedUrl]);
+    setCalendarFeedDraft(s.calendarFeedUrl);
+  }, [open, s.calendarFeedUrl, s.city, s.newsFeedUrl]);
 
   // Close on Escape
   useEffect(() => {
@@ -100,6 +102,13 @@ export function HomeSettingsPanel({ open, onClose }: HomeSettingsPanelProps) {
       s.update({ newsFeedUrl: trimmed });
     }
   }, [feedDraft, s]);
+
+  const commitCalendarFeed = useCallback(() => {
+    const trimmed = calendarFeedDraft.trim();
+    if (trimmed !== s.calendarFeedUrl) {
+      s.update({ calendarFeedUrl: trimmed });
+    }
+  }, [calendarFeedDraft, s]);
 
   const handleAddEvent = useCallback(() => {
     const title = evTitle.trim();
@@ -206,6 +215,16 @@ export function HomeSettingsPanel({ open, onClose }: HomeSettingsPanelProps) {
             />
           </SettingsField>
 
+          {/* Burn-in protection */}
+          <SettingsField label={t.settingsBurnInProtection}>
+            <SegmentedPicker
+              options={["off", "on"]}
+              labels={[t.settingsNightOff, t.settingsNightOn]}
+              value={s.burnInProtection ? "on" : "off"}
+              onChange={(v) => s.update({ burnInProtection: v === "on" })}
+            />
+          </SettingsField>
+
           {/* Language */}
           <SettingsField label={t.settingsLanguage}>
             <SegmentedPicker
@@ -237,6 +256,21 @@ export function HomeSettingsPanel({ open, onClose }: HomeSettingsPanelProps) {
                 if (e.key === "Enter") commitFeed();
               }}
               placeholder={DEFAULT_FEED_URL}
+              className="home-settings-input"
+            />
+          </SettingsField>
+
+          {/* Calendar Feed URL */}
+          <SettingsField label={t.settingsCalendarFeed}>
+            <input
+              type="text"
+              value={calendarFeedDraft}
+              onChange={(e) => setCalendarFeedDraft(e.target.value)}
+              onBlur={commitCalendarFeed}
+              onKeyDown={(e) => {
+                if (e.key === "Enter") commitCalendarFeed();
+              }}
+              placeholder="https://calendar.google.com/calendar/ical/..."
               className="home-settings-input"
             />
           </SettingsField>

--- a/src/home/metro-tiles.tsx
+++ b/src/home/metro-tiles.tsx
@@ -437,9 +437,10 @@ function CalendarTile() {
 }
 
 function VoiceTile({ onActivate, lang }: { onActivate: (text?: string) => void; lang: string }) {
+  const { strings } = useHomeSettings();
   const voice = useVoiceInput({ onResult: (text) => onActivate(text), lang: lang === "zh" ? "zh-CN" : "en-US" });
   const handleClick = useCallback(() => {
-    if (!voice.isSupported) { onActivate(); return; }
+    if (!voice.isSupported) { onActivate(""); return; }
     if (voice.orbState === "listening") voice.stop();
     else if (voice.orbState === "idle") voice.start();
   }, [voice, onActivate]);
@@ -448,6 +449,11 @@ function VoiceTile({ onActivate, lang }: { onActivate: (text?: string) => void; 
       <VoiceOrb state={voice.orbState} onClick={handleClick} />
       {voice.orbState === "listening" && voice.transcript && (
         <p className="metro-voice-transcript">{voice.transcript}</p>
+      )}
+      {(!voice.isSupported || voice.error) && (
+        <p className="metro-voice-transcript">
+          {voice.error ?? strings.voiceNotSupported}
+        </p>
       )}
     </div>
   );
@@ -630,11 +636,18 @@ function useTileResize(
 export function MetroTileGrid({ onActivate, nightActive }: MetroTileGridProps) {
   const [settingsOpen, setSettingsOpen] = useState(false);
   const [editMode, setEditMode] = useState(false);
-  const { strings, widgets, lang, metroLayout, setMetroLayout } = useHomeSettings();
+  const {
+    strings,
+    widgets,
+    lang,
+    metroLayout,
+    setMetroLayout,
+    burnInProtection,
+  } = useHomeSettings();
   const [layouts, setLayouts] = useState(() =>
     normalizeLayouts(metroLayout, defaultLayouts()),
   );
-  const burnIn = useBurnInProtection();
+  const burnIn = useBurnInProtection(burnInProtection);
   const gridRef = useRef<HTMLDivElement>(null);
   const gridCols = useMetroGridColumns();
 

--- a/src/home/photo-frame.test.tsx
+++ b/src/home/photo-frame.test.tsx
@@ -1,0 +1,28 @@
+import { cleanup, render, screen } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { PhotoFrame } from "./photo-frame";
+
+const photosMock = vi.hoisted(() => ({
+  currentUrl: null as string | null,
+}));
+
+vi.mock("./use-photos", () => ({
+  usePhotos: () => ({
+    currentUrl: photosMock.currentUrl,
+  }),
+}));
+
+describe("PhotoFrame", () => {
+  beforeEach(() => {
+    cleanup();
+    photosMock.currentUrl = null;
+  });
+
+  it("shows an online landscape image when the user has not configured photos", () => {
+    render(<PhotoFrame />);
+
+    const image = screen.getByRole("img", { name: /landscape/i });
+    expect(image.getAttribute("src")).toMatch(/^https:\/\/picsum\.photos\//);
+    expect(screen.getByText("Add photos in Settings")).toBeTruthy();
+  });
+});

--- a/src/home/photo-frame.tsx
+++ b/src/home/photo-frame.tsx
@@ -6,14 +6,46 @@
  */
 
 import { useEffect, useRef, useState } from "react";
-import { ImageIcon } from "lucide-react";
 import { usePhotos } from "./use-photos";
+
+const PLACEHOLDER_CYCLE_MS = 30_000;
+
+const LANDSCAPE_PLACEHOLDERS = [
+  {
+    src: "https://picsum.photos/id/1018/960/540",
+    label: "Mountain landscape",
+  },
+  {
+    src: "https://picsum.photos/id/1015/960/540",
+    label: "River valley landscape",
+  },
+  {
+    src: "https://picsum.photos/id/10/960/540",
+    label: "Forest landscape",
+  },
+];
 
 export function PhotoFrame() {
   const { currentUrl } = usePhotos();
   const [displayed, setDisplayed] = useState<string | null>(null);
   const [fading, setFading] = useState(false);
+  const [placeholderIndex, setPlaceholderIndex] = useState(0);
   const prevRef = useRef<string | null>(null);
+
+  useEffect(() => {
+    if (currentUrl) return;
+    const timer = window.setInterval(() => {
+      setPlaceholderIndex((index) => (index + 1) % LANDSCAPE_PLACEHOLDERS.length);
+    }, PLACEHOLDER_CYCLE_MS);
+    return () => window.clearInterval(timer);
+  }, [currentUrl]);
+
+  useEffect(() => {
+    if (currentUrl) return;
+    prevRef.current = null;
+    setDisplayed(null);
+    setFading(false);
+  }, [currentUrl]);
 
   useEffect(() => {
     if (!currentUrl || currentUrl === displayed) return;
@@ -27,10 +59,20 @@ export function PhotoFrame() {
   }, [currentUrl, displayed]);
 
   if (!currentUrl && !displayed) {
+    const placeholder =
+      LANDSCAPE_PLACEHOLDERS[placeholderIndex % LANDSCAPE_PLACEHOLDERS.length];
     return (
-      <div className="home-widget home-photo-frame mt-4 mx-4 px-5 py-6 flex flex-col items-center gap-2">
-        <ImageIcon size={24} className="text-white/20" />
-        <span className="text-sm text-white/25">Add photos in Settings</span>
+      <div className="home-photo-frame-container mt-4 mx-4">
+        <img
+          src={placeholder.src}
+          alt={placeholder.label}
+          className="home-photo-frame-img"
+          loading="lazy"
+        />
+        <div className="home-photo-placeholder-caption">
+          <span>{placeholder.label}</span>
+          <span>Add photos in Settings</span>
+        </div>
       </div>
     );
   }

--- a/src/home/use-burn-in-protection.ts
+++ b/src/home/use-burn-in-protection.ts
@@ -3,8 +3,8 @@
  *
  * 1. Every 3 minutes, micro-shifts the clock position by a random
  *    offset within +/-30px (CSS transform).
- * 2. After 5 minutes of no user interaction, dims the display to
- *    brightness 0.5 (applies a CSS filter on the root element).
+ * 2. After 30 minutes of no user interaction, gently dims the display
+ *    (applies a CSS filter on the root element).
  *
  * Returns:
  * - `offset` — { x, y } to feed into `transform: translate(...)`.
@@ -21,7 +21,7 @@ export interface BurnInState {
 }
 
 const SHIFT_INTERVAL = 3 * 60 * 1000; // 3 min
-const DIM_TIMEOUT = 5 * 60 * 1000; // 5 min
+const DIM_TIMEOUT = 30 * 60 * 1000; // 30 min
 const MAX_OFFSET = 30; // px
 
 function randomOffset(): { x: number; y: number } {
@@ -31,7 +31,7 @@ function randomOffset(): { x: number; y: number } {
   };
 }
 
-export function useBurnInProtection(): BurnInState {
+export function useBurnInProtection(enabled = false): BurnInState {
   const [offset, setOffset] = useState({ x: 0, y: 0 });
   const [dimmed, setDimmed] = useState(false);
   const dimTimerRef = useRef<ReturnType<typeof setTimeout> | undefined>(
@@ -44,30 +44,43 @@ export function useBurnInProtection(): BurnInState {
     lastActivityRef.current = Date.now();
     setDimmed(false);
     clearTimeout(dimTimerRef.current);
-    dimTimerRef.current = setTimeout(() => setDimmed(true), DIM_TIMEOUT);
-  }, []);
+    if (enabled) {
+      dimTimerRef.current = setTimeout(() => setDimmed(true), DIM_TIMEOUT);
+    }
+  }, [enabled]);
 
   // Public callback for user interaction events
   const onActivity = useCallback(() => {
+    if (!enabled) return;
     resetDim();
-  }, [resetDim]);
+  }, [enabled, resetDim]);
+
+  useEffect(() => {
+    if (enabled) return;
+    setOffset({ x: 0, y: 0 });
+    setDimmed(false);
+    clearTimeout(dimTimerRef.current);
+  }, [enabled]);
 
   // Periodic clock shift
   useEffect(() => {
+    if (!enabled) return;
     const id = setInterval(() => {
       setOffset(randomOffset());
     }, SHIFT_INTERVAL);
     return () => clearInterval(id);
-  }, []);
+  }, [enabled]);
 
   // Initial dim timer
   useEffect(() => {
+    if (!enabled) return;
     dimTimerRef.current = setTimeout(() => setDimmed(true), DIM_TIMEOUT);
     return () => clearTimeout(dimTimerRef.current);
-  }, []);
+  }, [enabled]);
 
   // Global interaction listeners for dim reset
   useEffect(() => {
+    if (!enabled) return;
     const handler = () => onActivity();
     window.addEventListener("mousemove", handler);
     window.addEventListener("touchstart", handler);
@@ -77,7 +90,7 @@ export function useBurnInProtection(): BurnInState {
       window.removeEventListener("touchstart", handler);
       window.removeEventListener("keydown", handler);
     };
-  }, [onActivity]);
+  }, [enabled, onActivity]);
 
   return { offset, dimmed, onActivity };
 }

--- a/src/home/use-events.test.ts
+++ b/src/home/use-events.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from "vitest";
+
+import { parseIcsEvents } from "./use-events";
+
+describe("parseIcsEvents", () => {
+  it("parses basic VEVENT entries from an iCal feed", () => {
+    const events = parseIcsEvents(`BEGIN:VCALENDAR
+BEGIN:VEVENT
+UID:evt-1
+DTSTART:20260615T190000Z
+SUMMARY:Dinner\\, home
+END:VEVENT
+BEGIN:VEVENT
+UID:evt-2
+DTSTART;VALUE=DATE:20260616
+SUMMARY:All-day planning
+END:VEVENT
+END:VCALENDAR`);
+
+    expect(events).toEqual([
+      {
+        id: "ics-evt-1",
+        title: "Dinner, home",
+        date: "2026-06-15",
+        time: "19:00",
+      },
+      {
+        id: "ics-evt-2",
+        title: "All-day planning",
+        date: "2026-06-16",
+        time: "00:00",
+      },
+    ]);
+  });
+});

--- a/src/home/use-events.ts
+++ b/src/home/use-events.ts
@@ -2,7 +2,7 @@
  * useEvents — derives calendar views from profile-backed Home settings.
  */
 
-import { useMemo } from "react";
+import { useEffect, useMemo, useState } from "react";
 import { useHomeSettings, type CalendarEvent } from "./home-settings-context";
 
 export type { CalendarEvent };
@@ -11,6 +11,8 @@ export interface EventsState {
   todayEvents: CalendarEvent[];
   upcomingEvents: CalendarEvent[];
 }
+
+const ICAL_PROXY_PREFIX = "https://r.jina.ai/http://";
 
 function fmtDate(d: Date): string {
   const y = d.getFullYear();
@@ -36,14 +38,134 @@ function sortByTime(a: CalendarEvent, b: CalendarEvent): number {
   return a.time.localeCompare(b.time);
 }
 
+function unfoldIcs(text: string): string[] {
+  return text
+    .replace(/\r\n[ \t]/g, "")
+    .replace(/\n[ \t]/g, "")
+    .split(/\r?\n/);
+}
+
+function icsValue(line: string): string {
+  const idx = line.indexOf(":");
+  return idx >= 0 ? line.slice(idx + 1).trim() : "";
+}
+
+function unescapeIcsText(value: string): string {
+  return value
+    .replace(/\\n/gi, " ")
+    .replace(/\\,/g, ",")
+    .replace(/\\;/g, ";")
+    .replace(/\\\\/g, "\\")
+    .replace(/\s+/g, " ")
+    .trim();
+}
+
+function parseIcsDateTime(value: string): { date: string; time: string } | null {
+  const compact = value.trim();
+  const match = compact.match(/^(\d{4})(\d{2})(\d{2})(?:T(\d{2})(\d{2}))?/);
+  if (!match) return null;
+
+  return {
+    date: `${match[1]}-${match[2]}-${match[3]}`,
+    time: match[4] && match[5] ? `${match[4]}:${match[5]}` : "00:00",
+  };
+}
+
+export function parseIcsEvents(text: string): CalendarEvent[] {
+  const lines = unfoldIcs(text);
+  const events: CalendarEvent[] = [];
+  let current: Record<string, string> | null = null;
+
+  for (const line of lines) {
+    if (line === "BEGIN:VEVENT") {
+      current = {};
+      continue;
+    }
+    if (line === "END:VEVENT") {
+      if (current) {
+        const startLine = Object.entries(current).find(([key]) =>
+          key.startsWith("DTSTART"),
+        );
+        const parsed = startLine ? parseIcsDateTime(startLine[1]) : null;
+        const title = unescapeIcsText(current.SUMMARY ?? "");
+        if (parsed && title) {
+          events.push({
+            id: `ics-${current.UID ?? `${parsed.date}-${parsed.time}-${title}`}`,
+            title,
+            date: parsed.date,
+            time: parsed.time,
+          });
+        }
+      }
+      current = null;
+      continue;
+    }
+    if (!current) continue;
+
+    const key = line.split(":", 1)[0];
+    if (key.startsWith("DTSTART")) {
+      current[key] = icsValue(line);
+    } else if (key === "SUMMARY" || key === "UID") {
+      current[key] = icsValue(line);
+    }
+  }
+
+  return events;
+}
+
+async function fetchIcsText(url: string): Promise<string> {
+  try {
+    const direct = await fetch(url);
+    if (direct.ok) return direct.text();
+  } catch {
+    // Fall through to the reader proxy for public feeds without CORS.
+  }
+
+  const proxied = await fetch(`${ICAL_PROXY_PREFIX}${url}`);
+  if (!proxied.ok) throw new Error(`Calendar feed HTTP ${proxied.status}`);
+  return proxied.text();
+}
+
 export function useEvents() {
-  const { events, addEvent, removeEvent } = useHomeSettings();
+  const { events, addEvent, removeEvent, calendarFeedUrl } = useHomeSettings();
+  const [feedEvents, setFeedEvents] = useState<CalendarEvent[]>([]);
+  const [calendarFeedError, setCalendarFeedError] = useState<string | null>(null);
+
+  useEffect(() => {
+    const url = calendarFeedUrl.trim();
+    if (!url) {
+      setFeedEvents([]);
+      setCalendarFeedError(null);
+      return;
+    }
+
+    let cancelled = false;
+    void (async () => {
+      try {
+        const text = await fetchIcsText(url);
+        if (cancelled) return;
+        setFeedEvents(parseIcsEvents(text));
+        setCalendarFeedError(null);
+      } catch (err) {
+        if (cancelled) return;
+        setFeedEvents([]);
+        setCalendarFeedError(
+          err instanceof Error ? err.message : "Calendar feed failed",
+        );
+      }
+    })();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [calendarFeedUrl]);
 
   const { todayEvents, upcomingEvents } = useMemo<EventsState>(() => {
     const now = new Date();
     const todayStr = fmtDate(now);
     const todayList: CalendarEvent[] = [];
     const upcomingList: CalendarEvent[] = [];
+    const combined = [...events, ...feedEvents];
 
     const upcomingDates: string[] = [];
     for (let i = 1; i <= 3; i++) {
@@ -52,7 +174,7 @@ export function useEvents() {
       upcomingDates.push(fmtDate(d));
     }
 
-    for (const event of events) {
+    for (const event of combined) {
       if (matchesDate(event, todayStr)) todayList.push(event);
       for (const date of upcomingDates) {
         if (matchesDate(event, date)) {
@@ -66,7 +188,15 @@ export function useEvents() {
     upcomingList.sort((a, b) => a.date.localeCompare(b.date) || sortByTime(a, b));
 
     return { todayEvents: todayList, upcomingEvents: upcomingList };
-  }, [events]);
+  }, [events, feedEvents]);
 
-  return { todayEvents, upcomingEvents, allEvents: events, addEvent, removeEvent };
+  return {
+    todayEvents,
+    upcomingEvents,
+    allEvents: events,
+    feedEvents,
+    calendarFeedError,
+    addEvent,
+    removeEvent,
+  };
 }

--- a/src/home/use-voice-input.ts
+++ b/src/home/use-voice-input.ts
@@ -53,6 +53,7 @@ export interface VoiceInputState {
   start: () => void;
   stop: () => void;
   transcript: string;
+  error: string | null;
   /** Externally set the orb to `speaking` state. */
   setSpeaking: (speaking: boolean) => void;
 }
@@ -72,6 +73,7 @@ export function useVoiceInput(options: VoiceInputOptions): VoiceInputState {
   const { lang = "en-US" } = options;
   const [orbState, setOrbState] = useState<OrbState>("idle");
   const [transcript, setTranscript] = useState("");
+  const [error, setError] = useState<string | null>(null);
   const [isSupported] = useState(() => getSpeechRecognition() !== null);
 
   const recognitionRef = useRef<SpeechRecognitionInstance | null>(null);
@@ -91,7 +93,10 @@ export function useVoiceInput(options: VoiceInputOptions): VoiceInputState {
   /* ── Start listening ─────────────────────────────────── */
   const start = useCallback(() => {
     const Ctor = getSpeechRecognition();
-    if (!Ctor) return;
+    if (!Ctor) {
+      setError("Voice is not supported in this browser.");
+      return;
+    }
 
     // Abort any existing session
     recognitionRef.current?.abort();
@@ -105,6 +110,7 @@ export function useVoiceInput(options: VoiceInputOptions): VoiceInputState {
 
     setOrbState("listening");
     setTranscript("");
+    setError(null);
 
     // Start silence timer
     silenceTimerRef.current = setTimeout(() => {
@@ -146,9 +152,10 @@ export function useVoiceInput(options: VoiceInputOptions): VoiceInputState {
       }
     };
 
-    rec.onerror = (_event: SpeechRecognitionErrorEvent) => {
+    rec.onerror = (event: SpeechRecognitionErrorEvent) => {
       if (silenceTimerRef.current) clearTimeout(silenceTimerRef.current);
       recognitionRef.current = null;
+      setError(event.message || event.error || "Microphone unavailable.");
       setOrbState("idle");
     };
 
@@ -163,6 +170,7 @@ export function useVoiceInput(options: VoiceInputOptions): VoiceInputState {
     try {
       rec.start();
     } catch {
+      setError("Microphone unavailable.");
       setOrbState("idle");
       recognitionRef.current = null;
     }
@@ -179,5 +187,5 @@ export function useVoiceInput(options: VoiceInputOptions): VoiceInputState {
     setOrbState(speaking ? "speaking" : "idle");
   }, []);
 
-  return { orbState, isSupported, start, stop, transcript, setSpeaking };
+  return { orbState, isSupported, start, stop, transcript, error, setSpeaking };
 }

--- a/src/home/use-weather.test.tsx
+++ b/src/home/use-weather.test.tsx
@@ -1,5 +1,5 @@
 import { render, screen, waitFor, cleanup } from "@testing-library/react";
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { HomeSettingsProvider } from "./home-settings-context";
 import { useWeather } from "./use-weather";
 
@@ -84,6 +84,8 @@ describe("useWeather", () => {
   beforeEach(() => {
     cleanup();
     localStorage.clear();
+    vi.restoreAllMocks();
+    vi.unstubAllGlobals();
     apiMocks.getMyProfile.mockReset();
     apiMocks.updateMyProfileConfig.mockReset();
     apiMocks.getMyProfile.mockResolvedValue(profileWithoutHomeCity());
@@ -97,9 +99,43 @@ describe("useWeather", () => {
     });
   });
 
-  it("does not call IP geolocation or fall back to a hardcoded city when location resolution fails", async () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+    vi.unstubAllGlobals();
+  });
+
+  it("uses a timezone city fallback when no city is configured", async () => {
+    vi.spyOn(Intl.DateTimeFormat.prototype, "resolvedOptions").mockReturnValue({
+      locale: "en-US",
+      calendar: "gregory",
+      numberingSystem: "latn",
+      timeZone: "Asia/Tokyo",
+    } as Intl.ResolvedDateTimeFormatOptions);
+
     const fetchMock = vi.fn(async (input: RequestInfo | URL) => {
-      throw new Error(`unexpected weather request: ${String(input)}`);
+      const url = String(input);
+      if (url.startsWith("https://geocoding-api.open-meteo.com")) {
+        return {
+          ok: true,
+          json: async () => ({
+            results: [{ latitude: 35.6762, longitude: 139.6503 }],
+          }),
+        } as Response;
+      }
+      if (url.startsWith("https://api.open-meteo.com")) {
+        return {
+          ok: true,
+          json: async () => ({
+            current: { temperature_2m: 23.4, weather_code: 1 },
+            hourly: {
+              time: ["2026-06-15T09:00"],
+              temperature_2m: [24],
+              weather_code: [1],
+            },
+          }),
+        } as Response;
+      }
+      throw new Error(`unexpected weather request: ${url}`);
     });
     vi.stubGlobal("fetch", fetchMock);
 
@@ -110,8 +146,8 @@ describe("useWeather", () => {
     );
 
     await waitFor(() => expect(screen.getByTestId("loading").textContent).toBe("no"));
-    expect(screen.getByTestId("error").textContent).toBe("location_unavailable");
-    expect(screen.getByTestId("city").textContent).toBe("");
-    expect(fetchMock).not.toHaveBeenCalled();
+    expect(screen.getByTestId("error").textContent).toBe("");
+    expect(screen.getByTestId("city").textContent).toBe("Tokyo");
+    expect(fetchMock).toHaveBeenCalledTimes(2);
   });
 });

--- a/src/home/use-weather.ts
+++ b/src/home/use-weather.ts
@@ -3,8 +3,9 @@
  *
  * Location resolution waterfall:
  *   1. City name from settings (geocoded via Open-Meteo Geocoding API)
- *   2. Browser Geolocation API
- *   3. Weather unavailable if no trusted location source resolves
+ *   2. Timezone-derived city fallback (no IP lookup)
+ *   3. Browser Geolocation API
+ *   4. Weather unavailable if no trusted location source resolves
  *
  * Refreshes every 15 minutes. If all location sources fail, the hook reports
  * an error instead of calling a third-party IP geolocation endpoint.
@@ -32,6 +33,19 @@ export interface WeatherState {
 }
 
 const REFRESH_INTERVAL = 15 * 60 * 1000; // 15 min
+
+const TIMEZONE_CITY_FALLBACKS: Record<string, string> = {
+  "Asia/Tokyo": "Tokyo",
+  "Asia/Shanghai": "Shanghai",
+  "Asia/Hong_Kong": "Hong Kong",
+  "Asia/Singapore": "Singapore",
+  "Europe/London": "London",
+  "Europe/Paris": "Paris",
+  "America/Los_Angeles": "Los Angeles",
+  "America/Denver": "Denver",
+  "America/Chicago": "Chicago",
+  "America/New_York": "New York",
+};
 
 interface ResolvedLocation {
   lat: number;
@@ -105,6 +119,15 @@ async function fetchWeather(
   };
 }
 
+function timezoneFallbackCity(): string | null {
+  try {
+    const timeZone = Intl.DateTimeFormat().resolvedOptions().timeZone;
+    return timeZone ? (TIMEZONE_CITY_FALLBACKS[timeZone] ?? null) : null;
+  } catch {
+    return null;
+  }
+}
+
 export function useWeather(): WeatherState {
   const { city } = useHomeSettings();
   const [state, setState] = useState<WeatherState>({
@@ -160,7 +183,17 @@ export function useWeather(): WeatherState {
         }
       }
 
-      // 2. Browser geolocation
+      // 2. Timezone-derived fallback. This avoids the "unavailable until the
+      // user grants geolocation" dead end without calling IP geolocation.
+      const fallbackCity = timezoneFallbackCity();
+      if (fallbackCity) {
+        const geo = await geocodeCity(fallbackCity);
+        if (geo) {
+          return { lat: geo.lat, lon: geo.lon, city: fallbackCity };
+        }
+      }
+
+      // 3. Browser geolocation
       try {
         const pos = await new Promise<GeolocationPosition>((resolve, reject) => {
           if (!navigator.geolocation) {

--- a/src/hooks/use-theme.test.ts
+++ b/src/hooks/use-theme.test.ts
@@ -11,7 +11,7 @@
 
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
-import { initTheme, resolveInitialTheme } from "./use-theme";
+import { initTheme, resolveInitialTheme, resolveInitialUiStyle } from "./use-theme";
 
 function stubMatchMedia(lightMatches: boolean) {
   vi.stubGlobal(
@@ -30,6 +30,7 @@ describe("initTheme", () => {
   beforeEach(() => {
     localStorage.clear();
     document.documentElement.removeAttribute("data-theme");
+    document.documentElement.removeAttribute("data-ui-style");
   });
 
   afterEach(() => {
@@ -72,5 +73,25 @@ describe("initTheme", () => {
     initTheme();
 
     expect(document.documentElement.getAttribute("data-theme")).toBe("dark");
+  });
+
+  it("should apply the stored legacy blue UI style before React mounts", () => {
+    localStorage.setItem("octos-ui-style", "legacy-blue");
+    stubMatchMedia(false);
+
+    initTheme();
+
+    expect(document.documentElement.getAttribute("data-ui-style")).toBe("legacy-blue");
+  });
+
+  it("should preserve warm palette variants before React mounts", () => {
+    localStorage.setItem("octos-ui-style", "warm-sage");
+    stubMatchMedia(false);
+
+    expect(resolveInitialUiStyle()).toBe("warm-sage");
+
+    initTheme();
+
+    expect(document.documentElement.getAttribute("data-ui-style")).toBe("warm-sage");
   });
 });

--- a/src/hooks/use-theme.ts
+++ b/src/hooks/use-theme.ts
@@ -1,8 +1,12 @@
 import { useState, useEffect, useCallback } from "react";
 
 type Theme = "dark" | "light";
+export type UiStyle = "warm" | "warm-sage" | "warm-daylight" | "legacy-blue";
 
 const STORAGE_KEY = "octos-theme";
+const UI_STYLE_STORAGE_KEY = "octos-ui-style";
+const THEME_CHANGE_EVENT = "octos-theme-change";
+const UI_STYLE_CHANGE_EVENT = "octos-ui-style-change";
 
 /**
  * Resolve the active theme from the stored preference, falling back to the
@@ -17,10 +21,29 @@ export function resolveInitialTheme(): Theme {
   return "dark";
 }
 
+export function resolveInitialUiStyle(): UiStyle {
+  const stored = localStorage.getItem(UI_STYLE_STORAGE_KEY);
+  if (
+    stored === "warm" ||
+    stored === "warm-sage" ||
+    stored === "warm-daylight" ||
+    stored === "legacy-blue"
+  ) {
+    return stored;
+  }
+  if (stored === "classic" || stored === "classic-blue") return "legacy-blue";
+  return "warm";
+}
+
 /** Reflect a theme onto `<html>` and persist it. */
 export function applyTheme(theme: Theme): void {
   document.documentElement.setAttribute("data-theme", theme);
   localStorage.setItem(STORAGE_KEY, theme);
+}
+
+export function applyUiStyle(uiStyle: UiStyle): void {
+  document.documentElement.setAttribute("data-ui-style", uiStyle);
+  localStorage.setItem(UI_STYLE_STORAGE_KEY, uiStyle);
 }
 
 /**
@@ -32,18 +55,79 @@ export function applyTheme(theme: Theme): void {
  */
 export function initTheme(): void {
   applyTheme(resolveInitialTheme());
+  applyUiStyle(resolveInitialUiStyle());
 }
 
 export function useTheme() {
   const [theme, setThemeState] = useState<Theme>(resolveInitialTheme);
+  const [uiStyle, setUiStyleState] = useState<UiStyle>(resolveInitialUiStyle);
+
+  useEffect(() => {
+    const onThemeChange = (event: Event) => {
+      const next = event instanceof CustomEvent ? event.detail : null;
+      if (next === "dark" || next === "light") {
+        setThemeState(next);
+      }
+    };
+    const onStorage = (event: StorageEvent) => {
+      if (event.key === STORAGE_KEY) setThemeState(resolveInitialTheme());
+    };
+    window.addEventListener(THEME_CHANGE_EVENT, onThemeChange);
+    window.addEventListener("storage", onStorage);
+    return () => {
+      window.removeEventListener(THEME_CHANGE_EVENT, onThemeChange);
+      window.removeEventListener("storage", onStorage);
+    };
+  }, []);
+
+  useEffect(() => {
+    const onUiStyleChange = (event: Event) => {
+      const next = event instanceof CustomEvent ? event.detail : null;
+      if (
+        next === "warm" ||
+        next === "warm-sage" ||
+        next === "warm-daylight" ||
+        next === "legacy-blue"
+      ) {
+        setUiStyleState(next);
+      }
+    };
+    const onStorage = (event: StorageEvent) => {
+      if (event.key === UI_STYLE_STORAGE_KEY) {
+        setUiStyleState(resolveInitialUiStyle());
+      }
+    };
+    window.addEventListener(UI_STYLE_CHANGE_EVENT, onUiStyleChange);
+    window.addEventListener("storage", onStorage);
+    return () => {
+      window.removeEventListener(UI_STYLE_CHANGE_EVENT, onUiStyleChange);
+      window.removeEventListener("storage", onStorage);
+    };
+  }, []);
 
   useEffect(() => {
     applyTheme(theme);
   }, [theme]);
 
+  useEffect(() => {
+    applyUiStyle(uiStyle);
+  }, [uiStyle]);
+
   const toggleTheme = useCallback(() => {
     setThemeState((t) => (t === "dark" ? "light" : "dark"));
   }, []);
 
-  return { theme, toggleTheme };
+  const setTheme = useCallback((next: Theme) => {
+    applyTheme(next);
+    setThemeState(next);
+    window.dispatchEvent(new CustomEvent(THEME_CHANGE_EVENT, { detail: next }));
+  }, []);
+
+  const setUiStyle = useCallback((next: UiStyle) => {
+    applyUiStyle(next);
+    setUiStyleState(next);
+    window.dispatchEvent(new CustomEvent(UI_STYLE_CHANGE_EVENT, { detail: next }));
+  }, []);
+
+  return { theme, setTheme, toggleTheme, uiStyle, setUiStyle };
 }

--- a/src/index.css
+++ b/src/index.css
@@ -104,6 +104,208 @@
   --workbench-danger-text: #b91c1c;
 }
 
+[data-ui-style="warm-sage"] {
+  --color-surface: #151914;
+  --color-surface-light: #1d241d;
+  --color-surface-dark: #0f130e;
+  --color-surface-container: #232c23;
+  --color-surface-elevated: #2b362b;
+
+  --color-accent: #c8a66f;
+  --color-accent-dim: #a98854;
+  --color-accent-container: rgba(200, 166, 111, 0.13);
+
+  --color-border: rgba(229, 239, 217, 0.11);
+  --color-outline: rgba(229, 239, 217, 0.18);
+
+  --color-muted: #99a392;
+  --color-text: #e3ecdc;
+  --color-text-strong: #f5fbef;
+
+  --color-user-bubble: rgba(143, 179, 126, 0.14);
+  --color-assistant-bubble: #1c231c;
+
+  --color-link: #8fb37e;
+  --color-heading: #c9ad78;
+  --color-heading-accent: #dabb7a;
+  --color-code-inline: #c9ad78;
+  --color-code-block-bg: #0d110d;
+  --color-code-header-bg: #141a14;
+  --color-code-text: #dfebd8;
+  --color-blockquote-border: #91ae74;
+  --color-sidebar: #10150f;
+  --color-highlight: #d1b15f;
+}
+
+[data-ui-style="warm-sage"][data-theme="light"] {
+  --color-surface: #f5f7f0;
+  --color-surface-light: #ffffff;
+  --color-surface-dark: #e7ece0;
+  --color-surface-container: #eef2e8;
+  --color-surface-elevated: #fcfdf9;
+
+  --color-accent: #987447;
+  --color-accent-dim: #755936;
+  --color-accent-container: rgba(117, 89, 54, 0.10);
+
+  --color-border: rgba(32, 47, 31, 0.13);
+  --color-outline: rgba(32, 47, 31, 0.20);
+
+  --color-muted: #66715f;
+  --color-text: #252d22;
+  --color-text-strong: #11170f;
+
+  --color-user-bubble: rgba(89, 120, 79, 0.10);
+  --color-assistant-bubble: #fbfcf8;
+
+  --color-link: #59784f;
+  --color-heading: #7d603c;
+  --color-heading-accent: #8d6b34;
+  --color-code-inline: #8b643f;
+  --color-code-block-bg: #172015;
+  --color-code-header-bg: #233020;
+  --color-code-text: #eef6e9;
+  --color-blockquote-border: #6e8d5e;
+  --color-sidebar: var(--color-surface-dark);
+  --color-highlight: #9c7a35;
+}
+
+[data-ui-style="warm-daylight"] {
+  --color-surface: #191613;
+  --color-surface-light: #231f1b;
+  --color-surface-dark: #11100d;
+  --color-surface-container: #2a241e;
+  --color-surface-elevated: #342c24;
+
+  --color-accent: #c58a61;
+  --color-accent-dim: #9d6a49;
+  --color-accent-container: rgba(197, 138, 97, 0.14);
+
+  --color-border: rgba(245, 232, 216, 0.11);
+  --color-outline: rgba(245, 232, 216, 0.18);
+
+  --color-muted: #a69b8c;
+  --color-text: #eadfd2;
+  --color-text-strong: #fff8ef;
+
+  --color-user-bubble: rgba(197, 138, 97, 0.14);
+  --color-assistant-bubble: #211d18;
+
+  --color-link: #91a274;
+  --color-heading: #d29b72;
+  --color-heading-accent: #e0b178;
+  --color-code-inline: #d39a70;
+  --color-code-block-bg: #11100d;
+  --color-code-header-bg: #1b1713;
+  --color-code-text: #eadfd2;
+  --color-blockquote-border: #b97855;
+  --color-sidebar: #14110e;
+  --color-highlight: #c89b49;
+}
+
+[data-ui-style="warm-daylight"][data-theme="light"] {
+  --color-surface: #f7f5ef;
+  --color-surface-light: #ffffff;
+  --color-surface-dark: #e8ecdf;
+  --color-surface-container: #f0eee7;
+  --color-surface-elevated: #fffdf8;
+
+  --color-accent: #b97750;
+  --color-accent-dim: #8f593a;
+  --color-accent-container: rgba(185, 119, 80, 0.10);
+
+  --color-border: rgba(38, 45, 35, 0.12);
+  --color-outline: rgba(38, 45, 35, 0.20);
+
+  --color-muted: #716a60;
+  --color-text: #28231d;
+  --color-text-strong: #15110d;
+
+  --color-user-bubble: rgba(185, 119, 80, 0.10);
+  --color-assistant-bubble: #fffefb;
+
+  --color-link: #6f8b66;
+  --color-heading: #9c603f;
+  --color-heading-accent: #a46a34;
+  --color-code-inline: #a46342;
+  --color-code-block-bg: #211b15;
+  --color-code-header-bg: #332920;
+  --color-code-text: #f7ecdd;
+  --color-blockquote-border: #9f6d4f;
+  --color-sidebar: var(--color-surface-dark);
+  --color-highlight: #a77832;
+}
+
+[data-ui-style="legacy-blue"] {
+  --color-surface: #0c2444;
+  --color-surface-light: #112d54;
+  --color-surface-dark: #081E3F;
+  --color-surface-container: #0e2a50;
+  --color-surface-elevated: #13325c;
+
+  --color-accent: #3B82F6;
+  --color-accent-dim: #2563EB;
+  --color-accent-container: rgba(59, 130, 246, 0.12);
+
+  --color-border: rgba(255, 255, 255, 0.08);
+  --color-outline: rgba(255, 255, 255, 0.12);
+
+  --color-muted: #8ba3c4;
+  --color-text: #d0ddef;
+  --color-text-strong: #f0f4f8;
+
+  --color-user-bubble: rgba(255, 95, 31, 0.10);
+  --color-assistant-bubble: #112d54;
+
+  --color-link: #00B4EF;
+  --color-heading: #00B4EF;
+  --color-heading-accent: #F9D53F;
+  --color-code-inline: #FF8C56;
+  --color-code-block-bg: #061533;
+  --color-code-header-bg: #0a1d40;
+  --color-code-text: #c8d8ec;
+  --color-blockquote-border: #E85B26;
+  --color-sidebar: #061533;
+  --color-highlight: #F9D53F;
+
+  --workbench-panel-shadow: 0 24px 60px rgba(3, 14, 34, 0.28);
+}
+
+[data-ui-style="legacy-blue"][data-theme="light"] {
+  --color-surface: #FFFFFF;
+  --color-surface-light: #F3F6FA;
+  --color-surface-dark: #EEF2F7;
+  --color-surface-container: #F7F9FC;
+  --color-surface-elevated: #FFFFFF;
+
+  --color-accent: #3B82F6;
+  --color-accent-dim: #2563EB;
+  --color-accent-container: rgba(59, 130, 246, 0.08);
+
+  --color-border: rgba(0, 0, 0, 0.06);
+  --color-outline: rgba(0, 0, 0, 0.10);
+
+  --color-muted: #5A7A9C;
+  --color-text: #1a3050;
+  --color-text-strong: #0a1a30;
+
+  --color-user-bubble: rgba(255, 95, 31, 0.07);
+  --color-assistant-bubble: #F3F6FA;
+
+  --color-link: #00B4EF;
+  --color-heading: #0090CC;
+  --color-heading-accent: #B8860B;
+  --color-code-inline: #E85B26;
+  --color-code-block-bg: #0D3B7C;
+  --color-code-header-bg: #0f4590;
+  --color-code-text: #d0ddef;
+  --color-blockquote-border: #E85B26;
+  --color-sidebar: var(--color-surface-dark);
+  --color-highlight: #F9D53F;
+
+  --workbench-panel-shadow: 0 14px 34px rgba(5, 16, 38, 0.12);
+}
+
 /* ── Base ───────────────────────────────────────────── */
 html, body, #root {
   height: 100%;
@@ -116,6 +318,24 @@ body {
   font-family: "SF Pro Text", "SF Pro Display", "PingFang SC", "Inter", -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
+}
+
+html[data-ui-style="legacy-blue"] body {
+  background:
+    radial-gradient(1200px 720px at -10% -10%, color-mix(in srgb, var(--color-accent) 22%, transparent), transparent 58%),
+    radial-gradient(900px 640px at 110% 0%, color-mix(in srgb, var(--color-heading-accent) 12%, transparent), transparent 56%),
+    linear-gradient(
+      180deg,
+      color-mix(in srgb, var(--color-surface-dark) 92%, black 8%) 0%,
+      color-mix(in srgb, var(--color-surface) 94%, transparent) 48%,
+      color-mix(in srgb, var(--color-surface-light) 96%, transparent) 100%
+    );
+  background-color: var(--color-surface-dark);
+}
+
+html[data-ui-style="legacy-blue"],
+html[data-ui-style="legacy-blue"] #root {
+  background-color: var(--color-surface-dark);
 }
 
 .chat-shell {
@@ -144,6 +364,26 @@ body {
 .chat-panel-toolbar {
   border-color: color-mix(in srgb, var(--color-border) 80%, var(--color-accent) 20%);
   background: color-mix(in srgb, var(--color-surface-container) 76%, var(--color-surface-elevated) 24%);
+}
+
+.chat-sidebar-panel .workbench-route-nav {
+  display: grid;
+  width: 100%;
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+  gap: 0.4rem;
+  overflow: visible;
+  margin-top: 0.9rem;
+}
+
+.chat-sidebar-panel .workbench-route-link {
+  min-width: 0;
+  width: 100%;
+  justify-content: center;
+  padding: 0.6rem;
+}
+
+.chat-sidebar-panel .workbench-route-link span {
+  display: none;
 }
 
 .chat-sidebar-footer {
@@ -354,7 +594,8 @@ body {
 .workbench-route-nav {
   scrollbar-width: none;
   min-width: 0;
-  mask-image: linear-gradient(90deg, transparent, #000 0.75rem, #000 calc(100% - 0.75rem), transparent);
+  mask-image: none;
+  -webkit-mask-image: none;
 }
 
 .workbench-route-nav::-webkit-scrollbar {
@@ -688,6 +929,58 @@ body {
 
 .settings-shell .text-link {
   color: var(--color-link);
+}
+
+[data-ui-style="legacy-blue"] .workbench-shell,
+[data-ui-style="legacy-blue"] .settings-shell {
+  background:
+    radial-gradient(1200px 720px at -10% -10%, color-mix(in srgb, var(--color-accent) 22%, transparent), transparent 58%),
+    radial-gradient(900px 640px at 110% 0%, color-mix(in srgb, var(--color-heading-accent) 12%, transparent), transparent 56%),
+    linear-gradient(
+      180deg,
+      color-mix(in srgb, var(--color-surface-dark) 92%, black 8%) 0%,
+      color-mix(in srgb, var(--color-surface) 94%, transparent) 48%,
+      color-mix(in srgb, var(--color-surface-light) 96%, transparent) 100%
+    );
+}
+
+[data-ui-style="legacy-blue"] .workbench-topbar,
+[data-ui-style="legacy-blue"] .settings-shell .workbench-topbar {
+  border-bottom-color: color-mix(in srgb, var(--color-text-strong) 10%, var(--color-border) 90%);
+  background: color-mix(in srgb, var(--color-surface-elevated) 72%, transparent);
+  backdrop-filter: blur(28px) saturate(150%);
+  -webkit-backdrop-filter: blur(28px) saturate(150%);
+}
+
+[data-ui-style="legacy-blue"] .workbench-rail,
+[data-ui-style="legacy-blue"] .settings-shell .settings-rail {
+  background: color-mix(in srgb, var(--color-surface-light) 76%, transparent);
+}
+
+[data-ui-style="legacy-blue"] .workbench-card,
+[data-ui-style="legacy-blue"] .workbench-panel,
+[data-ui-style="legacy-blue"] .settings-shell .glass-section {
+  border-color: color-mix(in srgb, var(--color-text-strong) 10%, var(--color-border) 90%);
+  background: color-mix(in srgb, var(--color-surface-container) 72%, transparent);
+  box-shadow:
+    0 14px 32px rgba(6, 18, 42, 0.14),
+    inset 0 1px 0 color-mix(in srgb, white 7%, transparent);
+}
+
+[data-ui-style="legacy-blue"] .workbench-card:hover {
+  border-color: color-mix(in srgb, var(--color-accent) 28%, var(--color-border) 72%);
+  background: color-mix(in srgb, var(--color-accent) 14%, var(--color-surface-elevated) 86%);
+  box-shadow:
+    0 16px 34px color-mix(in srgb, var(--color-accent) 16%, transparent),
+    inset 0 1px 0 color-mix(in srgb, white 8%, transparent);
+}
+
+[data-ui-style="legacy-blue"] .workbench-button-primary {
+  color: white;
+}
+
+[data-ui-style="legacy-blue"] .settings-main {
+  background: color-mix(in srgb, var(--color-surface-dark) 72%, transparent);
 }
 
 @media (max-width: 768px) {
@@ -1918,7 +2211,7 @@ button, a, input, textarea {
 
 /* ── Night mode ─────────────────────────────────────── */
 .home-night-mode {
-  filter: brightness(0.65) sepia(0.1);
+  filter: brightness(0.85) sepia(0.04);
   transition: filter 1s ease-in-out;
 }
 
@@ -1928,7 +2221,7 @@ button, a, input, textarea {
 
 /* ── Burn-in dimmed state ──────────────────────────── */
 .home-dimmed {
-  filter: brightness(0.5);
+  filter: brightness(0.82);
   transition: filter 2s ease-in-out;
 }
 
@@ -2149,6 +2442,28 @@ button, a, input, textarea {
   background: rgba(255, 255, 255, 0.12);
 }
 
+.home-tts-button {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 2rem;
+  height: 2rem;
+  border-radius: 8px;
+  color: rgba(255, 255, 255, 0.58);
+  background: rgba(255, 255, 255, 0.06);
+  border: 1px solid rgba(255, 255, 255, 0.1);
+  transition:
+    background 0.18s ease,
+    color 0.18s ease,
+    border-color 0.18s ease;
+}
+
+.home-tts-button:hover {
+  color: rgba(255, 255, 255, 0.9);
+  background: rgba(255, 255, 255, 0.12);
+  border-color: rgba(255, 255, 255, 0.18);
+}
+
 /* ── Photo frame widget ──────────────────────────── */
 .home-photo-frame-container {
   position: relative;
@@ -2169,6 +2484,31 @@ button, a, input, textarea {
   object-fit: cover;
   border-radius: 8px;
   transition: opacity 0.6s ease-in-out;
+}
+
+.home-photo-placeholder-caption {
+  position: absolute;
+  inset-inline: 0;
+  bottom: 0;
+  display: flex;
+  align-items: end;
+  justify-content: space-between;
+  gap: 1rem;
+  padding: 1rem;
+  color: rgba(255, 255, 255, 0.78);
+  background: linear-gradient(
+    to top,
+    rgba(0, 0, 0, 0.62),
+    rgba(0, 0, 0, 0)
+  );
+  font-size: 0.9rem;
+  line-height: 1.2;
+}
+
+.home-photo-placeholder-caption span:last-child {
+  color: rgba(255, 255, 255, 0.48);
+  font-size: 0.78rem;
+  text-align: right;
 }
 
 .home-photo-frame-out {
@@ -2362,6 +2702,191 @@ button, a, input, textarea {
   }
 }
 
+.home-root .classic-home-standby {
+  padding: 5rem 1.25rem 1.5rem;
+}
+
+.classic-home-grid {
+  display: grid;
+  width: min(100%, 1180px);
+  margin: 0 auto;
+  grid-template-columns: repeat(6, minmax(0, 1fr));
+  grid-auto-rows: minmax(112px, auto);
+  gap: 0.75rem;
+}
+
+.classic-home-grid > * {
+  min-width: 0;
+}
+
+.classic-home-grid .home-widget,
+.classic-home-grid .home-quick-actions,
+.classic-home-grid .classic-home-widget-slot {
+  width: 100%;
+  max-width: none;
+  height: 100%;
+  margin: 0;
+}
+
+.classic-home-clock-panel {
+  position: relative;
+  grid-column: span 3;
+  grid-row: span 2;
+  display: flex;
+  min-height: 240px;
+  flex-direction: column;
+  align-items: flex-start;
+  justify-content: center;
+  overflow: hidden;
+  padding: 1.5rem 2rem;
+}
+
+.classic-home-clock-panel .home-clock {
+  font-size: clamp(3.75rem, 9vw, 7rem);
+}
+
+.classic-home-clock-panel .home-date {
+  font-size: clamp(1rem, 2vw, 1.35rem);
+}
+
+.classic-home-voice-panel {
+  position: absolute;
+  right: 1.25rem;
+  bottom: 1.25rem;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+}
+
+.classic-home-voice-panel .home-voice-orb {
+  width: 92px;
+  height: 92px;
+}
+
+.classic-home-weather-panel {
+  grid-column: span 3;
+  display: flex;
+  align-items: center;
+  overflow: hidden;
+  min-height: 120px;
+}
+
+.classic-home-weather-panel .home-weather-layout {
+  width: 100%;
+  min-width: 0;
+}
+
+.classic-home-quick-panel {
+  grid-column: span 3;
+  align-self: stretch;
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+  padding: 0;
+}
+
+.classic-home-news-panel {
+  grid-column: span 4;
+}
+
+.classic-home-calendar-panel {
+  grid-column: span 2;
+}
+
+.classic-home-timer-panel,
+.classic-home-photo-panel {
+  grid-column: span 3;
+}
+
+.classic-home-grid .home-timer-widget,
+.classic-home-grid .home-photo-frame,
+.classic-home-grid .home-photo-frame-container {
+  width: 100%;
+  max-width: none;
+  margin: 0;
+}
+
+.classic-home-grid .home-timer-widget,
+.classic-home-grid .home-photo-frame {
+  height: 100%;
+}
+
+.classic-home-grid .home-photo-frame-container {
+  min-height: 180px;
+  height: 100%;
+  aspect-ratio: auto;
+}
+
+.home-night-mode .classic-home-grid {
+  opacity: 0.72;
+}
+
+.home-night-mode .classic-home-clock-panel {
+  opacity: 0.95;
+}
+
+@media (max-width: 1100px) {
+  .classic-home-grid {
+    grid-template-columns: repeat(4, minmax(0, 1fr));
+  }
+
+  .classic-home-clock-panel {
+    grid-column: span 4;
+  }
+
+  .classic-home-weather-panel,
+  .classic-home-quick-panel,
+  .classic-home-news-panel,
+  .classic-home-calendar-panel,
+  .classic-home-timer-panel,
+  .classic-home-photo-panel {
+    grid-column: span 2;
+  }
+
+  .classic-home-quick-panel {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+
+  .classic-home-weather-panel .home-weather-layout {
+    flex-wrap: wrap;
+    gap: 0.75rem;
+  }
+
+  .classic-home-weather-panel .home-weather-divider {
+    display: none;
+  }
+
+  .classic-home-weather-panel .home-forecast-strip {
+    flex-basis: 100%;
+    max-width: 100%;
+    padding-bottom: 0.1rem;
+  }
+}
+
+@media (max-width: 700px) {
+  .classic-home-grid {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+
+  .classic-home-clock-panel,
+  .classic-home-weather-panel,
+  .classic-home-quick-panel,
+  .classic-home-news-panel,
+  .classic-home-calendar-panel,
+  .classic-home-timer-panel,
+  .classic-home-photo-panel {
+    grid-column: span 2;
+  }
+}
+
+@media (max-height: 850px) {
+  .home-root .classic-home-standby {
+    padding-top: 4.5rem;
+  }
+
+  .classic-home-clock-panel {
+    min-height: 190px;
+  }
+}
+
 /* ══════════════════════════════════════════════════════════
    Metro Tile Grid — Windows Phone inspired
    ══════════════════════════════════════════════════════════ */
@@ -2520,37 +3045,48 @@ button, a, input, textarea {
 /* ── Resize handle (edit mode) ─── */
 .metro-resize-handle {
   position: absolute;
-  right: 0;
-  bottom: 0;
-  width: 28px;
-  height: 28px;
+  right: 6px;
+  bottom: 6px;
+  width: 34px;
+  height: 34px;
   cursor: nwse-resize;
   z-index: 10;
   touch-action: none;
-  background: none;
-  border: none;
+  background: rgba(20, 15, 11, 0.58);
+  border: 1px solid rgba(241, 198, 150, 0.26);
+  border-radius: 8px;
+  box-shadow: 0 8px 18px rgba(0, 0, 0, 0.24);
   padding: 0;
   margin: 0;
   outline: none;
 }
 .metro-resize-handle:focus-visible {
   outline: 2px solid rgba(212, 149, 106, 0.8);
-  outline-offset: -2px;
-  border-radius: 4px;
+  outline-offset: 2px;
 }
+.metro-resize-handle::before,
 .metro-resize-handle::after {
   content: "";
   position: absolute;
-  right: 4px;
-  bottom: 4px;
-  width: 10px;
-  height: 10px;
-  border-right: 2px solid rgba(212, 149, 106, 0.5);
-  border-bottom: 2px solid rgba(212, 149, 106, 0.5);
+  border-right: 2px solid rgba(241, 198, 150, 0.78);
+  border-bottom: 2px solid rgba(241, 198, 150, 0.78);
+}
+.metro-resize-handle::before {
+  right: 14px;
+  bottom: 14px;
+  width: 8px;
+  height: 8px;
+  opacity: 0.6;
+}
+.metro-resize-handle::after {
+  right: 8px;
+  bottom: 8px;
+  width: 13px;
+  height: 13px;
 }
 .metro-resize-handle:hover::after,
 .metro-resize-handle:active::after {
-  border-color: rgba(212, 149, 106, 0.9);
+  border-color: rgba(255, 222, 185, 1);
 }
 
 /* ── Clock tile ─── */

--- a/src/layouts/chat-layout.tsx
+++ b/src/layouts/chat-layout.tsx
@@ -110,7 +110,7 @@ export function ChatLayout({ children }: { children: ReactNode }) {
         {/* Header */}
         <div className="px-3 pt-3">
           <div className="chat-panel-toolbar glass-toolbar px-4 py-4">
-            <div className="flex items-start gap-3">
+            <div className="flex items-start justify-between gap-3">
               <div className="min-w-0 flex-1">
                 <div className="flex min-w-0 items-center gap-2.5">
                   <img
@@ -122,14 +122,16 @@ export function ChatLayout({ children }: { children: ReactNode }) {
                     Octos
                   </span>
                 </div>
-                <WorkbenchRouteNav compact />
-                <div className="shell-kicker mt-4">Session Stack</div>
-                <div className="mt-1 text-lg font-semibold tracking-tight text-text-strong">
-                  Chat History
-                </div>
               </div>
               <div className="flex items-center gap-2">
                 <WorkbenchThemeButton />
+              </div>
+            </div>
+            <WorkbenchRouteNav compact />
+            <div className="mt-4 flex flex-col items-start">
+              <div className="shell-kicker">Session Stack</div>
+              <div className="mt-1 text-lg font-semibold tracking-tight text-text-strong">
+                Chat History
               </div>
             </div>
           </div>

--- a/src/pages/home-page.tsx
+++ b/src/pages/home-page.tsx
@@ -5,12 +5,17 @@ import {
   Activity,
   ArrowRight,
   Globe,
+  LogOut,
   MessageSquare,
   Mic,
+  Moon,
   MonitorSmartphone,
   Presentation,
   Settings,
+  Sun,
 } from "lucide-react";
+import { useAuth } from "@/auth/auth-context";
+import { useTheme } from "@/hooks/use-theme";
 import { unlockAudio } from "@/home/voice/audio-playback";
 import {
   WorkbenchPage,
@@ -57,7 +62,47 @@ function QuickAction({
   );
 }
 
+function HomeStatusTile({
+  icon: Icon,
+  title,
+  description,
+  ariaLabel,
+  tone,
+  onClick,
+}: {
+  icon: typeof Activity;
+  title: ReactNode;
+  description: string;
+  ariaLabel: string;
+  tone: "link" | "accent";
+  onClick: () => void;
+}) {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      aria-label={ariaLabel}
+      data-testid="home-status-tile"
+      className="workbench-card p-4 text-left transition hover:border-accent/45 hover:bg-surface-elevated"
+    >
+      <Icon size={18} className={tone === "link" ? "text-link" : "text-accent"} />
+      <div className="mt-3 text-2xl font-semibold text-text-strong">{title}</div>
+      <div className="mt-1 text-xs text-muted">{description}</div>
+    </button>
+  );
+}
+
 export function HomePage() {
+  const { uiStyle } = useTheme();
+
+  if (uiStyle === "legacy-blue") {
+    return <LegacyBlueHomePage />;
+  }
+
+  return <WarmWorkbenchHomePage />;
+}
+
+function WarmWorkbenchHomePage() {
   const navigate = useNavigate();
   const counts = useLocalProjectCounts();
 
@@ -87,26 +132,38 @@ export function HomePage() {
               </div>
             </div>
             <div className="grid grid-cols-2 gap-3">
-              <div className="workbench-card p-4">
-                <Activity size={18} className="text-link" />
-                <div className="mt-3 text-2xl font-semibold text-text-strong">Ready</div>
-                <div className="mt-1 text-xs text-muted">Workbench shell</div>
-              </div>
-              <div className="workbench-card p-4">
-                <Presentation size={18} className="text-accent" />
-                <div className="mt-3 text-2xl font-semibold text-text-strong">{counts.slides}</div>
-                <div className="mt-1 text-xs text-muted">Local decks</div>
-              </div>
-              <div className="workbench-card p-4">
-                <Globe size={18} className="text-link" />
-                <div className="mt-3 text-2xl font-semibold text-text-strong">{counts.sites}</div>
-                <div className="mt-1 text-xs text-muted">Local sites</div>
-              </div>
-              <div className="workbench-card p-4">
-                <MonitorSmartphone size={18} className="text-accent" />
-                <div className="mt-3 text-2xl font-semibold text-text-strong">Touch</div>
-                <div className="mt-1 text-xs text-muted">Display mode</div>
-              </div>
+              <HomeStatusTile
+                icon={Activity}
+                title="Ready"
+                description="Open chat"
+                ariaLabel="Open chat status"
+                tone="link"
+                onClick={() => navigate("/chat")}
+              />
+              <HomeStatusTile
+                icon={Presentation}
+                title={counts.slides}
+                description="Local decks"
+                ariaLabel="Open deck count"
+                tone="accent"
+                onClick={() => navigate("/slides")}
+              />
+              <HomeStatusTile
+                icon={Globe}
+                title={counts.sites}
+                description="Local sites"
+                ariaLabel="Open site count"
+                tone="link"
+                onClick={() => navigate("/sites")}
+              />
+              <HomeStatusTile
+                icon={MonitorSmartphone}
+                title="Touch"
+                description="Display mode"
+                ariaLabel="Open display console"
+                tone="accent"
+                onClick={() => navigate("/home")}
+              />
             </div>
           </header>
 
@@ -177,5 +234,152 @@ export function HomePage() {
         </div>
       </div>
     </WorkbenchPage>
+  );
+}
+
+function LegacyHomeNav() {
+  const { user, portal, logout } = useAuth();
+  const { theme, toggleTheme, setUiStyle } = useTheme();
+  const navigate = useNavigate();
+
+  return (
+    <nav className="flex items-center gap-4 px-6 py-4">
+      <button
+        type="button"
+        onClick={() => navigate("/")}
+        className="flex items-center gap-2.5"
+        aria-label="Octos home"
+      >
+        <img
+          src="/images/octos-logo-color.svg"
+          alt="Octos"
+          className="h-7 w-auto select-none"
+        />
+        <span className="text-xl font-semibold tracking-tight text-text-strong">octos</span>
+      </button>
+
+      <div className="flex-1" />
+
+      <button
+        type="button"
+        onClick={() => setUiStyle("warm")}
+        className="flex items-center gap-2 rounded-xl bg-surface-container px-4 py-2.5 text-sm text-text hover:bg-surface-elevated"
+      >
+        Workbench
+      </button>
+      <button
+        type="button"
+        onClick={() => navigate("/chat")}
+        className="flex items-center gap-2 rounded-xl bg-surface-container px-4 py-2.5 text-sm text-text hover:bg-surface-elevated"
+      >
+        <MessageSquare size={16} />
+        Chat
+      </button>
+      {portal?.can_access_admin_portal && (
+        <button
+          type="button"
+          onClick={() => navigate("/settings")}
+          className="rounded-xl p-2.5 text-muted hover:bg-surface-container hover:text-text-strong"
+          title="Settings"
+          aria-label="Settings"
+        >
+          <Settings size={18} />
+        </button>
+      )}
+      <button
+        type="button"
+        onClick={toggleTheme}
+        className="rounded-xl p-2.5 text-muted hover:bg-surface-container hover:text-text-strong"
+        title={theme === "dark" ? "Light mode" : "Dark mode"}
+        aria-label={theme === "dark" ? "Light mode" : "Dark mode"}
+      >
+        {theme === "dark" ? <Sun size={18} /> : <Moon size={18} />}
+      </button>
+      {user && (
+        <div className="flex min-w-0 items-center gap-2">
+          <span className="max-w-[18rem] truncate text-sm text-muted">{user.email}</span>
+          <button
+            type="button"
+            onClick={logout}
+            className="rounded-xl p-2 text-muted hover:bg-surface-container hover:text-text-strong"
+            aria-label="Log out"
+            title="Log out"
+          >
+            <LogOut size={16} />
+          </button>
+        </div>
+      )}
+    </nav>
+  );
+}
+
+function LegacyActionCard({
+  icon: Icon,
+  title,
+  description,
+  toneClass,
+  onClick,
+}: {
+  icon: typeof MessageSquare;
+  title: string;
+  description: string;
+  toneClass: string;
+  onClick: () => void;
+}) {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      className="flex items-center gap-4 rounded-2xl bg-surface-container p-6 text-left transition-all hover:bg-surface-elevated elevation-1"
+    >
+      <div
+        className={`flex h-12 w-12 shrink-0 items-center justify-center rounded-2xl ${toneClass}`}
+      >
+        <Icon size={24} />
+      </div>
+      <div className="min-w-0 flex-1">
+        <div className="text-sm font-medium text-text-strong">{title}</div>
+        <div className="text-xs text-muted">{description}</div>
+      </div>
+      <ArrowRight size={16} className="ml-auto shrink-0 text-muted" />
+    </button>
+  );
+}
+
+function LegacyBlueHomePage() {
+  const navigate = useNavigate();
+
+  return (
+    <div className="legacy-blue-home flex h-screen flex-col bg-surface-dark">
+      <LegacyHomeNav />
+
+      <div className="flex-1 overflow-y-auto">
+        <div className="mx-auto max-w-5xl px-6 py-8">
+          <div className="mb-10 grid grid-cols-1 gap-4 md:grid-cols-3">
+            <LegacyActionCard
+              icon={MessageSquare}
+              title="Start chat"
+              description="Research, ask questions, explore"
+              toneClass="bg-link/10 text-link"
+              onClick={() => navigate("/chat")}
+            />
+            <LegacyActionCard
+              icon={Presentation}
+              title="Slides"
+              description="Build presentations with AI"
+              toneClass="bg-amber-500/10 text-amber-500"
+              onClick={() => navigate("/slides")}
+            />
+            <LegacyActionCard
+              icon={Globe}
+              title="Sites"
+              description="Create websites and landing pages"
+              toneClass="bg-emerald-500/10 text-emerald-500"
+              onClick={() => navigate("/sites")}
+            />
+          </div>
+        </div>
+      </div>
+    </div>
   );
 }

--- a/src/settings/appearance-tab.tsx
+++ b/src/settings/appearance-tab.tsx
@@ -1,0 +1,126 @@
+import { Check, Moon, Palette, Sun } from "lucide-react";
+
+import { useTheme, type UiStyle } from "@/hooks/use-theme";
+
+const STYLE_OPTIONS: Array<{
+  id: UiStyle;
+  label: string;
+  description: string;
+  swatches: string[];
+}> = [
+  {
+    id: "warm",
+    label: "Warm Hearth",
+    description: "Current family-console palette with restrained brown and sage accents.",
+    swatches: ["#1a1714", "#252019", "#d4a574", "#94a36f"],
+  },
+  {
+    id: "warm-sage",
+    label: "Garden Sage",
+    description: "Quieter green-led palette for a softer household console.",
+    swatches: ["#151914", "#263126", "#c8a66f", "#8fb37e"],
+  },
+  {
+    id: "warm-daylight",
+    label: "Soft Daylight",
+    description: "Lighter warm shell with clay and olive accents.",
+    swatches: ["#f7f5ef", "#e5eadf", "#b97750", "#6f8b66"],
+  },
+  {
+    id: "legacy-blue",
+    label: "Legacy Blue",
+    description: "The older deep-ocean Octos shell from the May workbench UI.",
+    swatches: ["#081e3f", "#0c2444", "#3b82f6", "#00b4ef"],
+  },
+];
+
+export function AppearanceTab() {
+  const { theme, setTheme, toggleTheme, uiStyle, setUiStyle } = useTheme();
+
+  const chooseStyle = (next: UiStyle) => {
+    setUiStyle(next);
+    if (next === "legacy-blue") {
+      setTheme("dark");
+    }
+  };
+
+  return (
+    <div className="space-y-5">
+      <section className="glass-section p-5">
+        <div className="flex items-start gap-3">
+          <div className="workbench-icon-tile flex h-10 w-10 shrink-0 items-center justify-center">
+            <Palette size={18} />
+          </div>
+          <div className="min-w-0">
+            <h3 className="text-base font-semibold text-text-strong">Interface Style</h3>
+            <p className="mt-1 text-sm text-muted">
+              Choose the global Octos shell used by Home, Settings, and shared workbench surfaces.
+            </p>
+          </div>
+        </div>
+
+        <div className="mt-5 grid gap-3 sm:grid-cols-2 xl:grid-cols-4">
+          {STYLE_OPTIONS.map((option) => {
+            const active = uiStyle === option.id;
+            return (
+              <button
+                key={option.id}
+                type="button"
+                aria-label={option.label}
+                aria-pressed={active}
+                data-active={active ? "true" : undefined}
+                onClick={() => chooseStyle(option.id)}
+                className="workbench-card flex min-h-36 flex-col items-start justify-between gap-4 p-4 text-left"
+              >
+                <span className="flex w-full items-start justify-between gap-3">
+                  <span>
+                    <span className="block text-sm font-semibold text-text-strong">
+                      {option.label}
+                    </span>
+                    <span className="mt-1 block text-xs leading-5 text-muted">
+                      {option.description}
+                    </span>
+                  </span>
+                  {active && (
+                    <span className="workbench-status-pill" data-tone="accent">
+                      <Check size={13} />
+                      Active
+                    </span>
+                  )}
+                </span>
+                <span className="flex gap-2" aria-hidden="true">
+                  {option.swatches.map((color) => (
+                    <span
+                      key={color}
+                      className="h-7 w-7 rounded-md border border-border"
+                      style={{ backgroundColor: color }}
+                    />
+                  ))}
+                </span>
+              </button>
+            );
+          })}
+        </div>
+      </section>
+
+      <section className="glass-section p-5">
+        <div className="flex flex-wrap items-center justify-between gap-4">
+          <div className="min-w-0">
+            <h3 className="text-base font-semibold text-text-strong">Brightness</h3>
+            <p className="mt-1 text-sm text-muted">
+              The color family and light/dark preference are stored separately.
+            </p>
+          </div>
+          <button
+            type="button"
+            onClick={toggleTheme}
+            className="workbench-button flex items-center gap-2 px-4 text-sm font-semibold"
+          >
+            {theme === "dark" ? <Sun size={16} /> : <Moon size={16} />}
+            {theme === "dark" ? "Light mode" : "Dark mode"}
+          </button>
+        </div>
+      </section>
+    </div>
+  );
+}

--- a/src/settings/settings-api.ts
+++ b/src/settings/settings-api.ts
@@ -90,8 +90,10 @@ export interface HomeProfileSettings {
   clock_format?: string | null;
   idle_seconds?: number | null;
   night_mode?: string | null;
+  burn_in_protection?: boolean | null;
   lang?: string | null;
   news_feed_url?: string | null;
+  calendar_feed_url?: string | null;
   ui_style?: string | null;
 }
 

--- a/src/settings/settings-page.tsx
+++ b/src/settings/settings-page.tsx
@@ -14,6 +14,7 @@ import {
   Waves,
   Loader2,
   Settings as SettingsIcon,
+  Palette,
 } from "lucide-react";
 import {
   WorkbenchPage,
@@ -33,8 +34,9 @@ import { ToolsTab } from "./tools-tab";
 import { SystemTab } from "./system-tab";
 import { ServerTab } from "./server-tab";
 import { OminixTab } from "./ominix-tab";
+import { AppearanceTab } from "./appearance-tab";
 
-type TabId = "profile" | "llm" | "skills" | "channels" | "sandbox" | "tools" | "users" | "system" | "server" | "ominix";
+type TabId = "profile" | "appearance" | "llm" | "skills" | "channels" | "sandbox" | "tools" | "users" | "system" | "server" | "ominix";
 
 interface TabDef {
   id: TabId;
@@ -45,6 +47,7 @@ interface TabDef {
 
 const TABS: TabDef[] = [
   { id: "profile", label: "Profile", icon: User },
+  { id: "appearance", label: "Appearance", icon: Palette },
   { id: "llm", label: "LLM", icon: Cpu },
   { id: "skills", label: "Skills", icon: Puzzle },
   { id: "channels", label: "Channels", icon: Radio },
@@ -158,6 +161,7 @@ export function AdminSettingsPage() {
                       canDeleteProfile={Boolean(portal?.can_access_admin_portal)}
                     />
                   )}
+                  {activeTab === "appearance" && <AppearanceTab />}
                   {activeTab === "llm" && (
                     <LlmTab profile={profile} onProfileUpdated={setProfile} />
                   )}

--- a/src/slides/components/slides-chat.tsx
+++ b/src/slides/components/slides-chat.tsx
@@ -230,8 +230,8 @@ export function SlidesChat({ sessionId, retryNonce = 0 }: Props) {
   return (
     <SessionContext.Provider value={sessionValue}>
       <ScopedRuntimeBridge>
-        <div className="flex flex-col h-full">
-          <div className="px-3 py-2 border-b border-border">
+        <div className="slides-chat flex h-full min-h-0 flex-col">
+          <div className="shrink-0 px-3 py-2 border-b border-border">
             <p className="text-xs text-muted truncate">
               {project?.title || "Slides Agent"}
             </p>
@@ -240,7 +240,7 @@ export function SlidesChat({ sessionId, retryNonce = 0 }: Props) {
               historyTopic={historyTopic}
             />
           </div>
-          <div className="flex-1 min-h-0 overflow-hidden">
+          <div className="slides-chat-thread min-h-0 flex-1 overflow-hidden">
             <ChatThread hideFileOnlyAssistantMessages />
           </div>
         </div>

--- a/src/slides/layouts/slides-editor-layout.tsx
+++ b/src/slides/layouts/slides-editor-layout.tsx
@@ -201,7 +201,7 @@ export function SlidesEditorLayout({
           <>
             <div
               style={{ width: chatWidth }}
-              className="glass-panel shrink-0 overflow-hidden rounded-lg max-lg:!h-72 max-lg:!w-full"
+              className="slides-editor-chat-panel glass-panel shrink-0 overflow-hidden rounded-lg max-lg:!h-[32rem] max-lg:!w-full"
             >
               {chatPanel || (
                 <div className="flex h-full items-center justify-center text-xs text-muted/50">

--- a/tests/settings-tabs.spec.ts
+++ b/tests/settings-tabs.spec.ts
@@ -665,7 +665,7 @@ test.describe("Settings page — tab smoke tests", () => {
   test("settings tab buttons are visible", async ({ page }) => {
     await goToSettings(page);
 
-    const baseTabs = ["Profile", "LLM", "Skills", "Channels", "Sandbox", "Tools"];
+    const baseTabs = ["Profile", "Appearance", "LLM", "Skills", "Channels", "Sandbox", "Tools"];
     const adminTabs = ["Users", "System", "Server", "OminiX"];
     const profileLoaded = await hasProfile(page);
 

--- a/tests/ui-redesign-smoke.spec.ts
+++ b/tests/ui-redesign-smoke.spec.ts
@@ -34,7 +34,23 @@ async function fulfillJson(route: Route, body: unknown) {
   });
 }
 
-async function installWorkbenchMocks(page: Page) {
+type UiSmokeMessage = {
+  seq: number;
+  role: "user" | "assistant";
+  content: string;
+  timestamp: string;
+  client_message_id?: string;
+  thread_id?: string;
+  response_to_client_message_id?: string;
+  message_id?: string;
+  source?: string;
+};
+
+async function installWorkbenchMocks(
+  page: Page,
+  options: { messages?: UiSmokeMessage[] } = {},
+) {
+  const messages = options.messages ?? [];
   const contentEntry = {
     id: "content-1",
     filename: "family-plan.md",
@@ -157,7 +173,7 @@ async function installWorkbenchMocks(page: Page) {
     }
     if (path.startsWith("/api/sessions")) {
       await fulfillJson(route, {
-        sessions: [{ id: "web-ui-smoke", title: "Visual review", message_count: 0 }],
+      sessions: [{ id: "web-ui-smoke", title: "Visual review", message_count: messages.length }],
         current: null,
       });
       return;
@@ -189,9 +205,9 @@ async function installWorkbenchMocks(page: Page) {
       if (!message.id) return;
       const result =
         message.method === "session/list"
-          ? { sessions: [{ id: "web-ui-smoke", title: "Visual review", message_count: 0 }] }
+          ? { sessions: [{ id: "web-ui-smoke", title: "Visual review", message_count: messages.length }] }
           : message.method === "session/messages_page"
-            ? { messages: [], has_more: false, next_offset: 0 }
+            ? { messages, has_more: false, next_offset: messages.length }
             : message.method === "session/open"
               ? { opened: { session_id: "web-ui-smoke", active_profile_id: "admin" } }
               : message.method === "router/get_metrics"
@@ -258,6 +274,18 @@ test.describe("UI redesign shell smoke", () => {
     }
   });
 
+  test("home status tiles navigate instead of looking inert", async ({ page }) => {
+    await page.setViewportSize({ width: 1440, height: 900 });
+    await page.goto("/", { waitUntil: "networkidle" });
+
+    await page.getByTestId("home-status-tile").filter({ hasText: "Local decks" }).click();
+    await expect(page).toHaveURL(/\/slides$/);
+
+    await page.goto("/", { waitUntil: "networkidle" });
+    await page.getByTestId("home-status-tile").filter({ hasText: "Display mode" }).click();
+    await expect(page).toHaveURL(/\/home$/);
+  });
+
   test("mobile home navigation keeps visible controls inside the viewport", async ({
     page,
   }) => {
@@ -293,6 +321,39 @@ test.describe("UI redesign shell smoke", () => {
     expect(offscreenControls).toEqual([]);
   });
 
+  test("workbench topbar route icons are readable and not edge-clipped", async ({
+    page,
+  }) => {
+    await page.setViewportSize({ width: 728, height: 694 });
+    await page.goto("/", { waitUntil: "networkidle" });
+
+    const geometry = await page.evaluate(() => {
+      const nav = document.querySelector(".workbench-route-nav");
+      const firstLink = document.querySelector(".workbench-route-link");
+      const firstIcon = firstLink?.querySelector("svg");
+      const brandIcon = document.querySelector(".workbench-brand img");
+      const navStyle = nav ? getComputedStyle(nav) : null;
+      const firstIconRect = firstIcon?.getBoundingClientRect();
+      const brandIconRect = brandIcon?.getBoundingClientRect();
+      return {
+        maskImage: navStyle?.maskImage ?? "",
+        webkitMaskImage: navStyle?.webkitMaskImage ?? "",
+        routeIconWidth: firstIconRect?.width ?? 0,
+        routeIconLeft: firstIconRect?.left ?? 0,
+        navLeft: nav?.getBoundingClientRect().left ?? 0,
+        brandIconWidth: brandIconRect?.width ?? 0,
+        brandIconHeight: brandIconRect?.height ?? 0,
+      };
+    });
+
+    expect(geometry.maskImage).toBe("none");
+    expect(geometry.webkitMaskImage).toBe("none");
+    expect(geometry.routeIconWidth).toBeGreaterThanOrEqual(18);
+    expect(geometry.routeIconLeft).toBeGreaterThanOrEqual(geometry.navLeft);
+    expect(geometry.brandIconWidth).toBeGreaterThanOrEqual(24);
+    expect(geometry.brandIconHeight).toBeGreaterThanOrEqual(24);
+  });
+
   test("home settings drawer hides closed controls from visual audits", async ({
     page,
   }) => {
@@ -304,6 +365,14 @@ test.describe("UI redesign shell smoke", () => {
 
     await page.locator(".home-settings-gear").click();
     await expect(panel).toHaveCSS("visibility", "visible");
+    const burnInField = page
+      .locator(".home-settings-panel .space-y-2")
+      .filter({ hasText: "Burn-in Protection" });
+    await expect(burnInField).toBeVisible();
+    await burnInField.getByRole("button", { name: "On" }).click();
+    await expect
+      .poll(() => page.evaluate(() => localStorage.getItem("octos_home_burn_in_protection")))
+      .toBe("true");
 
     await page.getByRole("button", { name: "Close" }).click();
     await expect(panel).toHaveCSS("visibility", "hidden");
@@ -353,7 +422,7 @@ test.describe("UI redesign shell smoke", () => {
     await expect(page.locator(".metro-grid")).toBeVisible();
 
     await page.locator(".home-settings-gear").click();
-    await page.getByRole("button", { name: "Classic" }).click();
+    await page.getByRole("button", { name: "Grid" }).click();
     await expect(page.locator(".classic-home-standby")).toBeVisible();
     await expect(page.locator(".metro-grid")).toHaveCount(0);
 
@@ -364,6 +433,87 @@ test.describe("UI redesign shell smoke", () => {
     await page.locator(".home-settings-gear").click();
     await page.getByRole("button", { name: "Metro" }).click();
     await expect(page.locator(".metro-grid")).toBeVisible();
+  });
+
+  test("classic home uses an aligned widget grid", async ({ page }) => {
+    await page.setViewportSize({ width: 859, height: 819 });
+    await page.addInitScript(() => {
+      localStorage.setItem("octos_home_ui_style", "classic");
+      localStorage.setItem("octos_home_night_mode", "off");
+    });
+
+    await page.goto("/home", { waitUntil: "networkidle" });
+    await expect(page.locator(".classic-home-grid")).toBeVisible();
+
+    const layout = await page.evaluate(() => {
+      const grid = document.querySelector(".classic-home-grid");
+      if (!grid) return { display: "", columns: 0, maxSameRow: 0 };
+      const style = getComputedStyle(grid);
+      const children = Array.from(grid.children)
+        .map((child) => child.getBoundingClientRect())
+        .filter((rect) => rect.width > 0 && rect.height > 0);
+      const rowCounts = new Map<number, number>();
+      for (const rect of children) {
+        const top = Math.round(rect.top / 4) * 4;
+        rowCounts.set(top, (rowCounts.get(top) ?? 0) + 1);
+      }
+      return {
+        display: style.display,
+        columns: style.gridTemplateColumns.split(" ").filter(Boolean).length,
+        maxSameRow: Math.max(0, ...rowCounts.values()),
+      };
+    });
+
+    expect(layout.display).toBe("grid");
+    expect(layout.columns).toBeGreaterThanOrEqual(4);
+    expect(layout.maxSameRow).toBeGreaterThanOrEqual(2);
+  });
+
+  test("classic home weather content stays inside its tile", async ({ page }) => {
+    await page.setViewportSize({ width: 859, height: 819 });
+    await page.addInitScript(() => {
+      localStorage.setItem("octos_home_ui_style", "classic");
+      localStorage.setItem("octos_home_night_mode", "off");
+    });
+    await page.route("https://geocoding-api.open-meteo.com/**", async (route) => {
+      await fulfillJson(route, {
+        results: [{ latitude: 35.6762, longitude: 139.6503 }],
+      });
+    });
+    await page.route("https://api.open-meteo.com/**", async (route) => {
+      await fulfillJson(route, {
+        current: { temperature_2m: 17, weather_code: 1 },
+        hourly: {
+          time: [
+            "2026-06-15T23:00",
+            "2026-06-16T00:00",
+            "2026-06-16T01:00",
+            "2026-06-16T02:00",
+            "2026-06-16T03:00",
+          ],
+          temperature_2m: [17, 17, 17, 17, 16],
+          weather_code: [1, 1, 1, 1, 0],
+        },
+      });
+    });
+
+    await page.goto("/home", { waitUntil: "networkidle" });
+    await expect(page.locator(".classic-home-weather-panel")).toContainText("Tokyo");
+
+    const overflow = await page.evaluate(() => {
+      const tile = document.querySelector(".classic-home-weather-panel");
+      const content = tile?.querySelector(".home-weather-layout");
+      const tileRect = tile?.getBoundingClientRect();
+      const contentRect = content?.getBoundingClientRect();
+      return {
+        tileRight: tileRect?.right ?? 0,
+        contentRight: contentRect?.right ?? 0,
+        scrollOverflow: tile ? tile.scrollWidth - tile.clientWidth : 0,
+      };
+    });
+
+    expect(overflow.contentRight).toBeLessThanOrEqual(overflow.tileRight + 1);
+    expect(overflow.scrollOverflow).toBeLessThanOrEqual(1);
   });
 
   test("workspace surfaces use the shared topbar titles", async ({ page }) => {
@@ -401,6 +551,123 @@ test.describe("UI redesign shell smoke", () => {
     expect(styling.link.toLowerCase()).not.toMatch(/7ca8b8|4d7f91|blue|purple/);
     expect(styling.sectionRadius).toBeLessThanOrEqual(8);
     expect(styling.tabRadius).toBeLessThanOrEqual(8);
+  });
+
+  test("settings can restore the legacy blue global UI style", async ({ page }) => {
+    await page.setViewportSize({ width: 1440, height: 900 });
+    await page.goto("/settings", { waitUntil: "networkidle" });
+
+    await page.getByRole("button", { name: "Appearance" }).click();
+    await page.getByRole("button", { name: "Legacy Blue" }).click();
+
+    await expect
+      .poll(() =>
+        page.evaluate(() => ({
+          attr: document.documentElement.getAttribute("data-ui-style"),
+          stored: localStorage.getItem("octos-ui-style"),
+          surfaceDark: getComputedStyle(document.documentElement)
+            .getPropertyValue("--color-surface-dark")
+            .trim()
+            .toLowerCase(),
+        })),
+      )
+      .toEqual({
+        attr: "legacy-blue",
+        stored: "legacy-blue",
+        surfaceDark: "#081e3f",
+      });
+
+    await page.goto("/", { waitUntil: "networkidle" });
+
+    await expect(page.locator(".legacy-blue-home")).toBeVisible();
+    await expect(page.locator(".workbench-shell")).toHaveCount(0);
+    await expect(page.getByRole("button", { name: /Start chat/i })).toBeVisible();
+    await expect(page.getByRole("button", { name: /Slides/i })).toBeVisible();
+    await expect(page.getByRole("button", { name: /Sites/i })).toBeVisible();
+    await expectNoHorizontalOverflow(page);
+  });
+
+  test("settings exposes multiple warm interface palettes", async ({ page }) => {
+    await page.setViewportSize({ width: 1440, height: 900 });
+    await page.goto("/settings", { waitUntil: "networkidle" });
+
+    await page.getByRole("button", { name: "Appearance" }).click();
+    await expect(page.getByRole("button", { name: "Warm Hearth" })).toBeVisible();
+    await expect(page.getByRole("button", { name: "Garden Sage" })).toBeVisible();
+    await expect(page.getByRole("button", { name: "Soft Daylight" })).toBeVisible();
+    await expect(page.getByRole("button", { name: "Legacy Blue" })).toBeVisible();
+
+    await page.getByRole("button", { name: "Garden Sage" }).click();
+
+    await expect
+      .poll(() =>
+        page.evaluate(() => ({
+          attr: document.documentElement.getAttribute("data-ui-style"),
+          stored: localStorage.getItem("octos-ui-style"),
+          link: getComputedStyle(document.documentElement)
+            .getPropertyValue("--color-link")
+            .trim()
+            .toLowerCase(),
+        })),
+      )
+      .toEqual({
+        attr: "warm-sage",
+        stored: "warm-sage",
+        link: "#59784f",
+      });
+  });
+
+  test("legacy blue home exposes a direct return to the warm workbench", async ({
+    page,
+  }) => {
+    await page.setViewportSize({ width: 1440, height: 900 });
+    await page.addInitScript(() => {
+      localStorage.setItem("octos-ui-style", "legacy-blue");
+      localStorage.setItem("octos-theme", "dark");
+    });
+
+    await page.goto("/", { waitUntil: "networkidle" });
+
+    await expect(page.locator(".legacy-blue-home")).toBeVisible();
+    await page.getByRole("button", { name: "Workbench" }).click();
+
+    await expect(page.locator(".workbench-shell")).toBeVisible();
+    await expect(page.locator(".legacy-blue-home")).toHaveCount(0);
+    await expect
+      .poll(() => page.evaluate(() => localStorage.getItem("octos-ui-style")))
+      .toBe("warm");
+    await expect(
+      page.getByRole("heading", { name: "Octos Workspace" }),
+    ).toBeVisible();
+  });
+
+  test("slides editor composer stays below its message viewport", async ({
+    page,
+  }) => {
+    await page.setViewportSize({ width: 859, height: 819 });
+    await page.goto("/slides/deck-1", { waitUntil: "networkidle" });
+
+    await expect(page.locator(".slides-editor-chat-panel")).toBeVisible();
+
+    const layout = await page.evaluate(() => {
+      const panel = document.querySelector(".slides-editor-chat-panel");
+      const viewport = panel?.querySelector(".chat-thread-viewport");
+      const composer = panel?.querySelector(".chat-composer-wrap");
+      const panelRect = panel?.getBoundingClientRect();
+      const viewportRect = viewport?.getBoundingClientRect();
+      const composerRect = composer?.getBoundingClientRect();
+      return {
+        panelBottom: panelRect?.bottom ?? 0,
+        viewportHeight: viewportRect?.height ?? 0,
+        viewportBottom: viewportRect?.bottom ?? 0,
+        composerTop: composerRect?.top ?? 0,
+        composerBottom: composerRect?.bottom ?? 0,
+      };
+    });
+
+    expect(layout.viewportHeight).toBeGreaterThanOrEqual(220);
+    expect(layout.composerTop).toBeGreaterThanOrEqual(layout.viewportBottom - 1);
+    expect(layout.composerBottom).toBeLessThanOrEqual(layout.panelBottom + 1);
   });
 
   test("content file panel keeps warm restrained control styling", async ({ page }) => {
@@ -449,5 +716,85 @@ test.describe("UI redesign shell smoke", () => {
     expect(styling.inputRadius).toBeLessThanOrEqual(8);
     expect(styling.hasOldRoundedClass).toBe(false);
     await expectNoHorizontalOverflow(page);
+  });
+
+  test("chat sidebar route navigation wraps without clipping", async ({ page }) => {
+    await page.setViewportSize({ width: 1067, height: 787 });
+    await page.goto("/chat", { waitUntil: "networkidle" });
+
+    await expect(page.locator(".chat-sidebar-panel .chat-panel-toolbar")).toBeVisible();
+
+    const layout = await page.evaluate(() => {
+      const toolbar = document.querySelector(".chat-sidebar-panel .chat-panel-toolbar");
+      const nav = toolbar?.querySelector(".workbench-route-nav");
+      const links = Array.from(nav?.querySelectorAll(".workbench-route-link") ?? []);
+      const toolbarRect = toolbar?.getBoundingClientRect();
+      const navRect = nav?.getBoundingClientRect();
+      const maxLinkOverflow = links.reduce((max, link) => {
+        const rect = link.getBoundingClientRect();
+        const overflow = Math.max(
+          0,
+          rect.right - (toolbarRect?.right ?? 0),
+          (toolbarRect?.left ?? 0) - rect.left,
+        );
+        return Math.max(max, overflow);
+      }, 0);
+
+      return {
+        visibleLinks: links.filter((link) => {
+          const rect = link.getBoundingClientRect();
+          return rect.width > 0 && rect.height > 0;
+        }).length,
+        navScrollOverflow: nav ? nav.scrollWidth - nav.clientWidth : 0,
+        navRight: navRect?.right ?? 0,
+        toolbarRight: toolbarRect?.right ?? 0,
+        maxLinkOverflow,
+      };
+    });
+
+    expect(layout.visibleLinks).toBeGreaterThanOrEqual(7);
+    expect(layout.navScrollOverflow).toBeLessThanOrEqual(1);
+    expect(layout.navRight).toBeLessThanOrEqual(layout.toolbarRight + 1);
+    expect(layout.maxLinkOverflow).toBeLessThanOrEqual(1);
+  });
+});
+
+test.describe("Home conversation TTS smoke", () => {
+  test("home assistant exposes TTS on completed assistant replies", async ({
+    page,
+  }) => {
+    await installWorkbenchMocks(page, {
+      messages: [
+        {
+          seq: 1,
+          role: "user",
+          content: "Summarize the room status",
+          timestamp: "2026-01-01T00:00:00Z",
+          client_message_id: "tts-thread",
+          thread_id: "tts-thread",
+          message_id: "user-tts",
+          source: "user",
+        },
+        {
+          seq: 2,
+          role: "assistant",
+          content: "The room is calm and ready.",
+          timestamp: "2026-01-01T00:00:01Z",
+          thread_id: "tts-thread",
+          response_to_client_message_id: "tts-thread",
+          message_id: "assistant-tts",
+          source: "assistant",
+        },
+      ],
+    });
+    await page.setViewportSize({ width: 859, height: 819 });
+    await page.goto("/home", { waitUntil: "networkidle" });
+
+    await page.getByRole("button", { name: "Chat" }).click();
+    await expect(page.locator(".home-conversation")).toBeVisible();
+    await expect(page.getByText("The room is calm and ready.")).toBeVisible();
+    await expect(
+      page.getByRole("button", { name: "Read response aloud" }),
+    ).toBeVisible();
   });
 });


### PR DESCRIPTION
## Summary
- Reworks the Home/Display experience with warm family-oriented palettes, legacy blue restore, aligned classic grid, safer burn-in behavior, weather/events fallbacks, and visible Metro resize affordances.
- Wires previously inert surfaces: status tiles navigate, Settings appearance/OminiX controls have real smoke coverage, photo frame uses online landscape placeholders, and Home conversation replies expose browser TTS.
- Fixes visual regressions across shared workbench chrome, slides composer layout, content panel styling, and chat sidebar navigation clipping.

## Validation
- npm run build
- npm run test:unit: 66 files / 663 tests passed
- BASE_URL=http://127.0.0.1:5174 npx playwright test --reporter=list: 108 passed / 35 skipped / 0 failed
- Browser QA on http://127.0.0.1:5174/chat: chat sidebar nav grid, navScrollOverflow=0, maxLinkOverflow=0

## Notes
- Build still emits the existing Vite CSS `file:` warning, sessions dynamic/static import warning, and chunk-size warning.
- No pinchtab config was found in this repo (`rg pinchtab|pinch-tab|pinch_tab`).
