### PR TITLE
feat(voice): camera / video chat in the voice screen

### DIFF
--- a/src/home/voice/camera-preview.tsx
+++ b/src/home/voice/camera-preview.tsx
@@ -1,0 +1,32 @@
+import { useEffect, useRef } from "react";
+
+/**
+ * Self-preview of the live camera stream — shows the user what the AI sees.
+ * Mirrored (selfie-style) and muted; binds the stream via ref since `srcObject`
+ * can't be set as a JSX attribute.
+ */
+export function CameraPreview({ stream }: { stream: MediaStream | null }) {
+  const ref = useRef<HTMLVideoElement | null>(null);
+
+  useEffect(() => {
+    const video = ref.current;
+    if (!video) return;
+    video.srcObject = stream;
+    if (stream) {
+      const p = video.play?.();
+      if (p && typeof p.catch === "function") p.catch(() => {});
+    }
+  }, [stream]);
+
+  return (
+    <video
+      ref={ref}
+      data-testid="camera-preview"
+      autoPlay
+      muted
+      playsInline
+      className="h-24 w-32 rounded-xl object-cover ring-1 ring-white/15 shadow-lg"
+      style={{ transform: "scaleX(-1)" }}
+    />
+  );
+}

--- a/src/home/voice/use-camera-frame.test.ts
+++ b/src/home/voice/use-camera-frame.test.ts
@@ -98,4 +98,21 @@ describe("useCameraFrame", () => {
     expect(stopTrack).toHaveBeenCalled();
     expect(result.current.active).toBe(false);
   });
+
+  it("exposes the live stream while active and clears it on stop", async () => {
+    const fakeStream = { getTracks: () => [{ stop: vi.fn() }] };
+    getUserMedia.mockResolvedValue(fakeStream);
+    const { result } = renderHook(() => useCameraFrame());
+
+    expect(result.current.stream).toBeNull();
+    await act(async () => {
+      await result.current.start();
+    });
+    expect(result.current.stream).toBe(fakeStream);
+
+    act(() => {
+      result.current.stop();
+    });
+    expect(result.current.stream).toBeNull();
+  });
 });

