### PR TITLE
fix(voice): illustrated marker + auto-listen + generating indicator

### DIFF
--- a/src/home/voice/use-voice-conversation.test.ts
+++ b/src/home/voice/use-voice-conversation.test.ts
@@ -75,6 +75,7 @@ describe("visual marker", () => {
   it("detects a well-formed marker and ignores empty/absent", () => {
     expect(hasVisualMarker("好的。\n[[VISUAL:html|负反馈电路]]")).toBe(true);
     expect(hasVisualMarker("[[VISUAL:image|一只猫]]")).toBe(true);
+    expect(hasVisualMarker("好的。\n[[VISUAL:illustrated|人类细胞结构]]")).toBe(true);
     expect(hasVisualMarker("纯口播没有标记")).toBe(false);
     expect(hasVisualMarker("[[VISUAL:html|]]")).toBe(false);
   });

--- a/src/home/voice/use-voice-conversation.ts
+++ b/src/home/voice/use-voice-conversation.ts
@@ -133,7 +133,7 @@ export function collectFreshAudio(
 const HTML_EXT = /\.html?$/i;
 const VISUAL_IMAGE_EXT = /\.(png|jpe?g|gif|webp|svg)$/i;
 /** Mirror of the backend in-band marker `[[VISUAL:kind|brief]]`. */
-const VISUAL_MARKER = /\[\[VISUAL:(html|image|infographic)\|([^\]]*)\]\]/;
+const VISUAL_MARKER = /\[\[VISUAL:(html|illustrated|image|infographic)\|([^\]]*)\]\]/;
 /** Safety net: clear the "generating" state if no artifact arrives in time. */
 const VISUAL_TIMEOUT_MS = 90000;
 

--- a/src/home/voice/use-voice-conversation.ts
+++ b/src/home/voice/use-voice-conversation.ts
@@ -606,7 +606,11 @@ export function useVoiceConversation(
       for (const v of fresh) seenVisualsRef.current.add(v.path);
       setVisual(fresh[fresh.length - 1]);
       setGenerating(false);
-      generatingKeyRef.current = null;
+      // Keep generatingKeyRef pointing at the just-satisfied marker (do NOT
+      // null it): the completed turn's marker text is still the newest in
+      // `threads`, so nulling here would let the scan below immediately
+      // re-enter the generating state on that stale marker. A genuinely new
+      // turn carries different marker text and still flags correctly.
       clearTimeout(generatingTimerRef.current);
       return;
     }

--- a/src/home/voice/voice-view.test.tsx
+++ b/src/home/voice/voice-view.test.tsx
@@ -8,10 +8,13 @@ const conversationMock = vi.hoisted(() => ({
   cameraActive: false,
   cameraStream: null as MediaStream | null,
   lastSentFrameUrl: null as string | null,
+  generating: false,
+  visual: null as VoiceConversation["visual"],
   start: vi.fn(),
   stop: vi.fn(),
   interrupt: vi.fn(),
   toggleCamera: vi.fn(),
+  dismissVisual: vi.fn(),
 }));
 
 vi.mock("./use-voice-conversation", () => ({
@@ -28,6 +31,9 @@ vi.mock("./use-voice-conversation", () => ({
     lastSentFrameUrl: conversationMock.lastSentFrameUrl,
     cameraError: null,
     toggleCamera: conversationMock.toggleCamera,
+    generating: conversationMock.generating,
+    visual: conversationMock.visual,
+    dismissVisual: conversationMock.dismissVisual,
   }),
 }));
 
@@ -45,6 +51,10 @@ vi.mock("./camera-preview", () => ({
   CameraPreview: () => <div data-testid="camera-preview" />,
 }));
 
+vi.mock("./visual-panel", () => ({
+  VisualPanel: () => <div data-testid="visual-panel" />,
+}));
+
 vi.mock("./audio-playback", () => ({
   unlockAudio: vi.fn(),
 }));
@@ -56,22 +66,28 @@ describe("VoiceView", () => {
     conversationMock.cameraActive = false;
     conversationMock.cameraStream = null;
     conversationMock.lastSentFrameUrl = null;
+    conversationMock.generating = false;
+    conversationMock.visual = null;
     conversationMock.start.mockReset();
     conversationMock.stop.mockReset();
     conversationMock.interrupt.mockReset();
     conversationMock.toggleCamera.mockReset();
+    conversationMock.dismissVisual.mockReset();
   });
 
-  it("waits for an orb click before starting microphone capture", () => {
+  it("auto-starts microphone capture on mount", () => {
     render(<VoiceView sessionId="voice-test" onBack={vi.fn()} />);
 
-    expect(conversationMock.start).not.toHaveBeenCalled();
-    expect(screen.getByText("点光球开始说话")).toBeTruthy();
-    expect(screen.queryByTestId("voice-selector")).toBeNull();
-
-    fireEvent.click(screen.getByRole("button", { name: "voice orb" }));
-
+    // Entering the voice view begins listening immediately — no orb tap needed.
     expect(conversationMock.start).toHaveBeenCalledTimes(1);
+  });
+
+  it("shows the generating indicator even while a prior visual is docked", () => {
+    conversationMock.generating = true;
+    conversationMock.visual = { path: "w/old.html", kind: "html" };
+    render(<VoiceView sessionId="voice-test" onBack={vi.fn()} />);
+
+    expect(screen.getByText("正在生成视觉内容…")).toBeTruthy();
   });
 
   it("toggles the camera when the camera button is clicked", () => {

--- a/src/home/voice/voice-view.tsx
+++ b/src/home/voice/voice-view.tsx
@@ -1,4 +1,4 @@
-import { useEffect } from "react";
+import { useEffect, useRef } from "react";
 import { Camera, CameraOff, X } from "lucide-react";
 import { useVoiceConversation, type VoiceState } from "./use-voice-conversation";
 import { VoiceOrb } from "./voice-orb";
@@ -25,7 +25,17 @@ interface VoiceViewProps {
 export function VoiceView({ sessionId, historyTopic, onBack }: VoiceViewProps) {
   const conv = useVoiceConversation(sessionId, historyTopic);
 
+  // Auto-enter listening on mount: the user reached this full-screen view via a
+  // navigation gesture, so unlock audio playback and begin capture immediately
+  // instead of requiring an extra orb tap. One-shot guarded so StrictMode's
+  // double-invoke (and any re-render) can't start the turn twice.
+  const startedRef = useRef(false);
   useEffect(() => {
+    if (!startedRef.current) {
+      startedRef.current = true;
+      unlockAudio();
+      void conv.start();
+    }
     return () => conv.stop();
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
@@ -116,8 +126,10 @@ export function VoiceView({ sessionId, historyTopic, onBack }: VoiceViewProps) {
           )}
         </div>
 
-        {/* Rich output: generating indicator while the visual is being produced. */}
-        {conv.generating && !conv.visual && (
+        {/* Rich output: generating indicator while a visual is being produced.
+            Shown even when a prior visual is still docked on the right, so a
+            follow-up turn that generates a NEW visual still signals progress. */}
+        {conv.generating && (
           <div className="mt-5 flex items-center gap-2 text-sm text-white/60">
             <span className="h-2 w-2 animate-ping rounded-full bg-white/70" />
             正在生成视觉内容…


### PR DESCRIPTION
Three voice-UX fixes found during E2E of the rich-output feature (backend: octos #1477).

1. **Recognize the `illustrated` marker** — the in-band marker regex only matched `html|image|infographic`, so an `[[VISUAL:illustrated|...]]` reply showed no "generating" hint and wasn't stripped from the spoken text.
2. **Auto-listen on entry** — begin microphone capture when the voice view mounts (the user already made a navigation gesture to get here), instead of requiring an extra orb tap. One-shot guarded against StrictMode double-invoke.
3. **Generating indicator over a docked visual** — the indicator was gated on `!visual`, so a follow-up turn that produced a new visual showed no progress while the previous visual was still docked. Show it whenever generating; also stop the effect from re-flagging a completed turn's stale marker.

Tests: 18 voice tests pass, tsc clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)