### PR TITLE
[codex] Add Bilibili music scene launcher

### DIFF
--- a/src/home/bilibili-music-panel.tsx
+++ b/src/home/bilibili-music-panel.tsx
@@ -1,0 +1,109 @@
+import { ExternalLink, Music, Square, X } from "lucide-react";
+import { useMemo, useState } from "react";
+
+import {
+  BILIBILI_MUSIC_SCENES,
+  type BilibiliMusicSnapshot,
+  createBilibiliMusicController,
+} from "./bilibili-music";
+
+interface BilibiliMusicPanelProps {
+  open: boolean;
+  onClose: () => void;
+}
+
+export function BilibiliMusicPanel({ open, onClose }: BilibiliMusicPanelProps) {
+  const controller = useMemo(() => createBilibiliMusicController(), []);
+  const [snapshot, setSnapshot] = useState<BilibiliMusicSnapshot>(
+    controller.getSnapshot(),
+  );
+  const [busyScene, setBusyScene] = useState<string | null>(null);
+
+  if (!open) return null;
+
+  const playScene = async (sceneId: string) => {
+    const scene = BILIBILI_MUSIC_SCENES.find((item) => item.id === sceneId);
+    if (!scene) return;
+    setBusyScene(scene.id);
+    await controller.playScene(scene);
+    setSnapshot(controller.getSnapshot());
+    setBusyScene(null);
+  };
+
+  const stop = () => {
+    controller.stop();
+    setSnapshot(controller.getSnapshot());
+  };
+
+  return (
+    <div
+      className="home-music-panel"
+      role="dialog"
+      aria-modal="false"
+      aria-label="Bilibili music"
+    >
+      <div className="home-music-panel-header">
+        <div className="flex items-center gap-3">
+          <span className="home-music-panel-icon">
+            <Music size={20} />
+          </span>
+          <div>
+            <h2 className="text-lg font-semibold leading-tight text-white">
+              Bilibili Music
+            </h2>
+            <p className="text-sm text-white/45">
+              {snapshot.playing
+                ? snapshot.fallback
+                  ? "Search opened"
+                  : "Video opened"
+                : "Pick a scene"}
+            </p>
+          </div>
+        </div>
+        <button
+          className="home-music-icon-button"
+          type="button"
+          aria-label="Close"
+          onClick={onClose}
+        >
+          <X size={18} />
+        </button>
+      </div>
+
+      <div className="home-music-scene-grid">
+        {BILIBILI_MUSIC_SCENES.map((scene) => (
+          <button
+            key={scene.id}
+            type="button"
+            className="home-music-scene-button"
+            onClick={() => void playScene(scene.id)}
+            disabled={busyScene !== null}
+          >
+            <span>{busyScene === scene.id ? "Opening..." : scene.label}</span>
+            <ExternalLink size={16} />
+          </button>
+        ))}
+      </div>
+
+      <div className="home-music-panel-footer">
+        <div className="min-w-0">
+          <p className="truncate text-sm text-white/70">
+            {snapshot.scene?.label ?? "No Bilibili window"}
+          </p>
+          <p className="truncate text-xs text-white/35">
+            {snapshot.title ?? snapshot.url ?? "Bilibili may start muted"}
+          </p>
+        </div>
+        <button
+          className="home-music-stop-button"
+          type="button"
+          onClick={stop}
+          disabled={!snapshot.playing}
+        >
+          <Square size={16} />
+          Stop
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/src/home/bilibili-music.test.ts
+++ b/src/home/bilibili-music.test.ts
@@ -1,0 +1,97 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  BILIBILI_MUSIC_SCENES,
+  buildBilibiliSearchUrl,
+  createBilibiliMusicController,
+} from "./bilibili-music";
+
+describe("bilibili music launcher", () => {
+  const originalOpen = window.open;
+
+  beforeEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  afterEach(() => {
+    window.open = originalOpen;
+  });
+
+  it("builds a Bilibili search URL from the scene keyword plus music", () => {
+    expect(buildBilibiliSearchUrl("Cooking / Dinner")).toBe(
+      "https://search.bilibili.com/all?keyword=Cooking%20%2F%20Dinner%20%E9%9F%B3%E4%B9%90",
+    );
+  });
+
+  it("opens the first resolved video in a named window", async () => {
+    const popup = {
+      closed: false,
+      location: { href: "about:blank" },
+      close: vi.fn(),
+      focus: vi.fn(),
+    };
+    window.open = vi.fn(() => popup as unknown as Window);
+    const controller = createBilibiliMusicController({
+      resolveFirstVideo: vi.fn().mockResolvedValue({
+        title: "first result",
+        url: "https://www.bilibili.com/video/BV123/",
+      }),
+    });
+
+    const result = await controller.playScene(BILIBILI_MUSIC_SCENES[1]);
+
+    expect(window.open).toHaveBeenCalledWith(
+      "about:blank",
+      "octos-bilibili-music",
+      "noopener=false,noreferrer=false",
+    );
+    expect(popup.location.href).toBe("https://www.bilibili.com/video/BV123/");
+    expect(popup.focus).toHaveBeenCalled();
+    expect(result).toEqual({
+      opened: true,
+      fallback: false,
+      title: "first result",
+      url: "https://www.bilibili.com/video/BV123/",
+    });
+  });
+
+  it("falls back to the Bilibili search page when the resolver fails", async () => {
+    const popup = {
+      closed: false,
+      location: { href: "about:blank" },
+      close: vi.fn(),
+      focus: vi.fn(),
+    };
+    window.open = vi.fn(() => popup as unknown as Window);
+    const controller = createBilibiliMusicController({
+      resolveFirstVideo: vi.fn().mockRejectedValue(new Error("blocked")),
+    });
+
+    const result = await controller.playScene(BILIBILI_MUSIC_SCENES[2]);
+
+    expect(result.fallback).toBe(true);
+    expect(popup.location.href).toBe(
+      buildBilibiliSearchUrl(BILIBILI_MUSIC_SCENES[2].keyword),
+    );
+  });
+
+  it("closes the owned Bilibili window on stop", async () => {
+    const popup = {
+      closed: false,
+      location: { href: "about:blank" },
+      close: vi.fn(() => {
+        popup.closed = true;
+      }),
+      focus: vi.fn(),
+    };
+    window.open = vi.fn(() => popup as unknown as Window);
+    const controller = createBilibiliMusicController({
+      resolveFirstVideo: vi.fn().mockResolvedValue(null),
+    });
+
+    await controller.playScene(BILIBILI_MUSIC_SCENES[0]);
+    controller.stop();
+
+    expect(popup.close).toHaveBeenCalled();
+    expect(controller.getSnapshot().playing).toBe(false);
+  });
+});

--- a/src/home/bilibili-music.ts
+++ b/src/home/bilibili-music.ts
@@ -1,0 +1,129 @@
+import { request } from "@/api/client";
+
+export interface BilibiliMusicScene {
+  id: string;
+  label: string;
+  keyword: string;
+}
+
+export interface BilibiliVideoResult {
+  title: string;
+  url: string;
+}
+
+export interface BilibiliMusicPlayResult {
+  opened: boolean;
+  fallback: boolean;
+  title?: string;
+  url: string;
+}
+
+export interface BilibiliMusicSnapshot {
+  playing: boolean;
+  scene?: BilibiliMusicScene;
+  title?: string;
+  url?: string;
+  fallback: boolean;
+}
+
+export type ResolveFirstBilibiliVideo = (
+  keyword: string,
+) => Promise<BilibiliVideoResult | null>;
+
+export const BILIBILI_MUSIC_SCENES: readonly BilibiliMusicScene[] = [
+  { id: "morning-radio", label: "Morning radio", keyword: "Morning radio" },
+  { id: "cooking-dinner", label: "Cooking / Dinner", keyword: "Cooking / Dinner" },
+  { id: "focus", label: "Focus", keyword: "Focus" },
+  { id: "kids", label: "Kids", keyword: "Kids" },
+  { id: "sleep", label: "Sleep", keyword: "Sleep" },
+  { id: "party", label: "Party", keyword: "Party" },
+];
+
+const BILIBILI_WINDOW_NAME = "octos-bilibili-music";
+
+export function buildBilibiliSearchUrl(keyword: string): string {
+  const query = `${keyword.trim()} \u97F3\u4E50`.trim();
+  return `https://search.bilibili.com/all?keyword=${encodeURIComponent(query)}`;
+}
+
+async function defaultResolveFirstVideo(
+  keyword: string,
+): Promise<BilibiliVideoResult | null> {
+  const query = `${keyword.trim()} \u97F3\u4E50`.trim();
+  const data = await request<Partial<BilibiliVideoResult>>(
+    `/api/integrations/bilibili/first-video?keyword=${encodeURIComponent(query)}`,
+  );
+  if (!data.url || !data.title) return null;
+  return { title: data.title, url: data.url };
+}
+
+export function createBilibiliMusicController(options?: {
+  resolveFirstVideo?: ResolveFirstBilibiliVideo;
+}) {
+  const resolveFirstVideo = options?.resolveFirstVideo ?? defaultResolveFirstVideo;
+  let musicWindow: Window | null = null;
+  let snapshot: BilibiliMusicSnapshot = { playing: false, fallback: false };
+
+  const navigateOwnedWindow = (url: string) => {
+    if (!musicWindow || musicWindow.closed) {
+      musicWindow = window.open(
+        "about:blank",
+        BILIBILI_WINDOW_NAME,
+        "noopener=false,noreferrer=false",
+      );
+    }
+    if (!musicWindow) return false;
+    musicWindow.location.href = url;
+    musicWindow.focus?.();
+    return true;
+  };
+
+  return {
+    getSnapshot: () => snapshot,
+
+    async playScene(scene: BilibiliMusicScene): Promise<BilibiliMusicPlayResult> {
+      const searchUrl = buildBilibiliSearchUrl(scene.keyword);
+      let video: BilibiliVideoResult | null = null;
+
+      // Open synchronously inside the click handler before awaiting the network.
+      if (!musicWindow || musicWindow.closed) {
+        musicWindow = window.open(
+          "about:blank",
+          BILIBILI_WINDOW_NAME,
+          "noopener=false,noreferrer=false",
+        );
+      }
+
+      try {
+        video = await resolveFirstVideo(scene.keyword);
+      } catch {
+        video = null;
+      }
+
+      const targetUrl = video?.url ?? searchUrl;
+      const opened = navigateOwnedWindow(targetUrl);
+      const result: BilibiliMusicPlayResult = {
+        opened,
+        fallback: !video,
+        title: video?.title,
+        url: targetUrl,
+      };
+      snapshot = {
+        playing: opened,
+        scene,
+        title: video?.title,
+        url: targetUrl,
+        fallback: !video,
+      };
+      return result;
+    },
+
+    stop() {
+      if (musicWindow && !musicWindow.closed) {
+        musicWindow.close();
+      }
+      musicWindow = null;
+      snapshot = { playing: false, fallback: false };
+    },
+  };
+}

--- a/src/home/classic-standby-view.tsx
+++ b/src/home/classic-standby-view.tsx
@@ -22,6 +22,7 @@ import type { WidgetConfig, WidgetType } from "./widget-registry";
 
 interface ClassicStandbyViewProps {
   onActivate: (prefill?: string) => void;
+  onMusicOpen: () => void;
   nightActive: boolean;
 }
 
@@ -32,6 +33,7 @@ function isWidgetOn(widgets: WidgetConfig[], type: WidgetType): boolean {
 
 export function ClassicStandbyView({
   onActivate,
+  onMusicOpen,
   nightActive,
 }: ClassicStandbyViewProps) {
   const clock = useClock();
@@ -240,7 +242,13 @@ export function ClassicStandbyView({
             {quickActions.map(({ id, icon: Icon, label, color, prefill }) => (
               <button
                 key={id}
-                onClick={() => onActivate(prefill || undefined)}
+                onClick={() => {
+                  if (id === "music") {
+                    onMusicOpen();
+                    return;
+                  }
+                  onActivate(prefill || undefined);
+                }}
                 className="home-quick-card group flex flex-col items-center justify-center gap-2"
                 aria-label={label}
               >

--- a/src/home/home-assistant-page.tsx
+++ b/src/home/home-assistant-page.tsx
@@ -35,6 +35,7 @@ import * as ThreadStore from "@/store/thread-store";
 import { useWakeLock } from "./use-wake-lock";
 import { StandbyView } from "./standby-view";
 import { ConversationView } from "./conversation-view";
+import { BilibiliMusicPanel } from "./bilibili-music-panel";
 import {
   HomeSettingsProvider,
   useHomeSettings,
@@ -104,6 +105,7 @@ function useNightMode(): boolean {
 function HomeAssistantShell() {
   const [mode, setMode] = useState<Mode>("standby");
   const [prefill, setPrefill] = useState<string | undefined>(undefined);
+  const [musicOpen, setMusicOpen] = useState(false);
   const nightActive = useNightMode();
 
   const activate = useCallback((cardPrefill?: string) => {
@@ -126,7 +128,11 @@ function HomeAssistantShell() {
             : "opacity-0 scale-[0.98] pointer-events-none z-0"
         }`}
       >
-        <StandbyView onActivate={activate} nightActive={nightActive} />
+        <StandbyView
+          onActivate={activate}
+          onMusicOpen={() => setMusicOpen(true)}
+          nightActive={nightActive}
+        />
       </div>
 
       {/* Conversation layer */}
@@ -141,6 +147,10 @@ function HomeAssistantShell() {
       </div>
 
       <UiProtocolApprovalHost />
+      <BilibiliMusicPanel
+        open={musicOpen && mode === "standby"}
+        onClose={() => setMusicOpen(false)}
+      />
     </div>
   );
 }

--- a/src/home/metro-tiles.tsx
+++ b/src/home/metro-tiles.tsx
@@ -29,6 +29,7 @@ import type { WidgetConfig, WidgetType } from "./widget-registry";
 
 interface MetroTileGridProps {
   onActivate: (prefill?: string) => void;
+  onMusicOpen: () => void;
   nightActive: boolean;
 }
 
@@ -633,7 +634,11 @@ function useTileResize(
 
 /* ─── Main Metro Tile Grid ─── */
 
-export function MetroTileGrid({ onActivate, nightActive }: MetroTileGridProps) {
+export function MetroTileGrid({
+  onActivate,
+  onMusicOpen,
+  nightActive,
+}: MetroTileGridProps) {
   const [settingsOpen, setSettingsOpen] = useState(false);
   const [editMode, setEditMode] = useState(false);
   const {
@@ -652,6 +657,7 @@ export function MetroTileGrid({ onActivate, nightActive }: MetroTileGridProps) {
   const gridCols = useMetroGridColumns();
 
   useEffect(() => {
+    // eslint-disable-next-line react-hooks/set-state-in-effect -- local drag state must track persisted layout changes.
     setLayouts(normalizeLayouts(metroLayout, defaultLayouts()));
   }, [metroLayout]);
 
@@ -696,7 +702,7 @@ export function MetroTileGrid({ onActivate, nightActive }: MetroTileGridProps) {
       case "weather": return <WeatherTile />;
       case "quick-chat": return <QuickActionTile icon={MessageSquare} label={strings.cardChat} color="text-[#E8B87C]" onClick={() => onActivate(strings.cardChatPrefill)} />;
       case "quick-news": return <QuickActionTile icon={Newspaper} label={strings.cardNews} color="text-[#C4A882]" onClick={() => onActivate(strings.cardNewsPrefill)} />;
-      case "quick-music": return <QuickActionTile icon={Music} label={strings.cardMusic} color="text-[#8BAF7B]" onClick={() => onActivate(strings.cardMusicPrefill)} />;
+      case "quick-music": return <QuickActionTile icon={Music} label={strings.cardMusic} color="text-[#8BAF7B]" onClick={onMusicOpen} />;
       case "quick-home": return <QuickActionTile icon={Home} label={strings.cardHome} color="text-[#C8A088]" onClick={() => onActivate(strings.cardHomePrefill)} />;
       case "voice": return <VoiceTile onActivate={onActivate} lang={lang} />;
       case "news": return <NewsTile onActivate={onActivate} />;
@@ -705,7 +711,7 @@ export function MetroTileGrid({ onActivate, nightActive }: MetroTileGridProps) {
       case "photo": return <PhotoFrame />;
       default: return null;
     }
-  }, [nightActive, strings, lang, onActivate]);
+  }, [nightActive, strings, lang, onActivate, onMusicOpen]);
 
   return (
     <div

--- a/src/home/standby-view.tsx
+++ b/src/home/standby-view.tsx
@@ -4,15 +4,30 @@ import { MetroTileGrid } from "./metro-tiles";
 
 interface StandbyViewProps {
   onActivate: (prefill?: string) => void;
+  onMusicOpen: () => void;
   nightActive: boolean;
 }
 
-export function StandbyView({ onActivate, nightActive }: StandbyViewProps) {
+export function StandbyView({
+  onActivate,
+  onMusicOpen,
+  nightActive,
+}: StandbyViewProps) {
   const { uiStyle } = useHomeSettings();
   if (uiStyle === "classic") {
     return (
-      <ClassicStandbyView onActivate={onActivate} nightActive={nightActive} />
+      <ClassicStandbyView
+        onActivate={onActivate}
+        onMusicOpen={onMusicOpen}
+        nightActive={nightActive}
+      />
     );
   }
-  return <MetroTileGrid onActivate={onActivate} nightActive={nightActive} />;
+  return (
+    <MetroTileGrid
+      onActivate={onActivate}
+      onMusicOpen={onMusicOpen}
+      nightActive={nightActive}
+    />
+  );
 }

--- a/src/index.css
+++ b/src/index.css
@@ -1786,6 +1786,109 @@ button, a, input, textarea {
   transform: scale(0.95);
 }
 
+.home-music-panel {
+  position: fixed;
+  right: 1.5rem;
+  bottom: 1.5rem;
+  z-index: 60;
+  width: min(420px, calc(100vw - 2rem));
+  padding: 1rem;
+  border: 1px solid rgba(226, 180, 127, 0.18);
+  border-radius: 10px;
+  background: rgba(23, 18, 13, 0.96);
+  box-shadow: 0 24px 72px rgba(0, 0, 0, 0.42);
+}
+
+.home-music-panel-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+}
+
+.home-music-panel-icon,
+.home-music-icon-button,
+.home-music-stop-button {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.home-music-panel-icon {
+  width: 44px;
+  height: 44px;
+  flex: 0 0 44px;
+  border: 1px solid rgba(226, 180, 127, 0.18);
+  border-radius: 8px;
+  color: #8baf7b;
+  background: rgba(226, 180, 127, 0.08);
+}
+
+.home-music-icon-button {
+  width: 40px;
+  height: 40px;
+  border: 1px solid rgba(255, 255, 255, 0.1);
+  border-radius: 8px;
+  color: rgba(255, 255, 255, 0.72);
+  background: rgba(255, 255, 255, 0.05);
+}
+
+.home-music-scene-grid {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 0.65rem;
+  margin-top: 1rem;
+}
+
+.home-music-scene-button {
+  display: flex;
+  min-height: 48px;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.75rem;
+  border: 1px solid rgba(226, 180, 127, 0.16);
+  border-radius: 8px;
+  padding: 0.7rem 0.8rem;
+  color: rgba(255, 255, 255, 0.84);
+  background: rgba(86, 61, 39, 0.22);
+}
+
+.home-music-scene-button:hover,
+.home-music-scene-button:focus-visible {
+  border-color: rgba(226, 180, 127, 0.3);
+  background: rgba(96, 69, 44, 0.34);
+}
+
+.home-music-scene-button:disabled {
+  cursor: wait;
+  opacity: 0.65;
+}
+
+.home-music-panel-footer {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+  margin-top: 1rem;
+  border-top: 1px solid rgba(255, 255, 255, 0.08);
+  padding-top: 0.85rem;
+}
+
+.home-music-stop-button {
+  min-height: 40px;
+  gap: 0.45rem;
+  border: 1px solid rgba(238, 93, 99, 0.32);
+  border-radius: 8px;
+  padding: 0 0.8rem;
+  color: rgba(255, 255, 255, 0.88);
+  background: rgba(185, 58, 67, 0.28);
+}
+
+.home-music-stop-button:disabled {
+  cursor: default;
+  opacity: 0.45;
+}
+
 .home-root .rounded-xl,
 .home-root .rounded-\[12px\] {
   border-radius: 8px !important;

--- a/tests/ui-redesign-smoke.spec.ts
+++ b/tests/ui-redesign-smoke.spec.ts
@@ -187,6 +187,13 @@ async function installWorkbenchMocks(
       });
       return;
     }
+    if (path === "/api/integrations/bilibili/first-video") {
+      await fulfillJson(route, {
+        title: "40分钟做饭神曲合集",
+        url: "https://www.bilibili.com/video/BV1cTcbzNE9p/",
+      });
+      return;
+    }
     if (path.includes("/ominix-api/models")) {
       await fulfillJson(route, { models: [] });
       return;
@@ -514,6 +521,109 @@ test.describe("UI redesign shell smoke", () => {
 
     expect(overflow.contentRight).toBeLessThanOrEqual(overflow.tileRight + 1);
     expect(overflow.scrollOverflow).toBeLessThanOrEqual(1);
+  });
+
+  test("home music tile opens and stops the Bilibili music window", async ({
+    page,
+  }) => {
+    await page.setViewportSize({ width: 859, height: 819 });
+    await page.addInitScript(() => {
+      const state = {
+        calls: [] as Array<{ type: string; url?: string; name?: string; features?: string }>,
+        href: "",
+        closed: false,
+      };
+      Object.defineProperty(window, "__octosBilibiliMusicWindow", {
+        value: state,
+        configurable: true,
+      });
+      window.open = ((url?: string | URL, name?: string, features?: string) => {
+        state.closed = false;
+        state.href = String(url ?? "");
+        state.calls.push({
+          type: "open",
+          url: state.href,
+          name,
+          features,
+        });
+        const location = {};
+        Object.defineProperty(location, "href", {
+          get: () => state.href,
+          set: (next: string) => {
+            state.href = next;
+            state.calls.push({ type: "navigate", url: next });
+          },
+        });
+        return {
+          get closed() {
+            return state.closed;
+          },
+          location,
+          focus: () => state.calls.push({ type: "focus" }),
+          close: () => {
+            state.closed = true;
+            state.calls.push({ type: "close" });
+          },
+        } as Window;
+      }) as typeof window.open;
+    });
+
+    await page.goto("/home", { waitUntil: "networkidle" });
+    await page.getByRole("button", { name: "Music", exact: true }).click();
+    await expect(
+      page.getByRole("dialog", { name: "Bilibili music" }),
+    ).toBeVisible();
+    await expect(page.getByRole("button", { name: "Cooking / Dinner" })).toBeVisible();
+    await expect(page.getByRole("button", { name: "Focus" })).toBeVisible();
+
+    await page.getByRole("button", { name: "Cooking / Dinner" }).click();
+    await expect(page.getByText("Video opened")).toBeVisible();
+    await expect(page.getByText("40分钟做饭神曲合集")).toBeVisible();
+    await expect
+      .poll(() =>
+        page.evaluate(() => {
+          const state = (
+            window as typeof window & {
+              __octosBilibiliMusicWindow?: {
+                href: string;
+                closed: boolean;
+                calls: Array<{ type: string; url?: string; name?: string; features?: string }>;
+              };
+            }
+          ).__octosBilibiliMusicWindow;
+          return {
+            href: state?.href,
+            closed: state?.closed,
+            openName: state?.calls.find((call) => call.type === "open")?.name,
+            navigated: state?.calls.some(
+              (call) =>
+                call.type === "navigate" &&
+                call.url === "https://www.bilibili.com/video/BV1cTcbzNE9p/",
+            ),
+          };
+        }),
+      )
+      .toEqual({
+        href: "https://www.bilibili.com/video/BV1cTcbzNE9p/",
+        closed: false,
+        openName: "octos-bilibili-music",
+        navigated: true,
+      });
+
+    await page.getByRole("button", { name: "Stop" }).click();
+    await expect(page.getByText("No Bilibili window")).toBeVisible();
+    await expect
+      .poll(() =>
+        page.evaluate(
+          () =>
+            (
+              window as typeof window & {
+                __octosBilibiliMusicWindow?: { closed: boolean };
+              }
+            ).__octosBilibiliMusicWindow?.closed,
+        ),
+      )
+      .toBe(true);
   });
 
   test("workspace surfaces use the shared topbar titles", async ({ page }) => {


### PR DESCRIPTION
## Summary
- Add a Home Music panel with Morning radio, Cooking / Dinner, Focus, Kids, Sleep, and Party scenes.
- Open a script-owned Bilibili window for the selected scene, resolve the first video through the backend when available, and fall back to the Bilibili search page when resolution fails.
- Wire Stop to close the owned Bilibili window and add unit plus Playwright smoke coverage.

## Notes
- Bilibili can still open muted due to browser/site autoplay policy. The app can open and close the page, but it cannot reliably force cross-origin Bilibili audio to be unmuted without a user click inside the Bilibili player.

## Validation
- `npm run test:unit -- src/home/bilibili-music.test.ts` -> 4 passed
- `BASE_URL=http://127.0.0.1:5174 npx playwright test tests/ui-redesign-smoke.spec.ts -g "home music tile opens"` -> 1 passed
- `BASE_URL=http://127.0.0.1:5174 npx playwright test tests/ui-redesign-smoke.spec.ts` -> 21 passed
- `BASE_URL=http://127.0.0.1:5174 npm run test` -> 109 passed, 35 skipped, 0 failed
- `npm run build` -> passed
- Changed-file ESLint -> passed

Full `npm run lint` still reports existing repo-wide lint debt outside this change set.