--- a/src/home/voice/use-camera-frame.test.ts
+++ b/src/home/voice/use-camera-frame.test.ts
@@ -1,0 +1,101 @@
+import { act, renderHook } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { computeDownscaledSize, useCameraFrame } from "./use-camera-frame";
+
+describe("computeDownscaledSize", () => {
+  it("downscales landscape so the long edge is the cap", () => {
+    expect(computeDownscaledSize(1920, 1080, 768)).toEqual({
+      width: 768,
+      height: 432,
+    });
+  });
+
+  it("downscales portrait so the long edge is the cap", () => {
+    expect(computeDownscaledSize(1080, 1920, 768)).toEqual({
+      width: 432,
+      height: 768,
+    });
+  });
+
+  it("never upscales a frame smaller than the cap", () => {
+    expect(computeDownscaledSize(640, 480, 768)).toEqual({
+      width: 640,
+      height: 480,
+    });
+  });
+
+  it("returns zero for empty dimensions", () => {
+    expect(computeDownscaledSize(0, 0, 768)).toEqual({ width: 0, height: 0 });
+  });
+});
+
+describe("useCameraFrame", () => {
+  const getUserMedia = vi.fn();
+
+  beforeEach(() => {
+    getUserMedia.mockReset();
+    Object.defineProperty(navigator, "mediaDevices", {
+      value: { getUserMedia },
+      configurable: true,
+    });
+    vi.spyOn(HTMLCanvasElement.prototype, "getContext").mockReturnValue({
+      drawImage: vi.fn(),
+    } as unknown as CanvasRenderingContext2D);
+    vi.spyOn(HTMLCanvasElement.prototype, "toBlob").mockImplementation(function (
+      cb: BlobCallback,
+    ) {
+      cb(new Blob(["x"], { type: "image/jpeg" }));
+    });
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("returns null from grabFrame when the camera is not started", async () => {
+    const { result } = renderHook(() => useCameraFrame());
+    await expect(result.current.grabFrame()).resolves.toBeNull();
+  });
+
+  it("returns a jpeg File from grabFrame when active", async () => {
+    getUserMedia.mockResolvedValue({ getTracks: () => [{ stop: vi.fn() }] });
+    const { result } = renderHook(() => useCameraFrame());
+
+    await act(async () => {
+      await result.current.start();
+    });
+    expect(result.current.active).toBe(true);
+
+    const frame = await result.current.grabFrame();
+    expect(frame).toBeInstanceOf(File);
+    expect(frame?.type).toBe("image/jpeg");
+  });
+
+  it("sets error and stays inactive when permission is denied", async () => {
+    getUserMedia.mockRejectedValue(new Error("Permission denied"));
+    const { result } = renderHook(() => useCameraFrame());
+
+    await act(async () => {
+      await result.current.start();
+    });
+
+    expect(result.current.active).toBe(false);
+    expect(result.current.error).toContain("Permission denied");
+  });
+
+  it("stops the media tracks on stop()", async () => {
+    const stopTrack = vi.fn();
+    getUserMedia.mockResolvedValue({ getTracks: () => [{ stop: stopTrack }] });
+    const { result } = renderHook(() => useCameraFrame());
+
+    await act(async () => {
+      await result.current.start();
+    });
+    act(() => {
+      result.current.stop();
+    });
+
+    expect(stopTrack).toHaveBeenCalled();
+    expect(result.current.active).toBe(false);
+  });
+});

--- a/src/home/voice/use-camera-frame.ts
+++ b/src/home/voice/use-camera-frame.ts
@@ -3,6 +3,8 @@ import { useCallback, useRef, useState } from "react";
 export interface CameraFrame {
   /** Whether the camera stream is live. */
   active: boolean;
+  /** Live camera stream, for binding to a preview `<video>`. Null when off. */
+  stream: MediaStream | null;
   /** Last error (permission denied / no device / capture failure). */
   error: string | null;
   /** Request camera access and start the stream. */
@@ -49,13 +51,15 @@ export function useCameraFrame(): CameraFrame {
   const streamRef = useRef<MediaStream | null>(null);
   const videoRef = useRef<HTMLVideoElement | null>(null);
   const [active, setActive] = useState(false);
+  // Exposed so a preview <video> can bind the live stream.
+  const [stream, setStream] = useState<MediaStream | null>(null);
   const [error, setError] = useState<string | null>(null);
 
   const stop = useCallback(() => {
-    const stream = streamRef.current;
+    const current = streamRef.current;
     streamRef.current = null;
-    if (stream) {
-      for (const track of stream.getTracks()) {
+    if (current) {
+      for (const track of current.getTracks()) {
         try {
           track.stop();
         } catch {
@@ -72,6 +76,7 @@ export function useCameraFrame(): CameraFrame {
       }
     }
     videoRef.current = null;
+    setStream(null);
     setActive(false);
   }, []);
 
@@ -92,6 +97,7 @@ export function useCameraFrame(): CameraFrame {
         // Autoplay may be deferred; frames can still be grabbed once data flows.
       }
       videoRef.current = video;
+      setStream(stream);
       setActive(true);
     } catch (e) {
       console.error("[camera] start failed", e);
@@ -99,6 +105,7 @@ export function useCameraFrame(): CameraFrame {
       setActive(false);
       streamRef.current = null;
       videoRef.current = null;
+      setStream(null);
     }
   }, []);
 
@@ -129,5 +136,5 @@ export function useCameraFrame(): CameraFrame {
     }
   }, []);
 
-  return { active, error, start, stop, grabFrame };
+  return { active, stream, error, start, stop, grabFrame };
 }

--- a/src/home/voice/use-camera-frame.ts
+++ b/src/home/voice/use-camera-frame.ts
@@ -1,0 +1,133 @@
+import { useCallback, useRef, useState } from "react";
+
+export interface CameraFrame {
+  /** Whether the camera stream is live. */
+  active: boolean;
+  /** Last error (permission denied / no device / capture failure). */
+  error: string | null;
+  /** Request camera access and start the stream. */
+  start: () => Promise<void>;
+  /** Stop the stream and release the device. */
+  stop: () => void;
+  /** Capture the current frame as a downscaled JPEG `File`, or `null` if the
+   *  camera isn't active or capture fails (caller then sends audio only). */
+  grabFrame: () => Promise<File | null>;
+}
+
+/** Longest edge of a captured frame, in px — caps vision-token cost + upload. */
+export const MAX_LONG_EDGE = 768;
+/** JPEG quality for captured frames. */
+export const JPEG_QUALITY = 0.7;
+/** Capture size used before the video reports its real dimensions. */
+const FALLBACK_W = 640;
+const FALLBACK_H = 480;
+
+/** Target canvas size, downscaled so the longest edge is `maxEdge` (never
+ *  upscaling). Exported for unit tests. */
+export function computeDownscaledSize(
+  width: number,
+  height: number,
+  maxEdge: number,
+): { width: number; height: number } {
+  if (width <= 0 || height <= 0) return { width: 0, height: 0 };
+  const scale = Math.min(1, maxEdge / Math.max(width, height));
+  return {
+    width: Math.round(width * scale),
+    height: Math.round(height * scale),
+  };
+}
+
+/**
+ * Manage a single camera stream behind a tiny start/stop/grab interface.
+ *
+ * The stream is attached to an off-DOM `<video>` element (no preview is
+ * rendered in the MVP); `grabFrame` paints the current frame onto an off-screen
+ * canvas, downscales it, and returns a JPEG. Failures are swallowed into `null`
+ * so a voice turn degrades to audio-only rather than breaking.
+ */
+export function useCameraFrame(): CameraFrame {
+  const streamRef = useRef<MediaStream | null>(null);
+  const videoRef = useRef<HTMLVideoElement | null>(null);
+  const [active, setActive] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const stop = useCallback(() => {
+    const stream = streamRef.current;
+    streamRef.current = null;
+    if (stream) {
+      for (const track of stream.getTracks()) {
+        try {
+          track.stop();
+        } catch {
+          // already stopped
+        }
+      }
+    }
+    const video = videoRef.current;
+    if (video) {
+      try {
+        video.srcObject = null;
+      } catch {
+        // ignore
+      }
+    }
+    videoRef.current = null;
+    setActive(false);
+  }, []);
+
+  const start = useCallback(async () => {
+    setError(null);
+    try {
+      const md = navigator.mediaDevices;
+      if (!md?.getUserMedia) throw new Error("camera unavailable");
+      const stream = await md.getUserMedia({ video: true, audio: false });
+      streamRef.current = stream;
+      const video = document.createElement("video");
+      video.muted = true;
+      video.playsInline = true;
+      video.srcObject = stream;
+      try {
+        await video.play?.();
+      } catch {
+        // Autoplay may be deferred; frames can still be grabbed once data flows.
+      }
+      videoRef.current = video;
+      setActive(true);
+    } catch (e) {
+      console.error("[camera] start failed", e);
+      setError(e instanceof Error ? e.message : "camera unavailable");
+      setActive(false);
+      streamRef.current = null;
+      videoRef.current = null;
+    }
+  }, []);
+
+  const grabFrame = useCallback(async (): Promise<File | null> => {
+    const video = videoRef.current;
+    if (!video || !streamRef.current) return null;
+    try {
+      const w = video.videoWidth || FALLBACK_W;
+      const h = video.videoHeight || FALLBACK_H;
+      const size = computeDownscaledSize(w, h, MAX_LONG_EDGE);
+      if (size.width === 0 || size.height === 0) return null;
+
+      const canvas = document.createElement("canvas");
+      canvas.width = size.width;
+      canvas.height = size.height;
+      const ctx = canvas.getContext("2d");
+      if (!ctx) return null;
+      ctx.drawImage(video, 0, 0, size.width, size.height);
+
+      const blob = await new Promise<Blob | null>((resolve) => {
+        canvas.toBlob((b) => resolve(b), "image/jpeg", JPEG_QUALITY);
+      });
+      if (!blob) return null;
+      return new File([blob], `frame-${Date.now()}.jpg`, { type: "image/jpeg" });
+    } catch (e) {
+      console.error("[camera] grabFrame failed", e);
+      return null;
+    }
+  }, []);
+
+  return { active, error, start, stop, grabFrame };
+}

--- a/src/home/voice/use-voice-conversation.test.ts
+++ b/src/home/voice/use-voice-conversation.test.ts
@@ -1,9 +1,34 @@
-import { describe, it, expect } from "vitest";
+import { describe, it, expect, vi } from "vitest";
 import {
+  assembleTurnFiles,
   collectFreshAudio,
   pickFreshAudio,
 } from "./use-voice-conversation";
 import type { Thread } from "@/store/thread-store";
+
+describe("assembleTurnFiles", () => {
+  const audio = new File(["a"], "utterance.wav", { type: "audio/wav" });
+  const frame = new File(["f"], "frame.jpg", { type: "image/jpeg" });
+
+  it("sends audio only when the camera is disabled", async () => {
+    const grab = vi.fn();
+    const files = await assembleTurnFiles(audio, false, grab);
+    expect(files).toEqual([audio]);
+    expect(grab).not.toHaveBeenCalled();
+  });
+
+  it("appends the frame when the camera is enabled", async () => {
+    const grab = vi.fn().mockResolvedValue(frame);
+    const files = await assembleTurnFiles(audio, true, grab);
+    expect(files).toEqual([audio, frame]);
+  });
+
+  it("falls back to audio only when grabFrame returns null", async () => {
+    const grab = vi.fn().mockResolvedValue(null);
+    const files = await assembleTurnFiles(audio, true, grab);
+    expect(files).toEqual([audio]);
+  });
+});
 
 describe("pickFreshAudio", () => {
   it("returns latest unplayed assistant audio file", () => {

--- a/src/home/voice/use-voice-conversation.ts
+++ b/src/home/voice/use-voice-conversation.ts
@@ -26,6 +26,10 @@ export interface VoiceConversation {
   cameraActive: boolean;
   /** Live camera stream for the self-preview (null when off). */
   cameraStream: MediaStream | null;
+  /** Object URL of the exact frame last sent to the AI (the model's view —
+   *  downscaled, not mirrored). Replaced on the next send, auto-cleared after
+   *  a while. Null when none/expired. */
+  lastSentFrameUrl: string | null;
   /** Last camera error (permission denied / no device). */
   cameraError: string | null;
   /** Toggle the camera on/off. */
@@ -54,6 +58,8 @@ const AUDIO_EXT = /\.(wav|mp3|ogg|m4a|flac)$/i;
  *  under memory pressure (tens of seconds each), so this is deliberately
  *  generous; cloud STT/TTS or more RAM would let us shrink it. */
 const REPLY_TIMEOUT_MS = 90000;
+/** How long the "frame sent to the AI" thumbnail lingers before auto-hiding. */
+const SENT_FRAME_TTL_MS = 12000;
 const LISTENING_VAD_OPTIONS = {
   positiveSpeechThreshold: 0.5,
   negativeSpeechThreshold: 0.35,
@@ -137,6 +143,36 @@ export function useVoiceConversation(
   const cameraActiveRef = useRef(false);
   cameraActiveRef.current = cameraActive;
 
+  // The exact frame last sent to the AI, as an object URL (for the bottom
+  // thumbnail). We own the URL's lifetime: revoke on replace / hide / unmount.
+  const [lastSentFrameUrl, setLastSentFrameUrl] = useState<string | null>(null);
+  const lastSentFrameUrlRef = useRef<string | null>(null);
+  const sentFrameTimerRef = useRef<ReturnType<typeof setTimeout> | undefined>(undefined);
+
+  const clearSentFrame = useCallback(() => {
+    clearTimeout(sentFrameTimerRef.current);
+    if (lastSentFrameUrlRef.current) {
+      URL.revokeObjectURL(lastSentFrameUrlRef.current);
+      lastSentFrameUrlRef.current = null;
+    }
+    setLastSentFrameUrl(null);
+  }, []);
+
+  const showSentFrame = useCallback(
+    (frame: File) => {
+      if (typeof URL.createObjectURL !== "function") return;
+      clearTimeout(sentFrameTimerRef.current);
+      if (lastSentFrameUrlRef.current) {
+        URL.revokeObjectURL(lastSentFrameUrlRef.current);
+      }
+      const url = URL.createObjectURL(frame);
+      lastSentFrameUrlRef.current = url;
+      setLastSentFrameUrl(url);
+      sentFrameTimerRef.current = setTimeout(clearSentFrame, SENT_FRAME_TTL_MS);
+    },
+    [clearSentFrame],
+  );
+
   const playedPathsRef = useRef<Set<string>>(new Set());
   const ignoredTurnIdsRef = useRef<Set<string>>(new Set());
   const activeTurnIdRef = useRef<string | null>(null);
@@ -213,6 +249,9 @@ export function useVoiceConversation(
           cameraActiveRef.current,
           cameraGrab,
         );
+        // Surface the exact image sent to the AI (the model's view).
+        const sentFrame = files.find((f) => f.type.startsWith("image/"));
+        if (sentFrame) showSentFrame(sentFrame);
         const paths = await uploadFiles(files, "recording");
         // The server-side STT transcribes the audio in `media` into the prompt.
         // The reply's TTS audio arrives asynchronously and is played by the
@@ -242,7 +281,7 @@ export function useVoiceConversation(
         setState("error");
       }
     },
-    [historyTopic, sessionId, cameraGrab],
+    [historyTopic, sessionId, cameraGrab, showSentFrame],
   );
 
   const beginThinkingInterrupt = useCallback(async () => {
@@ -402,10 +441,11 @@ export function useVoiceConversation(
     playingRef.current = false;
     void captureStop();
     cameraStop();
+    clearSentFrame();
     releaseAudio();
     stateRef.current = "idle";
     setState("idle");
-  }, [captureStop, cameraStop, releaseAudio]);
+  }, [captureStop, cameraStop, clearSentFrame, releaseAudio]);
 
   const toggleCamera = useCallback(() => {
     if (cameraActiveRef.current) {
@@ -490,6 +530,7 @@ export function useVoiceConversation(
     interrupt,
     cameraActive,
     cameraStream,
+    lastSentFrameUrl,
     cameraError,
     toggleCamera,
   };

--- a/src/home/voice/use-voice-conversation.ts
+++ b/src/home/voice/use-voice-conversation.ts
@@ -24,6 +24,8 @@ export interface VoiceConversation {
   interrupt: () => void;
   /** Whether the camera is on (each spoken turn then attaches a frame). */
   cameraActive: boolean;
+  /** Live camera stream for the self-preview (null when off). */
+  cameraStream: MediaStream | null;
   /** Last camera error (permission denied / no device). */
   cameraError: string | null;
   /** Toggle the camera on/off. */
@@ -127,6 +129,7 @@ export function useVoiceConversation(
   const cameraStop = camera.stop;
   const cameraGrab = camera.grabFrame;
   const cameraActive = camera.active;
+  const cameraStream = camera.stream;
   const cameraError = camera.error;
   const [state, setState] = useState<VoiceState>("idle");
   const [lastAssistantText, setLastAssistantText] = useState("");
@@ -486,6 +489,7 @@ export function useVoiceConversation(
     stop,
     interrupt,
     cameraActive,
+    cameraStream,
     cameraError,
     toggleCamera,
   };

--- a/src/home/voice/use-voice-conversation.ts
+++ b/src/home/voice/use-voice-conversation.ts
@@ -9,6 +9,7 @@ import { useThreads, type Thread, type ThreadMessage } from "@/store/thread-stor
 import { buildFileUrl } from "@/api/files";
 import { buildApiHeaders } from "@/api/client";
 import { useVoiceCapture } from "./use-voice-capture";
+import { useCameraFrame } from "./use-camera-frame";
 import { playAudioBlob, stopAudio, unlockAudio } from "./audio-playback";
 
 export type VoiceState = "idle" | "listening" | "thinking" | "speaking" | "error";
@@ -21,6 +22,27 @@ export interface VoiceConversation {
   start: () => Promise<void>;
   stop: () => void;
   interrupt: () => void;
+  /** Whether the camera is on (each spoken turn then attaches a frame). */
+  cameraActive: boolean;
+  /** Last camera error (permission denied / no device). */
+  cameraError: string | null;
+  /** Toggle the camera on/off. */
+  toggleCamera: () => void;
+}
+
+/**
+ * Assemble the files for one spoken turn: always the audio, plus a camera frame
+ * when the camera is on and a frame is available. A failed/empty grab degrades
+ * to audio-only so the turn still goes through. Exported for unit tests.
+ */
+export async function assembleTurnFiles(
+  audio: File,
+  cameraActive: boolean,
+  grabFrame: () => Promise<File | null>,
+): Promise<File[]> {
+  if (!cameraActive) return [audio];
+  const frame = await grabFrame();
+  return frame ? [audio, frame] : [audio];
 }
 
 const AUDIO_EXT = /\.(wav|mp3|ogg|m4a|flac)$/i;
@@ -99,8 +121,18 @@ export function useVoiceConversation(
   const captureStart = capture.start;
   const captureStop = capture.stop;
   const captureError = capture.error;
+  const camera = useCameraFrame();
+  // Stable fns (useCallback([])); the object identity churns each render.
+  const cameraStart = camera.start;
+  const cameraStop = camera.stop;
+  const cameraGrab = camera.grabFrame;
+  const cameraActive = camera.active;
+  const cameraError = camera.error;
   const [state, setState] = useState<VoiceState>("idle");
   const [lastAssistantText, setLastAssistantText] = useState("");
+  // Read camera-on inside the stable send callback without re-creating it.
+  const cameraActiveRef = useRef(false);
+  cameraActiveRef.current = cameraActive;
 
   const playedPathsRef = useRef<Set<string>>(new Set());
   const ignoredTurnIdsRef = useRef<Set<string>>(new Set());
@@ -170,10 +202,18 @@ export function useVoiceConversation(
         stateRef.current = "thinking";
         setState("thinking");
         const file = new File([wav], "utterance.wav", { type: "audio/wav" });
-        const paths = await uploadFiles([file], "recording");
-        // Audio-only turn: the server-side STT transcribes `media` into the
-        // prompt. The reply's TTS audio arrives asynchronously and is played
-        // by the threads watcher below (not here in onComplete).
+        // When the camera is on, attach the current frame so the turn is a
+        // video call (audio + image); the server transcribes the audio and the
+        // VLM sees the frame. Degrades to audio-only on a failed grab.
+        const files = await assembleTurnFiles(
+          file,
+          cameraActiveRef.current,
+          cameraGrab,
+        );
+        const paths = await uploadFiles(files, "recording");
+        // The server-side STT transcribes the audio in `media` into the prompt.
+        // The reply's TTS audio arrives asynchronously and is played by the
+        // threads watcher below (not here in onComplete).
         sendMessage({
           sessionId,
           historyTopic,
@@ -199,7 +239,7 @@ export function useVoiceConversation(
         setState("error");
       }
     },
-    [historyTopic, sessionId],
+    [historyTopic, sessionId, cameraGrab],
   );
 
   const beginThinkingInterrupt = useCallback(async () => {
@@ -358,10 +398,19 @@ export function useVoiceConversation(
     audioQueueRef.current = [];
     playingRef.current = false;
     void captureStop();
+    cameraStop();
     releaseAudio();
     stateRef.current = "idle";
     setState("idle");
-  }, [captureStop, releaseAudio]);
+  }, [captureStop, cameraStop, releaseAudio]);
+
+  const toggleCamera = useCallback(() => {
+    if (cameraActiveRef.current) {
+      cameraStop();
+    } else {
+      void cameraStart();
+    }
+  }, [cameraStart, cameraStop]);
 
   const interrupt = useCallback(() => {
     if (stateRef.current === "speaking") {
@@ -436,5 +485,8 @@ export function useVoiceConversation(
     start,
     stop,
     interrupt,
+    cameraActive,
+    cameraError,
+    toggleCamera,
   };
 }

--- a/src/home/voice/voice-view.test.tsx
+++ b/src/home/voice/voice-view.test.tsx
@@ -6,6 +6,7 @@ import type { VoiceConversation } from "./use-voice-conversation";
 const conversationMock = vi.hoisted(() => ({
   state: "idle" as VoiceConversation["state"],
   cameraActive: false,
+  cameraStream: null as MediaStream | null,
   start: vi.fn(),
   stop: vi.fn(),
   interrupt: vi.fn(),
@@ -22,6 +23,7 @@ vi.mock("./use-voice-conversation", () => ({
     stop: conversationMock.stop,
     interrupt: conversationMock.interrupt,
     cameraActive: conversationMock.cameraActive,
+    cameraStream: conversationMock.cameraStream,
     cameraError: null,
     toggleCamera: conversationMock.toggleCamera,
   }),
@@ -37,6 +39,10 @@ vi.mock("./voice-selector", () => ({
   VoiceSelector: () => <div data-testid="voice-selector" />,
 }));
 
+vi.mock("./camera-preview", () => ({
+  CameraPreview: () => <div data-testid="camera-preview" />,
+}));
+
 vi.mock("./audio-playback", () => ({
   unlockAudio: vi.fn(),
 }));
@@ -46,6 +52,7 @@ describe("VoiceView", () => {
     cleanup();
     conversationMock.state = "idle";
     conversationMock.cameraActive = false;
+    conversationMock.cameraStream = null;
     conversationMock.start.mockReset();
     conversationMock.stop.mockReset();
     conversationMock.interrupt.mockReset();
@@ -72,10 +79,30 @@ describe("VoiceView", () => {
     expect(conversationMock.toggleCamera).toHaveBeenCalledTimes(1);
   });
 
-  it("shows the camera status indicator only when the camera is active", () => {
+  it("shows a starting indicator when the camera is on but the stream isn't ready", () => {
     conversationMock.cameraActive = true;
+    conversationMock.cameraStream = null;
     render(<VoiceView sessionId="voice-test" onBack={vi.fn()} />);
 
-    expect(screen.getByText("摄像头开启中")).toBeTruthy();
+    expect(screen.getByText("摄像头开启中…")).toBeTruthy();
+    expect(screen.queryByTestId("camera-preview")).toBeNull();
+  });
+
+  it("shows the self-preview once the stream is live", () => {
+    conversationMock.cameraActive = true;
+    conversationMock.cameraStream = {} as MediaStream;
+    render(<VoiceView sessionId="voice-test" onBack={vi.fn()} />);
+
+    expect(screen.getByTestId("camera-preview")).toBeTruthy();
+    expect(screen.getByText("AI 看到的画面")).toBeTruthy();
+    // starting indicator gone once the stream is present
+    expect(screen.queryByText("摄像头开启中…")).toBeNull();
+  });
+
+  it("hides the self-preview when the camera is off", () => {
+    conversationMock.cameraActive = false;
+    render(<VoiceView sessionId="voice-test" onBack={vi.fn()} />);
+
+    expect(screen.queryByTestId("camera-preview")).toBeNull();
   });
 });

--- a/src/home/voice/voice-view.test.tsx
+++ b/src/home/voice/voice-view.test.tsx
@@ -7,6 +7,7 @@ const conversationMock = vi.hoisted(() => ({
   state: "idle" as VoiceConversation["state"],
   cameraActive: false,
   cameraStream: null as MediaStream | null,
+  lastSentFrameUrl: null as string | null,
   start: vi.fn(),
   stop: vi.fn(),
   interrupt: vi.fn(),
@@ -24,6 +25,7 @@ vi.mock("./use-voice-conversation", () => ({
     interrupt: conversationMock.interrupt,
     cameraActive: conversationMock.cameraActive,
     cameraStream: conversationMock.cameraStream,
+    lastSentFrameUrl: conversationMock.lastSentFrameUrl,
     cameraError: null,
     toggleCamera: conversationMock.toggleCamera,
   }),
@@ -53,6 +55,7 @@ describe("VoiceView", () => {
     conversationMock.state = "idle";
     conversationMock.cameraActive = false;
     conversationMock.cameraStream = null;
+    conversationMock.lastSentFrameUrl = null;
     conversationMock.start.mockReset();
     conversationMock.stop.mockReset();
     conversationMock.interrupt.mockReset();
@@ -94,7 +97,7 @@ describe("VoiceView", () => {
     render(<VoiceView sessionId="voice-test" onBack={vi.fn()} />);
 
     expect(screen.getByTestId("camera-preview")).toBeTruthy();
-    expect(screen.getByText("AI 看到的画面")).toBeTruthy();
+    expect(screen.getByText("实时画面")).toBeTruthy();
     // starting indicator gone once the stream is present
     expect(screen.queryByText("摄像头开启中…")).toBeNull();
   });
@@ -104,5 +107,21 @@ describe("VoiceView", () => {
     render(<VoiceView sessionId="voice-test" onBack={vi.fn()} />);
 
     expect(screen.queryByTestId("camera-preview")).toBeNull();
+  });
+
+  it("shows the frame sent to the AI when a frame URL is present", () => {
+    conversationMock.lastSentFrameUrl = "blob:fake-frame";
+    render(<VoiceView sessionId="voice-test" onBack={vi.fn()} />);
+
+    const img = screen.getByAltText("frame sent to AI") as HTMLImageElement;
+    expect(img.getAttribute("src")).toBe("blob:fake-frame");
+    expect(screen.getByText("已发给 AI")).toBeTruthy();
+  });
+
+  it("hides the sent-frame thumbnail when there is none", () => {
+    conversationMock.lastSentFrameUrl = null;
+    render(<VoiceView sessionId="voice-test" onBack={vi.fn()} />);
+
+    expect(screen.queryByAltText("frame sent to AI")).toBeNull();
   });
 });

--- a/src/home/voice/voice-view.test.tsx
+++ b/src/home/voice/voice-view.test.tsx
@@ -5,9 +5,11 @@ import type { VoiceConversation } from "./use-voice-conversation";
 
 const conversationMock = vi.hoisted(() => ({
   state: "idle" as VoiceConversation["state"],
+  cameraActive: false,
   start: vi.fn(),
   stop: vi.fn(),
   interrupt: vi.fn(),
+  toggleCamera: vi.fn(),
 }));
 
 vi.mock("./use-voice-conversation", () => ({
@@ -19,6 +21,9 @@ vi.mock("./use-voice-conversation", () => ({
     start: conversationMock.start,
     stop: conversationMock.stop,
     interrupt: conversationMock.interrupt,
+    cameraActive: conversationMock.cameraActive,
+    cameraError: null,
+    toggleCamera: conversationMock.toggleCamera,
   }),
 }));
 
@@ -40,9 +45,11 @@ describe("VoiceView", () => {
   beforeEach(() => {
     cleanup();
     conversationMock.state = "idle";
+    conversationMock.cameraActive = false;
     conversationMock.start.mockReset();
     conversationMock.stop.mockReset();
     conversationMock.interrupt.mockReset();
+    conversationMock.toggleCamera.mockReset();
   });
 
   it("waits for an orb click before starting microphone capture", () => {
@@ -55,5 +62,20 @@ describe("VoiceView", () => {
     fireEvent.click(screen.getByRole("button", { name: "voice orb" }));
 
     expect(conversationMock.start).toHaveBeenCalledTimes(1);
+  });
+
+  it("toggles the camera when the camera button is clicked", () => {
+    render(<VoiceView sessionId="voice-test" onBack={vi.fn()} />);
+
+    fireEvent.click(screen.getByRole("button", { name: "toggle camera" }));
+
+    expect(conversationMock.toggleCamera).toHaveBeenCalledTimes(1);
+  });
+
+  it("shows the camera status indicator only when the camera is active", () => {
+    conversationMock.cameraActive = true;
+    render(<VoiceView sessionId="voice-test" onBack={vi.fn()} />);
+
+    expect(screen.getByText("摄像头开启中")).toBeTruthy();
   });
 });

--- a/src/home/voice/voice-view.tsx
+++ b/src/home/voice/voice-view.tsx
@@ -56,11 +56,35 @@ export function VoiceView({ sessionId, historyTopic, onBack }: VoiceViewProps) {
         {conv.cameraActive ? <Camera size={20} /> : <CameraOff size={20} />}
       </button>
 
-      {/* Self-preview: show the user what the AI sees. */}
+      {/* Self-preview: show the user what the AI sees (continuous live feed). */}
       {conv.cameraActive && conv.cameraStream && (
         <div className="absolute left-1/2 top-5 flex -translate-x-1/2 flex-col items-center gap-1">
-          <CameraPreview stream={conv.cameraStream} />
-          <span className="text-[10px] text-white/40">AI 看到的画面</span>
+          <div className="relative">
+            <CameraPreview stream={conv.cameraStream} />
+            {/* One-shot border flash each time a frame is sent (keyed by URL). */}
+            {conv.lastSentFrameUrl && (
+              <span
+                key={conv.lastSentFrameUrl}
+                className="cam-sent-flash pointer-events-none absolute inset-0 rounded-xl"
+              />
+            )}
+          </div>
+          <span className="text-[10px] text-white/40">实时画面</span>
+        </div>
+      )}
+
+      {/* The exact frame sent to the AI this turn (model's view, not mirrored). */}
+      {conv.lastSentFrameUrl && (
+        <div
+          key={conv.lastSentFrameUrl}
+          className="cam-sent-pop absolute bottom-4 left-4 flex flex-col items-center gap-1"
+        >
+          <img
+            src={conv.lastSentFrameUrl}
+            alt="frame sent to AI"
+            className="h-20 w-[107px] rounded-lg object-cover ring-1 ring-white/15 shadow-lg"
+          />
+          <span className="text-[10px] text-white/40">已发给 AI</span>
         </div>
       )}
 

--- a/src/home/voice/voice-view.tsx
+++ b/src/home/voice/voice-view.tsx
@@ -3,6 +3,7 @@ import { Camera, CameraOff, X } from "lucide-react";
 import { useVoiceConversation, type VoiceState } from "./use-voice-conversation";
 import { VoiceOrb } from "./voice-orb";
 import { VoiceSelector } from "./voice-selector";
+import { CameraPreview } from "./camera-preview";
 import { unlockAudio } from "./audio-playback";
 import "./voice.css";
 
@@ -55,15 +56,23 @@ export function VoiceView({ sessionId, historyTopic, onBack }: VoiceViewProps) {
         {conv.cameraActive ? <Camera size={20} /> : <CameraOff size={20} />}
       </button>
 
+      {/* Self-preview: show the user what the AI sees. */}
+      {conv.cameraActive && conv.cameraStream && (
+        <div className="absolute left-1/2 top-5 flex -translate-x-1/2 flex-col items-center gap-1">
+          <CameraPreview stream={conv.cameraStream} />
+          <span className="text-[10px] text-white/40">AI 看到的画面</span>
+        </div>
+      )}
+
       <div onClick={onOrbClick} role="button" aria-label="voice orb">
         <VoiceOrb state={conv.state} />
       </div>
 
       <div className="mt-6 min-h-[20px] text-sm text-white/55">{STATE_WORD[conv.state]}</div>
 
-      {/* MVP: status indicator only — no self-preview. */}
-      {conv.cameraActive && (
-        <div className="mt-1 text-xs text-white/40">摄像头开启中</div>
+      {/* Camera on but stream not ready yet, or it failed. */}
+      {conv.cameraActive && !conv.cameraStream && (
+        <div className="mt-1 text-xs text-white/40">摄像头开启中…</div>
       )}
       {conv.cameraError && (
         <div className="mt-1 text-xs text-red-300/70">摄像头不可用，已切回纯语音</div>

--- a/src/home/voice/voice-view.tsx
+++ b/src/home/voice/voice-view.tsx
@@ -1,5 +1,5 @@
 import { useEffect } from "react";
-import { X } from "lucide-react";
+import { Camera, CameraOff, X } from "lucide-react";
 import { useVoiceConversation, type VoiceState } from "./use-voice-conversation";
 import { VoiceOrb } from "./voice-orb";
 import { VoiceSelector } from "./voice-selector";
@@ -46,11 +46,28 @@ export function VoiceView({ sessionId, historyTopic, onBack }: VoiceViewProps) {
         <X size={22} />
       </button>
 
+      <button
+        onClick={() => conv.toggleCamera()}
+        aria-label="toggle camera"
+        aria-pressed={conv.cameraActive}
+        className="absolute left-5 top-5 flex h-10 w-10 items-center justify-center rounded-full bg-white/10 text-white/70"
+      >
+        {conv.cameraActive ? <Camera size={20} /> : <CameraOff size={20} />}
+      </button>
+
       <div onClick={onOrbClick} role="button" aria-label="voice orb">
         <VoiceOrb state={conv.state} />
       </div>
 
       <div className="mt-6 min-h-[20px] text-sm text-white/55">{STATE_WORD[conv.state]}</div>
+
+      {/* MVP: status indicator only — no self-preview. */}
+      {conv.cameraActive && (
+        <div className="mt-1 text-xs text-white/40">摄像头开启中</div>
+      )}
+      {conv.cameraError && (
+        <div className="mt-1 text-xs text-red-300/70">摄像头不可用，已切回纯语音</div>
+      )}
 
       <div className="mt-4 max-w-[80%] text-center">
         {conv.lastUserText && (

--- a/src/home/voice/voice.css
+++ b/src/home/voice/voice.css
@@ -27,3 +27,17 @@
   70%{opacity:.18}
   100%{transform:scale(1.92);opacity:0}
 }
+
+/* Camera capture feedback: a one-shot border flash on the live preview when a
+   frame is sent to the AI, and a pop-in for the sent-frame thumbnail. Replayed
+   on each send via a changing React `key`. */
+.cam-sent-flash { animation: cam-flash .5s ease-out 1; }
+@keyframes cam-flash {
+  0%{opacity:1;box-shadow:0 0 0 2px rgba(196,116,69,.9),0 0 16px 2px rgba(196,116,69,.6)}
+  100%{opacity:0;box-shadow:0 0 0 2px rgba(196,116,69,0)}
+}
+.cam-sent-pop { animation: cam-pop .24s ease-out 1; }
+@keyframes cam-pop {
+  0%{transform:translateY(8px) scale(.94);opacity:0}
+  100%{transform:none;opacity:1}
+}


### PR DESCRIPTION
Adds the camera ("video call") capability to the voice screen.

- Capture camera frames during a voice conversation and attach the current frame to each spoken turn (audio + image) so the VLM "sees" what the user sees.
- Self-preview of the camera in the voice screen.
- Show the exact frame that was sent to the AI for that turn.

Note: this branch is behind `main` and also touches `src/home/voice/use-voice-conversation.ts`, which changes in the rich-output PR (#232) — expect merge conflicts; resolve at merge time. Pairs with the octos backend's live-camera context-hint work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)