### PR TITLE
feat(voice): rich-output rendering (image / interactive HTML) in voice chat

### DIFF
--- a/src/home/voice/use-voice-conversation.test.ts
+++ b/src/home/voice/use-voice-conversation.test.ts
@@ -1,7 +1,10 @@
 import { describe, it, expect } from "vitest";
 import {
   collectFreshAudio,
+  collectFreshVisuals,
+  hasVisualMarker,
   pickFreshAudio,
+  stripVisualMarker,
 } from "./use-voice-conversation";
 import type { Thread } from "@/store/thread-store";
 
@@ -40,5 +43,66 @@ describe("pickFreshAudio", () => {
     expect(collectFreshAudio(threads, new Set(), new Set(["old-turn"]))).toEqual([
       { path: "a/new.wav", text: "new" },
     ]);
+  });
+});
+
+describe("visual marker", () => {
+  it("detects a well-formed marker and ignores empty/absent", () => {
+    expect(hasVisualMarker("好的。\n[[VISUAL:html|负反馈电路]]")).toBe(true);
+    expect(hasVisualMarker("[[VISUAL:image|一只猫]]")).toBe(true);
+    expect(hasVisualMarker("纯口播没有标记")).toBe(false);
+    expect(hasVisualMarker("[[VISUAL:html|]]")).toBe(false);
+  });
+
+  it("strips the trailing marker for display", () => {
+    expect(stripVisualMarker("我给你画一个。\n[[VISUAL:html|电路]]")).toBe(
+      "我给你画一个。",
+    );
+    expect(stripVisualMarker("没有标记")).toBe("没有标记");
+  });
+});
+
+describe("collectFreshVisuals", () => {
+  it("collects unseen image/html artifacts and classifies by extension", () => {
+    const threads = [
+      {
+        id: "t1",
+        responses: [
+          {
+            role: "assistant",
+            text: "x",
+            files: [
+              { path: "w/reply.wav" }, // audio — ignored
+              { path: "w/visual-1.html" },
+              { path: "w/poster.png" },
+            ],
+          },
+        ],
+      },
+    ] as unknown as Thread[];
+    expect(collectFreshVisuals(threads, new Set())).toEqual([
+      { path: "w/visual-1.html", kind: "html" },
+      { path: "w/poster.png", kind: "image" },
+    ]);
+  });
+
+  it("skips already-seen artifacts and ignored turns", () => {
+    const threads = [
+      {
+        id: "old",
+        responses: [
+          { role: "assistant", text: "x", files: [{ path: "w/old.png" }] },
+        ],
+      },
+      {
+        id: "new",
+        responses: [
+          { role: "assistant", text: "y", files: [{ path: "w/new.html" }] },
+        ],
+      },
+    ] as unknown as Thread[];
+    expect(
+      collectFreshVisuals(threads, new Set(["w/seen.png"]), new Set(["old"])),
+    ).toEqual([{ path: "w/new.html", kind: "html" }]);
   });
 });

--- a/src/home/voice/use-voice-conversation.ts
+++ b/src/home/voice/use-voice-conversation.ts
@@ -13,6 +13,14 @@ import { playAudioBlob, stopAudio, unlockAudio } from "./audio-playback";
 
 export type VoiceState = "idle" | "listening" | "thinking" | "speaking" | "error";
 
