### PR TITLE
feat(voice): send live_video flag when camera is on (frontend, #1478)

### DIFF
--- a/src/home/voice/use-voice-conversation.ts
+++ b/src/home/voice/use-voice-conversation.ts
@@ -329,6 +329,10 @@ export function useVoiceConversation(
           text: "",
           media: paths,
           clientMessageId: turnId,
+          // #1478: this turn carries a live camera frame iff one was actually
+          // attached (camera on + grab succeeded) — tell the server so it
+          // treats the frame as a real-time view, never inferred from media.
+          liveVideo: sentFrame !== undefined,
           onComplete: () => {
             if (activeTurnIdRef.current === turnId) {
               activeTurnIdRef.current = null;

--- a/src/runtime/ui-protocol-send.test.ts
+++ b/src/runtime/ui-protocol-send.test.ts
@@ -62,6 +62,7 @@ vi.mock("./ui-protocol-bridge", async () => {
 
 import * as ThreadStore from "@/store/thread-store";
 import {
+  buildTurnStartExtras,
   interruptActiveTurn,
   sendMessage,
   __resetSendQueueForTest,
@@ -119,6 +120,24 @@ afterEach(() => {
   __resetUiProtocolRuntimeForTest();
   __resetSendQueueForTest();
   __bridgeFactoryOverride.current = null;
+});
+
+describe("buildTurnStartExtras live_video (#1478)", () => {
+  const base = { sessionId: SESSION, text: "", media: [] as string[] };
+
+  it("sets live_video only when the camera flag is on", () => {
+    expect(buildTurnStartExtras({ ...base, liveVideo: true })?.live_video).toBe(
+      true,
+    );
+  });
+
+  it("omits live_video (and the whole envelope) for an ordinary send", () => {
+    // No media / topic / rewrite / liveVideo → byte-identical to a plain send.
+    expect(buildTurnStartExtras({ ...base })).toBeUndefined();
+    expect(
+      buildTurnStartExtras({ ...base, liveVideo: false }),
+    ).toBeUndefined();
+  });
 });
 
 describe("sendMessage", () => {

--- a/src/runtime/ui-protocol-send.ts
+++ b/src/runtime/ui-protocol-send.ts
@@ -48,6 +48,10 @@ export interface SendOptions {
    *  gateway-mode `ApiChannel` and `octos chat` CLI use. */
   media: string[];
   clientMessageId?: string;
+  /** #1478: mark this turn as a live video call (camera on) so the server
+   *  treats the attached frame as the user's current camera view. Omitted /
+   *  false for ordinary sends. */
+  liveVideo?: boolean;
   /** Recording vs upload (audio surface). Unused on the WS path today. */
   audioUploadMode?: "recording" | "upload";
   /** M9-γ-4: Composer renders a `<GhostBubble>` overlay; skip the
@@ -89,7 +93,9 @@ export function sendMessage(opts: SendOptions): void {
  *  from `SendOptions`. Returns `undefined` when no extras are
  *  populated so the bridge omits all three fields and the on-wire
  *  shape stays byte-identical to a pre-β-1 text-only send. */
-function buildTurnStartExtras(opts: SendOptions): TurnStartExtras | undefined {
+export function buildTurnStartExtras(
+  opts: SendOptions,
+): TurnStartExtras | undefined {
   const extras: TurnStartExtras = {};
 
   if (opts.media.length > 0) {
@@ -127,10 +133,18 @@ function buildTurnStartExtras(opts: SendOptions): TurnStartExtras | undefined {
     extras.rewrite_for = opts.clientMessageId;
   }
 
+  // #1478: forward the explicit live-video flag (camera on) so the server
+  // treats the attached frame as a real-time camera view. Only set when true
+  // so non-video sends stay byte-identical on the wire.
+  if (opts.liveVideo) {
+    extras.live_video = true;
+  }
+
   if (
     (extras.media === undefined || extras.media.length === 0) &&
     (extras.topic === undefined || extras.topic.length === 0) &&
-    extras.rewrite_for === undefined
+    extras.rewrite_for === undefined &&
+    extras.live_video === undefined
   ) {
     return undefined;
   }

--- a/src/runtime/ui-protocol-types.ts
+++ b/src/runtime/ui-protocol-types.ts
@@ -70,6 +70,11 @@ export interface TurnStartExtras {
    *  flow). β-1 server logs the field; durable in-place ledger
    *  replace lands in a follow-up. */
   rewrite_for?: string;
+  /** #1478: explicit "this is a live video call" signal — the attached
+   *  image is the user's current camera frame, not an uploaded file. Set
+   *  by the voice screen when the camera is on. Omitted (≡ false) otherwise;
+   *  the server never infers live-video from attachment types. */
+  live_video?: boolean;
 }
 
 export interface SessionOpenedResult {


### PR DESCRIPTION
Frontend half of #1478 (backend: octos #1480).

The voice client sets `live_video: true` on `turn/start` whenever a live camera frame was actually attached this turn (camera on + grab succeeded), threaded through `SendOptions` → `buildTurnStartExtras` → the turn/start envelope.

This activates the server-side camera-frame context note and the rich-output camera grounding — driven by an **explicit** signal, never inferred from attachment types. Omitted (≡ false) for ordinary sends, so the wire shape for non-video turns is unchanged.

## Tests
`buildTurnStartExtras`: sets `live_video` only when the flag is on; omits the whole envelope for an ordinary send. 22 send tests pass, tsc clean.

Refs #1478. Pairs with octos #1480.

🤖 Generated with [Claude Code](https://claude.com/claude-code)