### PR TITLE
feat(voice): Voice settings tab + cloud-aware voice switcher

### DIFF
--- a/src/home/voice/voice-selector.test.tsx
+++ b/src/home/voice/voice-selector.test.tsx
@@ -71,4 +71,26 @@ describe("VoiceSelector (pills)", () => {
     await waitFor(() => expect(screen.queryByRole("option")).toBeNull());
     expect(screen.queryByText("vivian")).toBeNull();
   });
+
+  it("hides the switcher on the auto route when cloud credentials are configured", async () => {
+    getMyProfile.mockResolvedValue({
+      config: {
+        tts_provider: "auto",
+        tts_cloud: { appid: "9155" },
+        env_vars: { VOLC_TTS_TOKEN: "ab***yz" },
+      },
+    });
+    render(<VoiceSelector />);
+    await waitFor(() => expect(screen.queryByRole("option")).toBeNull());
+  });
+
+  it("keeps the switcher on the auto route when cloud is not configured", async () => {
+    getMyProfile.mockResolvedValue({
+      config: { tts_provider: "auto", tts_cloud: { appid: "9155" }, env_vars: {} },
+    });
+    render(<VoiceSelector />);
+    // resolve the profile fetch, then confirm the pills are still shown
+    await waitFor(() => expect(getMyProfile).toHaveBeenCalled());
+    expect(screen.getAllByRole("option")).toHaveLength(2);
+  });
 });

--- a/src/home/voice/voice-selector.test.tsx
+++ b/src/home/voice/voice-selector.test.tsx
@@ -1,8 +1,9 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
 
 const loadVoices = vi.fn();
 const selectVoice = vi.fn();
