### PR TITLE
feat(voice): exit intent — return home from /voice after farewell (UPCR-2026-025)

### DIFF
--- a/src/home/voice/use-voice-conversation.test.ts
+++ b/src/home/voice/use-voice-conversation.test.ts
@@ -3,8 +3,10 @@ import {
   assembleTurnFiles,
   collectFreshAudio,
   collectFreshVisuals,
+  farewellAudioActive,
   hasVisualMarker,
   pickFreshAudio,
+  shouldHandleExitEvent,
   stripVisualMarker,
 } from "./use-voice-conversation";
 import type { Thread } from "@/store/thread-store";
@@ -130,5 +132,76 @@ describe("collectFreshVisuals", () => {
     expect(
       collectFreshVisuals(threads, new Set(["w/seen.png"]), new Set(["old"])),
     ).toEqual([{ path: "w/new.html", kind: "html" }]);
+  });
+});
+
+describe("shouldHandleExitEvent (voice/exit dedup)", () => {
+  const SESSION = "voice-123";
+
+  it("accepts a fresh turn for this session", () => {
+    const consumed = new Set<string>();
+    expect(
+      shouldHandleExitEvent(
+        { sessionId: SESSION, turnId: "t1" },
+        SESSION,
+        consumed,
+      ),
+    ).toBe(true);
+  });
+
+  it("rejects a different session", () => {
+    expect(
+      shouldHandleExitEvent(
+        { sessionId: "other", turnId: "t1" },
+        SESSION,
+        new Set(),
+      ),
+    ).toBe(false);
+  });
+
+  it("rejects an already-consumed turn (replay / duplicate)", () => {
+    const consumed = new Set<string>(["t1"]);
+    expect(
+      shouldHandleExitEvent(
+        { sessionId: SESSION, turnId: "t1" },
+        SESSION,
+        consumed,
+      ),
+    ).toBe(false);
+  });
+
+  it("rejects missing/empty detail", () => {
+    expect(shouldHandleExitEvent(undefined, SESSION, new Set())).toBe(false);
+  });
+
+  it("accepts when turnId is absent (cannot dedup, still session-scoped)", () => {
+    expect(
+      shouldHandleExitEvent({ sessionId: SESSION }, SESSION, new Set(["t1"])),
+    ).toBe(true);
+  });
+});
+
+describe("farewellAudioActive (fallback must not cut off the goodbye)", () => {
+  it("is active while a clip is playing", () => {
+    expect(farewellAudioActive(true, 0, "speaking")).toBe(true);
+  });
+
+  it("is active while clips remain queued", () => {
+    expect(farewellAudioActive(false, 2, "thinking")).toBe(true);
+  });
+
+  it("is active in the speaking state", () => {
+    expect(farewellAudioActive(false, 0, "speaking")).toBe(true);
+  });
+
+  it("is NOT active when idle with an empty queue (already done / none)", () => {
+    expect(farewellAudioActive(false, 0, "idle")).toBe(false);
+    expect(farewellAudioActive(false, 0, "listening")).toBe(false);
+  });
+
+  it("is NOT active in `thinking` with an empty queue, so the no-audio case can still exit", () => {
+    // A turn that produced no farewell audio sits in `thinking`; the fallback
+    // timer must be allowed to leave rather than hang forever.
+    expect(farewellAudioActive(false, 0, "thinking")).toBe(false);
   });
 });

--- a/src/home/voice/use-voice-conversation.ts
+++ b/src/home/voice/use-voice-conversation.ts
@@ -152,6 +152,39 @@ export function stripVisualMarker(text: string): string {
   return i >= 0 ? text.slice(0, i).trimEnd() : text;
 }
 