+/** A rich-output artifact the assistant produced for this voice turn. */
+export type VisualKind = "html" | "image";
+export interface VisualArtifact {
+  /** Workspace-relative path, fetched via /api/files (session-scoped). */
+  path: string;
+  kind: VisualKind;
+}
+
 export interface VoiceConversation {
   state: VoiceState;
   lastUserText: string;
@@ -21,9 +29,57 @@ export interface VoiceConversation {
   start: () => Promise<void>;
   stop: () => void;
   interrupt: () => void;
+  /** The latest rich-output artifact (image/HTML) to render, or null. */
+  visual: VisualArtifact | null;
+  /** True while a visual is being generated (marker seen, artifact not yet in). */
+  generating: boolean;
+  /** Dismiss the currently shown visual artifact. */
+  dismissVisual: () => void;
 }
 
 const AUDIO_EXT = /\.(wav|mp3|ogg|m4a|flac)$/i;
+const HTML_EXT = /\.html?$/i;
+const VISUAL_IMAGE_EXT = /\.(png|jpe?g|gif|webp|svg)$/i;
+/** Mirror of the backend in-band marker `[[VISUAL:kind|brief]]`. */
+const VISUAL_MARKER = /\[\[VISUAL:(html|image|infographic)\|([^\]]*)\]\]/;
+/** Safety net: clear the "generating" state if no artifact arrives in time. */
+const VISUAL_TIMEOUT_MS = 90000;
+
+/** Whether the assistant reply carries an in-band visual marker. */
+export function hasVisualMarker(text: string): boolean {
+  const m = VISUAL_MARKER.exec(text);
+  return m !== null && m[2].trim().length > 0;
+}
+
+/** Strip a trailing `[[VISUAL:...]]` marker so it isn't shown to the user. */
+export function stripVisualMarker(text: string): string {
+  const i = text.indexOf("[[VISUAL:");
+  return i >= 0 ? text.slice(0, i).trimEnd() : text;
+}
+
+/** Collect ALL unseen assistant visual artifacts (image/HTML) in order. */
+export function collectFreshVisuals(
+  threads: Thread[],
+  seen: Set<string>,
+  ignoredThreadIds: Set<string> = new Set(),
+): VisualArtifact[] {
+  const out: VisualArtifact[] = [];
+  for (let i = 0; i < threads.length; i++) {
+    if (ignoredThreadIds.has(threads[i].id)) continue;
+    const asst = threads[i].responses.filter(
+      (m: ThreadMessage) => m.role === "assistant",
+    );
+    for (let j = 0; j < asst.length; j++) {
+      for (const f of asst[j].files) {
+        if (seen.has(f.path)) continue;
+        if (HTML_EXT.test(f.path)) out.push({ path: f.path, kind: "html" });
+        else if (VISUAL_IMAGE_EXT.test(f.path))
+          out.push({ path: f.path, kind: "image" });
+      }
+    }
+  }
+  return out;
+}
 
 /** Safety net: if no reply audio shows up within this window after sending,
  *  return to listening. On-device ominix can thrash ASR↔TTS model reloads
@@ -101,6 +157,15 @@ export function useVoiceConversation(
   const captureError = capture.error;
   const [state, setState] = useState<VoiceState>("idle");
   const [lastAssistantText, setLastAssistantText] = useState("");
+  const [visual, setVisual] = useState<VisualArtifact | null>(null);
+  const [generating, setGenerating] = useState(false);
+
+  // Rich output: artifacts already surfaced (so re-renders / re-entry don't
+  // re-show them), a key for the marker we last flagged as "generating", and a
+  // safety timer to clear a stuck generating state.
+  const seenVisualsRef = useRef<Set<string>>(new Set());
+  const generatingKeyRef = useRef<string | null>(null);
+  const generatingTimerRef = useRef<ReturnType<typeof setTimeout> | undefined>(undefined);
 
   const playedPathsRef = useRef<Set<string>>(new Set());
   const ignoredTurnIdsRef = useRef<Set<string>>(new Set());
@@ -333,6 +398,19 @@ export function useVoiceConversation(
     activeTurnIdRef.current = null;
     turnBaselineRef.current = threadsRef.current.length;
     setLastAssistantText("");
+    // Rich output: mark pre-existing artifacts as seen so re-entry doesn't
+    // re-surface a prior turn's visual; reset the live visual/generating state.
+    seenVisualsRef.current = new Set(
+      collectFreshVisuals(
+        threadsRef.current,
+        new Set(),
+        ignoredTurnIdsRef.current,
+      ).map((v) => v.path),
+    );
+    setVisual(null);
+    setGenerating(false);
+    generatingKeyRef.current = null;
+    clearTimeout(generatingTimerRef.current);
     audioQueueRef.current = [];
     playingRef.current = false;
     clearTimeout(graceTimerRef.current);
@@ -357,6 +435,10 @@ export function useVoiceConversation(
     speechInterruptArmedRef.current = false;
     audioQueueRef.current = [];
     playingRef.current = false;
+    clearTimeout(generatingTimerRef.current);
+    generatingKeyRef.current = null;
+    setVisual(null);
+    setGenerating(false);
     void captureStop();
     releaseAudio();
     stateRef.current = "idle";
@@ -404,7 +486,7 @@ export function useVoiceConversation(
     for (const f of fresh) {
       playedPathsRef.current.add(f.path);
       audioQueueRef.current.push(f.path);
-      setLastAssistantText(f.text);
+      setLastAssistantText(stripVisualMarker(f.text));
     }
     // Tear the barge-in VAD down and WAIT for it to finish BEFORE playback, so
     // its Silero ONNX/WASM + mic AudioContext shutdown doesn't contend with the
@@ -415,6 +497,47 @@ export function useVoiceConversation(
       await drainQueueRef.current();
     })();
   }, [captureStop, threads, state]);
+
+  // Rich output: surface visual artifacts as they land (decoupled from turn
+  // timing — HTML authoring / image gen can finish seconds after the reply),
+  // and reflect a "generating" state while a marker is seen but no artifact has
+  // arrived yet. Not gated on voice state, so a late artifact is still caught.
+  useEffect(() => {
+    const fresh = collectFreshVisuals(
+      threads,
+      seenVisualsRef.current,
+      ignoredTurnIdsRef.current,
+    );
+    if (fresh.length > 0) {
+      for (const v of fresh) seenVisualsRef.current.add(v.path);
+      setVisual(fresh[fresh.length - 1]);
+      setGenerating(false);
+      generatingKeyRef.current = null;
+      clearTimeout(generatingTimerRef.current);
+      return;
+    }
+    // No artifact yet: if the newest post-baseline assistant reply carries a
+    // marker we haven't flagged, enter the generating state (with a safety
+    // timeout so a failed generation can't wedge it on forever).
+    for (let i = threads.length - 1; i >= turnBaselineRef.current; i--) {
+      const t = threads[i];
+      if (!t) continue;
+      const asst = t.responses.filter((m) => m.role === "assistant");
+      const text = asst.length > 0 ? asst[asst.length - 1].text : "";
+      if (text && hasVisualMarker(text)) {
+        if (generatingKeyRef.current !== text) {
+          generatingKeyRef.current = text;
+          setGenerating(true);
+          clearTimeout(generatingTimerRef.current);
+          generatingTimerRef.current = setTimeout(
+            () => setGenerating(false),
+            VISUAL_TIMEOUT_MS,
+          );
+        }
+        break;
+      }
+    }
+  }, [threads]);
 
   // Stop ONLY on real unmount. Use a ref so identity churn of `stop` across
   // re-renders never re-fires this cleanup (that was tearing the VAD down on
@@ -428,6 +551,8 @@ export function useVoiceConversation(
       ? (threads[threads.length - 1].userMsg?.text ?? "")
       : "";
 
+  const dismissVisual = useCallback(() => setVisual(null), []);
+
   return {
     state,
     lastUserText,
@@ -436,5 +561,8 @@ export function useVoiceConversation(
     start,
     stop,
     interrupt,
+    visual,
+    generating,
+    dismissVisual,
   };
 }

--- a/src/home/voice/visual-panel.tsx
+++ b/src/home/voice/visual-panel.tsx
@@ -11,7 +11,9 @@ interface VisualPanelProps {
 }
 
 /**
- * Renders a voice-turn rich-output artifact over the orb.
+ * Renders a voice-turn rich-output artifact. Fills its container, which the
+ * voice view docks on the right so the next turn can be spoken while looking
+ * at it.
  *
  * - HTML → a **sandboxed iframe** (`sandbox="allow-scripts"`, no
  *   `allow-same-origin`) via `srcDoc`, so interactive demos run their own JS
@@ -57,7 +59,7 @@ export function VisualPanel({ visual, sessionId, onClose }: VisualPanelProps) {
   }, [visual.path, visual.kind, sessionId]);
 
   return (
-    <div className="absolute inset-0 z-20 flex flex-col bg-black/85 p-4 backdrop-blur-sm">
+    <div className="relative flex h-full w-full flex-col bg-black/40 p-4">
       <button
         onClick={onClose}
         aria-label="close visual"

--- a/src/home/voice/visual-panel.tsx
+++ b/src/home/voice/visual-panel.tsx
@@ -1,0 +1,93 @@
+import { useEffect, useState } from "react";
+import { X } from "lucide-react";
+import { buildFileUrl } from "@/api/files";
+import { buildApiHeaders } from "@/api/client";
+import type { VisualArtifact } from "./use-voice-conversation";
+
+interface VisualPanelProps {
+  visual: VisualArtifact;
+  sessionId: string;
+  onClose: () => void;
+}
+
+/**
+ * Renders a voice-turn rich-output artifact over the orb.
+ *
+ * - HTML → a **sandboxed iframe** (`sandbox="allow-scripts"`, no
+ *   `allow-same-origin`) via `srcDoc`, so interactive demos run their own JS
+ *   without any access to the host origin / storage / cookies.
+ * - Image → an `<img>` from an object URL.
+ *
+ * Both are fetched through `/api/files` (session-scoped, auth headers), mirroring
+ * how reply audio is fetched, since the file lives under the turn workspace.
+ */
+export function VisualPanel({ visual, sessionId, onClose }: VisualPanelProps) {
+  const [html, setHtml] = useState<string | null>(null);
+  const [imgUrl, setImgUrl] = useState<string | null>(null);
+  const [error, setError] = useState(false);
+
+  useEffect(() => {
+    // The parent keys this component by `visual.path`, so a new artifact mounts
+    // a fresh instance — no need to reset state synchronously here (which would
+    // trigger cascading renders). We only set state from the async callbacks.
+    let cancelled = false;
+    let objectUrl: string | null = null;
+    const url = `${buildFileUrl(visual.path)}?session=${encodeURIComponent(sessionId)}`;
+    void (async () => {
+      try {
+        const resp = await fetch(url, { headers: buildApiHeaders() });
+        if (!resp.ok) throw new Error(`visual fetch ${resp.status}`);
+        if (visual.kind === "html") {
+          const text = await resp.text();
+          if (!cancelled) setHtml(text);
+        } else {
+          const blob = await resp.blob();
+          objectUrl = URL.createObjectURL(blob);
+          if (!cancelled) setImgUrl(objectUrl);
+        }
+      } catch (e) {
+        console.error("[voice] visual fetch failed", e);
+        if (!cancelled) setError(true);
+      }
+    })();
+    return () => {
+      cancelled = true;
+      if (objectUrl) URL.revokeObjectURL(objectUrl);
+    };
+  }, [visual.path, visual.kind, sessionId]);
+
+  return (
+    <div className="absolute inset-0 z-20 flex flex-col bg-black/85 p-4 backdrop-blur-sm">
+      <button
+        onClick={onClose}
+        aria-label="close visual"
+        className="absolute right-5 top-5 z-10 flex h-10 w-10 items-center justify-center rounded-full bg-white/10 text-white/70"
+      >
+        <X size={22} />
+      </button>
+      <div className="flex min-h-0 flex-1 items-center justify-center overflow-auto rounded-2xl bg-white/5">
+        {error && <div className="text-sm text-white/60">视觉内容加载失败</div>}
+        {!error && visual.kind === "html" && html !== null && (
+          <iframe
+            title="rich-output"
+            srcDoc={html}
+            sandbox="allow-scripts"
+            className="h-full w-full rounded-2xl border-0 bg-white"
+          />
+        )}
+        {!error && visual.kind === "image" && imgUrl && (
+          <img
+            src={imgUrl}
+            alt="rich-output"
+            className="max-h-full max-w-full rounded-2xl object-contain"
+          />
+        )}
+        {!error &&
+          ((visual.kind === "html" && html === null) ||
+            (visual.kind === "image" && !imgUrl)) && (
+            <div className="text-sm text-white/55">加载中…</div>
+          )}
+      </div>
+    </div>
+  );
+}

