### PR TITLE
feat(voice): typed visual lifecycle events + race-free generating indicator

### DIFF
--- a/src/home/voice/use-voice-conversation.ts
+++ b/src/home/voice/use-voice-conversation.ts
@@ -200,10 +200,11 @@ export function useVoiceConversation(
   const [generating, setGenerating] = useState(false);
 
   // Rich output: artifacts already surfaced (so re-renders / re-entry don't
-  // re-show them), a key for the marker we last flagged as "generating", and a
-  // safety timer to clear a stuck generating state.
+  // re-show them), the `turn_id` of the visual currently shown as "generating"
+  // (#1477 — so only THAT turn's failure / artifact clears the placeholder, not
+  // a stale sibling turn's), and a safety timer to clear a stuck state.
   const seenVisualsRef = useRef<Set<string>>(new Set());
-  const generatingKeyRef = useRef<string | null>(null);
+  const generatingTurnRef = useRef<string | null>(null);
   const generatingTimerRef = useRef<ReturnType<typeof setTimeout> | undefined>(undefined);
 
   // Read camera-on inside the stable send callback without re-creating it.
@@ -497,7 +498,7 @@ export function useVoiceConversation(
     );
     setVisual(null);
     setGenerating(false);
-    generatingKeyRef.current = null;
+    generatingTurnRef.current = null;
     clearTimeout(generatingTimerRef.current);
     audioQueueRef.current = [];
     playingRef.current = false;
@@ -524,7 +525,7 @@ export function useVoiceConversation(
     audioQueueRef.current = [];
     playingRef.current = false;
     clearTimeout(generatingTimerRef.current);
-    generatingKeyRef.current = null;
+    generatingTurnRef.current = null;
     setVisual(null);
     setGenerating(false);
     void captureStop();
@@ -597,9 +598,10 @@ export function useVoiceConversation(
   }, [captureStop, threads, state]);
 
   // Rich output: surface visual artifacts as they land (decoupled from turn
-  // timing — HTML authoring / image gen can finish seconds after the reply),
-  // and reflect a "generating" state while a marker is seen but no artifact has
-  // arrived yet. Not gated on voice state, so a late artifact is still caught.
+  // timing — HTML authoring / image gen can finish seconds after the reply).
+  // Only SHOWS the latest artifact here; clearing the "generating" placeholder
+  // is turn-attributed in the typed-event effect below (#1477), so a late
+  // artifact from an EARLIER turn does not clear a newer turn's placeholder.
   useEffect(() => {
     const fresh = collectFreshVisuals(
       threads,
@@ -609,37 +611,61 @@ export function useVoiceConversation(
     if (fresh.length > 0) {
       for (const v of fresh) seenVisualsRef.current.add(v.path);
       setVisual(fresh[fresh.length - 1]);
-      setGenerating(false);
-      // Keep generatingKeyRef pointing at the just-satisfied marker (do NOT
-      // null it): the completed turn's marker text is still the newest in
-      // `threads`, so nulling here would let the scan below immediately
-      // re-enter the generating state on that stale marker. A genuinely new
-      // turn carries different marker text and still flags correctly.
-      clearTimeout(generatingTimerRef.current);
-      return;
-    }
-    // No artifact yet: if the newest post-baseline assistant reply carries a
-    // marker we haven't flagged, enter the generating state (with a safety
-    // timeout so a failed generation can't wedge it on forever).
-    for (let i = threads.length - 1; i >= turnBaselineRef.current; i--) {
-      const t = threads[i];
-      if (!t) continue;
-      const asst = t.responses.filter((m) => m.role === "assistant");
-      const text = asst.length > 0 ? asst[asst.length - 1].text : "";
-      if (text && hasVisualMarker(text)) {
-        if (generatingKeyRef.current !== text) {
-          generatingKeyRef.current = text;
-          setGenerating(true);
-          clearTimeout(generatingTimerRef.current);
-          generatingTimerRef.current = setTimeout(
-            () => setGenerating(false),
-            VISUAL_TIMEOUT_MS,
-          );
-        }
-        break;
-      }
     }
   }, [threads]);
+
+  // #1477 voice rich output: drive the "generating" placeholder off the typed
+  // `visual/generating` / `visual/failed` events instead of scraping an in-band
+  // `[[VISUAL:...]]` marker out of the assistant text (the backend no longer
+  // puts that marker on the wire). The placeholder is ATTRIBUTED to a turn_id:
+  // only the active turn's own success (`file/attached` of a visual artifact),
+  // failure (`visual/failed`), or the safety timeout clears it — so if visual A
+  // is still generating when the user starts visual B, A's late
+  // failure/attachment never clears B's placeholder.
+  // Consume the router's `crew:visual_*` DOM events rather than subscribing to
+  // the bridge directly. The router is attached AT bridge startup (before the
+  // bridge becomes `active`) and re-attaches on reconnect, so a window listener
+  // never races the async bridge start — a direct `getActiveBridge(...)`
+  // subscription here ran at mount, found no bridge yet, bailed, and never
+  // re-ran, so the placeholder never showed (#1477 follow-up). Filtered by
+  // sessionId; attributed by turn_id so a stale turn's success/failure cannot
+  // clear a newer turn's placeholder.
+  useEffect(() => {
+    const forThisSession = (d: unknown): d is { sessionId: string; turnId: string } =>
+      !!d &&
+      typeof d === "object" &&
+      (d as { sessionId?: unknown }).sessionId === sessionId;
+    const clearForTurn = (turnId: string) => {
+      if (generatingTurnRef.current !== turnId) return;
+      setGenerating(false);
+      generatingTurnRef.current = null;
+      clearTimeout(generatingTimerRef.current);
+    };
+    const onGenerating = (ev: Event) => {
+      const d = (ev as CustomEvent).detail;
+      if (!forThisSession(d)) return;
+      generatingTurnRef.current = d.turnId;
+      setGenerating(true);
+      clearTimeout(generatingTimerRef.current);
+      generatingTimerRef.current = setTimeout(() => {
+        // Safety net only — the active turn's success/failure never arrived.
+        setGenerating(false);
+        generatingTurnRef.current = null;
+      }, VISUAL_TIMEOUT_MS);
+    };
+    const onResolved = (ev: Event) => {
+      const d = (ev as CustomEvent).detail;
+      if (forThisSession(d)) clearForTurn(d.turnId);
+    };
+    window.addEventListener("crew:visual_generating", onGenerating);
+    window.addEventListener("crew:visual_failed", onResolved);
+    window.addEventListener("crew:visual_ready", onResolved);
+    return () => {
+      window.removeEventListener("crew:visual_generating", onGenerating);
+      window.removeEventListener("crew:visual_failed", onResolved);
+      window.removeEventListener("crew:visual_ready", onResolved);
+    };
+  }, [sessionId]);
 
   // Stop ONLY on real unmount. Use a ref so identity churn of `stop` across
   // re-renders never re-fires this cleanup (that was tearing the VAD down on

--- a/src/runtime/ui-protocol-bridge.ts
+++ b/src/runtime/ui-protocol-bridge.ts
@@ -28,6 +28,8 @@ import type {
   HydratedMessage,
   MessageDeltaEvent,
   FileAttachedEvent,
+  VisualGeneratingEvent,
+  VisualFailedEvent,
   MessagePersistedEvent,
   ProgressUpdatedEvent,
   QueueStateEvent,
@@ -84,6 +86,8 @@ export type {
   TurnInterruptResult,
   TurnSpawnCompleteEvent,
   FileAttachedEvent,
+  VisualGeneratingEvent,
+  VisualFailedEvent,
   TurnStartExtras,
   TurnStartInput,
   TurnStartMediaRef,
@@ -147,6 +151,10 @@ export const METHODS = {
   // row renders even when the richer-envelope reducers miss the
   // placement (slides soak 2026-05-24 failure mode).
   FILE_ATTACHED: "file/attached",
+  // #1477 voice rich output — typed visual lifecycle (replaces scraping an
+  // in-band `[[VISUAL:...]]` marker out of the assistant text).
+  VISUAL_GENERATING: "visual/generating",
+  VISUAL_FAILED: "visual/failed",
   APPROVAL_REQUESTED: "approval/requested",
   WARNING: "warning",
   // Synchronous tool-call lifecycle. Server emits these as
@@ -384,6 +392,12 @@ export interface UiProtocolBridge {
    *  but the placement reducer drops them, this signal lets the
    *  bubble surface a clickable button. */
   onFileAttached(handler: (e: FileAttachedEvent) => void): () => void;
+  /** #1477 voice rich output — a background visual artifact began generating. */
+  onVisualGenerating(
+    handler: (e: VisualGeneratingEvent) => void,
+  ): () => void;
+  /** #1477 voice rich output — a background visual task failed / timed out. */
+  onVisualFailed(handler: (e: VisualFailedEvent) => void): () => void;
   onTaskUpdated(handler: (e: TaskUpdatedEvent) => void): () => void;
   onTaskOutputDelta(handler: (e: TaskOutputDeltaEvent) => void): () => void;
   onTurnLifecycle(
@@ -801,6 +815,28 @@ function guardFileAttached(p: unknown): FileAttachedEvent | null {
         : undefined,
     mime:
       typeof p.mime === "string" && p.mime.length > 0 ? p.mime : undefined,
+  };
+}
+
+function guardVisualGenerating(p: unknown): VisualGeneratingEvent | null {
+  if (!isPlainObject(p)) return null;
+  if (!isString(p.session_id)) return null;
+  if (!isString(p.turn_id)) return null;
+  if (!isString(p.kind)) return null;
+  return { session_id: p.session_id, turn_id: p.turn_id, kind: p.kind };
+}
+
+function guardVisualFailed(p: unknown): VisualFailedEvent | null {
+  if (!isPlainObject(p)) return null;
+  if (!isString(p.session_id)) return null;
+  if (!isString(p.turn_id)) return null;
+  return {
+    session_id: p.session_id,
+    turn_id: p.turn_id,
+    reason:
+      typeof p.reason === "string" && p.reason.length > 0
+        ? p.reason
+        : undefined,
   };
 }
 
@@ -1413,6 +1449,9 @@ class UiProtocolBridgeImpl implements UiProtocolBridge {
   private readonly subMessagePersisted = new Subscribers<MessagePersistedEvent>();
   private readonly subSpawnComplete = new Subscribers<TurnSpawnCompleteEvent>();
   private readonly subFileAttached = new Subscribers<FileAttachedEvent>();
+  private readonly subVisualGenerating =
+    new Subscribers<VisualGeneratingEvent>();
+  private readonly subVisualFailed = new Subscribers<VisualFailedEvent>();
   private readonly subTaskUpdated = new Subscribers<TaskUpdatedEvent>();
   private readonly subTaskOutputDelta = new Subscribers<TaskOutputDeltaEvent>();
   private readonly subTurnLifecycle = new Subscribers<
@@ -1461,6 +1500,14 @@ class UiProtocolBridgeImpl implements UiProtocolBridge {
     [METHODS.FILE_ATTACHED]: {
       guard: guardFileAttached,
       emit: (v) => this.subFileAttached.emit(v as FileAttachedEvent),
+    },
+    [METHODS.VISUAL_GENERATING]: {
+      guard: guardVisualGenerating,
+      emit: (v) => this.subVisualGenerating.emit(v as VisualGeneratingEvent),
+    },
+    [METHODS.VISUAL_FAILED]: {
+      guard: guardVisualFailed,
+      emit: (v) => this.subVisualFailed.emit(v as VisualFailedEvent),
     },
     [METHODS.TASK_UPDATED]: {
       guard: guardTaskUpdated,
@@ -1629,6 +1676,8 @@ class UiProtocolBridgeImpl implements UiProtocolBridge {
     this.subMessagePersisted.clear();
     this.subSpawnComplete.clear();
     this.subFileAttached.clear();
+    this.subVisualGenerating.clear();
+    this.subVisualFailed.clear();
     this.subTaskUpdated.clear();
     this.subTaskOutputDelta.clear();
     this.subTurnLifecycle.clear();
@@ -1768,6 +1817,12 @@ class UiProtocolBridgeImpl implements UiProtocolBridge {
   }
   onFileAttached(handler: Listener<FileAttachedEvent>): () => void {
     return this.subFileAttached.add(handler);
+  }
+  onVisualGenerating(handler: Listener<VisualGeneratingEvent>): () => void {
+    return this.subVisualGenerating.add(handler);
+  }
+  onVisualFailed(handler: Listener<VisualFailedEvent>): () => void {
+    return this.subVisualFailed.add(handler);
   }
   onTaskUpdated(handler: Listener<TaskUpdatedEvent>): () => void {
     return this.subTaskUpdated.add(handler);

--- a/src/runtime/ui-protocol-event-router.test.ts
+++ b/src/runtime/ui-protocol-event-router.test.ts
@@ -38,6 +38,8 @@ import {
 import type {
   ApprovalRequestedEvent,
   FileAttachedEvent,
+  VisualGeneratingEvent,
+  VisualFailedEvent,
   MessageDeltaEvent,
   MessagePersistedEvent,
   ProgressUpdatedEvent,
@@ -2605,6 +2607,8 @@ class FakeBridge implements UiProtocolBridge {
   emitMessagePersisted?: (e: MessagePersistedEvent) => void;
   emitSpawnComplete?: (e: TurnSpawnCompleteEvent) => void;
   emitFileAttached?: (e: FileAttachedEvent) => void;
+  emitVisualGenerating?: (e: VisualGeneratingEvent) => void;
+  emitVisualFailed?: (e: VisualFailedEvent) => void;
   emitTaskUpdated?: (e: TaskUpdatedEvent) => void;
   emitTaskOutputDelta?: (e: TaskOutputDeltaEvent) => void;
   emitTurnLifecycle?: (
@@ -2653,6 +2657,18 @@ class FakeBridge implements UiProtocolBridge {
     this.emitFileAttached = h;
     return () => {
       this.emitFileAttached = undefined;
+    };
+  }
+  onVisualGenerating(h: (e: VisualGeneratingEvent) => void) {
+    this.emitVisualGenerating = h;
+    return () => {
+      this.emitVisualGenerating = undefined;
+    };
+  }
+  onVisualFailed(h: (e: VisualFailedEvent) => void) {
+    this.emitVisualFailed = h;
+    return () => {
+      this.emitVisualFailed = undefined;
     };
   }
   onTaskUpdated(h: (e: TaskUpdatedEvent) => void) {
@@ -2749,6 +2765,8 @@ describe("attachRouter", () => {
     expect(bridge.emitTaskOutputDelta).toBeDefined();
     expect(bridge.emitTurnLifecycle).toBeDefined();
     expect(bridge.emitApprovalRequested).toBeDefined();
+    expect(bridge.emitVisualGenerating).toBeDefined();
+    expect(bridge.emitVisualFailed).toBeDefined();
 
     att.detach();
     expect(bridge.emitMessageDelta).toBeUndefined();
@@ -2758,6 +2776,70 @@ describe("attachRouter", () => {
     expect(bridge.emitTaskOutputDelta).toBeUndefined();
     expect(bridge.emitTurnLifecycle).toBeUndefined();
     expect(bridge.emitApprovalRequested).toBeUndefined();
+    expect(bridge.emitVisualGenerating).toBeUndefined();
+    expect(bridge.emitVisualFailed).toBeUndefined();
+  });
+
+  // #1477 voice rich output: the router fans the typed visual lifecycle onto
+  // `crew:visual_*` DOM events. The voice hook listens on `window` (not the
+  // bridge) so it never races the async bridge start.
+  it("fans visual/generating + visual/failed onto crew:visual_* DOM events", () => {
+    const bridge = new FakeBridge();
+    const dispatched: Event[] = [];
+    attachRouter(bridge, {
+      sessionId: SESSION,
+      dispatchEvent: (e) => dispatched.push(e),
+    });
+
+    bridge.emitVisualGenerating?.({
+      session_id: SESSION,
+      turn_id: "cmid-v",
+      kind: "illustrated",
+    });
+    const gen = dispatched.find(
+      (e) => e.type === "crew:visual_generating",
+    ) as CustomEvent | undefined;
+    expect(gen).toBeDefined();
+    expect(gen!.detail.sessionId).toBe(SESSION);
+    expect(gen!.detail.turnId).toBe("cmid-v");
+    expect(gen!.detail.kind).toBe("illustrated");
+
+    bridge.emitVisualFailed?.({
+      session_id: SESSION,
+      turn_id: "cmid-v",
+      reason: "timed out after 180s",
+    });
+    const failed = dispatched.find(
+      (e) => e.type === "crew:visual_failed",
+    ) as CustomEvent | undefined;
+    expect(failed).toBeDefined();
+    expect(failed!.detail.turnId).toBe("cmid-v");
+    expect(failed!.detail.reason).toBe("timed out after 180s");
+  });
+
+  // A visual artifact landing via file/attached is the success signal — it
+  // fans onto `crew:visual_ready` carrying the turn_id. The reply audio (also
+  // file/attached) must NOT, so the placeholder is only cleared by a visual.
+  it("emits crew:visual_ready for a visual file/attached but not for audio", () => {
+    const dispatched: Event[] = [];
+    const cfg = {
+      sessionId: SESSION,
+      dispatchEvent: (e: Event) => dispatched.push(e),
+    };
+    handleFileAttached(cfg, {
+      session_id: SESSION,
+      turn_id: "cmid-r",
+      path: "visual-abc.html",
+    });
+    handleFileAttached(cfg, {
+      session_id: SESSION,
+      turn_id: "cmid-r",
+      path: "reply-123.wav",
+    });
+    const ready = dispatched.filter((e) => e.type === "crew:visual_ready");
+    expect(ready).toHaveLength(1);
+    expect((ready[0] as CustomEvent).detail.turnId).toBe("cmid-r");
+    expect((ready[0] as CustomEvent).detail.path).toBe("visual-abc.html");
   });
 
   it("turn lifecycle multiplexer routes started / completed / error correctly", () => {

--- a/src/runtime/ui-protocol-event-router.ts
+++ b/src/runtime/ui-protocol-event-router.ts
@@ -41,6 +41,8 @@ import type {
   TurnSpawnCompleteEvent,
   TurnStartedEvent,
   UiProtocolBridge,
+  VisualGeneratingEvent,
+  VisualFailedEvent,
 } from "./ui-protocol-bridge";
 import * as ThreadStore from "@/store/thread-store";
 import * as TaskStore from "@/store/task-store";
@@ -238,6 +240,12 @@ export interface RouterConfig {
   /** Override window event dispatch for tests / SSR. */
   dispatchEvent?: (event: Event) => void;
 }
+
+/** #1477 voice rich output: file extensions that denote a visual artifact
+ *  (illustrated HTML / image). Mirrors the voice hook's `HTML_EXT` +
+ *  `VISUAL_IMAGE_EXT`; used to tell a visual `file/attached` (the success
+ *  signal for the generating placeholder) apart from the reply audio. */
+const VISUAL_ARTIFACT_EXT = /\.(html?|png|jpe?g|gif|webp|svg)$/i;
 
 function dispatch(cfg: RouterConfig, event: Event): void {
   const fn = cfg.dispatchEvent ?? defaultDispatch;
@@ -701,6 +709,25 @@ export function handleFileAttached(
 ): void {
   if (!event.path || event.path.length === 0) {
     return;
+  }
+  // #1477 voice rich output: a visual artifact (HTML / image) landing is the
+  // SUCCESS signal for the "generating" placeholder. Fan it onto a
+  // `crew:visual_ready` DOM event carrying the turn_id so the voice hook can
+  // clear the placeholder only for the matching turn (the reply audio also
+  // arrives via `file/attached`, so gate on a visual extension). Dispatched
+  // independently of the placement logic below.
+  if (VISUAL_ARTIFACT_EXT.test(event.path)) {
+    dispatch(
+      cfg,
+      new CustomEvent("crew:visual_ready", {
+        detail: {
+          sessionId: cfg.sessionId,
+          topic: cfg.topic,
+          turnId: event.turn_id,
+          path: event.path,
+        },
+      }),
+    );
   }
   const file = {
     filename: filenameFromPath(event.path),
@@ -1704,6 +1731,46 @@ export interface RouterAttachment {
 }
 
 /**
+ * #1477 voice rich output: fan the typed `visual/generating` /
+ * `visual/failed` events onto `crew:visual_*` DOM events. Mirrors how the
+ * other bridge streams surface (e.g. `crew:turn_error`). The voice hook
+ * consumes these window events rather than subscribing to the bridge
+ * directly, so the "generating" placeholder is immune to the bridge-start
+ * race (the router is attached AT bridge startup, before the bridge becomes
+ * `active`) and to reconnects (the router re-attaches and keeps dispatching).
+ */
+function handleVisualGenerating(
+  cfg: RouterConfig,
+  event: VisualGeneratingEvent,
+): void {
+  dispatch(
+    cfg,
+    new CustomEvent("crew:visual_generating", {
+      detail: {
+        sessionId: cfg.sessionId,
+        topic: cfg.topic,
+        turnId: event.turn_id,
+        kind: event.kind,
+      },
+    }),
+  );
+}
+
+function handleVisualFailed(cfg: RouterConfig, event: VisualFailedEvent): void {
+  dispatch(
+    cfg,
+    new CustomEvent("crew:visual_failed", {
+      detail: {
+        sessionId: cfg.sessionId,
+        topic: cfg.topic,
+        turnId: event.turn_id,
+        reason: event.reason,
+      },
+    }),
+  );
+}
+
+/**
  * Subscribe the router to all relevant streams on a started bridge. The
  * caller owns bridge lifecycle (start/stop). Returns a detacher that
  * removes every listener registered here — call it before swapping the
@@ -1768,6 +1835,14 @@ export function attachRouter(
     handleRouterFailover(cfg, e),
   );
   const offQueueState = bridge.onQueueState((e) => handleQueueState(cfg, e));
+  // #1477 voice rich output: fan visual lifecycle onto `crew:visual_*` DOM
+  // events (see `handleVisualGenerating` / `handleVisualFailed`).
+  const offVisualGenerating = bridge.onVisualGenerating((e) =>
+    handleVisualGenerating(cfg, e),
+  );
+  const offVisualFailed = bridge.onVisualFailed((e) =>
+    handleVisualFailed(cfg, e),
+  );
 
   let detached = false;
   return {
@@ -1778,6 +1853,8 @@ export function attachRouter(
       offMessagePersisted();
       offSpawnComplete();
       offFileAttached();
+      offVisualGenerating();
+      offVisualFailed();
       offTaskUpdated();
       offTaskOutputDelta();
       offTurnLifecycle();

--- a/src/runtime/ui-protocol-runtime.test.ts
+++ b/src/runtime/ui-protocol-runtime.test.ts
@@ -93,6 +93,8 @@ function makeDeferredBridge(): DeferredBridge {
     onMessagePersisted: vi.fn(() => () => {}),
     onSpawnComplete: vi.fn(() => () => {}),
     onFileAttached: vi.fn(() => () => {}),
+    onVisualGenerating: vi.fn(() => () => {}),
+    onVisualFailed: vi.fn(() => () => {}),
     onTaskUpdated: vi.fn(() => () => {}),
     onTaskOutputDelta: vi.fn(() => () => {}),
     onTurnLifecycle: vi.fn(() => () => {}),

--- a/src/runtime/ui-protocol-types.ts
+++ b/src/runtime/ui-protocol-types.ts
@@ -324,6 +324,26 @@ export interface FileAttachedEvent {
   mime?: string;
 }
 
+/** #1477 voice rich output — a background visual artifact began generating for
+ *  the turn. The client shows a "generating" placeholder keyed off this typed
+ *  event instead of scraping an in-band `[[VISUAL:...]]` marker out of the
+ *  assistant text (the backend now keeps that marker off the wire entirely).
+ *  Cleared by the eventual `file/attached` (success) or `visual/failed`. */
+export interface VisualGeneratingEvent {
+  session_id: string;
+  turn_id: string;
+  /** `html` | `illustrated` | `image` | `infographic`. */
+  kind: string;
+}
+
+/** #1477 voice rich output — the background visual task failed / timed out, so
+ *  the client should clear the "generating" placeholder. */
+export interface VisualFailedEvent {
+  session_id: string;
+  turn_id: string;
+  reason?: string;
+}
+
 export interface TaskUpdatedEvent {
   session_id: string;
   /** Optional. Server's `TaskUpdatedEvent` struct does NOT carry


### PR DESCRIPTION
Frontend half of the voice rich-output work — pairs with octos **#1477** (backend).

## Why
The backend used to fold an internal `[[VISUAL:...]]` control marker into the
assistant text, and this client scraped that text to show the "正在生成可视化内容"
placeholder. #1477 moves that off the wire entirely and emits typed
`visual/generating` / `visual/failed` notifications instead. This PR consumes them.

## What
- **types / bridge**: `VisualGeneratingEvent` / `VisualFailedEvent`, METHODS,
  guards, dispatch-table entries, `onVisualGenerating` / `onVisualFailed`.
- **event-router**: fan `visual/generating` + `visual/failed` onto `crew:visual_*`
  DOM events, and emit `crew:visual_ready` (with `turn_id`) for a *visual*
  `file/attached`. The router attaches at bridge startup, so this path avoids the
  async-bridge-start race and survives reconnects.
- **use-voice-conversation**: drive the "generating" placeholder off the typed
  `crew:visual_*` window events instead of marker-scraping. Attributed by
  `turn_id` so a stale turn's success/failure can't clear a newer turn's
  placeholder. `stripVisualMarker` kept as display-only fallback for old sessions.

### Root-cause note
The first cut subscribed to `bridge.onVisualGenerating` directly inside the voice
hook. `startBridgeForSession` is async — at voice-view mount `getActiveBridge`
returns null, the effect bailed and never re-ran, so the placeholder never showed
(while `file/attached` worked via the persistent router). Routing through
`attachRouter` fixes it.

## Tests
- Router fan-out for `crew:visual_generating` / `_failed`, and
  `crew:visual_ready` vs audio discrimination; mock bridges updated.
- Full suite green (700); `tsc --noEmit` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)