+const getMyProfile = vi.fn();
 let mockStore = {
   voices: [
     { id: "doubao", aliases: ["vivian"] },
@@ -18,6 +19,10 @@ vi.mock("@/store/voice-store", () => ({
   selectVoice: (id: string) => selectVoice(id),
 }));
 
+vi.mock("@/settings/settings-api", () => ({
+  getMyProfile: () => getMyProfile(),
+}));
+
 import { VoiceSelector } from "./voice-selector";
 
 describe("VoiceSelector (pills)", () => {
@@ -25,6 +30,8 @@ describe("VoiceSelector (pills)", () => {
     cleanup();
     loadVoices.mockReset();
     selectVoice.mockReset().mockResolvedValue(undefined);
+    // Default: on-device route → switcher visible.
+    getMyProfile.mockReset().mockResolvedValue({ config: { tts_provider: "local" } });
     mockStore = {
       voices: [
         { id: "doubao", aliases: ["vivian"] },
@@ -56,5 +63,12 @@ describe("VoiceSelector (pills)", () => {
     render(<VoiceSelector />);
     fireEvent.click(screen.getByText("vivian")); // already current
     expect(selectVoice).not.toHaveBeenCalled();
+  });
+
+  it("hides the on-device switcher when the cloud route is selected", async () => {
+    getMyProfile.mockResolvedValue({ config: { tts_provider: "cloud" } });
+    render(<VoiceSelector />);
+    await waitFor(() => expect(screen.queryByRole("option")).toBeNull());
+    expect(screen.queryByText("vivian")).toBeNull();
   });
 });

--- a/src/home/voice/voice-selector.tsx
+++ b/src/home/voice/voice-selector.tsx
@@ -15,10 +15,11 @@ export function VoiceSelector() {
   const { voices, current, status } = useVoiceStore();
   const [busy, setBusy] = useState(false);
   const [failed, setFailed] = useState(false);
-  // These pills switch the ON-DEVICE reply voice (timbre). When the cloud
-  // (Volcano) route is selected they have no effect — the cloud voice is set
-  // in Settings → Voice — so hide the whole switcher. `auto`/`local` keep it
-  // (auto may still resolve to on-device).
+  // These pills switch the ON-DEVICE reply voice (timbre). Hide them whenever
+  // adjusting them would have no effect — i.e. the EFFECTIVE route is cloud:
+  //   - `cloud`/`volcano`            → always cloud
+  //   - `auto` + cloud creds present → resolves to cloud (token + appid set)
+  // `local`, or `auto` without creds, keep the switcher (on-device is used).
   const [cloudRoute, setCloudRoute] = useState(false);
 
   useEffect(() => {
@@ -29,9 +30,15 @@ export function VoiceSelector() {
     let cancelled = false;
     getMyProfile()
       .then((p) => {
-        if (cancelled) return;
-        const route = p?.config.tts_provider;
-        setCloudRoute(route === "cloud" || route === "volcano");
+        if (cancelled || !p) return;
+        const route = p.config.tts_provider ?? "auto";
+        const cloudConfigured =
+          !!p.config.tts_cloud?.appid && !!p.config.env_vars?.["VOLC_TTS_TOKEN"];
+        setCloudRoute(
+          route === "cloud" ||
+            route === "volcano" ||
+            (route === "auto" && cloudConfigured),
+        );
       })
       .catch(() => {
         /* keep the switcher visible if the profile can't be read */

--- a/src/home/voice/voice-selector.tsx
+++ b/src/home/voice/voice-selector.tsx
@@ -4,6 +4,7 @@
  */
 import { useEffect, useState } from "react";
 import { loadVoices, selectVoice, useVoiceStore } from "@/store/voice-store";
+import { getMyProfile } from "@/settings/settings-api";
 import type { VoiceInfo } from "@/api/voice";
 
 function labelFor(v: VoiceInfo): string {
@@ -14,10 +15,31 @@ export function VoiceSelector() {
   const { voices, current, status } = useVoiceStore();
   const [busy, setBusy] = useState(false);
   const [failed, setFailed] = useState(false);
+  // These pills switch the ON-DEVICE reply voice (timbre). When the cloud
+  // (Volcano) route is selected they have no effect — the cloud voice is set
+  // in Settings → Voice — so hide the whole switcher. `auto`/`local` keep it
+  // (auto may still resolve to on-device).
+  const [cloudRoute, setCloudRoute] = useState(false);
 
   useEffect(() => {
     if (status === "idle") void loadVoices();
   }, [status]);
+
+  useEffect(() => {
+    let cancelled = false;
+    getMyProfile()
+      .then((p) => {
+        if (cancelled) return;
+        const route = p?.config.tts_provider;
+        setCloudRoute(route === "cloud" || route === "volcano");
+      })
+      .catch(() => {
+        /* keep the switcher visible if the profile can't be read */
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, []);
 
   async function pick(id: string) {
     if (busy || id === current) return;
@@ -32,7 +54,7 @@ export function VoiceSelector() {
     }
   }
 
-  if (voices.length === 0) return null;
+  if (cloudRoute || voices.length === 0) return null;
 
   return (
     <div className="flex flex-col items-center gap-1">

--- a/src/settings/settings-api.test.ts
+++ b/src/settings/settings-api.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, it } from "vitest";
+import { mergeProfileConfig, normalizeProfileConfig } from "./settings-api";
+
+describe("mergeProfileConfig — voice TTS fields", () => {
+  it("should carry tts_provider and tts_cloud through a patch", () => {
+    const current = normalizeProfileConfig({});
+    const next = mergeProfileConfig(current, {
+      tts_provider: "cloud",
+      tts_cloud: { appid: "999", voice: "BV700" },
+    });
+    expect(next.tts_provider).toBe("cloud");
+    expect(next.tts_cloud).toEqual({ appid: "999", voice: "BV700" });
+  });
+
+  it("should default tts fields to undefined when absent", () => {
+    const cfg = normalizeProfileConfig({});
+    expect(cfg.tts_provider).toBeUndefined();
+    expect(cfg.tts_cloud ?? undefined).toBeUndefined();
+  });
+});

--- a/src/settings/settings-api.ts
+++ b/src/settings/settings-api.ts
@@ -151,7 +151,8 @@ export interface ProfileConfig {
   adaptive_routing: unknown;
   content_routing: unknown;
   plugins: { require_signed: boolean };
-  tts_provider?: string;
+  // `null` clears the per-profile override → inherit the server default.
+  tts_provider?: string | null;
   tts_cloud?: CloudTtsConfig | null;
 }
 

--- a/src/settings/settings-api.ts
+++ b/src/settings/settings-api.ts
@@ -126,6 +126,14 @@ export interface HomeProfileConfig {
   metro_layout?: Record<string, HomeProfileTileLayout>;
 }
 
+export interface CloudTtsConfig {
+  appid?: string;
+  voice?: string;
+  cluster?: string;
+  encoding?: string;
+  endpoint?: string;
+}
+
 export interface ProfileConfig {
   llm: {
     primary: LlmPrimary;
@@ -143,6 +151,8 @@ export interface ProfileConfig {
   adaptive_routing: unknown;
   content_routing: unknown;
   plugins: { require_signed: boolean };
+  tts_provider?: string;
+  tts_cloud?: CloudTtsConfig | null;
 }
 
 export interface ProfileStatus {
@@ -377,6 +387,12 @@ export function mergeProfileConfig(
   }
   if (patch.plugins) {
     next.plugins = { ...current.plugins, ...patch.plugins };
+  }
+  if (patch.tts_provider !== undefined) {
+    next.tts_provider = patch.tts_provider;
+  }
+  if (patch.tts_cloud !== undefined) {
+    next.tts_cloud = patch.tts_cloud;
   }
 
   return next;

--- a/src/settings/settings-page.tsx
+++ b/src/settings/settings-page.tsx
@@ -15,6 +15,7 @@ import {
   Loader2,
   Settings as SettingsIcon,
   Palette,
+  Volume2,
 } from "lucide-react";
 import {
   WorkbenchPage,
@@ -35,8 +36,9 @@ import { SystemTab } from "./system-tab";
 import { ServerTab } from "./server-tab";
 import { OminixTab } from "./ominix-tab";
 import { AppearanceTab } from "./appearance-tab";
+import { VoiceTab } from "./voice-tab";
 
-type TabId = "profile" | "appearance" | "llm" | "skills" | "channels" | "sandbox" | "tools" | "users" | "system" | "server" | "ominix";
+type TabId = "profile" | "appearance" | "llm" | "voice" | "skills" | "channels" | "sandbox" | "tools" | "users" | "system" | "server" | "ominix";
 
 interface TabDef {
   id: TabId;
@@ -49,6 +51,7 @@ const TABS: TabDef[] = [
   { id: "profile", label: "Profile", icon: User },
   { id: "appearance", label: "Appearance", icon: Palette },
   { id: "llm", label: "LLM", icon: Cpu },
+  { id: "voice", label: "Voice", icon: Volume2 },
   { id: "skills", label: "Skills", icon: Puzzle },
   { id: "channels", label: "Channels", icon: Radio },
   { id: "sandbox", label: "Sandbox", icon: Shield },
@@ -164,6 +167,9 @@ export function AdminSettingsPage() {
                   {activeTab === "appearance" && <AppearanceTab />}
                   {activeTab === "llm" && (
                     <LlmTab profile={profile} onProfileUpdated={setProfile} />
+                  )}
+                  {activeTab === "voice" && (
+                    <VoiceTab profile={profile} onProfileUpdated={setProfile} />
                   )}
                   {activeTab === "skills" && <SkillsTab />}
                   {activeTab === "channels" && <ChannelsTab profile={profile} onProfileUpdated={setProfile} />}

--- a/src/settings/settings-page.tsx
+++ b/src/settings/settings-page.tsx
@@ -169,7 +169,11 @@ export function AdminSettingsPage() {
                     <LlmTab profile={profile} onProfileUpdated={setProfile} />
                   )}
                   {activeTab === "voice" && (
-                    <VoiceTab profile={profile} onProfileUpdated={setProfile} />
+                    <VoiceTab
+                      key={profile.id}
+                      profile={profile}
+                      onProfileUpdated={setProfile}
+                    />
                   )}
                   {activeTab === "skills" && <SkillsTab />}
                   {activeTab === "channels" && <ChannelsTab profile={profile} onProfileUpdated={setProfile} />}

--- a/src/settings/voice-tab.test.tsx
+++ b/src/settings/voice-tab.test.tsx
@@ -56,4 +56,36 @@ describe("VoiceTab", () => {
     const [, patch] = apiMocks.updateMyProfileConfig.mock.calls[0];
     expect(patch.env_vars.VOLC_TTS_TOKEN).toBe("newtoken123");
   });
+
+  it("defaults to 'Inherit' when no tts_provider is set and sends null on save", async () => {
+    const inheritProfile = {
+      ...baseProfile,
+      config: { env_vars: {} },
+    } as any;
+    render(<VoiceTab profile={inheritProfile} onProfileUpdated={() => {}} />);
+    expect((screen.getByLabelText(/TTS route/i) as HTMLSelectElement).value).toBe(
+      "inherit",
+    );
+    fireEvent.click(screen.getByRole("button", { name: /save/i }));
+    await waitFor(() => expect(apiMocks.updateMyProfileConfig).toHaveBeenCalled());
+    const [, patch] = apiMocks.updateMyProfileConfig.mock.calls[0];
+    expect(patch.tts_provider).toBeNull(); // clears override → inherit
+  });
+
+  it("blocks save and shows an error when cloud route is missing credentials", () => {
+    const incompleteCloud = {
+      ...baseProfile,
+      config: { tts_provider: "cloud", tts_cloud: {}, env_vars: {} },
+    } as any;
+    render(<VoiceTab profile={incompleteCloud} onProfileUpdated={() => {}} />);
+    const saveBtn = screen.getByRole("button", { name: /save/i }) as HTMLButtonElement;
+    expect(saveBtn.disabled).toBe(true);
+    expect(screen.getByRole("alert").textContent).toMatch(/App ID/i);
+  });
+
+  it("no longer exposes a free-text endpoint field", () => {
+    render(<VoiceTab profile={baseProfile} onProfileUpdated={() => {}} />);
+    fireEvent.click(screen.getByRole("button", { name: /advanced/i }));
+    expect(screen.queryByLabelText(/Endpoint/i)).toBeNull();
+  });
 });

--- a/src/settings/voice-tab.test.tsx
+++ b/src/settings/voice-tab.test.tsx
@@ -45,4 +45,15 @@ describe("VoiceTab", () => {
     expect(patch.tts_provider).toBe("cloud");
     expect(patch.tts_cloud.appid).toBe("123");
   });
+
+  it("should write a newly typed token into the save patch", async () => {
+    render(<VoiceTab profile={baseProfile} onProfileUpdated={() => {}} />);
+    fireEvent.change(screen.getByLabelText(/Token/i), {
+      target: { value: "newtoken123" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: /save/i }));
+    await waitFor(() => expect(apiMocks.updateMyProfileConfig).toHaveBeenCalled());
+    const [, patch] = apiMocks.updateMyProfileConfig.mock.calls[0];
+    expect(patch.env_vars.VOLC_TTS_TOKEN).toBe("newtoken123");
+  });
 });

--- a/src/settings/voice-tab.test.tsx
+++ b/src/settings/voice-tab.test.tsx
@@ -1,0 +1,48 @@
+import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { VoiceTab } from "./voice-tab";
+
+const apiMocks = vi.hoisted(() => ({
+  updateMyProfileConfig: vi.fn(),
+  formatSettingsError: vi.fn((e: unknown, fb = "failed") =>
+    e instanceof Error ? e.message : fb,
+  ),
+}));
+vi.mock("./settings-api", () => apiMocks);
+
+const baseProfile = {
+  id: "p1",
+  name: "p1",
+  enabled: true,
+  data_dir: null,
+  config: {
+    tts_provider: "cloud",
+    tts_cloud: { appid: "123", voice: "BV700" },
+    env_vars: { VOLC_TTS_TOKEN: "ab***yz" }, // masked => already set
+  },
+} as any;
+
+describe("VoiceTab", () => {
+  beforeEach(() => {
+    cleanup();
+    apiMocks.updateMyProfileConfig.mockReset();
+    apiMocks.updateMyProfileConfig.mockResolvedValue(baseProfile);
+  });
+
+  it("should show cloud fields and render the appid in cleartext", () => {
+    render(<VoiceTab profile={baseProfile} onProfileUpdated={() => {}} />);
+    expect((screen.getByLabelText(/App ?ID/i) as HTMLInputElement).value).toBe("123");
+    expect((screen.getByLabelText(/Voice/i) as HTMLInputElement).value).toBe("BV700");
+  });
+
+  it("should omit an unchanged masked token from the save patch", async () => {
+    render(<VoiceTab profile={baseProfile} onProfileUpdated={() => {}} />);
+    fireEvent.click(screen.getByRole("button", { name: /save/i }));
+    await waitFor(() => expect(apiMocks.updateMyProfileConfig).toHaveBeenCalled());
+    const [, patch] = apiMocks.updateMyProfileConfig.mock.calls[0];
+    // token left as the stored masked value (save_with_merge restores it)
+    expect(patch.env_vars.VOLC_TTS_TOKEN).toBe("ab***yz");
+    expect(patch.tts_provider).toBe("cloud");
+    expect(patch.tts_cloud.appid).toBe("123");
+  });
+});

--- a/src/settings/voice-tab.test.tsx
+++ b/src/settings/voice-tab.test.tsx
@@ -1,6 +1,11 @@
 import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { VoiceTab } from "./voice-tab";
+import {
+  normalizeProfileConfig,
+  type Profile,
+  type ProfileConfig,
+} from "./settings-api";
 
 const apiMocks = vi.hoisted(() => ({
   updateMyProfileConfig: vi.fn(),
@@ -8,19 +13,32 @@ const apiMocks = vi.hoisted(() => ({
     e instanceof Error ? e.message : fb,
   ),
 }));
-vi.mock("./settings-api", () => apiMocks);
+// Keep the real module (normalizeProfileConfig etc.) and only spy the two
+// functions VoiceTab calls at runtime.
+vi.mock("./settings-api", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("./settings-api")>();
+  return { ...actual, ...apiMocks };
+});
 
-const baseProfile = {
-  id: "p1",
-  name: "p1",
-  enabled: true,
-  data_dir: null,
-  config: {
-    tts_provider: "cloud",
-    tts_cloud: { appid: "123", voice: "BV700" },
-    env_vars: { VOLC_TTS_TOKEN: "ab***yz" }, // masked => already set
-  },
-} as any;
+/** Build a fully-typed Profile from a partial config (no `as any`). */
+function makeProfile(config: Partial<ProfileConfig>): Profile {
+  return {
+    id: "p1",
+    name: "p1",
+    enabled: true,
+    data_dir: null,
+    config: normalizeProfileConfig(config),
+    created_at: "",
+    updated_at: "",
+    status: { running: false, pid: null, started_at: null, uptime_secs: null },
+  };
+}
+
+const baseProfile = makeProfile({
+  tts_provider: "cloud",
+  tts_cloud: { appid: "123", voice: "BV700" },
+  env_vars: { VOLC_TTS_TOKEN: "ab***yz" }, // masked => already set
+});
 
 describe("VoiceTab", () => {
   beforeEach(() => {
@@ -32,7 +50,7 @@ describe("VoiceTab", () => {
   it("should show cloud fields and render the appid in cleartext", () => {
     render(<VoiceTab profile={baseProfile} onProfileUpdated={() => {}} />);
     expect((screen.getByLabelText(/App ?ID/i) as HTMLInputElement).value).toBe("123");
-    expect((screen.getByLabelText(/Voice/i) as HTMLInputElement).value).toBe("BV700");
+    expect((screen.getByLabelText(/Voice/i) as HTMLSelectElement).value).toBe("BV700");
   });
 
   it("should omit an unchanged masked token from the save patch", async () => {
@@ -57,11 +75,8 @@ describe("VoiceTab", () => {
     expect(patch.env_vars.VOLC_TTS_TOKEN).toBe("newtoken123");
   });
 
-  it("defaults to 'Inherit' when no tts_provider is set and sends null on save", async () => {
-    const inheritProfile = {
-      ...baseProfile,
-      config: { env_vars: {} },
-    } as any;
+  it("defaults to 'Inherit' when no tts_provider is set and clears the override on save", async () => {
+    const inheritProfile = makeProfile({ env_vars: {} });
     render(<VoiceTab profile={inheritProfile} onProfileUpdated={() => {}} />);
     expect((screen.getByLabelText(/TTS route/i) as HTMLSelectElement).value).toBe(
       "inherit",
@@ -72,11 +87,25 @@ describe("VoiceTab", () => {
     expect(patch.tts_provider).toBeNull(); // clears override → inherit
   });
 
+  it("does not create an empty tts_cloud override when none existed", async () => {
+    // No tts_provider and no tts_cloud → Inherit save must send null, NOT `{}`,
+    // otherwise the backend treats `{}` as a per-profile override and clobbers
+    // the inherited server-level cloud config.
+    const inheritProfile = makeProfile({ env_vars: {} });
+    render(<VoiceTab profile={inheritProfile} onProfileUpdated={() => {}} />);
+    fireEvent.click(screen.getByRole("button", { name: /save/i }));
+    await waitFor(() => expect(apiMocks.updateMyProfileConfig).toHaveBeenCalled());
+    const [, patch] = apiMocks.updateMyProfileConfig.mock.calls[0];
+    expect(patch.tts_cloud).toBeNull();
+    expect(patch.tts_cloud).not.toEqual({});
+  });
+
   it("blocks save and shows an error when cloud route is missing credentials", () => {
-    const incompleteCloud = {
-      ...baseProfile,
-      config: { tts_provider: "cloud", tts_cloud: {}, env_vars: {} },
-    } as any;
+    const incompleteCloud = makeProfile({
+      tts_provider: "cloud",
+      tts_cloud: {},
+      env_vars: {},
+    });
     render(<VoiceTab profile={incompleteCloud} onProfileUpdated={() => {}} />);
     const saveBtn = screen.getByRole("button", { name: /save/i }) as HTMLButtonElement;
     expect(saveBtn.disabled).toBe(true);

--- a/src/settings/voice-tab.tsx
+++ b/src/settings/voice-tab.tsx
@@ -16,10 +16,13 @@ import {
 } from "./settings-api";
 
 const TOKEN_ENV = "VOLC_TTS_TOKEN";
+// `inherit` maps to a null `tts_provider` (no per-profile override → use the
+// server-level default). The other ids are explicit overrides.
 const ROUTES: { id: string; label: string; hint: string }[] = [
-  { id: "auto", label: "Auto", hint: "Cloud when a token is set, else on-device." },
+  { id: "inherit", label: "Inherit (server default)", hint: "Use the server-level TTS route." },
+  { id: "auto", label: "Auto", hint: "Cloud when credentials are set, else on-device." },
   { id: "local", label: "Local (on-device)", hint: "Local ominix-api engine." },
-  { id: "cloud", label: "Cloud (Volcano)", hint: "Volcano Engine cloud TTS." },
+  { id: "cloud", label: "Cloud (Volcano)", hint: "Volcano Engine cloud TTS (requires App ID + token)." },
 ];
 
 // Preset Volcano voices (voice_type IDs). Label = friendly name shown to the
@@ -50,7 +53,9 @@ export function VoiceTab({
   const cfg = profile.config;
   const storedToken = cfg.env_vars?.[TOKEN_ENV] ?? "";
 
-  const [route, setRoute] = useState(cfg.tts_provider ?? "auto");
+  // `null`/absent override → "inherit" (NOT "auto"): show the server-default
+  // option so we don't misrepresent the state or clobber inheritance on save.
+  const [route, setRoute] = useState(cfg.tts_provider ?? "inherit");
   const [cloud, setCloud] = useState<CloudTtsConfig>({ ...(cfg.tts_cloud ?? {}) });
   // empty input = leave the stored (masked) token untouched
   const [tokenInput, setTokenInput] = useState("");
@@ -61,7 +66,13 @@ export function VoiceTab({
 
   const showCloud = route === "auto" || route === "cloud";
   const tokenSet = isMasked(storedToken) || storedToken.length > 0;
-  const tokenWarning = route === "cloud" && !tokenSet && !tokenInput;
+  const tokenAvailable = tokenSet || tokenInput.length > 0;
+  const appidSet = !!cloud.appid?.trim();
+  // Cloud is an explicit choice → enforce complete creds (the backend would
+  // otherwise silently fall back to on-device). Auto may fall back, so it only
+  // gets a soft hint.
+  const cloudIncomplete = route === "cloud" && (!appidSet || !tokenAvailable);
+  const autoTokenHint = route === "auto" && !tokenAvailable;
 
   const setCloudField = (k: keyof CloudTtsConfig, v: string) =>
     setCloud((c) => ({ ...c, [k]: v }));
@@ -76,7 +87,8 @@ export function VoiceTab({
       // re-send the stored masked value so the backend restores the real one.
       if (tokenInput) envVars[TOKEN_ENV] = tokenInput;
       const updated = await updateMyProfileConfig(profile, {
-        tts_provider: route,
+        // `inherit` → null clears the override so the server default applies.
+        tts_provider: route === "inherit" ? null : route,
         tts_cloud: cloud,
         env_vars: envVars,
       });
@@ -214,22 +226,18 @@ export function VoiceTab({
                       className={INPUT_CLASS}
                     />
                   </Field>
-                  <Field label="Endpoint" htmlFor="volc-endpoint">
-                    <input
-                      id="volc-endpoint"
-                      value={cloud.endpoint ?? ""}
-                      placeholder="https://openspeech.bytedance.com/api/v1/tts"
-                      onChange={(e) => setCloudField("endpoint", e.target.value)}
-                      className={INPUT_CLASS}
-                    />
-                  </Field>
                 </div>
               )}
             </div>
 
-            {tokenWarning && (
+            {cloudIncomplete && (
+              <p role="alert" className="flex items-center gap-1.5 text-xs text-red-400">
+                <AlertCircle size={13} /> Cloud 模式需要同时填写 App ID 和 Token
+              </p>
+            )}
+            {autoTokenHint && (
               <p className="flex items-center gap-1.5 text-xs text-amber-400">
-                <AlertCircle size={13} /> 未填 token 将回退端侧
+                <AlertCircle size={13} /> 未填 token，Auto 将回退端侧
               </p>
             )}
           </div>
@@ -241,7 +249,7 @@ export function VoiceTab({
         <button
           type="button"
           onClick={save}
-          disabled={saving}
+          disabled={saving || cloudIncomplete}
           className="flex items-center gap-2 rounded-xl bg-accent px-5 py-2.5 text-sm font-medium text-white hover:bg-accent-dim disabled:opacity-30 transition"
         >
           {saving ? (

--- a/src/settings/voice-tab.tsx
+++ b/src/settings/voice-tab.tsx
@@ -57,6 +57,11 @@ export function VoiceTab({
   // option so we don't misrepresent the state or clobber inheritance on save.
   const [route, setRoute] = useState(cfg.tts_provider ?? "inherit");
   const [cloud, setCloud] = useState<CloudTtsConfig>({ ...(cfg.tts_cloud ?? {}) });
+  // Whether the profile already had a cloud override, and whether the user has
+  // edited any cloud field this session. Used to avoid persisting an empty `{}`
+  // override (which would clobber the inherited server-level cloud config).
+  const hadCloud = cfg.tts_cloud != null;
+  const [cloudEdited, setCloudEdited] = useState(false);
   // empty input = leave the stored (masked) token untouched
   const [tokenInput, setTokenInput] = useState("");
   const [showAdvanced, setShowAdvanced] = useState(false);
@@ -74,8 +79,10 @@ export function VoiceTab({
   const cloudIncomplete = route === "cloud" && (!appidSet || !tokenAvailable);
   const autoTokenHint = route === "auto" && !tokenAvailable;
 
-  const setCloudField = (k: keyof CloudTtsConfig, v: string) =>
+  const setCloudField = (k: keyof CloudTtsConfig, v: string) => {
+    setCloudEdited(true);
     setCloud((c) => ({ ...c, [k]: v }));
+  };
 
   async function save() {
     setSaving(true);
@@ -86,10 +93,14 @@ export function VoiceTab({
       // Only overwrite the token when the user typed a new value; otherwise
       // re-send the stored masked value so the backend restores the real one.
       if (tokenInput) envVars[TOKEN_ENV] = tokenInput;
+      // Only persist a cloud override when one already existed or the user
+      // actually edited cloud fields — otherwise send `null` so we don't create
+      // an empty `{}` that would override the inherited server-level config.
+      const ttsCloud = hadCloud || cloudEdited ? cloud : null;
       const updated = await updateMyProfileConfig(profile, {
         // `inherit` → null clears the override so the server default applies.
         tts_provider: route === "inherit" ? null : route,
-        tts_cloud: cloud,
+        tts_cloud: ttsCloud,
         env_vars: envVars,
       });
       onProfileUpdated(updated);

--- a/src/settings/voice-tab.tsx
+++ b/src/settings/voice-tab.tsx
@@ -1,0 +1,211 @@
+import { useState } from "react";
+import { Save, Loader2, Check, AlertCircle } from "lucide-react";
+import {
+  updateMyProfileConfig,
+  formatSettingsError,
+  type Profile,
+  type CloudTtsConfig,
+} from "./settings-api";
+
+const TOKEN_ENV = "VOLC_TTS_TOKEN";
+const ROUTES: { id: string; label: string; hint: string }[] = [
+  { id: "auto", label: "Auto", hint: "Cloud when a token is set, else on-device." },
+  { id: "local", label: "Local (on-device)", hint: "Local ominix-api engine." },
+  { id: "cloud", label: "Cloud (Volcano)", hint: "Volcano Engine cloud TTS." },
+];
+
+function isMasked(v: string | undefined): boolean {
+  return !!v && (v.includes("***") || v.includes("\u{1f511}"));
+}
+
+export function VoiceTab({
+  profile,
+  onProfileUpdated,
+}: {
+  profile: Profile;
+  onProfileUpdated: (p: Profile) => void;
+}) {
+  const cfg = profile.config;
+  const storedToken = cfg.env_vars?.[TOKEN_ENV] ?? "";
+
+  const [route, setRoute] = useState(cfg.tts_provider ?? "auto");
+  const [cloud, setCloud] = useState<CloudTtsConfig>({ ...(cfg.tts_cloud ?? {}) });
+  // empty input = leave the stored (masked) token untouched
+  const [tokenInput, setTokenInput] = useState("");
+  const [showAdvanced, setShowAdvanced] = useState(false);
+  const [saving, setSaving] = useState(false);
+  const [saved, setSaved] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const showCloud = route === "auto" || route === "cloud";
+  const tokenSet = isMasked(storedToken) || storedToken.length > 0;
+  const tokenWarning = route === "cloud" && !tokenSet && !tokenInput;
+
+  const setCloudField = (k: keyof CloudTtsConfig, v: string) =>
+    setCloud((c) => ({ ...c, [k]: v }));
+
+  async function save() {
+    setSaving(true);
+    setSaved(false);
+    setError(null);
+    try {
+      const envVars = { ...(cfg.env_vars ?? {}) };
+      // Only overwrite the token when the user typed a new value; otherwise
+      // re-send the stored masked value so the backend restores the real one.
+      if (tokenInput) envVars[TOKEN_ENV] = tokenInput;
+      const updated = await updateMyProfileConfig(profile, {
+        tts_provider: route,
+        tts_cloud: cloud,
+        env_vars: envVars,
+      });
+      onProfileUpdated(updated);
+      setTokenInput("");
+      setSaved(true);
+    } catch (err) {
+      setError(formatSettingsError(err, "Failed to update voice config."));
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  return (
+    <div className="space-y-6">
+      <div>
+        <label htmlFor="tts-route" className="block text-sm font-medium">
+          TTS route
+        </label>
+        <select
+          id="tts-route"
+          value={route}
+          onChange={(e) => setRoute(e.target.value)}
+          className="mt-1 w-full rounded-lg border px-3 py-2 text-sm"
+        >
+          {ROUTES.map((r) => (
+            <option key={r.id} value={r.id}>
+              {r.label}
+            </option>
+          ))}
+        </select>
+        <p className="mt-1 text-xs opacity-70">
+          {ROUTES.find((r) => r.id === route)?.hint}
+        </p>
+      </div>
+
+      {showCloud && (
+        <div className="space-y-4 rounded-lg border p-4">
+          <div className="text-sm font-medium">Volcano (cloud) credentials</div>
+
+          <Field label="App ID" htmlFor="volc-appid">
+            <input
+              id="volc-appid"
+              value={cloud.appid ?? ""}
+              onChange={(e) => setCloudField("appid", e.target.value)}
+              className="w-full rounded-lg border px-3 py-2 text-sm"
+            />
+          </Field>
+
+          <Field
+            label={`Token${tokenSet ? " (已设置)" : ""}`}
+            htmlFor="volc-token"
+          >
+            <input
+              id="volc-token"
+              type="password"
+              value={tokenInput}
+              placeholder={tokenSet ? "•••••• (unchanged)" : "Enter token"}
+              onChange={(e) => setTokenInput(e.target.value)}
+              className="w-full rounded-lg border px-3 py-2 text-sm"
+            />
+          </Field>
+
+          <Field label="Voice" htmlFor="volc-voice">
+            <input
+              id="volc-voice"
+              value={cloud.voice ?? ""}
+              placeholder="BV001_streaming"
+              onChange={(e) => setCloudField("voice", e.target.value)}
+              className="w-full rounded-lg border px-3 py-2 text-sm"
+            />
+          </Field>
+
+          <button
+            type="button"
+            onClick={() => setShowAdvanced((s) => !s)}
+            className="text-xs underline opacity-70"
+          >
+            {showAdvanced ? "Hide advanced" : "Advanced"}
+          </button>
+          {showAdvanced && (
+            <div className="space-y-4">
+              <Field label="Cluster" htmlFor="volc-cluster">
+                <input
+                  id="volc-cluster"
+                  value={cloud.cluster ?? ""}
+                  placeholder="volcano_tts"
+                  onChange={(e) => setCloudField("cluster", e.target.value)}
+                  className="w-full rounded-lg border px-3 py-2 text-sm"
+                />
+              </Field>
+              <Field label="Encoding" htmlFor="volc-encoding">
+                <input
+                  id="volc-encoding"
+                  value={cloud.encoding ?? ""}
+                  placeholder="mp3"
+                  onChange={(e) => setCloudField("encoding", e.target.value)}
+                  className="w-full rounded-lg border px-3 py-2 text-sm"
+                />
+              </Field>
+              <Field label="Endpoint" htmlFor="volc-endpoint">
+                <input
+                  id="volc-endpoint"
+                  value={cloud.endpoint ?? ""}
+                  placeholder="https://openspeech.bytedance.com/api/v1/tts"
+                  onChange={(e) => setCloudField("endpoint", e.target.value)}
+                  className="w-full rounded-lg border px-3 py-2 text-sm"
+                />
+              </Field>
+            </div>
+          )}
+
+          {tokenWarning && (
+            <p className="flex items-center gap-1 text-xs text-amber-600">
+              <AlertCircle size={12} /> 未填 token 将回退端侧
+            </p>
+          )}
+        </div>
+      )}
+
+      {error && <p className="text-sm text-red-600">{error}</p>}
+
+      <button
+        type="button"
+        onClick={save}
+        disabled={saving}
+        className="inline-flex items-center gap-2 rounded-lg border px-4 py-2 text-sm font-medium"
+      >
+        {saving ? <Loader2 size={14} className="animate-spin" /> : saved ? <Check size={14} /> : <Save size={14} />}
+        {saving ? "Saving…" : "Save"}
+      </button>
+      <p className="text-xs opacity-60">Restart the profile to apply credential changes.</p>
+    </div>
+  );
+}
+
+function Field({
+  label,
+  htmlFor,
+  children,
+}: {
+  label: string;
+  htmlFor: string;
+  children: React.ReactNode;
+}) {
+  return (
+    <div>
+      <label htmlFor={htmlFor} className="block text-sm font-medium">
+        {label}
+      </label>
+      <div className="mt-1">{children}</div>
+    </div>
+  );
+}

--- a/src/settings/voice-tab.tsx
+++ b/src/settings/voice-tab.tsx
@@ -22,6 +22,15 @@ const ROUTES: { id: string; label: string; hint: string }[] = [
   { id: "cloud", label: "Cloud (Volcano)", hint: "Volcano Engine cloud TTS." },
 ];
 
+// Preset Volcano voices (voice_type IDs). Label = friendly name shown to the
+// user; value = the `voice_type` written to `tts_cloud.voice`.
+const VOICES: { id: string; label: string }[] = [
+  { id: "zh_female_xiaohe_uranus_bigtts", label: "小何" },
+  { id: "zh_male_m191_uranus_bigtts", label: "云舟" },
+  { id: "zh_male_taocheng_uranus_bigtts", label: "小天" },
+  { id: "en_male_tim_uranus_bigtts", label: "Tim" },
+];
+
 const INPUT_CLASS =
   "w-full rounded-xl bg-surface-container px-4 py-2.5 text-sm text-text placeholder-muted/50 outline-none border border-transparent focus:border-accent/30 transition";
 const SELECT_CLASS =
@@ -155,13 +164,25 @@ export function VoiceTab({
             </Field>
 
             <Field label="Voice" htmlFor="volc-voice">
-              <input
+              <select
                 id="volc-voice"
                 value={cloud.voice ?? ""}
-                placeholder="BV001_streaming"
                 onChange={(e) => setCloudField("voice", e.target.value)}
-                className={INPUT_CLASS}
-              />
+                className={SELECT_CLASS}
+              >
+                <option value="">Default (BV001_streaming)</option>
+                {VOICES.map((v) => (
+                  <option key={v.id} value={v.id}>
+                    {v.label}
+                  </option>
+                ))}
+                {cloud.voice && !VOICES.some((v) => v.id === cloud.voice) && (
+                  <option value={cloud.voice}>{cloud.voice}</option>
+                )}
+              </select>
+              {cloud.voice && (
+                <p className="mt-1.5 text-xs text-muted">{cloud.voice}</p>
+              )}
             </Field>
 
             <div>

--- a/src/settings/voice-tab.tsx
+++ b/src/settings/voice-tab.tsx
@@ -1,5 +1,13 @@
 import { useState } from "react";
-import { Save, Loader2, Check, AlertCircle } from "lucide-react";
+import {
+  Save,
+  Loader2,
+  Check,
+  AlertCircle,
+  Volume2,
+  ChevronDown,
+  ChevronUp,
+} from "lucide-react";
 import {
   updateMyProfileConfig,
   formatSettingsError,
@@ -13,6 +21,11 @@ const ROUTES: { id: string; label: string; hint: string }[] = [
   { id: "local", label: "Local (on-device)", hint: "Local ominix-api engine." },
   { id: "cloud", label: "Cloud (Volcano)", hint: "Volcano Engine cloud TTS." },
 ];
+
+const INPUT_CLASS =
+  "w-full rounded-xl bg-surface-container px-4 py-2.5 text-sm text-text placeholder-muted/50 outline-none border border-transparent focus:border-accent/30 transition";
+const SELECT_CLASS =
+  "w-full rounded-xl bg-surface-container px-4 py-3 text-sm text-text outline-none border border-transparent focus:border-accent/30 transition";
 
 function isMasked(v: string | undefined): boolean {
   return !!v && (v.includes("***") || v.includes("\u{1f511}"));
@@ -61,6 +74,7 @@ export function VoiceTab({
       onProfileUpdated(updated);
       setTokenInput("");
       setSaved(true);
+      setTimeout(() => setSaved(false), 2000);
     } catch (err) {
       setError(formatSettingsError(err, "Failed to update voice config."));
     } finally {
@@ -70,123 +84,161 @@ export function VoiceTab({
 
   return (
     <div className="space-y-6">
-      <div>
-        <label htmlFor="tts-route" className="block text-sm font-medium">
-          TTS route
-        </label>
-        <select
-          id="tts-route"
-          value={route}
-          onChange={(e) => setRoute(e.target.value)}
-          className="mt-1 w-full rounded-lg border px-3 py-2 text-sm"
-        >
-          {ROUTES.map((r) => (
-            <option key={r.id} value={r.id}>
-              {r.label}
-            </option>
-          ))}
-        </select>
-        <p className="mt-1 text-xs opacity-70">
-          {ROUTES.find((r) => r.id === route)?.hint}
-        </p>
+      {/* Route card */}
+      <div className="glass-section rounded-lg p-6">
+        <div className="flex items-center gap-3 mb-6">
+          <div className="flex h-10 w-10 items-center justify-center rounded-xl bg-accent/10 text-accent">
+            <Volume2 size={20} />
+          </div>
+          <div>
+            <h3 className="text-sm font-semibold text-text-strong">Voice synthesis (TTS)</h3>
+            <p className="text-xs text-muted">Choose how spoken replies are synthesized</p>
+          </div>
+        </div>
+
+        <div>
+          <label htmlFor="tts-route" className="mb-1.5 block text-xs font-medium text-muted">
+            TTS route
+          </label>
+          <select
+            id="tts-route"
+            value={route}
+            onChange={(e) => setRoute(e.target.value)}
+            className={SELECT_CLASS}
+          >
+            {ROUTES.map((r) => (
+              <option key={r.id} value={r.id}>
+                {r.label}
+              </option>
+            ))}
+          </select>
+          <p className="mt-1.5 text-xs text-muted">
+            {ROUTES.find((r) => r.id === route)?.hint}
+          </p>
+        </div>
       </div>
 
+      {/* Volcano cloud credentials card */}
       {showCloud && (
-        <div className="space-y-4 rounded-lg border p-4">
-          <div className="text-sm font-medium">Volcano (cloud) credentials</div>
-
-          <Field label="App ID" htmlFor="volc-appid">
-            <input
-              id="volc-appid"
-              value={cloud.appid ?? ""}
-              onChange={(e) => setCloudField("appid", e.target.value)}
-              className="w-full rounded-lg border px-3 py-2 text-sm"
-            />
-          </Field>
-
-          <Field
-            label={`Token${tokenSet ? " (已设置)" : ""}`}
-            htmlFor="volc-token"
-          >
-            <input
-              id="volc-token"
-              type="password"
-              value={tokenInput}
-              placeholder={tokenSet ? "•••••• (unchanged)" : "Enter token"}
-              onChange={(e) => setTokenInput(e.target.value)}
-              className="w-full rounded-lg border px-3 py-2 text-sm"
-            />
-          </Field>
-
-          <Field label="Voice" htmlFor="volc-voice">
-            <input
-              id="volc-voice"
-              value={cloud.voice ?? ""}
-              placeholder="BV001_streaming"
-              onChange={(e) => setCloudField("voice", e.target.value)}
-              className="w-full rounded-lg border px-3 py-2 text-sm"
-            />
-          </Field>
-
-          <button
-            type="button"
-            onClick={() => setShowAdvanced((s) => !s)}
-            className="text-xs underline opacity-70"
-          >
-            {showAdvanced ? "Hide advanced" : "Advanced"}
-          </button>
-          {showAdvanced && (
-            <div className="space-y-4">
-              <Field label="Cluster" htmlFor="volc-cluster">
-                <input
-                  id="volc-cluster"
-                  value={cloud.cluster ?? ""}
-                  placeholder="volcano_tts"
-                  onChange={(e) => setCloudField("cluster", e.target.value)}
-                  className="w-full rounded-lg border px-3 py-2 text-sm"
-                />
-              </Field>
-              <Field label="Encoding" htmlFor="volc-encoding">
-                <input
-                  id="volc-encoding"
-                  value={cloud.encoding ?? ""}
-                  placeholder="mp3"
-                  onChange={(e) => setCloudField("encoding", e.target.value)}
-                  className="w-full rounded-lg border px-3 py-2 text-sm"
-                />
-              </Field>
-              <Field label="Endpoint" htmlFor="volc-endpoint">
-                <input
-                  id="volc-endpoint"
-                  value={cloud.endpoint ?? ""}
-                  placeholder="https://openspeech.bytedance.com/api/v1/tts"
-                  onChange={(e) => setCloudField("endpoint", e.target.value)}
-                  className="w-full rounded-lg border px-3 py-2 text-sm"
-                />
-              </Field>
+        <div className="glass-section rounded-lg p-6">
+          <div className="flex items-center gap-3 mb-6">
+            <div className="flex h-10 w-10 items-center justify-center rounded-xl bg-accent/10 text-accent">
+              <Volume2 size={20} />
             </div>
-          )}
+            <div>
+              <h3 className="text-sm font-semibold text-text-strong">Volcano (cloud) credentials</h3>
+              <p className="text-xs text-muted">
+                Token is stored securely; other fields are plain settings
+              </p>
+            </div>
+          </div>
 
-          {tokenWarning && (
-            <p className="flex items-center gap-1 text-xs text-amber-600">
-              <AlertCircle size={12} /> 未填 token 将回退端侧
-            </p>
-          )}
+          <div className="space-y-5">
+            <Field label="App ID" htmlFor="volc-appid">
+              <input
+                id="volc-appid"
+                value={cloud.appid ?? ""}
+                onChange={(e) => setCloudField("appid", e.target.value)}
+                className={INPUT_CLASS}
+              />
+            </Field>
+
+            <Field label={`Token${tokenSet ? " (已设置)" : ""}`} htmlFor="volc-token">
+              <input
+                id="volc-token"
+                type="password"
+                value={tokenInput}
+                placeholder={tokenSet ? "•••••• (unchanged)" : "Enter token"}
+                onChange={(e) => setTokenInput(e.target.value)}
+                className={INPUT_CLASS}
+              />
+            </Field>
+
+            <Field label="Voice" htmlFor="volc-voice">
+              <input
+                id="volc-voice"
+                value={cloud.voice ?? ""}
+                placeholder="BV001_streaming"
+                onChange={(e) => setCloudField("voice", e.target.value)}
+                className={INPUT_CLASS}
+              />
+            </Field>
+
+            <div>
+              <button
+                type="button"
+                onClick={() => setShowAdvanced((s) => !s)}
+                className="flex items-center gap-1.5 rounded-xl px-3 py-2 text-xs font-medium text-muted hover:text-accent hover:bg-accent/10 transition"
+              >
+                {showAdvanced ? <ChevronUp size={14} /> : <ChevronDown size={14} />}
+                {showAdvanced ? "Hide advanced" : "Advanced"}
+              </button>
+              {showAdvanced && (
+                <div className="mt-4 space-y-5">
+                  <Field label="Cluster" htmlFor="volc-cluster">
+                    <input
+                      id="volc-cluster"
+                      value={cloud.cluster ?? ""}
+                      placeholder="volcano_tts"
+                      onChange={(e) => setCloudField("cluster", e.target.value)}
+                      className={INPUT_CLASS}
+                    />
+                  </Field>
+                  <Field label="Encoding" htmlFor="volc-encoding">
+                    <input
+                      id="volc-encoding"
+                      value={cloud.encoding ?? ""}
+                      placeholder="mp3"
+                      onChange={(e) => setCloudField("encoding", e.target.value)}
+                      className={INPUT_CLASS}
+                    />
+                  </Field>
+                  <Field label="Endpoint" htmlFor="volc-endpoint">
+                    <input
+                      id="volc-endpoint"
+                      value={cloud.endpoint ?? ""}
+                      placeholder="https://openspeech.bytedance.com/api/v1/tts"
+                      onChange={(e) => setCloudField("endpoint", e.target.value)}
+                      className={INPUT_CLASS}
+                    />
+                  </Field>
+                </div>
+              )}
+            </div>
+
+            {tokenWarning && (
+              <p className="flex items-center gap-1.5 text-xs text-amber-400">
+                <AlertCircle size={13} /> 未填 token 将回退端侧
+              </p>
+            )}
+          </div>
         </div>
       )}
 
-      {error && <p className="text-sm text-red-600">{error}</p>}
-
-      <button
-        type="button"
-        onClick={save}
-        disabled={saving}
-        className="inline-flex items-center gap-2 rounded-lg border px-4 py-2 text-sm font-medium"
-      >
-        {saving ? <Loader2 size={14} className="animate-spin" /> : saved ? <Check size={14} /> : <Save size={14} />}
-        {saving ? "Saving…" : "Save"}
-      </button>
-      <p className="text-xs opacity-60">Restart the profile to apply credential changes.</p>
+      {/* Save actions */}
+      <div className="flex items-center gap-3">
+        <button
+          type="button"
+          onClick={save}
+          disabled={saving}
+          className="flex items-center gap-2 rounded-xl bg-accent px-5 py-2.5 text-sm font-medium text-white hover:bg-accent-dim disabled:opacity-30 transition"
+        >
+          {saving ? (
+            <Loader2 size={14} className="animate-spin" />
+          ) : saved ? (
+            <Check size={14} />
+          ) : (
+            <Save size={14} />
+          )}
+          {saving ? "Saving…" : saved ? "Saved" : "Save"}
+        </button>
+        {error && (
+          <span role="alert" className="text-xs text-red-400">
+            {error}
+          </span>
+        )}
+      </div>
+      <p className="text-xs text-muted">Restart the profile to apply credential changes.</p>
     </div>
   );
 }
@@ -202,10 +254,10 @@ function Field({
 }) {
   return (
     <div>
-      <label htmlFor={htmlFor} className="block text-sm font-medium">
+      <label htmlFor={htmlFor} className="mb-1.5 block text-xs font-medium text-muted">
         {label}
       </label>
-      <div className="mt-1">{children}</div>
+      {children}
     </div>
   );
 }


### PR DESCRIPTION
## Summary

Adds a per-user **Settings → Voice** tab to configure the TTS route and Volcano (cloud) settings, and makes the in-conversation on-device voice switcher cloud-aware. Pairs with the octos backend PR that adds per-profile `tts_provider` / `tts_cloud`.

## What changed

- **`voice-tab.tsx`** (new, per-user): route dropdown (`Inherit` / `Auto` / `Local` / `Cloud`), Volcano credentials (App ID, masked Token, preset Voice dropdown, advanced cluster/encoding), saved via the existing `PUT /api/my/profile`. Styled with the shared design-system tokens so it matches sibling tabs and follows theme switching.
- **`settings-page.tsx`**: registers the tab; mounts it with `key={profile.id}` so switching profiles in-place remounts and resets the draft (incl. unsaved token).
- **`settings-api.ts`**: `CloudTtsConfig` type + `tts_provider?: string | null` / `tts_cloud?: CloudTtsConfig | null`.
- **`voice-selector.tsx`**: hides the on-device timbre pills whenever the **effective** route is cloud (`cloud`/`volcano`, or `auto` with configured credentials) — adjusting them would be a no-op there.

## Correctness / safety

- **Token never overwritten by a mask:** a stored token shows as “已设置”; the save patch re-sends the masked value unchanged so the backend restores the real one, and only writes a newly typed value.
- **Inherit semantics:** an unset override shows as “Inherit (server default)”, not “Auto”. Saving Inherit clears the override (`tts_provider: null`) and, when no cloud config existed and none was edited, sends `tts_cloud: null` rather than an empty `{}` (which the backend would treat as an override and clobber the inherited server-level config).
- **Cloud requires credentials:** on the explicit `cloud` route, Save is disabled with an inline error until App ID + token are present (the backend otherwise silently falls back to on-device — this is a UX guard, not a backend hard-rejection).
- No free-text endpoint field is exposed (the backend allowlists the endpoint).

## Testing

- `npm run test:unit` — 716 passing (new cases: masked-token omission, token write path, Inherit→null override, cloud-incomplete blocks save, cloud-aware switcher visibility).
- `npm run build` passes; ESLint clean on the changed files (no `as any` — typed `makeProfile` fixture via the real `normalizeProfileConfig`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)