### PR TITLE
feat(voice): typed visual/succeeded + live_video grounding (follow-up to #238)

### DIFF
--- a/src/home/voice/use-voice-conversation.ts
+++ b/src/home/voice/use-voice-conversation.ts
@@ -615,13 +615,13 @@ export function useVoiceConversation(
   }, [threads]);
 
   // #1477 voice rich output: drive the "generating" placeholder off the typed
-  // `visual/generating` / `visual/failed` events instead of scraping an in-band
-  // `[[VISUAL:...]]` marker out of the assistant text (the backend no longer
-  // puts that marker on the wire). The placeholder is ATTRIBUTED to a turn_id:
-  // only the active turn's own success (`file/attached` of a visual artifact),
-  // failure (`visual/failed`), or the safety timeout clears it — so if visual A
-  // is still generating when the user starts visual B, A's late
-  // failure/attachment never clears B's placeholder.
+  // visual lifecycle events instead of scraping an in-band `[[VISUAL:...]]`
+  // marker out of the assistant text (the backend no longer puts that marker on
+  // the wire). The placeholder is ATTRIBUTED to a turn_id: only the active
+  // turn's own success (`visual/succeeded`), failure (`visual/failed`), or the
+  // safety timeout clears it — so if visual A is still generating when the user
+  // starts visual B, A's late success/failure never clears B's placeholder.
+  // Success is a dedicated typed event, NOT inferred from `file/attached`.
   // Consume the router's `crew:visual_*` DOM events rather than subscribing to
   // the bridge directly. The router is attached AT bridge startup (before the
   // bridge becomes `active`) and re-attaches on reconnect, so a window listener
@@ -657,13 +657,16 @@ export function useVoiceConversation(
       const d = (ev as CustomEvent).detail;
       if (forThisSession(d)) clearForTurn(d.turnId);
     };
+    // Success + failure are both typed lifecycle events (#1477); the
+    // placeholder is never cleared by inferring success from a `file/attached`
+    // file extension.
     window.addEventListener("crew:visual_generating", onGenerating);
+    window.addEventListener("crew:visual_succeeded", onResolved);
     window.addEventListener("crew:visual_failed", onResolved);
-    window.addEventListener("crew:visual_ready", onResolved);
     return () => {
       window.removeEventListener("crew:visual_generating", onGenerating);
+      window.removeEventListener("crew:visual_succeeded", onResolved);
       window.removeEventListener("crew:visual_failed", onResolved);
-      window.removeEventListener("crew:visual_ready", onResolved);
     };
   }, [sessionId]);
 

--- a/src/runtime/ui-protocol-bridge.test.ts
+++ b/src/runtime/ui-protocol-bridge.test.ts
@@ -1786,6 +1786,27 @@ describe("notification dispatch", () => {
     expect(seen[0].turn_id).toBe("t1");
   });
 
+  // #1478/#1477: sendTurn must forward `extras.live_video` onto the wire
+  // `turn/start` params — without it the server never grounds the rich-output
+  // illustration on the camera frame (it sees live_video=false).
+  it("sendTurn forwards live_video extras onto the wire", async () => {
+    const { bridge, ws } = await freshConnected();
+    void bridge.sendTurn("turn-lv", [{ kind: "text", text: "" }], {
+      media: ["uploads/frame.jpg"],
+      live_video: true,
+    });
+    const req = findRequest(ws, METHODS.TURN_START);
+    expect(req.params?.live_video).toBe(true);
+    expect(req.params?.media).toEqual(["uploads/frame.jpg"]);
+  });
+
+  it("sendTurn omits live_video when not set (byte-identical legacy shape)", async () => {
+    const { bridge, ws } = await freshConnected();
+    void bridge.sendTurn("turn-plain", [{ kind: "text", text: "hi" }]);
+    const req = findRequest(ws, METHODS.TURN_START);
+    expect(req.params?.live_video).toBeUndefined();
+  });
+
   // #1477 voice rich output: the typed visual lifecycle decodes from JSON-RPC
   // straight to its typed subscriber (the router relies on this; success is no
   // longer inferred from file/attached).

