### PR TITLE
[codex] Add in-page Bilibili sound toggle

### DIFF
--- a/src/home/bilibili-music.test.ts
+++ b/src/home/bilibili-music.test.ts
@@ -1,6 +1,7 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import {
   BILIBILI_MUSIC_SCENES,
+  buildBilibiliPlayerUrl,
   buildBilibiliSearchUrl,
   createBilibiliMusicController,
 } from "./bilibili-music";
@@ -14,6 +15,9 @@ describe("bilibili music launcher", () => {
 
   afterEach(() => {
     window.open = originalOpen;
+    document.querySelectorAll("[data-octos-bilibili-audio]").forEach((node) => {
+      node.remove();
+    });
   });
 
   it("builds a Bilibili search URL from the scene keyword plus music", () => {
@@ -22,46 +26,44 @@ describe("bilibili music launcher", () => {
     );
   });
 
-  it("opens the first resolved video in a named window", async () => {
-    const popup = {
-      closed: false,
-      location: { href: "about:blank" },
-      close: vi.fn(),
-      focus: vi.fn(),
-    };
-    window.open = vi.fn(() => popup as unknown as Window);
+  it("builds a hidden Bilibili player URL from a video URL", () => {
+    expect(buildBilibiliPlayerUrl("https://www.bilibili.com/video/BV1cTcbzNE9p/")).toBe(
+      "https://player.bilibili.com/player.html?bvid=BV1cTcbzNE9p&autoplay=1&danmaku=0&high_quality=1",
+    );
+  });
+
+  it("starts Bilibili sound in a hidden in-page iframe without opening a window", async () => {
+    window.open = vi.fn();
     const controller = createBilibiliMusicController({
       resolveFirstVideo: vi.fn().mockResolvedValue({
         title: "first result",
-        url: "https://www.bilibili.com/video/BV123/",
+        url: "https://www.bilibili.com/video/BV1cTcbzNE9p/",
       }),
     });
 
     const result = await controller.playScene(BILIBILI_MUSIC_SCENES[1]);
 
-    expect(window.open).toHaveBeenCalledWith(
-      "about:blank",
-      "octos-bilibili-music",
-      "noopener=false,noreferrer=false",
+    expect(window.open).not.toHaveBeenCalled();
+    const frame = document.querySelector<HTMLIFrameElement>(
+      "iframe[data-octos-bilibili-audio]",
     );
-    expect(popup.location.href).toBe("https://www.bilibili.com/video/BV123/");
-    expect(popup.focus).toHaveBeenCalled();
+    expect(frame).not.toBeNull();
+    expect(frame?.src).toBe(
+      "https://player.bilibili.com/player.html?bvid=BV1cTcbzNE9p&autoplay=1&danmaku=0&high_quality=1",
+    );
+    expect(frame?.allow).toContain("autoplay");
     expect(result).toEqual({
-      opened: true,
+      playing: true,
       fallback: false,
       title: "first result",
-      url: "https://www.bilibili.com/video/BV123/",
+      url: "https://www.bilibili.com/video/BV1cTcbzNE9p/",
+      embedUrl:
+        "https://player.bilibili.com/player.html?bvid=BV1cTcbzNE9p&autoplay=1&danmaku=0&high_quality=1",
     });
   });
 
-  it("falls back to the Bilibili search page when the resolver fails", async () => {
-    const popup = {
-      closed: false,
-      location: { href: "about:blank" },
-      close: vi.fn(),
-      focus: vi.fn(),
-    };
-    window.open = vi.fn(() => popup as unknown as Window);
+  it("uses the built-in default video when the resolver fails", async () => {
+    window.open = vi.fn();
     const controller = createBilibiliMusicController({
       resolveFirstVideo: vi.fn().mockRejectedValue(new Error("blocked")),
     });
@@ -69,21 +71,12 @@ describe("bilibili music launcher", () => {
     const result = await controller.playScene(BILIBILI_MUSIC_SCENES[2]);
 
     expect(result.fallback).toBe(true);
-    expect(popup.location.href).toBe(
-      buildBilibiliSearchUrl(BILIBILI_MUSIC_SCENES[2].keyword),
-    );
+    expect(window.open).not.toHaveBeenCalled();
+    expect(result.embedUrl).toContain("player.bilibili.com/player.html");
   });
 
-  it("closes the owned Bilibili window on stop", async () => {
-    const popup = {
-      closed: false,
-      location: { href: "about:blank" },
-      close: vi.fn(() => {
-        popup.closed = true;
-      }),
-      focus: vi.fn(),
-    };
-    window.open = vi.fn(() => popup as unknown as Window);
+  it("removes the hidden Bilibili iframe on stop", async () => {
+    window.open = vi.fn();
     const controller = createBilibiliMusicController({
       resolveFirstVideo: vi.fn().mockResolvedValue(null),
     });
@@ -91,7 +84,7 @@ describe("bilibili music launcher", () => {
     await controller.playScene(BILIBILI_MUSIC_SCENES[0]);
     controller.stop();
 
-    expect(popup.close).toHaveBeenCalled();
+    expect(document.querySelector("iframe[data-octos-bilibili-audio]")).toBeNull();
     expect(controller.getSnapshot().playing).toBe(false);
   });
 });

--- a/src/home/bilibili-music.ts
+++ b/src/home/bilibili-music.ts
@@ -12,10 +12,11 @@ export interface BilibiliVideoResult {
 }
 
 export interface BilibiliMusicPlayResult {
-  opened: boolean;
+  playing: boolean;
   fallback: boolean;
   title?: string;
   url: string;
+  embedUrl: string;
 }
 
 export interface BilibiliMusicSnapshot {
@@ -23,6 +24,7 @@ export interface BilibiliMusicSnapshot {
   scene?: BilibiliMusicScene;
   title?: string;
   url?: string;
+  embedUrl?: string;
   fallback: boolean;
 }
 
@@ -39,11 +41,33 @@ export const BILIBILI_MUSIC_SCENES: readonly BilibiliMusicScene[] = [
   { id: "party", label: "Party", keyword: "Party" },
 ];
 
-const BILIBILI_WINDOW_NAME = "octos-bilibili-music";
+const BILIBILI_AUDIO_SELECTOR = "iframe[data-octos-bilibili-audio]";
+const DEFAULT_BILIBILI_MUSIC_VIDEO: BilibiliVideoResult = {
+  title: "Bilibili music",
+  url: "https://www.bilibili.com/video/BV1cTcbzNE9p/",
+};
 
 export function buildBilibiliSearchUrl(keyword: string): string {
   const query = `${keyword.trim()} \u97F3\u4E50`.trim();
   return `https://search.bilibili.com/all?keyword=${encodeURIComponent(query)}`;
+}
+
+function extractBilibiliBvid(url: string): string | null {
+  const direct = url.match(/\/video\/(BV[0-9A-Za-z]+)/);
+  if (direct?.[1]) return direct[1];
+  try {
+    const parsed = new URL(url);
+    return parsed.searchParams.get("bvid");
+  } catch {
+    return null;
+  }
+}
+
+export function buildBilibiliPlayerUrl(url: string): string {
+  const bvid = extractBilibiliBvid(url) ?? extractBilibiliBvid(DEFAULT_BILIBILI_MUSIC_VIDEO.url);
+  return `https://player.bilibili.com/player.html?bvid=${encodeURIComponent(
+    bvid ?? "BV1cTcbzNE9p",
+  )}&autoplay=1&danmaku=0&high_quality=1`;
 }
 
 async function defaultResolveFirstVideo(
@@ -61,38 +85,61 @@ export function createBilibiliMusicController(options?: {
   resolveFirstVideo?: ResolveFirstBilibiliVideo;
 }) {
   const resolveFirstVideo = options?.resolveFirstVideo ?? defaultResolveFirstVideo;
-  let musicWindow: Window | null = null;
   let snapshot: BilibiliMusicSnapshot = { playing: false, fallback: false };
 
-  const navigateOwnedWindow = (url: string) => {
-    if (!musicWindow || musicWindow.closed) {
-      musicWindow = window.open(
-        "about:blank",
-        BILIBILI_WINDOW_NAME,
-        "noopener=false,noreferrer=false",
-      );
-    }
-    if (!musicWindow) return false;
-    musicWindow.location.href = url;
-    musicWindow.focus?.();
-    return true;
+  const ensureAudioFrame = (embedUrl: string) => {
+    const existing = document.querySelector<HTMLIFrameElement>(BILIBILI_AUDIO_SELECTOR);
+    const frame = existing ?? document.createElement("iframe");
+    frame.title = "Bilibili music audio";
+    frame.setAttribute("data-octos-bilibili-audio", "true");
+    frame.allow = "autoplay; encrypted-media; picture-in-picture; fullscreen";
+    frame.referrerPolicy = "no-referrer-when-downgrade";
+    frame.src = embedUrl;
+    Object.assign(frame.style, {
+      position: "fixed",
+      width: "1px",
+      height: "1px",
+      right: "0",
+      bottom: "0",
+      opacity: "0.001",
+      pointerEvents: "none",
+      border: "0",
+      zIndex: "-1",
+    });
+    if (!existing) document.body.appendChild(frame);
+  };
+
+  const activateVideo = (
+    scene: BilibiliMusicScene,
+    video: BilibiliVideoResult,
+    fallback: boolean,
+  ): BilibiliMusicPlayResult => {
+    const embedUrl = buildBilibiliPlayerUrl(video.url);
+    ensureAudioFrame(embedUrl);
+    const result: BilibiliMusicPlayResult = {
+      playing: true,
+      fallback,
+      title: video.title,
+      url: video.url,
+      embedUrl,
+    };
+    snapshot = {
+      playing: true,
+      scene,
+      title: video.title,
+      url: video.url,
+      embedUrl,
+      fallback,
+    };
+    return result;
   };
 
   return {
     getSnapshot: () => snapshot,
 
     async playScene(scene: BilibiliMusicScene): Promise<BilibiliMusicPlayResult> {
-      const searchUrl = buildBilibiliSearchUrl(scene.keyword);
       let video: BilibiliVideoResult | null = null;
-
-      // Open synchronously inside the click handler before awaiting the network.
-      if (!musicWindow || musicWindow.closed) {
-        musicWindow = window.open(
-          "about:blank",
-          BILIBILI_WINDOW_NAME,
-          "noopener=false,noreferrer=false",
-        );
-      }
+      let result = activateVideo(scene, DEFAULT_BILIBILI_MUSIC_VIDEO, true);
 
       try {
         video = await resolveFirstVideo(scene.keyword);
@@ -100,29 +147,14 @@ export function createBilibiliMusicController(options?: {
         video = null;
       }
 
-      const targetUrl = video?.url ?? searchUrl;
-      const opened = navigateOwnedWindow(targetUrl);
-      const result: BilibiliMusicPlayResult = {
-        opened,
-        fallback: !video,
-        title: video?.title,
-        url: targetUrl,
-      };
-      snapshot = {
-        playing: opened,
-        scene,
-        title: video?.title,
-        url: targetUrl,
-        fallback: !video,
-      };
+      if (video) result = activateVideo(scene, video, false);
       return result;
     },
 
     stop() {
-      if (musicWindow && !musicWindow.closed) {
-        musicWindow.close();
-      }
-      musicWindow = null;
+      document.querySelectorAll(BILIBILI_AUDIO_SELECTOR).forEach((node) => {
+        node.remove();
+      });
       snapshot = { playing: false, fallback: false };
     },
   };

--- a/src/home/classic-standby-view.tsx
+++ b/src/home/classic-standby-view.tsx
@@ -22,7 +22,8 @@ import type { WidgetConfig, WidgetType } from "./widget-registry";
 
 interface ClassicStandbyViewProps {
   onActivate: (prefill?: string) => void;
-  onMusicOpen: () => void;
+  onMusicToggle: () => void;
+  musicPlaying: boolean;
   nightActive: boolean;
 }
 
@@ -33,7 +34,8 @@ function isWidgetOn(widgets: WidgetConfig[], type: WidgetType): boolean {
 
 export function ClassicStandbyView({
   onActivate,
-  onMusicOpen,
+  onMusicToggle,
+  musicPlaying,
   nightActive,
 }: ClassicStandbyViewProps) {
   const clock = useClock();
@@ -107,9 +109,9 @@ export function ClassicStandbyView({
     {
       id: "music",
       icon: Music,
-      label: strings.cardMusic,
+      label: musicPlaying ? strings.cardMusicOff : strings.cardMusicOn,
       color: "text-emerald-400",
-      prefill: strings.cardMusicPrefill,
+      prefill: "",
     },
     {
       id: "home",
@@ -244,7 +246,7 @@ export function ClassicStandbyView({
                 key={id}
                 onClick={() => {
                   if (id === "music") {
-                    onMusicOpen();
+                    onMusicToggle();
                     return;
                   }
                   onActivate(prefill || undefined);

--- a/src/home/constants.ts
+++ b/src/home/constants.ts
@@ -16,6 +16,8 @@ export interface HomeStrings {
   cardChat: string;
   cardNews: string;
   cardMusic: string;
+  cardMusicOn: string;
+  cardMusicOff: string;
   cardHome: string;
 
   // Quick-action card prefills (empty string = no prefill)
@@ -126,6 +128,8 @@ export const HOME_I18N: Record<string, HomeStrings> = {
     cardChat: "Chat",
     cardNews: "News",
     cardMusic: "Music",
+    cardMusicOn: "Sound on",
+    cardMusicOff: "Sound off",
     cardHome: "Home",
 
     cardChatPrefill: "",
@@ -228,6 +232,8 @@ export const HOME_I18N: Record<string, HomeStrings> = {
     cardChat: "\u804A\u5929",
     cardNews: "\u65B0\u95FB",
     cardMusic: "\u97F3\u4E50",
+    cardMusicOn: "\u58F0\u97F3\u5F00",
+    cardMusicOff: "\u58F0\u97F3\u5173",
     cardHome: "\u9996\u9875",
 
     cardChatPrefill: "",

--- a/src/home/home-assistant-page.tsx
+++ b/src/home/home-assistant-page.tsx
@@ -35,7 +35,10 @@ import * as ThreadStore from "@/store/thread-store";
 import { useWakeLock } from "./use-wake-lock";
 import { StandbyView } from "./standby-view";
 import { ConversationView } from "./conversation-view";
-import { BilibiliMusicPanel } from "./bilibili-music-panel";
+import {
+  BILIBILI_MUSIC_SCENES,
+  createBilibiliMusicController,
+} from "./bilibili-music";
 import {
   HomeSettingsProvider,
   useHomeSettings,
@@ -105,7 +108,10 @@ function useNightMode(): boolean {
 function HomeAssistantShell() {
   const [mode, setMode] = useState<Mode>("standby");
   const [prefill, setPrefill] = useState<string | undefined>(undefined);
-  const [musicOpen, setMusicOpen] = useState(false);
+  const musicController = useMemo(() => createBilibiliMusicController(), []);
+  const [musicSnapshot, setMusicSnapshot] = useState(
+    musicController.getSnapshot(),
+  );
   const nightActive = useNightMode();
 
   const activate = useCallback((cardPrefill?: string) => {
@@ -117,6 +123,28 @@ function HomeAssistantShell() {
     setPrefill(undefined);
     setMode("standby");
   }, []);
+
+  const toggleMusic = useCallback(() => {
+    if (musicController.getSnapshot().playing) {
+      musicController.stop();
+      setMusicSnapshot(musicController.getSnapshot());
+      return;
+    }
+
+    const scene =
+      BILIBILI_MUSIC_SCENES.find((item) => item.id === "cooking-dinner") ??
+      BILIBILI_MUSIC_SCENES[0];
+    void musicController.playScene(scene).finally(() => {
+      setMusicSnapshot(musicController.getSnapshot());
+    });
+    setMusicSnapshot(musicController.getSnapshot());
+  }, [musicController]);
+
+  useEffect(() => {
+    return () => {
+      musicController.stop();
+    };
+  }, [musicController]);
 
   return (
     <div className={`relative h-full w-full ${nightActive ? "home-night-mode" : ""}`}>
@@ -130,7 +158,8 @@ function HomeAssistantShell() {
       >
         <StandbyView
           onActivate={activate}
-          onMusicOpen={() => setMusicOpen(true)}
+          onMusicToggle={toggleMusic}
+          musicPlaying={musicSnapshot.playing}
           nightActive={nightActive}
         />
       </div>
@@ -147,10 +176,6 @@ function HomeAssistantShell() {
       </div>
 
       <UiProtocolApprovalHost />
-      <BilibiliMusicPanel
-        open={musicOpen && mode === "standby"}
-        onClose={() => setMusicOpen(false)}
-      />
     </div>
   );
 }

--- a/src/home/metro-tiles.tsx
+++ b/src/home/metro-tiles.tsx
@@ -29,7 +29,8 @@ import type { WidgetConfig, WidgetType } from "./widget-registry";
 
 interface MetroTileGridProps {
   onActivate: (prefill?: string) => void;
-  onMusicOpen: () => void;
+  onMusicToggle: () => void;
+  musicPlaying: boolean;
   nightActive: boolean;
 }
 
@@ -636,7 +637,8 @@ function useTileResize(
 
 export function MetroTileGrid({
   onActivate,
-  onMusicOpen,
+  onMusicToggle,
+  musicPlaying,
   nightActive,
 }: MetroTileGridProps) {
   const [settingsOpen, setSettingsOpen] = useState(false);
@@ -702,7 +704,7 @@ export function MetroTileGrid({
       case "weather": return <WeatherTile />;
       case "quick-chat": return <QuickActionTile icon={MessageSquare} label={strings.cardChat} color="text-[#E8B87C]" onClick={() => onActivate(strings.cardChatPrefill)} />;
       case "quick-news": return <QuickActionTile icon={Newspaper} label={strings.cardNews} color="text-[#C4A882]" onClick={() => onActivate(strings.cardNewsPrefill)} />;
-      case "quick-music": return <QuickActionTile icon={Music} label={strings.cardMusic} color="text-[#8BAF7B]" onClick={onMusicOpen} />;
+      case "quick-music": return <QuickActionTile icon={Music} label={musicPlaying ? strings.cardMusicOff : strings.cardMusicOn} color="text-[#8BAF7B]" onClick={onMusicToggle} />;
       case "quick-home": return <QuickActionTile icon={Home} label={strings.cardHome} color="text-[#C8A088]" onClick={() => onActivate(strings.cardHomePrefill)} />;
       case "voice": return <VoiceTile onActivate={onActivate} lang={lang} />;
       case "news": return <NewsTile onActivate={onActivate} />;
@@ -711,7 +713,7 @@ export function MetroTileGrid({
       case "photo": return <PhotoFrame />;
       default: return null;
     }
-  }, [nightActive, strings, lang, onActivate, onMusicOpen]);
+  }, [nightActive, strings, lang, onActivate, onMusicToggle, musicPlaying]);
 
   return (
     <div

--- a/src/home/standby-view.tsx
+++ b/src/home/standby-view.tsx
@@ -4,13 +4,15 @@ import { MetroTileGrid } from "./metro-tiles";
 
 interface StandbyViewProps {
   onActivate: (prefill?: string) => void;
-  onMusicOpen: () => void;
+  onMusicToggle: () => void;
+  musicPlaying: boolean;
   nightActive: boolean;
 }
 
 export function StandbyView({
   onActivate,
-  onMusicOpen,
+  onMusicToggle,
+  musicPlaying,
   nightActive,
 }: StandbyViewProps) {
   const { uiStyle } = useHomeSettings();
@@ -18,7 +20,8 @@ export function StandbyView({
     return (
       <ClassicStandbyView
         onActivate={onActivate}
-        onMusicOpen={onMusicOpen}
+        onMusicToggle={onMusicToggle}
+        musicPlaying={musicPlaying}
         nightActive={nightActive}
       />
     );
@@ -26,7 +29,8 @@ export function StandbyView({
   return (
     <MetroTileGrid
       onActivate={onActivate}
-      onMusicOpen={onMusicOpen}
+      onMusicToggle={onMusicToggle}
+      musicPlaying={musicPlaying}
       nightActive={nightActive}
     />
   );

--- a/tests/ui-redesign-smoke.spec.ts
+++ b/tests/ui-redesign-smoke.spec.ts
@@ -523,107 +523,48 @@ test.describe("UI redesign shell smoke", () => {
     expect(overflow.scrollOverflow).toBeLessThanOrEqual(1);
   });
 
-  test("home music tile opens and stops the Bilibili music window", async ({
+  test("home music tile toggles hidden Bilibili sound without leaving home", async ({
     page,
   }) => {
     await page.setViewportSize({ width: 859, height: 819 });
     await page.addInitScript(() => {
-      const state = {
-        calls: [] as Array<{ type: string; url?: string; name?: string; features?: string }>,
-        href: "",
-        closed: false,
-      };
-      Object.defineProperty(window, "__octosBilibiliMusicWindow", {
-        value: state,
+      const calls: string[] = [];
+      Object.defineProperty(window, "__octosWindowOpenCalls", {
+        value: calls,
         configurable: true,
       });
       window.open = ((url?: string | URL, name?: string, features?: string) => {
-        state.closed = false;
-        state.href = String(url ?? "");
-        state.calls.push({
-          type: "open",
-          url: state.href,
-          name,
-          features,
-        });
-        const location = {};
-        Object.defineProperty(location, "href", {
-          get: () => state.href,
-          set: (next: string) => {
-            state.href = next;
-            state.calls.push({ type: "navigate", url: next });
-          },
-        });
-        return {
-          get closed() {
-            return state.closed;
-          },
-          location,
-          focus: () => state.calls.push({ type: "focus" }),
-          close: () => {
-            state.closed = true;
-            state.calls.push({ type: "close" });
-          },
-        } as Window;
+        calls.push(`${String(url ?? "")}|${name ?? ""}|${features ?? ""}`);
+        return null;
       }) as typeof window.open;
     });
 
     await page.goto("/home", { waitUntil: "networkidle" });
-    await page.getByRole("button", { name: "Music", exact: true }).click();
-    await expect(
-      page.getByRole("dialog", { name: "Bilibili music" }),
-    ).toBeVisible();
-    await expect(page.getByRole("button", { name: "Cooking / Dinner" })).toBeVisible();
-    await expect(page.getByRole("button", { name: "Focus" })).toBeVisible();
-
-    await page.getByRole("button", { name: "Cooking / Dinner" }).click();
-    await expect(page.getByText("Video opened")).toBeVisible();
-    await expect(page.getByText("40分钟做饭神曲合集")).toBeVisible();
+    await page.getByRole("button", { name: "Sound on", exact: true }).click();
+    await expect(page.getByRole("dialog", { name: "Bilibili music" })).toHaveCount(0);
+    await expect(page.getByRole("button", { name: "Sound off", exact: true })).toBeVisible();
+    const audioFrame = page.locator("iframe[data-octos-bilibili-audio]");
+    await expect(audioFrame).toHaveCount(1);
+    await expect(audioFrame).toHaveAttribute(
+      "src",
+      /https:\/\/player\.bilibili\.com\/player\.html\?bvid=BV1cTcbzNE9p&autoplay=1&danmaku=0&high_quality=1/,
+    );
+    await expect(audioFrame).toHaveAttribute("allow", /autoplay/);
     await expect
       .poll(() =>
         page.evaluate(() => {
-          const state = (
+          return (
             window as typeof window & {
-              __octosBilibiliMusicWindow?: {
-                href: string;
-                closed: boolean;
-                calls: Array<{ type: string; url?: string; name?: string; features?: string }>;
-              };
+              __octosWindowOpenCalls?: string[];
             }
-          ).__octosBilibiliMusicWindow;
-          return {
-            href: state?.href,
-            closed: state?.closed,
-            openName: state?.calls.find((call) => call.type === "open")?.name,
-            navigated: state?.calls.some(
-              (call) =>
-                call.type === "navigate" &&
-                call.url === "https://www.bilibili.com/video/BV1cTcbzNE9p/",
-            ),
-          };
+          ).__octosWindowOpenCalls?.length;
         }),
       )
-      .toEqual({
-        href: "https://www.bilibili.com/video/BV1cTcbzNE9p/",
-        closed: false,
-        openName: "octos-bilibili-music",
-        navigated: true,
-      });
+      .toBe(0);
 
-    await page.getByRole("button", { name: "Stop" }).click();
-    await expect(page.getByText("No Bilibili window")).toBeVisible();
-    await expect
-      .poll(() =>
-        page.evaluate(
-          () =>
-            (
-              window as typeof window & {
-                __octosBilibiliMusicWindow?: { closed: boolean };
-              }
-            ).__octosBilibiliMusicWindow?.closed,
-        ),
-      )
-      .toBe(true);
+    await page.getByRole("button", { name: "Sound off", exact: true }).click();
+    await expect(page.locator("iframe[data-octos-bilibili-audio]")).toHaveCount(0);
+    await expect(page.getByRole("button", { name: "Sound on", exact: true })).toBeVisible();
   });
 
   test("workspace surfaces use the shared topbar titles", async ({ page }) => {


### PR DESCRIPTION
## Summary
- Replace the Home Music popup flow with a direct Sound on / Sound off toggle.
- Play Bilibili through a hidden in-page player iframe instead of opening or navigating to Bilibili.
- Cover the new behavior in unit and Playwright smoke tests.

## Validation
- npm run test:unit -- src/home/bilibili-music.test.ts
- BASE_URL=http://127.0.0.1:5174 npx playwright test tests/ui-redesign-smoke.spec.ts -g "home music tile toggles"
- BASE_URL=http://127.0.0.1:5174 npx playwright test tests/ui-redesign-smoke.spec.ts
- npx eslint src/home/bilibili-music.ts src/home/home-assistant-page.tsx src/home/standby-view.tsx src/home/classic-standby-view.tsx src/home/metro-tiles.tsx src/home/constants.ts src/home/bilibili-music.test.ts tests/ui-redesign-smoke.spec.ts
- npm run build
- BASE_URL=http://127.0.0.1:5174 npm run test: 109 passed, 35 skipped
