### PR TITLE
feat(settings): configure Vertex AI service-account JSON in the LLM tab

### DIFF
--- a/src/settings/llm-providers.test.ts
+++ b/src/settings/llm-providers.test.ts
@@ -1,0 +1,45 @@
+import { describe, it, expect } from "vitest";
+import {
+  buildCredentialEnvPatch,
+  findProvider,
+  usesJsonCredential,
+} from "./llm-providers";
+
+describe("vertex provider entry", () => {
+  it("is registered and uses a JSON credential", () => {
+    const vertex = findProvider("vertex");
+    expect(vertex).toBeDefined();
+    expect(vertex?.envKey).toBe("VERTEX_SA_JSON");
+    expect(usesJsonCredential(vertex)).toBe(true);
+  });
+
+  it("treats normal providers as single-line API keys", () => {
+    expect(usesJsonCredential(findProvider("openai"))).toBe(false);
+    expect(usesJsonCredential(findProvider("google"))).toBe(false);
+  });
+});
+
+describe("buildCredentialEnvPatch", () => {
+  const vertex = findProvider("vertex");
+  const openai = findProvider("openai");
+
+  it("overlays the JSON onto existing env vars", () => {
+    const patch = buildCredentialEnvPatch(
+      vertex,
+      { OPENAI_API_KEY: "abcd***xyz" },
+      '{"project_id":"p"}',
+    );
+    expect(patch).toEqual({
+      OPENAI_API_KEY: "abcd***xyz",
+      VERTEX_SA_JSON: '{"project_id":"p"}',
+    });
+  });
+
+  it("returns undefined for a blank input (keep what's stored)", () => {
+    expect(buildCredentialEnvPatch(vertex, {}, "   ")).toBeUndefined();
+  });
+
+  it("returns undefined for non-JSON providers", () => {
+    expect(buildCredentialEnvPatch(openai, {}, '{"x":1}')).toBeUndefined();
+  });
+});