--- a/src/runtime/ui-protocol-bridge.test.ts
+++ b/src/runtime/ui-protocol-bridge.test.ts
@@ -34,6 +34,9 @@ import type {
   ApprovalRequestedEvent,
   ConnectionState,
   MessageDeltaEvent,
+  VisualSucceededEvent,
+  VisualGeneratingEvent,
+  VisualFailedEvent,
   MessagePersistedEvent,
   TaskOutputDeltaEvent,
   TaskUpdatedEvent,
@@ -1781,6 +1784,68 @@ describe("notification dispatch", () => {
     });
     expect(seen).toHaveLength(1);
     expect(seen[0].turn_id).toBe("t1");
+  });
+
+  // #1477 voice rich output: the typed visual lifecycle decodes from JSON-RPC
+  // straight to its typed subscriber (the router relies on this; success is no
+  // longer inferred from file/attached).
+  it("routes visual/generating, visual/succeeded, visual/failed to their handlers", async () => {
+    const { bridge, ws } = await freshConnected();
+    const gen: VisualGeneratingEvent[] = [];
+    const ok: VisualSucceededEvent[] = [];
+    const failed: VisualFailedEvent[] = [];
+    bridge.onVisualGenerating((e) => gen.push(e));
+    bridge.onVisualSucceeded((e) => ok.push(e));
+    bridge.onVisualFailed((e) => failed.push(e));
+
+    ws.triggerMessage({
+      jsonrpc: "2.0",
+      method: METHODS.VISUAL_GENERATING,
+      params: { session_id: "sess-1", turn_id: "t1", kind: "illustrated" },
+    });
+    ws.triggerMessage({
+      jsonrpc: "2.0",
+      method: METHODS.VISUAL_SUCCEEDED,
+      params: {
+        session_id: "sess-1",
+        turn_id: "t1",
+        kind: "illustrated",
+        files: ["visual-abc.html"],
+      },
+    });
+    ws.triggerMessage({
+      jsonrpc: "2.0",
+      method: METHODS.VISUAL_FAILED,
+      params: { session_id: "sess-1", turn_id: "t1", reason: "timed out" },
+    });
+
+    expect(gen).toHaveLength(1);
+    expect(gen[0].kind).toBe("illustrated");
+    expect(ok).toHaveLength(1);
+    expect(ok[0].turn_id).toBe("t1");
+    expect(ok[0].kind).toBe("illustrated");
+    expect(ok[0].files).toEqual(["visual-abc.html"]);
+    expect(failed).toHaveLength(1);
+    expect(failed[0].reason).toBe("timed out");
+  });
+
+  // A visual/succeeded missing the required `kind` is rejected (fail-closed),
+  // surfaced as a warning, and not delivered.
+  it("rejects visual/succeeded without kind and warns", async () => {
+    const { bridge, ws } = await freshConnected();
+    const ok: VisualSucceededEvent[] = [];
+    const warnings: WarningEvent[] = [];
+    bridge.onVisualSucceeded((e) => ok.push(e));
+    bridge.onWarning((w) => warnings.push(w));
+    ws.triggerMessage({
+      jsonrpc: "2.0",
+      method: METHODS.VISUAL_SUCCEEDED,
+      params: { session_id: "sess-1", turn_id: "t1" },
+    });
+    expect(ok).toHaveLength(0);
+    expect(
+      warnings.some((w) => w.reason === "invalid_event:visual/succeeded"),
+    ).toBe(true);
   });
 
   it("emits warning when message/delta is missing turn_id", async () => {

--- a/src/runtime/ui-protocol-bridge.ts
+++ b/src/runtime/ui-protocol-bridge.ts
@@ -29,6 +29,7 @@ import type {
   MessageDeltaEvent,
   FileAttachedEvent,
   VisualGeneratingEvent,
+  VisualSucceededEvent,
   VisualFailedEvent,
   MessagePersistedEvent,
   ProgressUpdatedEvent,
@@ -87,6 +88,7 @@ export type {
   TurnSpawnCompleteEvent,
   FileAttachedEvent,
   VisualGeneratingEvent,
+  VisualSucceededEvent,
   VisualFailedEvent,
   TurnStartExtras,
   TurnStartInput,
@@ -154,6 +156,7 @@ export const METHODS = {
   // #1477 voice rich output — typed visual lifecycle (replaces scraping an
   // in-band `[[VISUAL:...]]` marker out of the assistant text).
   VISUAL_GENERATING: "visual/generating",
+  VISUAL_SUCCEEDED: "visual/succeeded",
   VISUAL_FAILED: "visual/failed",
   APPROVAL_REQUESTED: "approval/requested",
   WARNING: "warning",
@@ -395,6 +398,10 @@ export interface UiProtocolBridge {
   /** #1477 voice rich output — a background visual artifact began generating. */
   onVisualGenerating(
     handler: (e: VisualGeneratingEvent) => void,
+  ): () => void;
+  /** #1477 voice rich output — a background visual artifact was produced. */
+  onVisualSucceeded(
+    handler: (e: VisualSucceededEvent) => void,
   ): () => void;
   /** #1477 voice rich output — a background visual task failed / timed out. */
   onVisualFailed(handler: (e: VisualFailedEvent) => void): () => void;
@@ -824,6 +831,22 @@ function guardVisualGenerating(p: unknown): VisualGeneratingEvent | null {
   if (!isString(p.turn_id)) return null;
   if (!isString(p.kind)) return null;
   return { session_id: p.session_id, turn_id: p.turn_id, kind: p.kind };
+}
+
+function guardVisualSucceeded(p: unknown): VisualSucceededEvent | null {
+  if (!isPlainObject(p)) return null;
+  if (!isString(p.session_id)) return null;
+  if (!isString(p.turn_id)) return null;
+  if (!isString(p.kind)) return null;
+  const files = Array.isArray(p.files)
+    ? p.files.filter((f): f is string => typeof f === "string")
+    : undefined;
+  return {
+    session_id: p.session_id,
+    turn_id: p.turn_id,
+    kind: p.kind,
+    files,
+  };
 }
 
 function guardVisualFailed(p: unknown): VisualFailedEvent | null {
@@ -1451,6 +1474,8 @@ class UiProtocolBridgeImpl implements UiProtocolBridge {
   private readonly subFileAttached = new Subscribers<FileAttachedEvent>();
   private readonly subVisualGenerating =
     new Subscribers<VisualGeneratingEvent>();
+  private readonly subVisualSucceeded =
+    new Subscribers<VisualSucceededEvent>();
   private readonly subVisualFailed = new Subscribers<VisualFailedEvent>();
   private readonly subTaskUpdated = new Subscribers<TaskUpdatedEvent>();
   private readonly subTaskOutputDelta = new Subscribers<TaskOutputDeltaEvent>();
@@ -1504,6 +1529,10 @@ class UiProtocolBridgeImpl implements UiProtocolBridge {
     [METHODS.VISUAL_GENERATING]: {
       guard: guardVisualGenerating,
       emit: (v) => this.subVisualGenerating.emit(v as VisualGeneratingEvent),
+    },
+    [METHODS.VISUAL_SUCCEEDED]: {
+      guard: guardVisualSucceeded,
+      emit: (v) => this.subVisualSucceeded.emit(v as VisualSucceededEvent),
     },
     [METHODS.VISUAL_FAILED]: {
       guard: guardVisualFailed,
@@ -1677,6 +1706,7 @@ class UiProtocolBridgeImpl implements UiProtocolBridge {
     this.subSpawnComplete.clear();
     this.subFileAttached.clear();
     this.subVisualGenerating.clear();
+    this.subVisualSucceeded.clear();
     this.subVisualFailed.clear();
     this.subTaskUpdated.clear();
     this.subTaskOutputDelta.clear();
@@ -1820,6 +1850,9 @@ class UiProtocolBridgeImpl implements UiProtocolBridge {
   }
   onVisualGenerating(handler: Listener<VisualGeneratingEvent>): () => void {
     return this.subVisualGenerating.add(handler);
+  }
+  onVisualSucceeded(handler: Listener<VisualSucceededEvent>): () => void {
+    return this.subVisualSucceeded.add(handler);
   }
   onVisualFailed(handler: Listener<VisualFailedEvent>): () => void {
     return this.subVisualFailed.add(handler);

--- a/src/runtime/ui-protocol-bridge.ts
+++ b/src/runtime/ui-protocol-bridge.ts
@@ -1752,6 +1752,14 @@ class UiProtocolBridgeImpl implements UiProtocolBridge {
     if (extras?.rewrite_for && extras.rewrite_for.length > 0) {
       params.rewrite_for = extras.rewrite_for;
     }
+    // #1478/#1477: forward the explicit live-video flag so the server treats
+    // the attached frame as a real-time camera view and grounds the rich-output
+    // illustration on it. Without this mapping the flag set by
+    // `buildTurnStartExtras` was silently dropped before the wire, so the
+    // server always saw `live_video=false` and forwarded zero reference frames.
+    if (extras?.live_video) {
+      params.live_video = true;
+    }
     return this.request<TurnStartResult>(METHODS.TURN_START, params);
   }
 

--- a/src/runtime/ui-protocol-event-router.test.ts
+++ b/src/runtime/ui-protocol-event-router.test.ts
@@ -39,6 +39,7 @@ import type {
   ApprovalRequestedEvent,
   FileAttachedEvent,
   VisualGeneratingEvent,
+  VisualSucceededEvent,
   VisualFailedEvent,
   MessageDeltaEvent,
   MessagePersistedEvent,
@@ -2608,6 +2609,7 @@ class FakeBridge implements UiProtocolBridge {
   emitSpawnComplete?: (e: TurnSpawnCompleteEvent) => void;
   emitFileAttached?: (e: FileAttachedEvent) => void;
   emitVisualGenerating?: (e: VisualGeneratingEvent) => void;
+  emitVisualSucceeded?: (e: VisualSucceededEvent) => void;
   emitVisualFailed?: (e: VisualFailedEvent) => void;
   emitTaskUpdated?: (e: TaskUpdatedEvent) => void;
   emitTaskOutputDelta?: (e: TaskOutputDeltaEvent) => void;
@@ -2663,6 +2665,12 @@ class FakeBridge implements UiProtocolBridge {
     this.emitVisualGenerating = h;
     return () => {
       this.emitVisualGenerating = undefined;
+    };
+  }
+  onVisualSucceeded(h: (e: VisualSucceededEvent) => void) {
+    this.emitVisualSucceeded = h;
+    return () => {
+      this.emitVisualSucceeded = undefined;
     };
   }
   onVisualFailed(h: (e: VisualFailedEvent) => void) {
@@ -2777,13 +2785,14 @@ describe("attachRouter", () => {
     expect(bridge.emitTurnLifecycle).toBeUndefined();
     expect(bridge.emitApprovalRequested).toBeUndefined();
     expect(bridge.emitVisualGenerating).toBeUndefined();
+    expect(bridge.emitVisualSucceeded).toBeUndefined();
     expect(bridge.emitVisualFailed).toBeUndefined();
   });
 
   // #1477 voice rich output: the router fans the typed visual lifecycle onto
   // `crew:visual_*` DOM events. The voice hook listens on `window` (not the
   // bridge) so it never races the async bridge start.
-  it("fans visual/generating + visual/failed onto crew:visual_* DOM events", () => {
+  it("fans visual/generating + visual/succeeded + visual/failed onto crew:visual_* DOM events", () => {
     const bridge = new FakeBridge();
     const dispatched: Event[] = [];
     attachRouter(bridge, {
@@ -2804,6 +2813,21 @@ describe("attachRouter", () => {
     expect(gen!.detail.turnId).toBe("cmid-v");
     expect(gen!.detail.kind).toBe("illustrated");
 
+    // Structured success — replaces inferring success from a file extension.
+    bridge.emitVisualSucceeded?.({
+      session_id: SESSION,
+      turn_id: "cmid-v",
+      kind: "illustrated",
+      files: ["visual-abc.html"],
+    });
+    const ok = dispatched.find(
+      (e) => e.type === "crew:visual_succeeded",
+    ) as CustomEvent | undefined;
+    expect(ok).toBeDefined();
+    expect(ok!.detail.turnId).toBe("cmid-v");
+    expect(ok!.detail.kind).toBe("illustrated");
+    expect(ok!.detail.files).toEqual(["visual-abc.html"]);
+
     bridge.emitVisualFailed?.({
       session_id: SESSION,
       turn_id: "cmid-v",
@@ -2817,10 +2841,9 @@ describe("attachRouter", () => {
     expect(failed!.detail.reason).toBe("timed out after 180s");
   });
 
-  // A visual artifact landing via file/attached is the success signal — it
-  // fans onto `crew:visual_ready` carrying the turn_id. The reply audio (also
-  // file/attached) must NOT, so the placeholder is only cleared by a visual.
-  it("emits crew:visual_ready for a visual file/attached but not for audio", () => {
+  // file/attached is a pure artifact-delivery signal — it must NOT fan out any
+  // visual-lifecycle DOM event (success is carried by visual/succeeded).
+  it("does not derive any crew:visual_* event from file/attached", () => {
     const dispatched: Event[] = [];
     const cfg = {
       sessionId: SESSION,
@@ -2831,15 +2854,9 @@ describe("attachRouter", () => {
       turn_id: "cmid-r",
       path: "visual-abc.html",
     });
-    handleFileAttached(cfg, {
-      session_id: SESSION,
-      turn_id: "cmid-r",
-      path: "reply-123.wav",
-    });
-    const ready = dispatched.filter((e) => e.type === "crew:visual_ready");
-    expect(ready).toHaveLength(1);
-    expect((ready[0] as CustomEvent).detail.turnId).toBe("cmid-r");
-    expect((ready[0] as CustomEvent).detail.path).toBe("visual-abc.html");
+    expect(
+      dispatched.filter((e) => e.type.startsWith("crew:visual_")),
+    ).toHaveLength(0);
   });
 
   it("turn lifecycle multiplexer routes started / completed / error correctly", () => {

--- a/src/runtime/ui-protocol-event-router.ts
+++ b/src/runtime/ui-protocol-event-router.ts
@@ -42,6 +42,7 @@ import type {
   TurnStartedEvent,
   UiProtocolBridge,
   VisualGeneratingEvent,
+  VisualSucceededEvent,
   VisualFailedEvent,
 } from "./ui-protocol-bridge";
 import * as ThreadStore from "@/store/thread-store";
@@ -240,12 +241,6 @@ export interface RouterConfig {
   /** Override window event dispatch for tests / SSR. */
   dispatchEvent?: (event: Event) => void;
 }
-
-/** #1477 voice rich output: file extensions that denote a visual artifact
- *  (illustrated HTML / image). Mirrors the voice hook's `HTML_EXT` +
- *  `VISUAL_IMAGE_EXT`; used to tell a visual `file/attached` (the success
- *  signal for the generating placeholder) apart from the reply audio. */
-const VISUAL_ARTIFACT_EXT = /\.(html?|png|jpe?g|gif|webp|svg)$/i;
 
 function dispatch(cfg: RouterConfig, event: Event): void {
   const fn = cfg.dispatchEvent ?? defaultDispatch;
@@ -710,25 +705,10 @@ export function handleFileAttached(
   if (!event.path || event.path.length === 0) {
     return;
   }
-  // #1477 voice rich output: a visual artifact (HTML / image) landing is the
-  // SUCCESS signal for the "generating" placeholder. Fan it onto a
-  // `crew:visual_ready` DOM event carrying the turn_id so the voice hook can
-  // clear the placeholder only for the matching turn (the reply audio also
-  // arrives via `file/attached`, so gate on a visual extension). Dispatched
-  // independently of the placement logic below.
-  if (VISUAL_ARTIFACT_EXT.test(event.path)) {
-    dispatch(
-      cfg,
-      new CustomEvent("crew:visual_ready", {
-        detail: {
-          sessionId: cfg.sessionId,
-          topic: cfg.topic,
-          turnId: event.turn_id,
-          path: event.path,
-        },
-      }),
-    );
-  }
+  // #1477 voice rich output: `file/attached` is a pure artifact-delivery
+  // signal — visual lifecycle SUCCESS is carried by the typed
+  // `visual/succeeded` event (see `handleVisualSucceeded`), so nothing visual
+  // is derived from a file extension here.
   const file = {
     filename: filenameFromPath(event.path),
     path: event.path,
@@ -1756,6 +1736,24 @@ function handleVisualGenerating(
   );
 }
 
+function handleVisualSucceeded(
+  cfg: RouterConfig,
+  event: VisualSucceededEvent,
+): void {
+  dispatch(
+    cfg,
+    new CustomEvent("crew:visual_succeeded", {
+      detail: {
+        sessionId: cfg.sessionId,
+        topic: cfg.topic,
+        turnId: event.turn_id,
+        kind: event.kind,
+        files: event.files ?? [],
+      },
+    }),
+  );
+}
+
 function handleVisualFailed(cfg: RouterConfig, event: VisualFailedEvent): void {
   dispatch(
     cfg,
@@ -1840,6 +1838,9 @@ export function attachRouter(
   const offVisualGenerating = bridge.onVisualGenerating((e) =>
     handleVisualGenerating(cfg, e),
   );
+  const offVisualSucceeded = bridge.onVisualSucceeded((e) =>
+    handleVisualSucceeded(cfg, e),
+  );
   const offVisualFailed = bridge.onVisualFailed((e) =>
     handleVisualFailed(cfg, e),
   );
@@ -1854,6 +1855,7 @@ export function attachRouter(
       offSpawnComplete();
       offFileAttached();
       offVisualGenerating();
+      offVisualSucceeded();
       offVisualFailed();
       offTaskUpdated();
       offTaskOutputDelta();

--- a/src/runtime/ui-protocol-runtime.test.ts
+++ b/src/runtime/ui-protocol-runtime.test.ts
@@ -94,6 +94,7 @@ function makeDeferredBridge(): DeferredBridge {
     onSpawnComplete: vi.fn(() => () => {}),
     onFileAttached: vi.fn(() => () => {}),
     onVisualGenerating: vi.fn(() => () => {}),
+    onVisualSucceeded: vi.fn(() => () => {}),
     onVisualFailed: vi.fn(() => () => {}),
     onTaskUpdated: vi.fn(() => () => {}),
     onTaskOutputDelta: vi.fn(() => () => {}),

--- a/src/runtime/ui-protocol-types.ts
+++ b/src/runtime/ui-protocol-types.ts
@@ -336,6 +336,20 @@ export interface VisualGeneratingEvent {
   kind: string;
 }
 
+/** #1477 voice rich output — the background visual task produced its
+ *  artifact(s). The structured success counterpart of VisualGeneratingEvent:
+ *  the client clears the "generating" placeholder off this, NOT off
+ *  `file/attached` (which stays a pure artifact-delivery signal). Emitted
+ *  alongside `file/attached` on the success branch. */
+export interface VisualSucceededEvent {
+  session_id: string;
+  turn_id: string;
+  /** `html` | `illustrated` | `image` | `infographic`. */
+  kind: string;
+  /** Workspace-relative filenames of the delivered artifact(s). */
+  files?: string[];
+}
+
 /** #1477 voice rich output — the background visual task failed / timed out, so
  *  the client should clear the "generating" placeholder. */
 export interface VisualFailedEvent {

--- a/src/runtime/ui-protocol-types.ts
+++ b/src/runtime/ui-protocol-types.ts
@@ -328,7 +328,8 @@ export interface FileAttachedEvent {
  *  the turn. The client shows a "generating" placeholder keyed off this typed
  *  event instead of scraping an in-band `[[VISUAL:...]]` marker out of the
  *  assistant text (the backend now keeps that marker off the wire entirely).
- *  Cleared by the eventual `file/attached` (success) or `visual/failed`. */
+ *  The lifecycle terminates on the typed `visual/succeeded` or `visual/failed`
+ *  — never on `file/attached` (a pure artifact-delivery signal). */
 export interface VisualGeneratingEvent {
   session_id: string;
   turn_id: string;


### PR DESCRIPTION
Follow-up to #238 (which merged the first cut of the typed visual lifecycle).
These commits were pushed after #238 merged, so they need their own PR. Pairs
with octos #1477.

## What
1. **Structured success (`visual/succeeded`)** — the visual lifecycle is now
   fully typed. `file/attached` is a pure artifact-delivery signal again; the
   "generating" placeholder is cleared by a dedicated `visual/succeeded` event
   (turn-attributed), never inferred from a file extension. Keeps the lifecycle
   intact under a future `projection.envelope.v1` cutover.
2. **P3 cleanups** — direct bridge JSON-RPC decode tests for
   `visual/generating` / `visual/succeeded` / `visual/failed` (+ fail-closed on
   missing `kind`); fixed stale comments that still said success comes from
   `file/attached`.
3. **`live_video` wire fix** — `buildTurnStartExtras` set `extras.live_video`,
   but `UiProtocolBridge.sendTurn` mapped only `media`/`topic`/`rewrite_for` and
   silently dropped `live_video`. The server therefore always saw
   `live_video=false` and forwarded zero camera frames to the illustration
   generator (confirmed in e2e logs). Added the mapping (set only when true,
   preserving the legacy wire shape) + regression tests.

## Tests
Full suite green (704); `tsc --noEmit` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)