### PR TITLE
Fix Octos smart home controls

### DIFF
--- a/src/home/classic-standby-view.tsx
+++ b/src/home/classic-standby-view.tsx
@@ -14,6 +14,7 @@ import { useEvents } from "./use-events";
 import { useHomeSettings } from "./home-settings-context";
 import { useNews, timeAgo } from "./use-news";
 import { PhotoFrame } from "./photo-frame";
+import { SmartHomePanel } from "./smart-home";
 import { TimerWidget } from "./timer-widget";
 import { useVoiceInput } from "./use-voice-input";
 import { useWeather } from "./use-weather";
@@ -266,6 +267,12 @@ export function ClassicStandbyView({
               </button>
             ))}
           </div>
+        )}
+
+        {isWidgetOn(widgets, "smart-home") && (
+          <section className="classic-home-smart-panel">
+            <SmartHomePanel variant="classic" />
+          </section>
         )}
 
         {isWidgetOn(widgets, "news") && (

--- a/src/home/constants.ts
+++ b/src/home/constants.ts
@@ -75,6 +75,7 @@ export interface HomeStrings {
   widgetCalendar: string;
   widgetTimer: string;
   widgetPhotoFrame: string;
+  widgetSmartHome: string;
   settingsWidgets: string;
 
   // Photo frame
@@ -180,6 +181,7 @@ export const HOME_I18N: Record<string, HomeStrings> = {
     widgetCalendar: "Calendar",
     widgetTimer: "Timer",
     widgetPhotoFrame: "Photos",
+    widgetSmartHome: "Smart Home",
     settingsWidgets: "Widgets",
 
     settingsPhotos: "Photo Frame",
@@ -284,6 +286,7 @@ export const HOME_I18N: Record<string, HomeStrings> = {
     widgetCalendar: "\u65E5\u5386",
     widgetTimer: "\u8BA1\u65F6\u5668",
     widgetPhotoFrame: "\u76F8\u518C",
+    widgetSmartHome: "\u667A\u80FD\u5BB6\u5C45",
     settingsWidgets: "\u7EC4\u4EF6",
 
     settingsPhotos: "\u7167\u7247\u76F8\u6846",

--- a/src/home/home-settings.tsx
+++ b/src/home/home-settings.tsx
@@ -7,7 +7,7 @@
  */
 
 import { useCallback, useEffect, useRef, useState } from "react";
-import { Settings, X, ChevronUp, ChevronDown, Clock, CloudSun, Zap, Mic, MessageCircle, Newspaper, CalendarDays, Timer, ImageIcon, Trash2, Plus } from "lucide-react";
+import { Settings, X, ChevronUp, ChevronDown, Clock, CloudSun, Zap, Mic, MessageCircle, Newspaper, CalendarDays, Timer, ImageIcon, Trash2, Plus, Home } from "lucide-react";
 import {
   useHomeSettings,
   DEFAULT_FEED_URL,
@@ -490,6 +490,7 @@ const WIDGET_ICONS: Record<WidgetType, typeof Clock> = {
   calendar: CalendarDays,
   timer: Timer,
   "photo-frame": ImageIcon,
+  "smart-home": Home,
 };
 
 function widgetLabel(type: WidgetType, t: ReturnType<typeof useHomeSettings>["strings"]): string {
@@ -503,6 +504,7 @@ function widgetLabel(type: WidgetType, t: ReturnType<typeof useHomeSettings>["st
     calendar: t.widgetCalendar,
     timer: t.widgetTimer,
     "photo-frame": t.widgetPhotoFrame,
+    "smart-home": t.widgetSmartHome,
   };
   return map[type];
 }

--- a/src/home/metro-tiles.tsx
+++ b/src/home/metro-tiles.tsx
@@ -25,6 +25,7 @@ import { VoiceOrb } from "./voice-orb";
 import { TimerWidget } from "./timer-widget";
 import { PhotoFrame } from "./photo-frame";
 import { SettingsGearButton, HomeSettingsPanel } from "./home-settings";
+import { SmartHomePanel } from "./smart-home";
 import type { WidgetConfig, WidgetType } from "./widget-registry";
 
 interface MetroTileGridProps {
@@ -51,25 +52,27 @@ interface TileDef {
 
 const COLS = 6;
 const MOBILE_COLS = 4;
-const MAX_ROWS = 12;
+const MAX_ROWS = 20;
 const MOBILE_QUERY = "(max-width: 600px)";
 
 const TILE_DEFS: TileDef[] = [
   { id: "clock", widgetType: "clock", label: "Clock", accent: "#1c1712", defaultLayout: { col: 1, row: 1, w: 4, h: 2 } },
   { id: "weather", widgetType: "weather", label: "Weather", accent: "#405646", defaultLayout: { col: 5, row: 1, w: 2, h: 2 } },
-  { id: "quick-chat", widgetType: "quick-chat", label: "Chat", accent: "#b86f44", defaultLayout: { col: 1, row: 3, w: 1, h: 1 } },
-  { id: "quick-news", widgetType: "quick-news", label: "News", accent: "#8a704f", defaultLayout: { col: 2, row: 3, w: 1, h: 1 } },
-  { id: "quick-music", widgetType: "quick-music", label: "Music", accent: "#647a57", defaultLayout: { col: 3, row: 3, w: 1, h: 1 } },
-  { id: "quick-home", widgetType: "quick-home", label: "Home", accent: "#766250", defaultLayout: { col: 4, row: 3, w: 1, h: 1 } },
+  { id: "quick-chat", widgetType: "quick-chat", label: "Chat", accent: "#b86f44", defaultLayout: { col: 5, row: 5, w: 1, h: 1 } },
+  { id: "quick-news", widgetType: "quick-news", label: "News", accent: "#8a704f", defaultLayout: { col: 6, row: 5, w: 1, h: 1 } },
+  { id: "quick-music", widgetType: "quick-music", label: "Music", accent: "#647a57", defaultLayout: { col: 5, row: 6, w: 1, h: 1 } },
+  { id: "quick-home", widgetType: "quick-home", label: "Home", accent: "#766250", defaultLayout: { col: 6, row: 6, w: 1, h: 1 } },
   { id: "voice", widgetType: "voice-orb", label: "Voice", accent: "#30251d", defaultLayout: { col: 5, row: 3, w: 2, h: 2 } },
-  { id: "news", widgetType: "news", label: "Headlines", accent: "#2a211a", defaultLayout: { col: 1, row: 4, w: 4, h: 2 } },
-  { id: "calendar", widgetType: "calendar", label: "Calendar", accent: "#32483c", defaultLayout: { col: 1, row: 6, w: 2, h: 2 } },
-  { id: "timer", widgetType: "timer", label: "Timer", accent: "#5a4227", defaultLayout: { col: 3, row: 6, w: 2, h: 2 } },
-  { id: "photo", widgetType: "photo-frame", label: "Photos", accent: "#241f1a", defaultLayout: { col: 5, row: 5, w: 2, h: 2 } },
+  { id: "smart-home", widgetType: "smart-home", label: "Smart Home", accent: "#203c35", defaultLayout: { col: 1, row: 3, w: 4, h: 4 } },
+  { id: "news", widgetType: "news", label: "Headlines", accent: "#2a211a", defaultLayout: { col: 1, row: 7, w: 4, h: 2 } },
+  { id: "calendar", widgetType: "calendar", label: "Calendar", accent: "#32483c", defaultLayout: { col: 5, row: 7, w: 2, h: 2 } },
+  { id: "timer", widgetType: "timer", label: "Timer", accent: "#5a4227", defaultLayout: { col: 1, row: 9, w: 2, h: 2 } },
+  { id: "photo", widgetType: "photo-frame", label: "Photos", accent: "#241f1a", defaultLayout: { col: 3, row: 9, w: 2, h: 2 } },
 ];
 
 const TILE_INDEX = new Map(TILE_DEFS.map((tile, index) => [tile.id, index]));
 const TILE_MIN_HEIGHTS: Record<string, { desktop: number; mobile?: number }> = {
+  "smart-home": { desktop: 4, mobile: 5 },
   timer: { desktop: 2, mobile: 3 },
 };
 
@@ -102,15 +105,27 @@ function normalizeLayouts(
   const out: Record<string, TileLayout> = {};
   for (const tile of TILE_DEFS) {
     const saved = record[tile.id] ?? {};
+    const defaultLayout = defaults[tile.id];
     out[tile.id] = {
-      col: numberOr(saved.col, defaults[tile.id].col),
-      row: numberOr(saved.row, defaults[tile.id].row),
-      w: numberOr(saved.w, defaults[tile.id].w),
+      col: numberOr(saved.col, defaultLayout.col),
+      row: numberOr(saved.row, defaultLayout.row),
+      w: numberOr(saved.w, defaultLayout.w),
       h: Math.max(
         minHeightForTile(tile.id),
-        numberOr(saved.h, defaults[tile.id].h),
+        numberOr(saved.h, defaultLayout.h),
       ),
     };
+  }
+  const savedSmartHome = record["smart-home"];
+  if (
+    !savedSmartHome ||
+    (
+      numberOr(savedSmartHome.w, 0) === 4 &&
+      numberOr(savedSmartHome.h, 0) >= 5 &&
+      numberOr(savedSmartHome.row, 0) > 4
+    )
+  ) {
+    out["smart-home"] = { ...defaults["smart-home"] };
   }
   return out;
 }
@@ -155,9 +170,17 @@ function widgetTypeForOrder(tile: TileDef): WidgetType {
 
 function orderedTiles(tiles: TileDef[], widgets: WidgetConfig[]): TileDef[] {
   const order = new Map(widgets.map((widget) => [widget.type, widget.order]));
+  const sortOrder = (tile: TileDef) => {
+    const type = widgetTypeForOrder(tile);
+    const configured = order.get(type);
+    if (type === "smart-home" && (configured === undefined || configured > 5)) {
+      return 1.5;
+    }
+    return configured ?? Number.MAX_SAFE_INTEGER;
+  };
   return [...tiles].sort((a, b) => {
-    const aOrder = order.get(widgetTypeForOrder(a)) ?? Number.MAX_SAFE_INTEGER;
-    const bOrder = order.get(widgetTypeForOrder(b)) ?? Number.MAX_SAFE_INTEGER;
+    const aOrder = sortOrder(a);
+    const bOrder = sortOrder(b);
     return aOrder - bOrder || (TILE_INDEX.get(a.id) ?? 0) - (TILE_INDEX.get(b.id) ?? 0);
   });
 }
@@ -195,27 +218,29 @@ function compactLayouts(
 ): Record<string, TileLayout> {
   const sorted = [...visibleIds]
     .map(id => ({ id, layout: clampLayoutForTile(id, layouts[id] ?? { col: 1, row: 1, w: 1, h: 1 }, cols) }))
-    .sort((a, b) => a.layout.row - b.layout.row || a.layout.col - b.layout.col);
+    .sort((a, b) =>
+      a.layout.row - b.layout.row ||
+      a.layout.col - b.layout.col ||
+      (TILE_INDEX.get(a.id) ?? 0) - (TILE_INDEX.get(b.id) ?? 0)
+    );
 
   const result = { ...layouts };
+  const placed: Record<string, TileLayout> = {};
   for (const { id, layout } of sorted) {
-    let bestRow = 1;
-    for (let tryRow = 1; tryRow <= layout.row; tryRow++) {
-      const candidate = { ...layout, row: tryRow };
-      const occupied = new Set(visibleIds);
-      let fits = true;
-      for (const otherId of occupied) {
-        if (otherId === id) continue;
-        const other = result[otherId];
-        if (!other) continue;
-        if (tilesOverlap(candidate, clampLayoutForTile(otherId, other, cols))) {
-          fits = false;
+    let best = layout;
+    let found = false;
+    for (let row = 1; row <= MAX_ROWS - layout.h + 1 && !found; row++) {
+      for (let col = 1; col <= cols - layout.w + 1; col++) {
+        const candidate = { ...layout, row, col };
+        if (!Object.values(placed).some((other) => tilesOverlap(candidate, other))) {
+          best = candidate;
+          found = true;
           break;
         }
       }
-      if (fits) { bestRow = tryRow; break; }
     }
-    result[id] = { ...layout, row: bestRow };
+    result[id] = best;
+    placed[id] = best;
   }
   return result;
 }
@@ -308,7 +333,7 @@ function shouldShowTile(tile: TileDef, widgets: WidgetConfig[], nightActive: boo
   if (wt === "quick-chat" || wt === "quick-news" || wt === "quick-music" || wt === "quick-home") {
     return isWidgetOn(widgets, "quick-actions");
   }
-  if (wt === "voice-orb" || wt === "weather" || wt === "news" || wt === "calendar" || wt === "timer" || wt === "photo-frame" || wt === "clock") {
+  if (wt === "voice-orb" || wt === "weather" || wt === "news" || wt === "calendar" || wt === "timer" || wt === "photo-frame" || wt === "clock" || wt === "smart-home") {
     return isWidgetOn(widgets, wt);
   }
   return true;
@@ -707,6 +732,7 @@ export function MetroTileGrid({
       case "quick-music": return <QuickActionTile icon={Music} label={musicPlaying ? strings.cardMusicOff : strings.cardMusicOn} color="text-[#8BAF7B]" onClick={onMusicToggle} />;
       case "quick-home": return <QuickActionTile icon={Home} label={strings.cardHome} color="text-[#C8A088]" onClick={() => onActivate(strings.cardHomePrefill)} />;
       case "voice": return <VoiceTile onActivate={onActivate} lang={lang} />;
+      case "smart-home": return <SmartHomePanel variant="metro" />;
       case "news": return <NewsTile onActivate={onActivate} />;
       case "calendar": return <CalendarTile />;
       case "timer": return <TimerWidget />;

--- a/src/home/smart-home.tsx
+++ b/src/home/smart-home.tsx
@@ -1,0 +1,1063 @@
+import {
+  AirVent,
+  Camera,
+  CirclePower,
+  Home,
+  Minus,
+  Monitor,
+  Plus,
+  Radio,
+  RefreshCw,
+  Square,
+  Thermometer,
+  Volume2,
+  Wifi,
+  X,
+  type LucideIcon,
+} from "lucide-react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { createPortal } from "react-dom";
+import type { CSSProperties, ReactNode } from "react";
+
+import { useHomeSettings } from "./home-settings-context";
+
+type DeviceKind =
+  | "camera"
+  | "climate"
+  | "cover"
+  | "network"
+  | "sensor"
+  | "speaker"
+  | "tv";
+
+interface SmartHomeDevice {
+  id: string;
+  name: string;
+  home?: string;
+  room?: string;
+  kind: DeviceKind | string;
+  on: boolean;
+  online?: boolean;
+  readonly?: boolean;
+  brightness?: number;
+  volume?: number;
+  temperature?: number;
+  humidity?: number;
+  position?: number;
+  color?: string;
+  speed?: number;
+  mode?: string;
+  note?: string;
+  muted?: boolean;
+  stream?: string;
+  stream_capable?: boolean;
+  stream_protocol?: string;
+}
+
+interface SmartHomeResponse {
+  source?: string;
+  devices?: SmartHomeDevice[];
+  ok?: boolean;
+  error?: string;
+}
+
+interface CameraStreamInfo {
+  ok?: boolean;
+  protocol?: string;
+  playback_url?: string;
+  stream_url?: string;
+  error?: string;
+}
+
+interface SmartHomeLabels {
+  title: string;
+  subtitle: string;
+  refresh: string;
+  loading: string;
+  offline: string;
+  online: string;
+  unavailable: string;
+  devices: string;
+  controllable: string;
+  cameras: string;
+  fanSpeed: string;
+  modeAuto: string;
+  modeCool: string;
+  modeDry: string;
+  modeFan: string;
+  modeHeat: string;
+  playPause: string;
+  power: string;
+  open: string;
+  close: string;
+  stop: string;
+  tempDown: string;
+  tempUp: string;
+  volumeDown: string;
+  volumeUp: string;
+  home: string;
+  back: string;
+  ok: string;
+  wake: string;
+  music: string;
+  radio: string;
+  say: string;
+  startCamera: string;
+  stopCamera: string;
+  readOnly: string;
+}
+
+const SMART_HOME_API_BASE =
+  (import.meta.env.VITE_SMART_HOME_API_BASE as string | undefined)?.replace(/\/$/, "") ||
+  "/smart-home-api";
+const POLL_MS = 4000;
+const REQUEST_TIMEOUT_MS = 3500;
+
+const LABELS: Record<"en" | "zh", SmartHomeLabels> = {
+  en: {
+    title: "Smart Home",
+    subtitle: "Home Assistant bridge",
+    refresh: "Refresh",
+    loading: "Loading devices",
+    offline: "Bridge offline",
+    online: "Online",
+    unavailable: "Unavailable",
+    devices: "Devices",
+    controllable: "Actions",
+    cameras: "Cameras",
+    fanSpeed: "Fan",
+    modeAuto: "Auto",
+    modeCool: "Cool",
+    modeDry: "Dry",
+    modeFan: "Fan",
+    modeHeat: "Heat",
+    playPause: "Play",
+    power: "Power",
+    open: "Open",
+    close: "Close",
+    stop: "Stop",
+    tempDown: "Cooler",
+    tempUp: "Warmer",
+    volumeDown: "Vol -",
+    volumeUp: "Vol +",
+    home: "Home",
+    back: "Back",
+    ok: "OK",
+    wake: "Wake",
+    music: "Music",
+    radio: "Radio",
+    say: "Say",
+    startCamera: "Live",
+    stopCamera: "Stop",
+    readOnly: "Read only",
+  },
+  zh: {
+    title: "\u667A\u80FD\u5BB6\u5C45",
+    subtitle: "Home Assistant \u6865\u63A5",
+    refresh: "\u5237\u65B0",
+    loading: "\u6B63\u5728\u8BFB\u53D6\u8BBE\u5907",
+    offline: "\u6865\u63A5\u79BB\u7EBF",
+    online: "\u5728\u7EBF",
+    unavailable: "\u4E0D\u53EF\u7528",
+    devices: "\u8BBE\u5907",
+    controllable: "\u52A8\u4F5C",
+    cameras: "\u6444\u50CF\u5934",
+    fanSpeed: "\u98CE\u91CF",
+    modeAuto: "\u81EA\u52A8",
+    modeCool: "\u5236\u51B7",
+    modeDry: "\u9664\u6E7F",
+    modeFan: "\u9001\u98CE",
+    modeHeat: "\u5236\u70ED",
+    playPause: "\u64AD\u653E",
+    power: "\u7535\u6E90",
+    open: "\u6253\u5F00",
+    close: "\u5173\u95ED",
+    stop: "\u505C\u6B62",
+    tempDown: "\u964D\u6E29",
+    tempUp: "\u5347\u6E29",
+    volumeDown: "\u97F3\u91CF-",
+    volumeUp: "\u97F3\u91CF+",
+    home: "\u4E3B\u9875",
+    back: "\u8FD4\u56DE",
+    ok: "\u786E\u8BA4",
+    wake: "\u5524\u9192",
+    music: "\u97F3\u4E50",
+    radio: "\u7535\u53F0",
+    say: "\u64AD\u62A5",
+    startCamera: "\u76F4\u64AD",
+    stopCamera: "\u505C\u6B62",
+    readOnly: "\u53EA\u8BFB",
+  },
+};
+
+function apiPath(path: string): string {
+  return `${SMART_HOME_API_BASE}${path.startsWith("/") ? path : `/${path}`}`;
+}
+
+function numberOrZero(value: unknown): number {
+  return typeof value === "number" && Number.isFinite(value) ? value : 0;
+}
+
+function clampPercent(value: number): number {
+  return Math.max(0, Math.min(100, Math.round(value)));
+}
+
+function postBody(params: Record<string, string | number | boolean>): URLSearchParams {
+  const body = new URLSearchParams();
+  Object.entries(params).forEach(([key, value]) => body.set(key, String(value)));
+  return body;
+}
+
+async function fetchJson<T>(url: string, init?: RequestInit): Promise<T> {
+  const controller = new AbortController();
+  const timer = window.setTimeout(() => controller.abort(), REQUEST_TIMEOUT_MS);
+  try {
+    const response = await fetch(url, {
+      cache: "no-store",
+      ...init,
+      signal: controller.signal,
+    });
+    const data = (await response.json().catch(() => ({}))) as T;
+    if (!response.ok) {
+      const error = data && typeof data === "object" && "error" in data
+        ? String((data as { error?: unknown }).error)
+        : `HTTP ${response.status}`;
+      throw new Error(error);
+    }
+    return data;
+  } finally {
+    window.clearTimeout(timer);
+  }
+}
+
+function useSmartHomeDevices() {
+  const [devices, setDevices] = useState<SmartHomeDevice[]>([]);
+  const [source, setSource] = useState("home_assistant");
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [actionId, setActionId] = useState<string | null>(null);
+  const [cameraStreams, setCameraStreams] = useState<Record<string, CameraStreamInfo>>({});
+  const aliveRef = useRef(true);
+
+  const loadDevices = useCallback(async (silent = false) => {
+    if (!silent) setLoading(true);
+    try {
+      const data = await fetchJson<SmartHomeResponse>(apiPath("/devices"));
+      if (!aliveRef.current) return;
+      setDevices(Array.isArray(data.devices) ? data.devices : []);
+      setSource(data.source ?? "home_assistant");
+      setError(data.ok === false ? data.error ?? "Bridge error" : null);
+    } catch (err) {
+      if (!aliveRef.current) return;
+      setError(err instanceof Error ? err.message : "Bridge error");
+    } finally {
+      if (aliveRef.current) setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    aliveRef.current = true;
+    void loadDevices();
+    const timer = window.setInterval(() => void loadDevices(true), POLL_MS);
+    return () => {
+      aliveRef.current = false;
+      window.clearInterval(timer);
+    };
+  }, [loadDevices]);
+
+  const updateDevice = useCallback(
+    async (id: string, params: Record<string, string | number | boolean>) => {
+      setActionId(id);
+      try {
+        await fetchJson(apiPath(`/devices/${encodeURIComponent(id)}`), {
+          method: "POST",
+          headers: { "Content-Type": "application/x-www-form-urlencoded" },
+          body: postBody(params),
+        });
+        setError(null);
+        await loadDevices(true);
+      } catch (err) {
+        setError(err instanceof Error ? err.message : "Bridge action failed");
+      } finally {
+        setActionId(null);
+      }
+    },
+    [loadDevices],
+  );
+
+  const startCamera = useCallback(async (id: string) => {
+    setActionId(id);
+    try {
+      const data = await fetchJson<CameraStreamInfo>(
+        apiPath(`/cameras/${encodeURIComponent(id)}/stream`),
+        {
+          method: "POST",
+          headers: { "Content-Type": "application/x-www-form-urlencoded" },
+          body: postBody({ quality: 2 }),
+        },
+      );
+      setCameraStreams((prev) => ({ ...prev, [id]: data }));
+      setError(null);
+      await loadDevices(true);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Camera stream failed");
+    } finally {
+      setActionId(null);
+    }
+  }, [loadDevices]);
+
+  const stopCamera = useCallback(async (id: string) => {
+    setActionId(id);
+    try {
+      await fetchJson(apiPath(`/cameras/${encodeURIComponent(id)}/stop`), {
+        method: "POST",
+      });
+      setCameraStreams((prev) => {
+        const next = { ...prev };
+        delete next[id];
+        return next;
+      });
+      setError(null);
+      await loadDevices(true);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Camera stop failed");
+    } finally {
+      setActionId(null);
+    }
+  }, [loadDevices]);
+
+  return {
+    actionId,
+    cameraStreams,
+    devices,
+    error,
+    loading,
+    loadDevices,
+    source,
+    startCamera,
+    stopCamera,
+    updateDevice,
+  };
+}
+
+function iconForDevice(kind: string): LucideIcon {
+  switch (kind) {
+    case "camera":
+      return Camera;
+    case "climate":
+      return AirVent;
+    case "network":
+      return Wifi;
+    case "sensor":
+      return Thermometer;
+    case "speaker":
+      return Radio;
+    case "tv":
+      return Monitor;
+    default:
+      return Home;
+  }
+}
+
+function primaryValue(device: SmartHomeDevice): string {
+  switch (device.kind) {
+    case "climate":
+      return `${Math.round(numberOrZero(device.temperature))}C`;
+    case "cover":
+      return `${clampPercent(numberOrZero(device.position ?? device.brightness))}%`;
+    case "sensor":
+      return `${numberOrZero(device.temperature).toFixed(1)}C / ${Math.round(numberOrZero(device.humidity))}%`;
+    case "speaker":
+    case "tv":
+      return `${clampPercent(numberOrZero(device.volume ?? device.brightness))}%`;
+    case "camera":
+      return device.stream ?? device.mode ?? "";
+    default:
+      return device.mode ?? "";
+  }
+}
+
+function deviceMeta(device: SmartHomeDevice): string {
+  return [device.home, device.room].filter(Boolean).join(" / ");
+}
+
+function hasDeviceActions(device: SmartHomeDevice): boolean {
+  return (
+    device.kind === "tv" ||
+    device.kind === "speaker" ||
+    device.kind === "climate" ||
+    device.kind === "cover" ||
+    (device.kind === "camera" && device.stream_capable === true)
+  );
+}
+
+function StatusPill({
+  device,
+  labels,
+}: {
+  device: SmartHomeDevice;
+  labels: SmartHomeLabels;
+}) {
+  const online = device.online !== false;
+  return (
+    <span className={`smart-home-status-pill ${online ? "is-online" : "is-offline"}`}>
+      {online ? labels.online : labels.unavailable}
+    </span>
+  );
+}
+
+function StatusDot({ device }: { device: SmartHomeDevice }) {
+  const online = device.online !== false;
+  return (
+    <span
+      className={`smart-home-status-dot ${online ? "is-online" : "is-offline"}`}
+      aria-hidden="true"
+    />
+  );
+}
+
+function IconButton({
+  label,
+  onClick,
+  disabled,
+  children,
+}: {
+  label: string;
+  onClick: () => void;
+  disabled?: boolean;
+  children: ReactNode;
+}) {
+  return (
+    <button
+      type="button"
+      className="smart-home-icon-button"
+      onClick={(event) => {
+        event.stopPropagation();
+        onClick();
+      }}
+      disabled={disabled}
+      aria-label={label}
+      title={label}
+    >
+      {children}
+    </button>
+  );
+}
+
+function DeviceControls({
+  device,
+  labels,
+  busy,
+  stream,
+  updateDevice,
+  startCamera,
+  stopCamera,
+}: {
+  device: SmartHomeDevice;
+  labels: SmartHomeLabels;
+  busy: boolean;
+  stream?: CameraStreamInfo;
+  updateDevice: (id: string, params: Record<string, string | number | boolean>) => Promise<void>;
+  startCamera: (id: string) => Promise<void>;
+  stopCamera: (id: string) => Promise<void>;
+}) {
+  const [positionDraft, setPositionDraft] = useState(
+    clampPercent(numberOrZero(device.position ?? device.brightness)),
+  );
+
+  useEffect(() => {
+    setPositionDraft(clampPercent(numberOrZero(device.position ?? device.brightness)));
+  }, [device.brightness, device.position]);
+
+  if (device.kind === "climate") {
+    const temp = Math.round(numberOrZero(device.temperature || 24));
+    const speed = clampPercent(numberOrZero(device.speed));
+    const modes = [
+      ["cool", labels.modeCool],
+      ["heat", labels.modeHeat],
+      ["dry", labels.modeDry],
+      ["fan", labels.modeFan],
+      ["auto", labels.modeAuto],
+    ] as const;
+    return (
+      <div className="smart-home-control-stack">
+        <div className="smart-home-controls">
+          <IconButton
+            label={`${device.name} ${labels.power}`}
+            disabled={busy}
+            onClick={() => void updateDevice(device.id, { on: !device.on })}
+          >
+            <CirclePower size={18} />
+          </IconButton>
+          <IconButton
+            label={`${device.name} ${labels.tempDown}`}
+            disabled={busy}
+            onClick={() => void updateDevice(device.id, { temperature: temp - 1, on: true })}
+          >
+            <Minus size={18} />
+          </IconButton>
+          <span className="smart-home-control-readout">{temp}C</span>
+          <IconButton
+            label={`${device.name} ${labels.tempUp}`}
+            disabled={busy}
+            onClick={() => void updateDevice(device.id, { temperature: temp + 1, on: true })}
+          >
+            <Plus size={18} />
+          </IconButton>
+        </div>
+        <label className="smart-home-slider-row">
+          <span>{labels.fanSpeed}</span>
+          <input
+            type="range"
+            min={0}
+            max={100}
+            value={speed}
+            disabled={busy}
+            aria-label={`${device.name} ${labels.fanSpeed}`}
+            onChange={(event) =>
+              void updateDevice(device.id, { speed: Number(event.currentTarget.value), on: true })
+            }
+          />
+        </label>
+        <div className="smart-home-mode-row">
+          {modes.map(([mode, label]) => (
+            <button
+              key={mode}
+              type="button"
+              className={`smart-home-mode-button ${
+                device.mode === mode || (mode === "fan" && device.mode === "fan_only")
+                  ? "is-active"
+                  : ""
+              }`}
+              disabled={busy}
+              onClick={(event) => {
+                event.stopPropagation();
+                void updateDevice(device.id, { mode, on: true });
+              }}
+            >
+              {label}
+            </button>
+          ))}
+        </div>
+      </div>
+    );
+  }
+
+  if (device.kind === "cover") {
+    return (
+      <div className="smart-home-cover-controls">
+        <div className="smart-home-controls">
+          <IconButton
+            label={`${device.name} ${labels.open}`}
+            disabled={busy}
+            onClick={() => void updateDevice(device.id, { action: "open" })}
+          >
+            <Plus size={18} />
+          </IconButton>
+          <IconButton
+            label={`${device.name} ${labels.stop}`}
+            disabled={busy}
+            onClick={() => void updateDevice(device.id, { action: "stop" })}
+          >
+            <Square size={15} />
+          </IconButton>
+          <IconButton
+            label={`${device.name} ${labels.close}`}
+            disabled={busy}
+            onClick={() => void updateDevice(device.id, { action: "close" })}
+          >
+            <Minus size={18} />
+          </IconButton>
+        </div>
+        <label className="smart-home-slider-row">
+          <span>{positionDraft}%</span>
+          <input
+            type="range"
+            min={0}
+            max={100}
+            value={positionDraft}
+            disabled={busy}
+            aria-label={`${device.name} position`}
+            onChange={(event) => setPositionDraft(Number(event.currentTarget.value))}
+            onPointerUp={(event) =>
+              void updateDevice(device.id, { position: Number(event.currentTarget.value) })
+            }
+            onKeyUp={(event) => {
+              if (event.key === "Enter") {
+                void updateDevice(device.id, { position: positionDraft });
+              }
+            }}
+            onBlur={() => {
+              if (positionDraft !== clampPercent(numberOrZero(device.position ?? device.brightness))) {
+                void updateDevice(device.id, { position: positionDraft });
+              }
+            }}
+          />
+        </label>
+      </div>
+    );
+  }
+
+  if (device.kind === "tv") {
+    return (
+      <div className="smart-home-controls">
+        <IconButton
+          label={`${device.name} ${labels.volumeDown}`}
+          disabled={busy}
+          onClick={() => void updateDevice(device.id, { action: "volume_down" })}
+        >
+          <Volume2 size={17} />
+        </IconButton>
+        <IconButton
+          label={`${device.name} ${labels.volumeUp}`}
+          disabled={busy}
+          onClick={() => void updateDevice(device.id, { action: "volume_up" })}
+        >
+          <Plus size={18} />
+        </IconButton>
+        <IconButton
+          label={`${device.name} ${labels.home}`}
+          disabled={busy}
+          onClick={() => void updateDevice(device.id, { action: "home" })}
+        >
+          <Home size={17} />
+        </IconButton>
+        <IconButton
+          label={`${device.name} ${labels.ok}`}
+          disabled={busy}
+          onClick={() => void updateDevice(device.id, { action: "ok" })}
+        >
+          <span>OK</span>
+        </IconButton>
+        <IconButton
+          label={`${device.name} ${labels.back}`}
+          disabled={busy}
+          onClick={() => void updateDevice(device.id, { action: "back" })}
+        >
+          <span>{labels.back}</span>
+        </IconButton>
+        <IconButton
+          label={`${device.name} ${labels.playPause}`}
+          disabled={busy}
+          onClick={() => void updateDevice(device.id, { action: "play_pause" })}
+        >
+          <span>{labels.playPause}</span>
+        </IconButton>
+      </div>
+    );
+  }
+
+  if (device.kind === "speaker") {
+    return (
+      <div className="smart-home-controls">
+        <IconButton
+          label={`${device.name} ${labels.wake}`}
+          disabled={busy}
+          onClick={() => void updateDevice(device.id, { action: "wake" })}
+        >
+          <CirclePower size={17} />
+        </IconButton>
+        <IconButton
+          label={`${device.name} ${labels.music}`}
+          disabled={busy}
+          onClick={() => void updateDevice(device.id, { action: "music" })}
+        >
+          <Radio size={17} />
+        </IconButton>
+        <IconButton
+          label={`${device.name} ${labels.radio}`}
+          disabled={busy}
+          onClick={() => void updateDevice(device.id, { action: "radio" })}
+        >
+          <Volume2 size={17} />
+        </IconButton>
+        <IconButton
+          label={`${device.name} ${labels.say}`}
+          disabled={busy}
+          onClick={() => void updateDevice(device.id, { action: "say" })}
+        >
+          <Volume2 size={17} />
+        </IconButton>
+      </div>
+    );
+  }
+
+  if (device.kind === "camera" && device.stream_capable) {
+    const activeUrl = stream?.playback_url ?? stream?.stream_url;
+    return (
+      <div className="smart-home-camera-controls">
+        <div className="smart-home-controls">
+          <IconButton
+            label={`${device.name} ${labels.startCamera}`}
+            disabled={busy}
+            onClick={() => void startCamera(device.id)}
+          >
+            <Camera size={17} />
+          </IconButton>
+          <IconButton
+            label={`${device.name} ${labels.stopCamera}`}
+            disabled={busy || !stream}
+            onClick={() => void stopCamera(device.id)}
+          >
+            <Square size={15} />
+          </IconButton>
+        </div>
+        {activeUrl && (
+          <iframe
+            title={device.name}
+            src={activeUrl}
+            className="smart-home-camera-frame"
+            loading="lazy"
+          />
+        )}
+      </div>
+    );
+  }
+
+  return <div className="smart-home-readonly">{labels.readOnly}</div>;
+}
+
+function DeviceCard({
+  device,
+  labels,
+  busy,
+  stream,
+  updateDevice,
+  startCamera,
+  stopCamera,
+}: {
+  device: SmartHomeDevice;
+  labels: SmartHomeLabels;
+  busy: boolean;
+  stream?: CameraStreamInfo;
+  updateDevice: (id: string, params: Record<string, string | number | boolean>) => Promise<void>;
+  startCamera: (id: string) => Promise<void>;
+  stopCamera: (id: string) => Promise<void>;
+}) {
+  const Icon = iconForDevice(device.kind);
+  const accent = device.color || "#7dd3fc";
+  return (
+    <article
+      className={`smart-home-device-card ${device.on ? "is-on" : "is-off"} ${
+        device.online === false ? "is-unavailable" : ""
+      }`}
+      style={{ "--smart-home-accent": accent } as CSSProperties}
+    >
+      <div className="smart-home-device-top">
+        <div className="smart-home-device-icon">
+          <Icon size={20} />
+        </div>
+        <div className="smart-home-device-main">
+          <div className="smart-home-device-title-row">
+            <h3>{device.name}</h3>
+            <StatusPill device={device} labels={labels} />
+          </div>
+          <div className="smart-home-device-meta">{deviceMeta(device)}</div>
+        </div>
+        <div className="smart-home-device-value">{primaryValue(device)}</div>
+      </div>
+      {device.note && <p className="smart-home-device-note">{device.note}</p>}
+      <DeviceControls
+        device={device}
+        labels={labels}
+        busy={busy}
+        stream={stream}
+        updateDevice={updateDevice}
+        startCamera={startCamera}
+        stopCamera={stopCamera}
+      />
+    </article>
+  );
+}
+
+function CompactDeviceCard({
+  device,
+  onSelect,
+}: {
+  device: SmartHomeDevice;
+  onSelect: (device: SmartHomeDevice) => void;
+}) {
+  const Icon = iconForDevice(device.kind);
+  const accent = device.color || "#7dd3fc";
+  return (
+    <button
+      type="button"
+      className={`smart-home-device-card smart-home-device-compact smart-home-device-button ${
+        device.on ? "is-on" : "is-off"
+      } ${device.online === false ? "is-unavailable" : ""}`}
+      style={{ "--smart-home-accent": accent } as CSSProperties}
+      onClick={(event) => {
+        event.stopPropagation();
+        onSelect(device);
+      }}
+      onKeyDown={(event) => {
+        if (event.key === "Enter" || event.key === " ") {
+          event.stopPropagation();
+          onSelect(device);
+        }
+      }}
+      aria-label={`${device.name} controls`}
+    >
+      <div className="smart-home-device-top">
+        <div className="smart-home-device-icon">
+          <Icon size={18} />
+        </div>
+        <div className="smart-home-device-main">
+          <div className="smart-home-device-title-row">
+            <h3>{device.name}</h3>
+            <StatusDot device={device} />
+          </div>
+          <div className="smart-home-device-meta">{device.room || device.home || device.kind}</div>
+        </div>
+        <div className="smart-home-device-value">{primaryValue(device)}</div>
+      </div>
+    </button>
+  );
+}
+
+function DeviceDetailPanel({
+  device,
+  labels,
+  busy,
+  stream,
+  onClose,
+  updateDevice,
+  startCamera,
+  stopCamera,
+}: {
+  device: SmartHomeDevice;
+  labels: SmartHomeLabels;
+  busy: boolean;
+  stream?: CameraStreamInfo;
+  onClose: () => void;
+  updateDevice: (id: string, params: Record<string, string | number | boolean>) => Promise<void>;
+  startCamera: (id: string) => Promise<void>;
+  stopCamera: (id: string) => Promise<void>;
+}) {
+  const Icon = iconForDevice(device.kind);
+  const accent = device.color || "#7dd3fc";
+  if (typeof document === "undefined") return null;
+
+  return createPortal(
+    <div
+      className="smart-home-device-popover-backdrop"
+      onClick={(event) => {
+        event.stopPropagation();
+        onClose();
+      }}
+    >
+      <div
+        className="smart-home-device-popover"
+        role="dialog"
+        aria-modal="false"
+        aria-label={`${device.name} controls`}
+        style={{ "--smart-home-accent": accent } as CSSProperties}
+        onClick={(event) => event.stopPropagation()}
+      >
+        <header className="smart-home-device-popover-header">
+          <div className="smart-home-device-popover-title">
+            <span className="smart-home-device-popover-icon">
+              <Icon size={19} />
+            </span>
+            <div className="min-w-0">
+              <h3>{device.name}</h3>
+              <p>{device.room || device.home || device.kind}</p>
+            </div>
+          </div>
+          <button
+            type="button"
+            className="smart-home-device-popover-close"
+            aria-label={`${device.name} close controls`}
+            onClick={(event) => {
+              event.stopPropagation();
+              onClose();
+            }}
+          >
+            <X size={18} />
+          </button>
+        </header>
+
+        <div className="smart-home-device-popover-readout">
+          <div>
+            <strong>{primaryValue(device) || (device.on ? labels.online : labels.unavailable)}</strong>
+            <span>{device.kind}</span>
+          </div>
+          <div>
+            <strong>{device.online === false ? labels.unavailable : labels.online}</strong>
+            <span>{device.mode || device.stream || "-"}</span>
+          </div>
+        </div>
+
+        {device.note && <p className="smart-home-device-popover-note">{device.note}</p>}
+
+        <DeviceControls
+          device={device}
+          labels={labels}
+          busy={busy}
+          stream={stream}
+          updateDevice={updateDevice}
+          startCamera={startCamera}
+          stopCamera={stopCamera}
+        />
+      </div>
+    </div>,
+    document.body,
+  );
+}
+
+export function SmartHomePanel({ variant = "metro" }: { variant?: "metro" | "classic" }) {
+  const { lang } = useHomeSettings();
+  const labels = LABELS[lang];
+  const [selectedId, setSelectedId] = useState<string | null>(null);
+  const {
+    actionId,
+    cameraStreams,
+    devices,
+    error,
+    loading,
+    loadDevices,
+    source,
+    startCamera,
+    stopCamera,
+    updateDevice,
+  } = useSmartHomeDevices();
+
+  const summary = useMemo(() => {
+    const online = devices.filter((device) => device.online !== false).length;
+    const controllable = devices.filter(hasDeviceActions).length;
+    const cameras = devices.filter((device) => device.kind === "camera").length;
+    return { online, controllable, cameras };
+  }, [devices]);
+  const displayedDevices = useMemo(() => {
+    if (variant !== "metro") return devices;
+    const kindWeight: Record<string, number> = {
+      tv: 0,
+      climate: 1,
+      cover: 2,
+      speaker: 3,
+      camera: 4,
+      sensor: 5,
+      network: 6,
+    };
+    return [...devices].sort((a, b) => {
+      const aWeight = kindWeight[a.kind] ?? 10;
+      const bWeight = kindWeight[b.kind] ?? 10;
+      return aWeight - bWeight || a.name.localeCompare(b.name);
+    });
+  }, [devices, variant]);
+  const selectedDevice = useMemo(
+    () => devices.find((device) => device.id === selectedId) ?? null,
+    [devices, selectedId],
+  );
+
+  useEffect(() => {
+    if (selectedId && !selectedDevice) setSelectedId(null);
+  }, [selectedDevice, selectedId]);
+
+  return (
+    <section className={`smart-home-panel smart-home-panel-${variant}`} data-testid="smart-home-panel">
+      <header className="smart-home-header">
+        <div>
+          <div className="smart-home-eyebrow">{variant === "metro" ? labels.title : source}</div>
+          <h2>{labels.title}</h2>
+          <p>
+            {error
+              ? labels.offline
+              : variant === "metro"
+                ? `${summary.online}/${devices.length || 0} ${labels.online}`
+                : labels.subtitle}
+          </p>
+        </div>
+        <button
+          type="button"
+          className="smart-home-refresh"
+          onClick={(event) => {
+            event.stopPropagation();
+            void loadDevices();
+          }}
+          aria-label={labels.refresh}
+          title={labels.refresh}
+        >
+          <RefreshCw size={17} className={loading ? "smart-home-spin" : ""} />
+        </button>
+      </header>
+
+      {variant === "metro" ? (
+        <div className="smart-home-metro-summary" aria-label={`${devices.length} ${labels.devices}`}>
+          <span>
+            <strong>{devices.length}</strong>
+            {labels.devices}
+          </span>
+          <span>
+            <strong>{summary.controllable}</strong>
+            {labels.controllable}
+          </span>
+          <span>
+            <strong>{summary.cameras}</strong>
+            {labels.cameras}
+          </span>
+        </div>
+      ) : (
+        <div className="smart-home-summary">
+          <div>
+            <strong>{devices.length}</strong>
+            <span>{labels.devices}</span>
+          </div>
+          <div>
+            <strong>{summary.online}</strong>
+            <span>{labels.online}</span>
+          </div>
+          <div>
+            <strong>{summary.controllable}</strong>
+            <span>{labels.controllable}</span>
+          </div>
+          <div>
+            <strong>{summary.cameras}</strong>
+            <span>{labels.cameras}</span>
+          </div>
+        </div>
+      )}
+
+      {loading && devices.length === 0 ? (
+        <div className="smart-home-empty">{labels.loading}</div>
+      ) : error && devices.length === 0 ? (
+        <div className="smart-home-empty">{error}</div>
+      ) : (
+        <div className="smart-home-device-list">
+          {displayedDevices.map((device) =>
+            variant === "metro" ? (
+              <CompactDeviceCard
+                key={device.id}
+                device={device}
+                onSelect={(nextDevice) => setSelectedId(nextDevice.id)}
+              />
+            ) : (
+              <DeviceCard
+                key={device.id}
+                device={device}
+                labels={labels}
+                busy={actionId === device.id}
+                stream={cameraStreams[device.id]}
+                updateDevice={updateDevice}
+                startCamera={startCamera}
+                stopCamera={stopCamera}
+              />
+            ),
+          )}
+        </div>
+      )}
+      {variant === "metro" && selectedDevice && (
+        <DeviceDetailPanel
+          device={selectedDevice}
+          labels={labels}
+          busy={actionId === selectedDevice.id}
+          stream={cameraStreams[selectedDevice.id]}
+          onClose={() => setSelectedId(null)}
+          updateDevice={updateDevice}
+          startCamera={startCamera}
+          stopCamera={stopCamera}
+        />
+      )}
+    </section>
+  );
+}

--- a/src/home/widget-registry.ts
+++ b/src/home/widget-registry.ts
@@ -14,7 +14,8 @@ export type WidgetType =
   | "news"
   | "calendar"
   | "timer"
-  | "photo-frame";
+  | "photo-frame"
+  | "smart-home";
 
 export interface WidgetConfig {
   type: WidgetType;
@@ -25,13 +26,14 @@ export interface WidgetConfig {
 export const DEFAULT_WIDGETS: WidgetConfig[] = [
   { type: "greeting", enabled: true, order: 0 },
   { type: "clock", enabled: true, order: 1 },
-  { type: "voice-orb", enabled: true, order: 2 },
-  { type: "weather", enabled: true, order: 3 },
-  { type: "quick-actions", enabled: true, order: 4 },
-  { type: "news", enabled: true, order: 5 },
-  { type: "calendar", enabled: true, order: 6 },
-  { type: "timer", enabled: true, order: 7 },
-  { type: "photo-frame", enabled: false, order: 8 },
+  { type: "smart-home", enabled: true, order: 2 },
+  { type: "voice-orb", enabled: true, order: 3 },
+  { type: "weather", enabled: true, order: 4 },
+  { type: "quick-actions", enabled: true, order: 5 },
+  { type: "news", enabled: true, order: 6 },
+  { type: "calendar", enabled: true, order: 7 },
+  { type: "timer", enabled: true, order: 8 },
+  { type: "photo-frame", enabled: false, order: 9 },
 ];
 
 const LS_KEY = "octos_home_widgets";

--- a/src/index.css
+++ b/src/index.css
@@ -2890,6 +2890,11 @@ button, a, input, textarea {
   grid-column: span 4;
 }
 
+.classic-home-smart-panel {
+  grid-column: span 6;
+  min-width: 0;
+}
+
 .classic-home-calendar-panel {
   grid-column: span 2;
 }
@@ -2937,6 +2942,7 @@ button, a, input, textarea {
 
   .classic-home-weather-panel,
   .classic-home-quick-panel,
+  .classic-home-smart-panel,
   .classic-home-news-panel,
   .classic-home-calendar-panel,
   .classic-home-timer-panel,
@@ -2972,6 +2978,7 @@ button, a, input, textarea {
   .classic-home-clock-panel,
   .classic-home-weather-panel,
   .classic-home-quick-panel,
+  .classic-home-smart-panel,
   .classic-home-news-panel,
   .classic-home-calendar-panel,
   .classic-home-timer-panel,
@@ -3509,4 +3516,740 @@ button, a, input, textarea {
 }
 .metro-tile[data-tile-id="photo"] .metro-tile-content {
   padding: 0;
+}
+
+/* ── Smart home widget ───────────────────────────────── */
+.smart-home-panel {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  width: 100%;
+  min-width: 0;
+  height: 100%;
+  min-height: 0;
+  color: rgba(255, 255, 255, 0.88);
+  container-type: size;
+}
+
+.classic-home-smart-panel .smart-home-panel {
+  min-height: 320px;
+  padding: 1rem;
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  border-radius: 8px;
+  background: rgba(255, 255, 255, 0.045);
+  backdrop-filter: blur(18px);
+  -webkit-backdrop-filter: blur(18px);
+}
+
+.metro-tile[data-tile-id="smart-home"] .metro-tile-content {
+  align-items: stretch;
+  justify-content: stretch;
+  padding: 12px;
+}
+
+.smart-home-panel-metro {
+  gap: 7px;
+}
+
+.smart-home-header {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 12px;
+  margin-bottom: 10px;
+  flex-shrink: 0;
+}
+
+.smart-home-panel-metro .smart-home-header {
+  align-items: center;
+  margin-bottom: 0;
+}
+
+.smart-home-eyebrow {
+  margin-bottom: 2px;
+  font-size: 0.62rem;
+  font-weight: 600;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  color: rgba(255, 255, 255, 0.34);
+}
+
+.smart-home-panel-metro .smart-home-eyebrow {
+  display: none;
+}
+
+.smart-home-header h2 {
+  margin: 0;
+  font-size: clamp(1.05rem, 2vw, 1.35rem);
+  font-weight: 650;
+  line-height: 1.1;
+  color: rgba(255, 255, 255, 0.96);
+}
+
+.smart-home-panel-metro .smart-home-header h2 {
+  font-size: clamp(1rem, 3.4cqw, 1.25rem);
+  font-weight: 520;
+  letter-spacing: 0;
+  color: rgba(255, 255, 255, 0.9);
+}
+
+.smart-home-header p {
+  margin: 4px 0 0;
+  font-size: 0.78rem;
+  color: rgba(255, 255, 255, 0.45);
+}
+
+.smart-home-panel-metro .smart-home-header p {
+  margin-top: 2px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  font-size: 0.72rem;
+  color: rgba(255, 255, 255, 0.46);
+}
+
+.smart-home-refresh,
+.smart-home-icon-button {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  flex-shrink: 0;
+  min-width: 44px;
+  min-height: 44px;
+  border: 1px solid rgba(255, 255, 255, 0.1);
+  border-radius: 8px;
+  background: rgba(255, 255, 255, 0.07);
+  color: rgba(255, 255, 255, 0.74);
+  transition: background 0.15s ease, border-color 0.15s ease, transform 0.12s ease;
+}
+
+.smart-home-panel-metro .smart-home-refresh {
+  min-width: 38px;
+  min-height: 38px;
+  border-color: rgba(255, 255, 255, 0.08);
+  border-radius: 6px;
+  background: rgba(0, 0, 0, 0.16);
+}
+
+.smart-home-refresh:hover,
+.smart-home-icon-button:hover:not(:disabled),
+.smart-home-refresh:focus-visible,
+.smart-home-icon-button:focus-visible {
+  border-color: rgba(255, 255, 255, 0.2);
+  background: rgba(255, 255, 255, 0.12);
+  color: rgba(255, 255, 255, 0.95);
+  outline: none;
+}
+
+.smart-home-refresh:active,
+.smart-home-icon-button:active:not(:disabled) {
+  transform: scale(0.96);
+}
+
+.smart-home-icon-button:disabled {
+  cursor: not-allowed;
+  opacity: 0.42;
+}
+
+.smart-home-spin {
+  animation: smartHomeSpin 0.85s linear infinite;
+}
+
+@keyframes smartHomeSpin {
+  to {
+    transform: rotate(360deg);
+  }
+}
+
+.smart-home-summary {
+  display: grid;
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+  gap: 6px;
+  margin-bottom: 10px;
+  flex-shrink: 0;
+}
+
+.smart-home-metro-summary {
+  display: flex;
+  align-items: center;
+  gap: 5px;
+  min-height: 24px;
+  overflow: hidden;
+  flex-shrink: 0;
+}
+
+.smart-home-metro-summary span {
+  display: inline-flex;
+  align-items: baseline;
+  gap: 4px;
+  min-width: 0;
+  border-radius: 5px;
+  padding: 4px 7px;
+  background: rgba(0, 0, 0, 0.12);
+  color: rgba(255, 255, 255, 0.42);
+  font-size: 0.62rem;
+  line-height: 1;
+  white-space: nowrap;
+}
+
+.smart-home-metro-summary strong {
+  color: rgba(255, 255, 255, 0.82);
+  font-size: 0.78rem;
+  font-weight: 620;
+  font-variant-numeric: tabular-nums;
+}
+
+.smart-home-summary div {
+  min-width: 0;
+  padding: 8px 7px;
+  border-radius: 7px;
+  background: rgba(0, 0, 0, 0.16);
+}
+
+.smart-home-summary strong {
+  display: block;
+  font-size: 1rem;
+  line-height: 1.05;
+  font-variant-numeric: tabular-nums;
+  color: rgba(255, 255, 255, 0.92);
+}
+
+.smart-home-summary span {
+  display: block;
+  margin-top: 2px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  font-size: 0.66rem;
+  color: rgba(255, 255, 255, 0.4);
+}
+
+.smart-home-empty {
+  display: flex;
+  min-height: 120px;
+  align-items: center;
+  justify-content: center;
+  border-radius: 8px;
+  background: rgba(0, 0, 0, 0.13);
+  color: rgba(255, 255, 255, 0.42);
+  font-size: 0.86rem;
+}
+
+.smart-home-device-list {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(260px, 1fr));
+  gap: 8px;
+  min-height: 0;
+  overflow-y: auto;
+  padding-right: 2px;
+  scrollbar-width: none;
+}
+
+.smart-home-device-list::-webkit-scrollbar {
+  display: none;
+}
+
+.metro-tile[data-tile-id="smart-home"] .smart-home-device-list {
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  align-content: start;
+  gap: 6px;
+  overflow: hidden;
+  padding-right: 0;
+}
+
+.smart-home-device-card {
+  --smart-home-accent: #7dd3fc;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  min-width: 0;
+  min-height: 134px;
+  padding: 10px;
+  border: 1px solid color-mix(in srgb, var(--smart-home-accent) 24%, transparent);
+  border-radius: 8px;
+  background:
+    linear-gradient(135deg, color-mix(in srgb, var(--smart-home-accent) 16%, transparent), transparent 56%),
+    rgba(0, 0, 0, 0.18);
+}
+
+.smart-home-device-button {
+  width: 100%;
+  border-style: solid;
+  text-align: left;
+  cursor: pointer;
+  transition:
+    border-color 0.15s ease,
+    background 0.15s ease,
+    transform 0.12s ease;
+}
+
+.smart-home-device-button:hover,
+.smart-home-device-button:focus-visible {
+  border-color: color-mix(in srgb, var(--smart-home-accent) 42%, rgba(255, 255, 255, 0.12));
+  background:
+    linear-gradient(90deg, color-mix(in srgb, var(--smart-home-accent) 17%, transparent), transparent 62%),
+    rgba(0, 0, 0, 0.15);
+  outline: none;
+}
+
+.smart-home-device-button:active {
+  transform: scale(0.985);
+}
+
+.smart-home-device-compact {
+  min-height: 40px;
+  gap: 0;
+  padding: 6px 7px;
+  border-color: rgba(255, 255, 255, 0.055);
+  border-radius: 5px;
+  background:
+    linear-gradient(90deg, color-mix(in srgb, var(--smart-home-accent) 11%, transparent), transparent 58%),
+    rgba(0, 0, 0, 0.11);
+}
+
+.smart-home-device-compact .smart-home-device-icon {
+  width: 27px;
+  height: 27px;
+  border-radius: 6px;
+}
+
+.smart-home-device-compact .smart-home-device-title-row {
+  align-items: center;
+  gap: 5px;
+}
+
+.smart-home-device-compact .smart-home-device-title-row h3 {
+  max-width: 100%;
+  font-size: clamp(0.68rem, 2.7cqw, 0.78rem);
+  font-weight: 540;
+  color: rgba(255, 255, 255, 0.86);
+}
+
+.smart-home-device-compact .smart-home-status-pill {
+  display: none;
+}
+
+.smart-home-device-compact .smart-home-device-meta {
+  margin-top: 1px;
+  font-size: clamp(0.56rem, 2.2cqw, 0.62rem);
+  color: rgba(255, 255, 255, 0.34);
+}
+
+.smart-home-device-compact .smart-home-device-value {
+  max-width: 48px;
+  font-size: clamp(0.62rem, 2.4cqw, 0.72rem);
+  font-weight: 620;
+  color: rgba(255, 255, 255, 0.66);
+}
+
+.smart-home-device-card.is-unavailable {
+  filter: grayscale(0.45);
+  opacity: 0.68;
+}
+
+.smart-home-device-top {
+  display: flex;
+  align-items: flex-start;
+  gap: 9px;
+  min-width: 0;
+}
+
+.smart-home-device-icon {
+  display: flex;
+  width: 36px;
+  height: 36px;
+  align-items: center;
+  justify-content: center;
+  flex-shrink: 0;
+  border-radius: 8px;
+  background: color-mix(in srgb, var(--smart-home-accent) 18%, rgba(255, 255, 255, 0.07));
+  color: color-mix(in srgb, var(--smart-home-accent) 78%, white);
+}
+
+.smart-home-device-compact .smart-home-device-icon svg {
+  width: 15px;
+  height: 15px;
+}
+
+.smart-home-device-main {
+  min-width: 0;
+  flex: 1;
+}
+
+.smart-home-device-title-row {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  min-width: 0;
+}
+
+.smart-home-device-title-row h3 {
+  min-width: 0;
+  margin: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  font-size: 0.9rem;
+  font-weight: 650;
+  line-height: 1.25;
+  color: rgba(255, 255, 255, 0.92);
+}
+
+.smart-home-device-meta,
+.smart-home-device-note {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  font-size: 0.7rem;
+  color: rgba(255, 255, 255, 0.42);
+}
+
+.smart-home-device-note {
+  margin: 0;
+  color: rgba(255, 255, 255, 0.48);
+}
+
+.smart-home-device-value {
+  flex-shrink: 0;
+  max-width: 92px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  font-size: 0.86rem;
+  font-weight: 700;
+  font-variant-numeric: tabular-nums;
+  color: rgba(255, 255, 255, 0.86);
+}
+
+.smart-home-status-pill {
+  flex-shrink: 0;
+  border-radius: 999px;
+  padding: 3px 7px;
+  font-size: 0.62rem;
+  line-height: 1;
+  color: rgba(255, 255, 255, 0.72);
+  background: rgba(255, 255, 255, 0.08);
+}
+
+.smart-home-status-pill.is-online {
+  color: rgba(187, 247, 208, 0.92);
+  background: rgba(34, 197, 94, 0.13);
+}
+
+.smart-home-status-pill.is-offline {
+  color: rgba(254, 202, 202, 0.9);
+  background: rgba(239, 68, 68, 0.13);
+}
+
+.smart-home-status-dot {
+  width: 6px;
+  height: 6px;
+  flex: 0 0 auto;
+  border-radius: 999px;
+  background: rgba(255, 255, 255, 0.26);
+}
+
+.smart-home-status-dot.is-online {
+  background: rgba(134, 239, 172, 0.78);
+  box-shadow: 0 0 10px rgba(134, 239, 172, 0.24);
+}
+
+.smart-home-status-dot.is-offline {
+  background: rgba(248, 113, 113, 0.78);
+}
+
+.smart-home-controls {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+}
+
+.smart-home-control-stack {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+
+.smart-home-control-readout {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 52px;
+  min-height: 44px;
+  border-radius: 8px;
+  background: rgba(0, 0, 0, 0.16);
+  font-size: 0.82rem;
+  font-weight: 650;
+  font-variant-numeric: tabular-nums;
+  color: rgba(255, 255, 255, 0.78);
+}
+
+.smart-home-cover-controls,
+.smart-home-camera-controls {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.smart-home-slider-row {
+  display: grid;
+  grid-template-columns: 42px minmax(0, 1fr);
+  align-items: center;
+  gap: 8px;
+  min-height: 44px;
+  font-size: 0.78rem;
+  font-variant-numeric: tabular-nums;
+  color: rgba(255, 255, 255, 0.62);
+}
+
+.smart-home-mode-row {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+}
+
+.smart-home-mode-button {
+  min-height: 38px;
+  border: 1px solid rgba(255, 255, 255, 0.09);
+  border-radius: 8px;
+  padding: 0 11px;
+  background: rgba(255, 255, 255, 0.055);
+  color: rgba(255, 255, 255, 0.7);
+  font-size: 0.75rem;
+  font-weight: 620;
+}
+
+.smart-home-mode-button:hover:not(:disabled),
+.smart-home-mode-button:focus-visible {
+  border-color: rgba(255, 255, 255, 0.18);
+  background: rgba(255, 255, 255, 0.1);
+  outline: none;
+}
+
+.smart-home-mode-button.is-active {
+  border-color: color-mix(in srgb, var(--smart-home-accent) 42%, rgba(255, 255, 255, 0.12));
+  background: color-mix(in srgb, var(--smart-home-accent) 18%, rgba(255, 255, 255, 0.06));
+  color: rgba(255, 255, 255, 0.92);
+}
+
+.smart-home-mode-button:disabled {
+  cursor: wait;
+  opacity: 0.5;
+}
+
+.smart-home-slider-row input[type="range"] {
+  width: 100%;
+  accent-color: var(--smart-home-accent);
+  min-height: 36px;
+}
+
+.smart-home-readonly {
+  display: inline-flex;
+  align-self: flex-start;
+  align-items: center;
+  min-height: 34px;
+  border-radius: 7px;
+  padding: 0 10px;
+  background: rgba(255, 255, 255, 0.06);
+  color: rgba(255, 255, 255, 0.42);
+  font-size: 0.72rem;
+}
+
+.smart-home-camera-frame {
+  width: 100%;
+  min-height: 160px;
+  border: 0;
+  border-radius: 8px;
+  background: rgba(0, 0, 0, 0.35);
+}
+
+.smart-home-device-popover-backdrop {
+  position: fixed;
+  inset: 0;
+  z-index: 80;
+  background: transparent;
+}
+
+.smart-home-device-popover {
+  position: fixed;
+  right: 1.5rem;
+  bottom: 1.5rem;
+  z-index: 1;
+  width: min(430px, calc(100vw - 2rem));
+  max-height: min(620px, calc(100vh - 2rem));
+  overflow-y: auto;
+  border: 1px solid color-mix(in srgb, var(--smart-home-accent) 28%, rgba(255, 255, 255, 0.1));
+  border-radius: 10px;
+  padding: 1rem;
+  background:
+    linear-gradient(135deg, color-mix(in srgb, var(--smart-home-accent) 13%, transparent), transparent 44%),
+    rgba(23, 18, 13, 0.97);
+  box-shadow: 0 24px 72px rgba(0, 0, 0, 0.46);
+  scrollbar-width: none;
+}
+
+.smart-home-device-popover::-webkit-scrollbar {
+  display: none;
+}
+
+.smart-home-device-popover-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+}
+
+.smart-home-device-popover-title {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  min-width: 0;
+}
+
+.smart-home-device-popover-title h3 {
+  margin: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  font-size: 1rem;
+  font-weight: 650;
+  color: rgba(255, 255, 255, 0.93);
+}
+
+.smart-home-device-popover-title p {
+  margin: 2px 0 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  font-size: 0.75rem;
+  color: rgba(255, 255, 255, 0.42);
+}
+
+.smart-home-device-popover-icon,
+.smart-home-device-popover-close {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.smart-home-device-popover-icon {
+  width: 42px;
+  height: 42px;
+  flex: 0 0 42px;
+  border: 1px solid color-mix(in srgb, var(--smart-home-accent) 28%, rgba(255, 255, 255, 0.1));
+  border-radius: 8px;
+  color: color-mix(in srgb, var(--smart-home-accent) 78%, white);
+  background: color-mix(in srgb, var(--smart-home-accent) 14%, rgba(255, 255, 255, 0.05));
+}
+
+.smart-home-device-popover-close {
+  width: 40px;
+  height: 40px;
+  flex: 0 0 40px;
+  border: 1px solid rgba(255, 255, 255, 0.1);
+  border-radius: 8px;
+  color: rgba(255, 255, 255, 0.72);
+  background: rgba(255, 255, 255, 0.055);
+}
+
+.smart-home-device-popover-close:hover,
+.smart-home-device-popover-close:focus-visible {
+  border-color: rgba(255, 255, 255, 0.2);
+  background: rgba(255, 255, 255, 0.11);
+  outline: none;
+}
+
+.smart-home-device-popover-readout {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 8px;
+  margin: 1rem 0 0.75rem;
+}
+
+.smart-home-device-popover-readout div {
+  min-width: 0;
+  border-radius: 8px;
+  padding: 0.7rem 0.8rem;
+  background: rgba(255, 255, 255, 0.055);
+}
+
+.smart-home-device-popover-readout strong,
+.smart-home-device-popover-readout span {
+  display: block;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.smart-home-device-popover-readout strong {
+  font-size: 0.95rem;
+  color: rgba(255, 255, 255, 0.9);
+}
+
+.smart-home-device-popover-readout span {
+  margin-top: 2px;
+  font-size: 0.68rem;
+  color: rgba(255, 255, 255, 0.38);
+}
+
+.smart-home-device-popover-note {
+  margin: 0 0 0.9rem;
+  border-left: 2px solid color-mix(in srgb, var(--smart-home-accent) 46%, rgba(255, 255, 255, 0.16));
+  padding-left: 0.65rem;
+  color: rgba(255, 255, 255, 0.5);
+  font-size: 0.76rem;
+  line-height: 1.45;
+}
+
+.smart-home-device-popover .smart-home-readonly {
+  min-height: 42px;
+}
+
+@media (max-width: 600px) {
+  .smart-home-device-popover {
+    right: 0.75rem;
+    bottom: 0.75rem;
+    width: calc(100vw - 1.5rem);
+    max-height: min(78vh, 620px);
+  }
+}
+
+@media (max-width: 720px) {
+  .smart-home-device-list {
+    grid-template-columns: minmax(0, 1fr);
+  }
+
+  .metro-tile[data-tile-id="smart-home"] .smart-home-device-list {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+
+  .smart-home-summary {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+}
+
+@container (max-width: 360px) {
+  .smart-home-panel-metro .smart-home-device-list {
+    grid-template-columns: minmax(0, 1fr);
+  }
+
+  .smart-home-panel-metro .smart-home-metro-summary span:nth-child(2) {
+    display: none;
+  }
+}
+
+@container (min-width: 620px) {
+  .smart-home-panel-metro .smart-home-device-list {
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+  }
+}
+
+@container (max-height: 330px) {
+  .smart-home-panel-metro .smart-home-metro-summary {
+    display: none;
+  }
+
+  .smart-home-panel-metro .smart-home-device-compact {
+    min-height: 38px;
+  }
 }

--- a/tests/metro-tiles.spec.ts
+++ b/tests/metro-tiles.spec.ts
@@ -20,23 +20,12 @@ test.describe("Metro tiles", () => {
       .first();
     await expect(handle).toBeVisible();
 
-    const box = await handle.boundingBox();
-    expect(box).not.toBeNull();
-    if (!box) return;
+    await handle.press("ArrowDown");
 
-    await page.mouse.move(box.x + box.width / 2, box.y + box.height / 2);
-    await page.mouse.down();
-    await page.mouse.move(box.x + box.width / 2, box.y + box.height / 2 + 110, {
-      steps: 6,
-    });
-    await page.mouse.up();
-
-    const savedTimer = await page.evaluate(() => {
+    await expect.poll(() => page.evaluate(() => {
       const raw = localStorage.getItem("octos_home_metro_layout");
-      return raw ? JSON.parse(raw).timer : null;
-    });
-
-    expect(savedTimer?.h).toBeGreaterThan(1);
+      return raw ? (JSON.parse(raw).timer?.h ?? 0) : 0;
+    })).toBeGreaterThan(1);
   });
 
   test("default timer tile contains its idle controls without clipping", async ({ page }) => {
@@ -222,7 +211,7 @@ test.describe("Metro tiles", () => {
     }
   });
 
-  test("row position is clamped to MAX_ROWS (12)", async ({ page }) => {
+  test("row position is clamped to MAX_ROWS (20)", async ({ page }) => {
     // Set a layout with a tile at row 20
     await page.evaluate(() => {
       const layouts = {
@@ -239,7 +228,7 @@ test.describe("Metro tiles", () => {
       .getAttribute("style");
     const rowMatch = clockStyle?.match(/grid-row:\s*(\d+)/);
     if (rowMatch) {
-      expect(Number(rowMatch[1])).toBeLessThanOrEqual(12);
+      expect(Number(rowMatch[1])).toBeLessThanOrEqual(20);
     }
   });
 

--- a/tests/ui-redesign-smoke.spec.ts
+++ b/tests/ui-redesign-smoke.spec.ts
@@ -26,6 +26,70 @@ const mockProfile = {
   },
 };
 
+const mockSmartHomeDevices = [
+  {
+    id: "real_tv",
+    name: "Living Room TV",
+    home: "Main home",
+    room: "Living room",
+    kind: "tv",
+    on: true,
+    online: true,
+    readonly: true,
+    volume: 24,
+    brightness: 24,
+    mode: "HDMI 1",
+    note: "Input HDMI 1",
+    color: "#60a5fa",
+  },
+  {
+    id: "real_ac",
+    name: "Bedroom AC",
+    home: "Main home",
+    room: "Bedroom",
+    kind: "climate",
+    on: true,
+    online: true,
+    readonly: false,
+    temperature: 24,
+    brightness: 24,
+    mode: "cool",
+    note: "Target 24C",
+    color: "#38bdf8",
+  },
+  {
+    id: "curtain",
+    name: "Kitchen Curtain",
+    home: "Main home",
+    room: "Kitchen",
+    kind: "cover",
+    on: true,
+    online: true,
+    readonly: false,
+    position: 66,
+    brightness: 66,
+    mode: "open",
+    note: "Position 66%",
+    color: "#22c55e",
+  },
+  {
+    id: "camera_wangwang",
+    name: "Wangwang Camera",
+    home: "Camera home",
+    room: "Living room",
+    kind: "camera",
+    on: true,
+    online: true,
+    readonly: true,
+    stream: "available",
+    stream_capable: true,
+    stream_protocol: "rtc",
+    mode: "ready",
+    note: "Stream available",
+    color: "#64748b",
+  },
+];
+
 async function fulfillJson(route: Route, body: unknown) {
   await route.fulfill({
     status: 200,
@@ -196,6 +260,38 @@ async function installWorkbenchMocks(
     }
     if (path.includes("/ominix-api/models")) {
       await fulfillJson(route, { models: [] });
+      return;
+    }
+    await fulfillJson(route, { ok: true });
+  });
+
+  await page.route((url) => url.pathname.startsWith("/smart-home-api/"), async (route) => {
+    const path = new URL(route.request().url()).pathname;
+    if (path === "/smart-home-api/health") {
+      await fulfillJson(route, {
+        ok: true,
+        devices: mockSmartHomeDevices.length,
+        home_assistant: "connected",
+      });
+      return;
+    }
+    if (path === "/smart-home-api/devices") {
+      await fulfillJson(route, {
+        source: "home_assistant",
+        devices: mockSmartHomeDevices,
+      });
+      return;
+    }
+    if (path.startsWith("/smart-home-api/devices/")) {
+      await fulfillJson(route, { ok: true, source: "home_assistant" });
+      return;
+    }
+    if (path.startsWith("/smart-home-api/cameras/")) {
+      await fulfillJson(route, {
+        ok: true,
+        protocol: "rtc",
+        playback_url: "http://127.0.0.1:1984/stream.html?src=wangwang",
+      });
       return;
     }
     await fulfillJson(route, { ok: true });
@@ -442,11 +538,71 @@ test.describe("UI redesign shell smoke", () => {
     await expect(page.locator(".metro-grid")).toBeVisible();
   });
 
+  test("home smart home widget renders bridge devices", async ({ page }) => {
+    await page.setViewportSize({ width: 390, height: 844 });
+    await page.goto("/home", { waitUntil: "networkidle" });
+
+    const panel = page.getByTestId("smart-home-panel");
+    await expect(panel).toBeVisible();
+    await expect(panel).toContainText("Smart Home");
+    await expect(panel).toContainText("Living Room TV");
+    await expect(panel).toContainText("Kitchen Curtain");
+    await expect(panel).toContainText("4");
+    await expect(panel.getByRole("button", { name: "Refresh" })).toBeVisible();
+
+    const overflow = await page.evaluate(() => {
+      const panelEl = document.querySelector('[data-testid="smart-home-panel"]');
+      const rect = panelEl?.getBoundingClientRect();
+      return {
+        documentOverflow: document.documentElement.scrollWidth - window.innerWidth,
+        panelRight: rect?.right ?? 0,
+        viewportWidth: window.innerWidth,
+      };
+    });
+
+    expect(overflow.documentOverflow).toBeLessThanOrEqual(1);
+    expect(overflow.panelRight).toBeLessThanOrEqual(overflow.viewportWidth + 1);
+  });
+
+  test("home smart home device rows open device-specific controls", async ({ page }) => {
+    await page.setViewportSize({ width: 948, height: 749 });
+    await page.goto("/home", { waitUntil: "networkidle" });
+
+    await page.getByRole("button", { name: "Living Room TV controls" }).click();
+    const panel = page.getByRole("dialog", { name: "Living Room TV controls" });
+    await expect(panel).toBeVisible();
+    const panelBox = await page.locator(".smart-home-device-popover").boundingBox();
+    expect(panelBox).not.toBeNull();
+    expect(panelBox!.y).toBeGreaterThanOrEqual(8);
+    expect(panelBox!.y + panelBox!.height).toBeLessThanOrEqual(749 - 8);
+    await expect(panel).toContainText("HDMI 1");
+    await expect(panel.getByRole("button", { name: "Living Room TV Vol +" })).toBeVisible();
+    await expect(panel.getByRole("button", { name: "Living Room TV Home" })).toBeVisible();
+    const tvVolumeAction = page.waitForRequest((request) => {
+      const url = new URL(request.url());
+      return (
+        request.method() === "POST" &&
+        url.pathname === "/smart-home-api/devices/real_tv" &&
+        request.postData()?.includes("action=volume_up") === true
+      );
+    });
+    await panel.getByRole("button", { name: "Living Room TV Vol +" }).click();
+    await tvVolumeAction;
+
+    await panel.getByRole("button", { name: "Living Room TV close controls" }).click();
+    await page.getByRole("button", { name: "Bedroom AC controls" }).click();
+    const climatePanel = page.getByRole("dialog", { name: "Bedroom AC controls" });
+    await expect(climatePanel).toBeVisible();
+    await expect(climatePanel.getByLabel("Bedroom AC Fan")).toBeVisible();
+    await expect(climatePanel.getByRole("button", { name: "Cool", exact: true })).toBeVisible();
+  });
+
   test("classic home uses an aligned widget grid", async ({ page }) => {
     await page.setViewportSize({ width: 859, height: 819 });
     await page.addInitScript(() => {
       localStorage.setItem("octos_home_ui_style", "classic");
       localStorage.setItem("octos_home_night_mode", "off");
+      localStorage.setItem("octos_home_city", "Tokyo");
     });
 
     await page.goto("/home", { waitUntil: "networkidle" });
@@ -481,6 +637,7 @@ test.describe("UI redesign shell smoke", () => {
     await page.addInitScript(() => {
       localStorage.setItem("octos_home_ui_style", "classic");
       localStorage.setItem("octos_home_night_mode", "off");
+      localStorage.setItem("octos_home_city", "Tokyo");
     });
     await page.route("https://geocoding-api.open-meteo.com/**", async (route) => {
       await fulfillJson(route, {

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -24,6 +24,11 @@ export default defineConfig({
           });
         },
       },
+      "/smart-home-api": {
+        target: "http://localhost:8787",
+        changeOrigin: true,
+        rewrite: (path) => path.replace(/^\/smart-home-api/, "/api"),
+      },
     },
   },
   build: {


### PR DESCRIPTION
## Summary

- Add a Smart Home widget to the Octos home dashboard for the existing Home Assistant bridge.
- Wire the widget through `/smart-home-api/*` so Octos keeps the bridge boundary separate.
- Make device cards open touch-friendly, viewport-safe controls for TV, AC, curtain, speaker, cameras, and read-only devices.
- Update Metro/classic home layout and smoke tests so the widget stays in the first usable viewport and device controls are not inert.

## Validation

- `node node_modules/typescript/bin/tsc -b`
- `node node_modules/vite/bin/vite.js build`
- `BASE_URL=http://127.0.0.1:5174 node node_modules/@playwright/test/cli.js test --config playwright.chrome.config.ts` -> 111 passed, 36 skipped