+/**
+ * UPCR-2026-025: whether a `crew:voice_exit` event should be acted on. It must
+ * target THIS voice session AND carry a turn id we have not already consumed —
+ * guarding against ledger replays / duplicate events (re-delivered on reconnect)
+ * re-triggering navigation for an already-handled turn. Exported for unit tests.
+ */
+export function shouldHandleExitEvent(
+  detail: { sessionId?: string; turnId?: string } | undefined,
+  sessionId: string,
+  consumed: Set<string>,
+): boolean {
+  if (!detail || detail.sessionId !== sessionId) return false;
+  const turnId = typeof detail.turnId === "string" ? detail.turnId : "";
+  if (turnId && consumed.has(turnId)) return false;
+  return true;
+}
+
+/**
+ * UPCR-2026-025: whether a farewell clip is still actively playing or queued —
+ * i.e. the goodbye may still be heard, so navigation must wait for the
+ * drainQueue grace-timer rather than be forced by the fallback timer. Note this
+ * deliberately does NOT treat `thinking` as active: a turn that produced NO
+ * farewell audio sits in `thinking`, and the fallback must still leave there.
+ * Exported for unit tests.
+ */
+export function farewellAudioActive(
+  playing: boolean,
+  queueLength: number,
+  state: VoiceState,
+): boolean {
+  return playing || queueLength > 0 || state === "speaking";
+}
+
 /** Collect ALL unseen assistant visual artifacts (image/HTML) in order. */
 export function collectFreshVisuals(
   threads: Thread[],
@@ -278,6 +311,9 @@ export function useVoiceConversation(
   const exitPendingRef = useRef(false);
   const exitedRef = useRef(false);
   const exitFallbackTimerRef = useRef<ReturnType<typeof setTimeout> | undefined>(undefined);
+  // Turn ids whose `voice/exit` we've already acted on — dedups ledger replays /
+  // duplicate events so a stale exit can't re-trigger navigation.
+  const consumedExitTurnsRef = useRef<Set<string>>(new Set());
   const onExitRef = useRef<(() => void) | undefined>(undefined);
   onExitRef.current = onExit;
   const performExitRef = useRef<() => void>(() => {});
@@ -729,22 +765,50 @@ export function useVoiceConversation(
   useEffect(() => {
     const EXIT_FALLBACK_MS = 8000;
     const onExitEvent = (ev: Event) => {
-      const d = (ev as CustomEvent).detail as { sessionId?: string } | undefined;
-      if (!d || d.sessionId !== sessionId) return;
+      const d = (ev as CustomEvent).detail as
+        | { sessionId?: string; turnId?: string }
+        | undefined;
+      // Filter by session AND dedup by turn id (replay / duplicate guard).
+      if (!shouldHandleExitEvent(d, sessionId, consumedExitTurnsRef.current)) {
+        return;
+      }
+      const turnId = typeof d?.turnId === "string" ? d.turnId : "";
+      if (turnId) consumedExitTurnsRef.current.add(turnId);
       exitPendingRef.current = true;
       setExiting(true);
-      const speakingOrQueued =
-        playingRef.current ||
-        audioQueueRef.current.length > 0 ||
-        stateRef.current === "speaking" ||
-        stateRef.current === "thinking";
-      if (!speakingOrQueued) {
+      // If a farewell is playing/queued OR the reply is still arriving
+      // (`thinking`), wait — the drainQueue grace-timer leaves after the audio
+      // drains. Otherwise (idle/listening, nothing in flight) the farewell is
+      // already done or never came, so leave now.
+      const inFlight =
+        farewellAudioActive(
+          playingRef.current,
+          audioQueueRef.current.length,
+          stateRef.current,
+        ) || stateRef.current === "thinking";
+      if (!inFlight) {
         performExitRef.current();
         return;
       }
       clearTimeout(exitFallbackTimerRef.current);
       exitFallbackTimerRef.current = setTimeout(() => {
-        if (exitPendingRef.current) performExitRef.current();
+        if (!exitPendingRef.current) return;
+        // Review fix: a farewell may still be playing/queued past the fallback
+        // window (slow fetch/decode, long clip). Do NOT cut it off — defer to
+        // the drainQueue grace-timer, which performExit()s once the audio
+        // drains. Only force-exit when nothing is in flight (e.g. the model
+        // produced no farewell audio at all, so the turn is stuck in `thinking`
+        // with an empty queue).
+        if (
+          farewellAudioActive(
+            playingRef.current,
+            audioQueueRef.current.length,
+            stateRef.current,
+          )
+        ) {
+          return;
+        }
+        performExitRef.current();
       }, EXIT_FALLBACK_MS);
     };
     window.addEventListener("crew:voice_exit", onExitEvent);

--- a/src/home/voice/use-voice-conversation.ts
+++ b/src/home/voice/use-voice-conversation.ts
@@ -40,6 +40,9 @@ export interface VoiceConversation {
   generating: boolean;
   /** Dismiss the currently shown visual artifact. */
   dismissVisual: () => void;
+  /** UPCR-2026-025: true once an exit intent fired; the view shows a farewell
+   *  while the last reply audio finishes, then navigates home. */
+  exiting: boolean;
 }
 
 /** A rich-output artifact the assistant produced for this voice turn. */
@@ -176,6 +179,9 @@ export function collectFreshVisuals(
 export function useVoiceConversation(
   sessionId: string,
   historyTopic?: string,
+  /** UPCR-2026-025: called to leave the voice screen (e.g. navigate('/')) when
+   *  the user expresses an exit intent — invoked AFTER the farewell audio. */
+  onExit?: () => void,
 ): VoiceConversation {
   const threads = useThreads(sessionId, historyTopic);
   const capture = useVoiceCapture();
@@ -198,6 +204,7 @@ export function useVoiceConversation(
   const [lastAssistantText, setLastAssistantText] = useState("");
   const [visual, setVisual] = useState<VisualArtifact | null>(null);
   const [generating, setGenerating] = useState(false);
+  const [exiting, setExiting] = useState(false);
 
   // Rich output: artifacts already surfaced (so re-renders / re-entry don't
   // re-show them), the `turn_id` of the visual currently shown as "generating"
@@ -261,6 +268,19 @@ export function useVoiceConversation(
   const audioQueueRef = useRef<string[]>([]);
   const playingRef = useRef(false);
   const graceTimerRef = useRef<ReturnType<typeof setTimeout> | undefined>(undefined);
+
+  // Voice exit intent (UPCR-2026-025): a `crew:voice_exit` DOM event sets
+  // `exitPendingRef`; the drainQueue grace-timer then leaves /voice AFTER the
+  // farewell audio finishes (so the goodbye is heard). `exitedRef` guards the
+  // one-shot teardown; `exitFallbackTimerRef` is a safety net for a missing /
+  // late farewell. `onExitRef` holds the latest navigation callback;
+  // `performExitRef` breaks the cycle with `stop` (set after `stop` each render).
+  const exitPendingRef = useRef(false);
+  const exitedRef = useRef(false);
+  const exitFallbackTimerRef = useRef<ReturnType<typeof setTimeout> | undefined>(undefined);
+  const onExitRef = useRef<(() => void) | undefined>(undefined);
+  onExitRef.current = onExit;
+  const performExitRef = useRef<() => void>(() => {});
 
   // Stable refs that break the circular dependency between beginListening ↔
   // drainQueue. Each stores itself into its own ref every render.
@@ -457,7 +477,13 @@ export function useVoiceConversation(
         !playingRef.current &&
         (stateRef.current === "speaking" || stateRef.current === "thinking")
       ) {
-        void beginListeningRef.current();
+        // UPCR-2026-025: the farewell audio has finished — if an exit intent is
+        // pending, leave /voice now instead of returning to listening.
+        if (exitPendingRef.current) {
+          performExitRef.current();
+        } else {
+          void beginListeningRef.current();
+        }
       }
     }, 1500);
   }, [playOne]);
@@ -503,6 +529,13 @@ export function useVoiceConversation(
     audioQueueRef.current = [];
     playingRef.current = false;
     clearTimeout(graceTimerRef.current);
+    // UPCR-2026-025: a fresh start clears any prior exit-pending state (e.g. an
+    // error-retry re-entry); a real exit unmounts the view so this never undoes
+    // an in-flight navigation.
+    exitPendingRef.current = false;
+    exitedRef.current = false;
+    clearTimeout(exitFallbackTimerRef.current);
+    setExiting(false);
     // Wait for the WS bridge to actually connect before we start listening.
     // Otherwise a fast first utterance races the (re)connect and the turn
     // never reaches the server — the "you must wait a few seconds after a
@@ -528,6 +561,7 @@ export function useVoiceConversation(
     generatingTurnRef.current = null;
     setVisual(null);
     setGenerating(false);
+    clearTimeout(exitFallbackTimerRef.current);
     void captureStop();
     cameraStop();
     clearSentFrame();
@@ -535,6 +569,20 @@ export function useVoiceConversation(
     stateRef.current = "idle";
     setState("idle");
   }, [captureStop, cameraStop, clearSentFrame, releaseAudio]);
+
+  // Leave the voice screen: one-shot. Tears down capture/audio/camera, then
+  // invokes the navigation callback (e.g. navigate('/')). Called from the exit
+  // event (already-idle case), the drain grace-timer (after the farewell), or
+  // the fallback timer — `exitedRef` makes the duplicate calls no-ops.
+  const performExit = useCallback(() => {
+    if (exitedRef.current) return;
+    exitedRef.current = true;
+    exitPendingRef.current = false;
+    clearTimeout(exitFallbackTimerRef.current);
+    stop();
+    onExitRef.current?.();
+  }, [stop]);
+  performExitRef.current = performExit;
 
   const toggleCamera = useCallback(() => {
     if (cameraActiveRef.current) {
@@ -670,6 +718,39 @@ export function useVoiceConversation(
     };
   }, [sessionId]);
 
+  // Voice exit intent (UPCR-2026-025): consume the router's `crew:voice_exit`
+  // DOM event (filtered by sessionId). Mark exit pending + show the farewell
+  // state; the drainQueue grace-timer performs the navigation after the reply
+  // audio drains, so the goodbye is heard first. If nothing is queued/playing
+  // (the farewell already finished, or the model sent no audio), leave now. A
+  // fallback timer covers the case where reply audio never arrives. Listening on
+  // `window` (not the bridge) avoids racing the async bridge start — the router
+  // re-attaches on reconnect and keeps dispatching (mirrors the visual hook).
+  useEffect(() => {
+    const EXIT_FALLBACK_MS = 8000;
+    const onExitEvent = (ev: Event) => {
+      const d = (ev as CustomEvent).detail as { sessionId?: string } | undefined;
+      if (!d || d.sessionId !== sessionId) return;
+      exitPendingRef.current = true;
+      setExiting(true);
+      const speakingOrQueued =
+        playingRef.current ||
+        audioQueueRef.current.length > 0 ||
+        stateRef.current === "speaking" ||
+        stateRef.current === "thinking";
+      if (!speakingOrQueued) {
+        performExitRef.current();
+        return;
+      }
+      clearTimeout(exitFallbackTimerRef.current);
+      exitFallbackTimerRef.current = setTimeout(() => {
+        if (exitPendingRef.current) performExitRef.current();
+      }, EXIT_FALLBACK_MS);
+    };
+    window.addEventListener("crew:voice_exit", onExitEvent);
+    return () => window.removeEventListener("crew:voice_exit", onExitEvent);
+  }, [sessionId]);
+
   // Stop ONLY on real unmount. Use a ref so identity churn of `stop` across
   // re-renders never re-fires this cleanup (that was tearing the VAD down on
   // every render). `[]` deps → cleanup runs once, at unmount.
@@ -700,5 +781,6 @@ export function useVoiceConversation(
     visual,
     generating,
     dismissVisual,
+    exiting,
   };
 }

--- a/src/home/voice/voice-view.tsx
+++ b/src/home/voice/voice-view.tsx
@@ -23,7 +23,10 @@ interface VoiceViewProps {
 }
 
 export function VoiceView({ sessionId, historyTopic, onBack }: VoiceViewProps) {
-  const conv = useVoiceConversation(sessionId, historyTopic);
+  // UPCR-2026-025: a spoken exit intent ("再见 / 退出 / 静音") leaves the voice
+  // screen via the same destination as the manual X button — the hook fires it
+  // only AFTER the farewell audio finishes.
+  const conv = useVoiceConversation(sessionId, historyTopic, onBack);
 
   // Auto-enter listening on mount: the user reached this full-screen view via a
   // navigation gesture, so unlock audio playback and begin capture immediately
@@ -107,7 +110,9 @@ export function VoiceView({ sessionId, historyTopic, onBack }: VoiceViewProps) {
           <VoiceOrb state={conv.state} />
         </div>
 
-        <div className="mt-6 min-h-[20px] text-sm text-white/55">{STATE_WORD[conv.state]}</div>
+        <div className="mt-6 min-h-[20px] text-sm text-white/55">
+          {conv.exiting ? "再见 👋" : STATE_WORD[conv.state]}
+        </div>
 
         {/* Camera on but stream not ready yet, or it failed. */}
         {conv.cameraActive && !conv.cameraStream && (

--- a/src/runtime/ui-protocol-bridge.test.ts
+++ b/src/runtime/ui-protocol-bridge.test.ts
@@ -37,6 +37,7 @@ import type {
   VisualSucceededEvent,
   VisualGeneratingEvent,
   VisualFailedEvent,
+  VoiceExitEvent,
   MessagePersistedEvent,
   TaskOutputDeltaEvent,
   TaskUpdatedEvent,
@@ -1866,6 +1867,39 @@ describe("notification dispatch", () => {
     expect(ok).toHaveLength(0);
     expect(
       warnings.some((w) => w.reason === "invalid_event:visual/succeeded"),
+    ).toBe(true);
+  });
+
+  it("routes voice/exit to its handler", async () => {
+    const { bridge, ws } = await freshConnected();
+    const exits: VoiceExitEvent[] = [];
+    bridge.onVoiceExit((e) => exits.push(e));
+    ws.triggerMessage({
+      jsonrpc: "2.0",
+      method: METHODS.VOICE_EXIT,
+      params: { session_id: "sess-1", turn_id: "t1" },
+    });
+    expect(exits).toHaveLength(1);
+    expect(exits[0].session_id).toBe("sess-1");
+    expect(exits[0].turn_id).toBe("t1");
+  });
+
+  // A voice/exit missing the required turn_id is rejected (fail-closed),
+  // surfaced as a warning, and not delivered.
+  it("rejects voice/exit without turn_id and warns", async () => {
+    const { bridge, ws } = await freshConnected();
+    const exits: VoiceExitEvent[] = [];
+    const warnings: WarningEvent[] = [];
+    bridge.onVoiceExit((e) => exits.push(e));
+    bridge.onWarning((w) => warnings.push(w));
+    ws.triggerMessage({
+      jsonrpc: "2.0",
+      method: METHODS.VOICE_EXIT,
+      params: { session_id: "sess-1" },
+    });
+    expect(exits).toHaveLength(0);
+    expect(
+      warnings.some((w) => w.reason === "invalid_event:voice/exit"),
     ).toBe(true);
   });
 

--- a/src/runtime/ui-protocol-bridge.ts
+++ b/src/runtime/ui-protocol-bridge.ts
@@ -410,6 +410,9 @@ export interface UiProtocolBridge {
   ): () => void;
   /** #1477 voice rich output — a background visual task failed / timed out. */
   onVisualFailed(handler: (e: VisualFailedEvent) => void): () => void;
+  /** UPCR-2026-025 voice exit intent — the voice turn should end; the client
+   *  leaves /voice after the farewell audio finishes. */
+  onVoiceExit(handler: (e: VoiceExitEvent) => void): () => void;
   onTaskUpdated(handler: (e: TaskUpdatedEvent) => void): () => void;
   onTaskOutputDelta(handler: (e: TaskOutputDeltaEvent) => void): () => void;
   onTurnLifecycle(

--- a/src/runtime/ui-protocol-bridge.ts
+++ b/src/runtime/ui-protocol-bridge.ts
@@ -31,6 +31,7 @@ import type {
   VisualGeneratingEvent,
   VisualSucceededEvent,
   VisualFailedEvent,
+  VoiceExitEvent,
   MessagePersistedEvent,
   ProgressUpdatedEvent,
   QueueStateEvent,
@@ -90,6 +91,7 @@ export type {
   VisualGeneratingEvent,
   VisualSucceededEvent,
   VisualFailedEvent,
+  VoiceExitEvent,
   TurnStartExtras,
   TurnStartInput,
   TurnStartMediaRef,
@@ -158,6 +160,9 @@ export const METHODS = {
   VISUAL_GENERATING: "visual/generating",
   VISUAL_SUCCEEDED: "visual/succeeded",
   VISUAL_FAILED: "visual/failed",
+  // UPCR-2026-025 voice exit intent — typed signal that the voice turn should
+  // end (replaces scraping an in-band `[[EXIT]]` marker out of the reply).
+  VOICE_EXIT: "voice/exit",
   APPROVAL_REQUESTED: "approval/requested",
   WARNING: "warning",
   // Synchronous tool-call lifecycle. Server emits these as
@@ -863,6 +868,13 @@ function guardVisualFailed(p: unknown): VisualFailedEvent | null {
   };
 }
 
+function guardVoiceExit(p: unknown): VoiceExitEvent | null {
+  if (!isPlainObject(p)) return null;
+  if (!isString(p.session_id)) return null;
+  if (!isString(p.turn_id)) return null;
+  return { session_id: p.session_id, turn_id: p.turn_id };
+}
+
 /**
  * Guard for one row in `SessionHydrateResult.messages`. Fail-closed on
  * type / required-field violations. `message_id` and `source` are
@@ -1477,6 +1489,7 @@ class UiProtocolBridgeImpl implements UiProtocolBridge {
   private readonly subVisualSucceeded =
     new Subscribers<VisualSucceededEvent>();
   private readonly subVisualFailed = new Subscribers<VisualFailedEvent>();
+  private readonly subVoiceExit = new Subscribers<VoiceExitEvent>();
   private readonly subTaskUpdated = new Subscribers<TaskUpdatedEvent>();
   private readonly subTaskOutputDelta = new Subscribers<TaskOutputDeltaEvent>();
   private readonly subTurnLifecycle = new Subscribers<
@@ -1537,6 +1550,10 @@ class UiProtocolBridgeImpl implements UiProtocolBridge {
     [METHODS.VISUAL_FAILED]: {
       guard: guardVisualFailed,
       emit: (v) => this.subVisualFailed.emit(v as VisualFailedEvent),
+    },
+    [METHODS.VOICE_EXIT]: {
+      guard: guardVoiceExit,
+      emit: (v) => this.subVoiceExit.emit(v as VoiceExitEvent),
     },
     [METHODS.TASK_UPDATED]: {
       guard: guardTaskUpdated,
@@ -1864,6 +1881,9 @@ class UiProtocolBridgeImpl implements UiProtocolBridge {
   }
   onVisualFailed(handler: Listener<VisualFailedEvent>): () => void {
     return this.subVisualFailed.add(handler);
+  }
+  onVoiceExit(handler: Listener<VoiceExitEvent>): () => void {
+    return this.subVoiceExit.add(handler);
   }
   onTaskUpdated(handler: Listener<TaskUpdatedEvent>): () => void {
     return this.subTaskUpdated.add(handler);

--- a/src/runtime/ui-protocol-event-router.test.ts
+++ b/src/runtime/ui-protocol-event-router.test.ts
@@ -41,6 +41,7 @@ import type {
   VisualGeneratingEvent,
   VisualSucceededEvent,
   VisualFailedEvent,
+  VoiceExitEvent,
   MessageDeltaEvent,
   MessagePersistedEvent,
   ProgressUpdatedEvent,
@@ -2611,6 +2612,7 @@ class FakeBridge implements UiProtocolBridge {
   emitVisualGenerating?: (e: VisualGeneratingEvent) => void;
   emitVisualSucceeded?: (e: VisualSucceededEvent) => void;
   emitVisualFailed?: (e: VisualFailedEvent) => void;
+  emitVoiceExit?: (e: VoiceExitEvent) => void;
   emitTaskUpdated?: (e: TaskUpdatedEvent) => void;
   emitTaskOutputDelta?: (e: TaskOutputDeltaEvent) => void;
   emitTurnLifecycle?: (
@@ -2677,6 +2679,12 @@ class FakeBridge implements UiProtocolBridge {
     this.emitVisualFailed = h;
     return () => {
       this.emitVisualFailed = undefined;
+    };
+  }
+  onVoiceExit(h: (e: VoiceExitEvent) => void) {
+    this.emitVoiceExit = h;
+    return () => {
+      this.emitVoiceExit = undefined;
     };
   }
   onTaskUpdated(h: (e: TaskUpdatedEvent) => void) {
@@ -2839,6 +2847,26 @@ describe("attachRouter", () => {
     expect(failed).toBeDefined();
     expect(failed!.detail.turnId).toBe("cmid-v");
     expect(failed!.detail.reason).toBe("timed out after 180s");
+  });
+
+  // UPCR-2026-025 voice exit intent: the router fans the typed `voice/exit`
+  // event onto a `crew:voice_exit` DOM event. The voice hook listens on
+  // `window` and leaves /voice after its reply-audio queue drains.
+  it("fans voice/exit onto a crew:voice_exit DOM event", () => {
+    const bridge = new FakeBridge();
+    const dispatched: Event[] = [];
+    attachRouter(bridge, {
+      sessionId: SESSION,
+      dispatchEvent: (e) => dispatched.push(e),
+    });
+
+    bridge.emitVoiceExit?.({ session_id: SESSION, turn_id: "cmid-x" });
+    const exit = dispatched.find(
+      (e) => e.type === "crew:voice_exit",
+    ) as CustomEvent | undefined;
+    expect(exit).toBeDefined();
+    expect(exit!.detail.sessionId).toBe(SESSION);
+    expect(exit!.detail.turnId).toBe("cmid-x");
   });
 
   // file/attached is a pure artifact-delivery signal — it must NOT fan out any

--- a/src/runtime/ui-protocol-event-router.ts
+++ b/src/runtime/ui-protocol-event-router.ts
@@ -44,6 +44,7 @@ import type {
   VisualGeneratingEvent,
   VisualSucceededEvent,
   VisualFailedEvent,
+  VoiceExitEvent,
 } from "./ui-protocol-bridge";
 import * as ThreadStore from "@/store/thread-store";
 import * as TaskStore from "@/store/task-store";
@@ -1769,6 +1770,26 @@ function handleVisualFailed(cfg: RouterConfig, event: VisualFailedEvent): void {
 }
 
 /**
+ * UPCR-2026-025 voice exit intent: fan the typed `voice/exit` event onto a
+ * `crew:voice_exit` DOM event. The voice hook consumes this window event and
+ * leaves the `/voice` screen — gating the actual navigation on its own reply-
+ * audio queue draining, so the farewell is heard first. Mirrors the visual
+ * lifecycle fan-out so it is immune to the bridge-start race and to reconnects.
+ */
+function handleVoiceExit(cfg: RouterConfig, event: VoiceExitEvent): void {
+  dispatch(
+    cfg,
+    new CustomEvent("crew:voice_exit", {
+      detail: {
+        sessionId: cfg.sessionId,
+        topic: cfg.topic,
+        turnId: event.turn_id,
+      },
+    }),
+  );
+}
+
+/**
  * Subscribe the router to all relevant streams on a started bridge. The
  * caller owns bridge lifecycle (start/stop). Returns a detacher that
  * removes every listener registered here — call it before swapping the
@@ -1844,6 +1865,9 @@ export function attachRouter(
   const offVisualFailed = bridge.onVisualFailed((e) =>
     handleVisualFailed(cfg, e),
   );
+  // UPCR-2026-025 voice exit intent: fan `voice/exit` onto a `crew:voice_exit`
+  // DOM event (see `handleVoiceExit`).
+  const offVoiceExit = bridge.onVoiceExit((e) => handleVoiceExit(cfg, e));
 
   let detached = false;
   return {
@@ -1857,6 +1881,7 @@ export function attachRouter(
       offVisualGenerating();
       offVisualSucceeded();
       offVisualFailed();
+      offVoiceExit();
       offTaskUpdated();
       offTaskOutputDelta();
       offTurnLifecycle();

--- a/src/runtime/ui-protocol-runtime.test.ts
+++ b/src/runtime/ui-protocol-runtime.test.ts
@@ -96,6 +96,7 @@ function makeDeferredBridge(): DeferredBridge {
     onVisualGenerating: vi.fn(() => () => {}),
     onVisualSucceeded: vi.fn(() => () => {}),
     onVisualFailed: vi.fn(() => () => {}),
+    onVoiceExit: vi.fn(() => () => {}),
     onTaskUpdated: vi.fn(() => () => {}),
     onTaskOutputDelta: vi.fn(() => () => {}),
     onTurnLifecycle: vi.fn(() => () => {}),

--- a/src/runtime/ui-protocol-types.ts
+++ b/src/runtime/ui-protocol-types.ts
@@ -359,6 +359,16 @@ export interface VisualFailedEvent {
   reason?: string;
 }
 
+/** UPCR-2026-025 voice exit intent — the voice turn detected an end / goodbye /
+ *  mute intent (the model appended an in-band `[[EXIT]]` control marker, which
+ *  the backend strips from every model-/client-facing surface). The client
+ *  leaves the `/voice` screen and returns home — but only AFTER the turn's
+ *  farewell audio finishes playing, so the goodbye is heard before navigation. */
+export interface VoiceExitEvent {
+  session_id: string;
+  turn_id: string;
+}
+
 export interface TaskUpdatedEvent {
   session_id: string;
   /** Optional. Server's `TaskUpdatedEvent` struct does NOT carry


### PR DESCRIPTION
## What & why

Frontend half of the voice-assistant exit mechanism: on receiving the backend's typed `voice/exit` notification, the client returns from `/voice` to home `/` — but only **after the turn's farewell audio finishes playing**.

> Companion backend PR: octos-org/octos#1500 (UPCR-2026-025, which defines and emits `voice/exit`)

## What changed

- **bridge** (`ui-protocol-bridge.ts` / `ui-protocol-types.ts`): add the `VoiceExitEvent` type, the `VOICE_EXIT` method, a fail-closed guard, the subscriber + `onVoiceExit`, mirroring the `visual/*` lifecycle
- **event-router** (`ui-protocol-event-router.ts`): fan `voice/exit` onto a `crew:voice_exit` DOM event (`sessionId` / `turnId`); the hook listens on `window` to avoid racing the async bridge start
- **voice hook** (`use-voice-conversation.ts`): listen for `crew:voice_exit` → mark exit-pending, show "再见 👋"; the drainQueue grace-timer performs `performExit()` (navigate `/`) after the audio drains; an 8s fallback is only a safety net
- `voice-view.tsx`: `onExit` reuses the same destination as the manual close button

## Review fixes (pre-PR)

- **Blocker**: the 8s fallback originally checked only `exitPending`, so a farewell playing past 8s (slow fetch/decode or a long clip) got cut off by `stop()` → the fallback now re-checks `farewellAudioActive()` and defers to the grace-timer while audio is still in flight, only force-exiting when nothing is playing/queued
- **Dedup**: `voice/exit` was filtered by `sessionId` only, so a ledger replay / duplicate could re-trigger navigation → dedup by `turn_id` via `consumedExitTurnsRef` + `shouldHandleExitEvent`

Both decision points were extracted as pure helpers (`farewellAudioActive`, `shouldHandleExitEvent`) and unit-tested.

## Tests

- `pnpm test:unit` → 717 passed (incl. new bridge/router/helper cases) ✅
- `tsc -b` ✅ / `vite build` ✅
- lint failures are pre-existing repo-wide debt (same as main), not introduced by this diff

🤖 Generated with [Claude Code](https://claude.com/claude-code)