--- a/src/settings/llm-providers.ts
+++ b/src/settings/llm-providers.ts
@@ -4,6 +4,13 @@ export interface LlmProvider {
   envKey: string;
   defaultBaseUrl?: string;
   models: { id: string; name: string }[];
+  /**
+   * How the credential is entered. `"apiKey"` (default) is a single-line key
+   * set in the Environment Variables editor. `"json"` is a multi-line blob
+   * (e.g. a Vertex service-account JSON) entered inline and stored in the OS
+   * keychain by the backend.
+   */
+  credentialKind?: "apiKey" | "json";
 }
 
 export const LLM_PROVIDERS: LlmProvider[] = [
@@ -45,6 +52,16 @@ export const LLM_PROVIDERS: LlmProvider[] = [
     models: [
       { id: "gemini-3.1-pro-preview", name: "Gemini 3.1 Pro" },
       { id: "gemini-3-flash-preview", name: "Gemini 3 Flash" },
+    ],
+  },
+  {
+    id: "vertex",
+    name: "Google Vertex AI",
+    envKey: "VERTEX_SA_JSON",
+    credentialKind: "json",
+    models: [
+      { id: "gemini-2.5-flash", name: "Gemini 2.5 Flash" },
+      { id: "gemini-2.5-pro", name: "Gemini 2.5 Pro" },
     ],
   },
   {
@@ -103,4 +120,26 @@ export function showsBaseUrl(provider: LlmProvider): boolean {
     provider.id === "vllm" ||
     provider.id === "__custom_family__"
   );
+}
+
+/** Whether this provider's credential is a multi-line JSON blob (entered inline). */
+export function usesJsonCredential(provider: LlmProvider | undefined): boolean {
+  return provider?.credentialKind === "json";
+}
+
+/**
+ * Build the env_vars patch for a JSON-credential provider. Returns the full
+ * existing map with the credential overlaid (so the backend's masked-value
+ * merge preserves other keys), or `undefined` when nothing should change
+ * (non-JSON provider, or a blank input meaning "keep what's stored").
+ */
+export function buildCredentialEnvPatch(
+  provider: LlmProvider | undefined,
+  existing: Record<string, string>,
+  credentialInput: string,
+): Record<string, string> | undefined {
+  if (!usesJsonCredential(provider)) return undefined;
+  const value = credentialInput.trim();
+  if (!value) return undefined;
+  return { ...existing, [provider!.envKey]: value };
 }

--- a/src/settings/llm-tab.tsx
+++ b/src/settings/llm-tab.tsx
@@ -301,13 +301,18 @@ export function LlmTab({ profile, onProfileUpdated }: LlmTabProps) {
       const baseUrl = needsBaseUrl
         ? form.base_url.trim()
         : selectedProvider?.defaultBaseUrl;
+      // For a JSON-credential provider, test the freshly-pasted JSON directly
+      // (it isn't saved yet). Blank → omit so the backend resolves the saved
+      // keychain value. Non-JSON providers test the saved api_key_env.
+      const jsonCred = isJsonCredential ? form.sa_json.trim() : "";
+      const apiKey = jsonCred || (envKey ? undefined : "not-required");
       const resp = await request<{ ok: boolean; message?: string; error?: string }>("/api/my/test-provider", {
         method: "POST",
         body: JSON.stringify({
           provider: effectiveFamilyId,
           model: effectiveModelId,
           api_key_env: envKey || undefined,
-          api_key: envKey ? undefined : "not-required",
+          api_key: apiKey,
           base_url: baseUrl || undefined,
           profile_id: profile.id,
         }),

--- a/src/settings/llm-tab.tsx
+++ b/src/settings/llm-tab.tsx
@@ -27,8 +27,10 @@ import {
 } from "./settings-api";
 import {
   LLM_PROVIDERS,
+  buildCredentialEnvPatch,
   findProvider,
   showsBaseUrl,
+  usesJsonCredential,
   type LlmProvider,
 } from "./llm-providers";
 
@@ -57,6 +59,8 @@ interface LlmFormState {
   custom_family_id: string;
   custom_model_id: string;
   base_url: string;
+  /** Inline JSON credential (Vertex SA JSON). Blank = keep what's stored. */
+  sa_json: string;
   system_prompt: string;
   max_output_tokens: string;
   max_history: string;
@@ -92,6 +96,8 @@ function profileToForm(profile: Profile): LlmFormState {
     custom_family_id: knownProvider ? "" : familyId,
     custom_model_id: knownProvider ? "" : (profile.config.llm.primary.model_id ?? ""),
     base_url: primaryRoute?.base_url ?? knownProvider?.defaultBaseUrl ?? "",
+    // Never prefill the secret; blank means "keep what's stored".
+    sa_json: "",
     system_prompt: profile.config.gateway.system_prompt ?? "",
     max_output_tokens:
       profile.config.gateway.max_output_tokens != null
@@ -193,6 +199,12 @@ export function LlmTab({ profile, onProfileUpdated }: LlmTabProps) {
   const needsBaseUrl = selectedProvider
     ? showsBaseUrl(selectedProvider)
     : isCustom;
+  const isJsonCredential = usesJsonCredential(selectedProvider);
+  // env_vars values come back masked; a non-empty entry means it's already set.
+  const saAlreadyConfigured = Boolean(
+    selectedProvider?.envKey &&
+      profile.config.env_vars?.[selectedProvider.envKey],
+  );
   const providerModels = useMemo(
     () =>
       mergeModelOptions(
@@ -330,8 +342,17 @@ export function LlmTab({ profile, onProfileUpdated }: LlmTabProps) {
       base_url: needsBaseUrl ? form.base_url.trim() || null : null,
     };
 
+    // For JSON-credential providers (Vertex), overlay the pasted SA JSON onto
+    // env_vars; the backend relocates it into the keychain. Blank = no change.
+    const envPatch = buildCredentialEnvPatch(
+      selectedProvider,
+      profile.config.env_vars ?? {},
+      form.sa_json,
+    );
+
     try {
       const result = await updateMyProfileConfig(profile, {
+        ...(envPatch ? { env_vars: envPatch } : {}),
         llm: {
           primary: {
             family_id: effectiveFamilyId,
@@ -469,8 +490,43 @@ export function LlmTab({ profile, onProfileUpdated }: LlmTabProps) {
             </div>
           )}
 
-          {/* Env key hint */}
-          {selectedProvider?.envKey && (
+          {/* Inline JSON credential (e.g. Vertex service-account JSON) */}
+          {isJsonCredential && (
+            <div>
+              <label className={labelClass}>Service Account JSON</label>
+              <textarea
+                value={form.sa_json}
+                onChange={(e) =>
+                  setForm((f) => ({ ...f, sa_json: e.target.value }))
+                }
+                placeholder={
+                  saAlreadyConfigured
+                    ? "Stored in keychain — paste new JSON to replace"
+                    : "Paste the full service-account JSON…"
+                }
+                rows={6}
+                spellCheck={false}
+                className="w-full resize-y rounded-xl bg-surface-container px-4 py-3 font-mono text-xs text-text placeholder-muted/50 outline-none border border-transparent focus:border-accent/30 transition"
+              />
+              <p className="mt-2 flex items-center gap-1.5 text-xs text-muted">
+                {saAlreadyConfigured ? (
+                  <>
+                    <CheckCircle2 size={13} className="text-green-400" />
+                    Configured (stored in macOS Keychain). Leave blank to keep.
+                  </>
+                ) : (
+                  <>
+                    <AlertCircle size={13} className="text-amber-400" />
+                    The private key is stored in the macOS Keychain, never in
+                    plaintext config. macOS only.
+                  </>
+                )}
+              </p>
+            </div>
+          )}
+
+          {/* Env key hint (single-line API-key providers) */}
+          {!isJsonCredential && selectedProvider?.envKey && (
             <div className="flex items-start gap-2 rounded-xl bg-surface-dark/50 px-4 py-3">
               <AlertCircle
                 size={14}


### PR DESCRIPTION
## Summary
Adds **Google Vertex AI** to the provider list and an inline **Service Account JSON** field in the LLM settings tab, so the Vertex credential can be configured from the dashboard. The backend stores the private key in the macOS Keychain.

## What's included
- **`llm-providers.ts`** — `credentialKind` on the provider type; `vertex` entry (`VERTEX_SA_JSON`, gemini-2.5 models); pure helpers `usesJsonCredential` + `buildCredentialEnvPatch` (overlay the pasted JSON onto existing env vars; blank = no change), unit-tested.
- **`llm-tab.tsx`** — render a JSON textarea for Vertex instead of the single-line key hint; show a "configured (stored in macOS Keychain)" state when already set and never prefill the secret; on save, send the `env_vars` patch so the backend relocates the key into the keychain.
- **Test Connection** — sends the freshly-pasted JSON as `api_key` so it can be verified before saving (blank falls back to the saved keychain value).

## Depends on
octos backend PR **octos-org/octos#1468** (`feat/vertex-gemini-auth`) — the `vertex` provider, keychain relocation, and keychain hex-decode all live there. Without it the saved JSON won't be picked up at runtime.

## Test plan
- `pnpm test` (helper unit tests), `pnpm build`, `tsc --noEmit`.
- End-to-end (with the backend PR): Settings → LLM → Google Vertex AI → paste SA JSON → Test Connection returns OK → chat replies via Gemini/Vertex.

🤖 Generated with [Claude Code](https://claude.com/claude-code)