--- a/src/home/voice/voice-view.tsx
+++ b/src/home/voice/voice-view.tsx
@@ -3,6 +3,7 @@ import { X } from "lucide-react";
 import { useVoiceConversation, type VoiceState } from "./use-voice-conversation";
 import { VoiceOrb } from "./voice-orb";
 import { VoiceSelector } from "./voice-selector";
+import { VisualPanel } from "./visual-panel";
 import { unlockAudio } from "./audio-playback";
 import "./voice.css";
 
@@ -61,11 +62,29 @@ export function VoiceView({ sessionId, historyTopic, onBack }: VoiceViewProps) {
         )}
       </div>
 
+      {/* Rich output: generating indicator while the visual is being produced. */}
+      {conv.generating && !conv.visual && (
+        <div className="mt-5 flex items-center gap-2 text-sm text-white/60">
+          <span className="h-2 w-2 animate-ping rounded-full bg-white/70" />
+          正在生成视觉内容…
+        </div>
+      )}
+
       {/* Quick voice switcher — same store as the settings panel. */}
-      {conv.state !== "idle" && (
+      {conv.state !== "idle" && !conv.visual && (
         <div className="absolute inset-x-0 bottom-6 px-6">
           <VoiceSelector />
         </div>
+      )}
+
+      {/* Rich output: the produced image / interactive HTML, over the orb. */}
+      {conv.visual && (
+        <VisualPanel
+          key={conv.visual.path}
+          visual={conv.visual}
+          sessionId={sessionId}
+          onClose={conv.dismissVisual}
+        />
       )}
     </div>
   );

--- a/src/home/voice/voice-view.tsx
+++ b/src/home/voice/voice-view.tsx
@@ -38,53 +38,61 @@ export function VoiceView({ sessionId, historyTopic, onBack }: VoiceViewProps) {
   };
 
   return (
-    <div className="voice-view relative flex h-full w-full flex-col items-center justify-center bg-black">
-      <button
-        onClick={onBack}
-        aria-label="exit voice mode"
-        className="absolute right-5 top-5 flex h-10 w-10 items-center justify-center rounded-full bg-white/10 text-white/70"
-      >
-        <X size={22} />
-      </button>
+    <div className="voice-view relative flex h-full w-full bg-black">
+      {/* Conversation column. Takes the full width on its own; shrinks to the
+          left when a visual is docked on the right so the user can keep talking
+          while referencing it. */}
+      <div className="relative flex flex-1 flex-col items-center justify-center min-w-0">
+        <button
+          onClick={onBack}
+          aria-label="exit voice mode"
+          className="absolute right-5 top-5 flex h-10 w-10 items-center justify-center rounded-full bg-white/10 text-white/70"
+        >
+          <X size={22} />
+        </button>
 
-      <div onClick={onOrbClick} role="button" aria-label="voice orb">
-        <VoiceOrb state={conv.state} />
+        <div onClick={onOrbClick} role="button" aria-label="voice orb">
+          <VoiceOrb state={conv.state} />
+        </div>
+
+        <div className="mt-6 min-h-[20px] text-sm text-white/55">{STATE_WORD[conv.state]}</div>
+
+        <div className="mt-4 max-w-[80%] text-center">
+          {conv.lastUserText && (
+            <div className="mb-2 text-sm text-white/45">{conv.lastUserText}</div>
+          )}
+          {conv.lastAssistantText && (
+            <div className="text-lg leading-relaxed text-white/90">{conv.lastAssistantText}</div>
+          )}
+        </div>
+
+        {/* Rich output: generating indicator while the visual is being produced. */}
+        {conv.generating && !conv.visual && (
+          <div className="mt-5 flex items-center gap-2 text-sm text-white/60">
+            <span className="h-2 w-2 animate-ping rounded-full bg-white/70" />
+            正在生成视觉内容…
+          </div>
+        )}
+
+        {/* Quick voice switcher — same store as the settings panel. */}
+        {conv.state !== "idle" && (
+          <div className="absolute inset-x-0 bottom-6 px-6">
+            <VoiceSelector />
+          </div>
+        )}
       </div>
 
-      <div className="mt-6 min-h-[20px] text-sm text-white/55">{STATE_WORD[conv.state]}</div>
-
-      <div className="mt-4 max-w-[80%] text-center">
-        {conv.lastUserText && (
-          <div className="mb-2 text-sm text-white/45">{conv.lastUserText}</div>
-        )}
-        {conv.lastAssistantText && (
-          <div className="text-lg leading-relaxed text-white/90">{conv.lastAssistantText}</div>
-        )}
-      </div>
-
-      {/* Rich output: generating indicator while the visual is being produced. */}
-      {conv.generating && !conv.visual && (
-        <div className="mt-5 flex items-center gap-2 text-sm text-white/60">
-          <span className="h-2 w-2 animate-ping rounded-full bg-white/70" />
-          正在生成视觉内容…
-        </div>
-      )}
-
-      {/* Quick voice switcher — same store as the settings panel. */}
-      {conv.state !== "idle" && !conv.visual && (
-        <div className="absolute inset-x-0 bottom-6 px-6">
-          <VoiceSelector />
-        </div>
-      )}
-
-      {/* Rich output: the produced image / interactive HTML, over the orb. */}
+      {/* Rich output: produced image / interactive HTML, docked on the right so
+          the next turn can be spoken while looking at it. */}
       {conv.visual && (
-        <VisualPanel
-          key={conv.visual.path}
-          visual={conv.visual}
-          sessionId={sessionId}
-          onClose={conv.dismissVisual}
-        />
+        <div className="h-full w-[55%] shrink-0 border-l border-white/10">
+          <VisualPanel
+            key={conv.visual.path}
+            visual={conv.visual}
+            sessionId={sessionId}
+            onClose={conv.dismissVisual}
+          />
+        </div>
       )}
     </div>
   );


### PR DESCRIPTION
Renders the rich-output artifacts the backend produces for a voice turn that carries an in-band `[[VISUAL:kind|brief]]` marker.

- Parse/strip the marker from the assistant reply: display text drops it; its presence drives a "generating" state until the artifact lands.
- `collectFreshVisuals` picks image/HTML files off the assistant message (the same `files` channel as reply audio), surfaced via a state-independent effect so a late artifact is still caught.
- `VisualPanel` renders HTML in a **sandboxed iframe** (`allow-scripts`, no `same-origin`) and images from an object URL, both fetched session-scoped.
- The visual docks in a **right-hand panel** beside the orb (left conversation column + right visual column), so the next spoken turn can reference it while the orb and reply text stay visible.

Pure helpers unit-tested; `tsc -b`, `vite build`, lint, and existing voice tests green.

Note: touches `src/home/voice/use-voice-conversation.ts`, which also changes in the camera/video-chat PR — expect a merge conflict there depending on merge order.

🤖 Generated with [Claude Code](https://claude.com/claude-code)