### PR TITLE
feat(voice): gate readiness on the full pipeline; show only on problems

### DIFF
--- a/src/home/classic-standby-view.tsx
+++ b/src/home/classic-standby-view.tsx
@@ -175,9 +175,11 @@ export function ClassicStandbyView({
                   onClick={handleOrbClick}
                   disabled={voiceRuntime.loading}
                 />
-                <p className={`classic-home-voice-status is-${voiceRuntime.tone}`}>
-                  {voiceRuntime.label}
-                </p>
+                {voiceRuntime.needsAttention && (
+                  <p className={`classic-home-voice-status is-${voiceRuntime.tone}`}>
+                    {voiceRuntime.label}
+                  </p>
+                )}
                 {wakeWordStatus && (
                   <p className={`classic-home-voice-status is-${wakeWordStatus.tone}`}>
                     {wakeWordStatus.label}

--- a/src/home/metro-tiles.tsx
+++ b/src/home/metro-tiles.tsx
@@ -493,7 +493,9 @@ function VoiceTile({
         onClick={handleClick}
         disabled={runtime.loading}
       />
-      <p className={`metro-voice-status is-${runtime.tone}`}>{runtime.label}</p>
+      {runtime.needsAttention && (
+        <p className={`metro-voice-status is-${runtime.tone}`}>{runtime.label}</p>
+      )}
       {wakeWordStatus && (
         <p className={`metro-voice-wake is-${wakeWordStatus.tone}`}>
           {wakeWordStatus.label}

--- a/src/home/use-ominix-runtime-summary.test.ts
+++ b/src/home/use-ominix-runtime-summary.test.ts
@@ -1,36 +1,16 @@
 import { describe, expect, it } from "vitest";
 import {
-  summarizeOminixRuntime,
+  summarizeVoiceReadiness,
   type OminixRuntimeSummary,
 } from "./use-ominix-runtime-summary";
-import type { OminixRuntimeStatus } from "@/settings/settings-api";
+import type { VoiceReadiness } from "@/settings/settings-api";
 
-function runtime(overrides: Partial<OminixRuntimeStatus>): OminixRuntimeStatus {
+function readiness(overrides: Partial<VoiceReadiness> = {}): VoiceReadiness {
   return {
-    state: "healthy",
-    url: "http://127.0.0.1:8081",
-    url_source: "env",
-    port: 8081,
-    home_dir: "/tmp",
-    ominix_dir: "/tmp/.ominix",
-    binary_path: "/tmp/bin/ominix-api",
-    binary_installed: true,
-    metallib_path: "/tmp/bin/mlx.metallib",
-    metallib_installed: true,
-    models_dir: "/tmp/models",
-    models_dir_exists: true,
-    plist_path: "/tmp/Library/LaunchAgents/io.ominix.ominix-api.plist",
-    plist_exists: true,
-    plist_port: 8081,
-    discovery_path: "/tmp/.ominix/api_url",
-    discovery_url: "http://127.0.0.1:8081",
-    service_registered: true,
-    service_running: true,
-    launchctl_skipped: false,
-    health: { healthy: true, http_status: 200 },
-    issues: [],
-    can_repair: true,
-    suggested_action: "ready",
+    ready: true,
+    asr: { ready: true, detail: "On-device ASR ready" },
+    llm: { ready: true, detail: "LLM provider: openai" },
+    tts: { ready: true, mode: "local", detail: "On-device GPT-SoVITS ready" },
     ...overrides,
   };
 }
@@ -39,9 +19,9 @@ function stripRefresh(summary: Omit<OminixRuntimeSummary, "refresh">) {
   return summary;
 }
 
-describe("summarizeOminixRuntime", () => {
-  it("marks a healthy runtime as ready", () => {
-    expect(stripRefresh(summarizeOminixRuntime(runtime({})))).toMatchObject({
+describe("summarizeVoiceReadiness", () => {
+  it("marks a fully-ready pipeline as ready", () => {
+    expect(stripRefresh(summarizeVoiceReadiness(readiness()))).toMatchObject({
       label: "Voice engine ready",
       tone: "success",
       ready: true,
@@ -49,61 +29,72 @@ describe("summarizeOminixRuntime", () => {
     });
   });
 
-  it("marks a healthy runtime with missing voice models as not ready", () => {
-    expect(
-      stripRefresh(summarizeOminixRuntime(
-        runtime({
-          state: "models_missing",
-          voice_models_ready: false,
-          suggested_action: "bootstrap_voice_models",
-        }),
-      )),
-    ).toMatchObject({
-      label: "Voice models not ready",
+  it("blocks on ASR first and offers repair (ASR is always on-device)", () => {
+    const summary = summarizeVoiceReadiness(
+      readiness({
+        ready: false,
+        asr: { ready: false, detail: "On-device ASR model not ready" },
+        // Even with a downstream TTS failure, ASR is reported first.
+        tts: { ready: false, mode: "local", detail: "No on-device voice available" },
+      }),
+    );
+    expect(stripRefresh(summary)).toMatchObject({
+      label: "On-device ASR model not ready",
       tone: "warning",
       ready: false,
       canRepair: true,
-      state: "models_missing",
+      state: "asr_not_ready",
     });
   });
 
-  it("marks a repairable runtime as warning", () => {
-    expect(
-      stripRefresh(summarizeOminixRuntime(
-        runtime({
-          state: "missing_plist",
-          health: { healthy: false },
-          service_registered: false,
-          can_repair: true,
-          suggested_action: "repair",
-        }),
-      )),
-    ).toMatchObject({
-      label: "Voice engine needs repair",
+  it("blocks on LLM with no repair affordance (configure, not repair)", () => {
+    const summary = summarizeVoiceReadiness(
+      readiness({
+        ready: false,
+        llm: { ready: false, detail: "LLM provider not configured" },
+      }),
+    );
+    expect(stripRefresh(summary)).toMatchObject({
+      label: "LLM provider not configured",
       tone: "warning",
       ready: false,
-      canRepair: true,
-      state: "missing_plist",
+      canRepair: false,
+      state: "llm_not_ready",
     });
   });
 
-  it("marks a missing binary runtime as installable", () => {
-    expect(
-      stripRefresh(summarizeOminixRuntime(
-        runtime({
-          state: "missing_binary",
-          health: { healthy: false },
-          binary_installed: false,
-          can_repair: false,
-          suggested_action: "install_ominix_api_binary",
-        }),
-      )),
-    ).toMatchObject({
-      label: "Voice engine not installed",
+  it("flags missing cloud TTS credentials without offering repair", () => {
+    const summary = summarizeVoiceReadiness(
+      readiness({
+        ready: false,
+        tts: {
+          ready: false,
+          mode: "cloud",
+          detail: "Cloud TTS selected but credentials missing (appid + VOLC_TTS_TOKEN)",
+        },
+      }),
+    );
+    expect(stripRefresh(summary)).toMatchObject({
+      label: "Cloud TTS selected but credentials missing (appid + VOLC_TTS_TOKEN)",
       tone: "warning",
       ready: false,
+      canRepair: false,
+      state: "tts_not_ready_cloud",
+    });
+  });
+
+  it("offers repair when the on-device TTS engine is the gap", () => {
+    const summary = summarizeVoiceReadiness(
+      readiness({
+        ready: false,
+        tts: { ready: false, mode: "local", detail: "No on-device voice available" },
+      }),
+    );
+    expect(stripRefresh(summary)).toMatchObject({
+      label: "No on-device voice available",
+      ready: false,
       canRepair: true,
-      state: "missing_binary",
+      state: "tts_not_ready_local",
     });
   });
 });

--- a/src/home/use-ominix-runtime-summary.ts
+++ b/src/home/use-ominix-runtime-summary.ts
@@ -1,7 +1,7 @@
 import { useEffect, useState } from "react";
 import {
-  fetchOminixRuntimeStatus,
-  type OminixRuntimeStatus,
+  fetchVoiceReadiness,
+  type VoiceReadiness,
 } from "@/settings/settings-api";
 
 export type OminixRuntimeTone = "default" | "success" | "warning" | "danger";
@@ -13,10 +13,20 @@ export interface OminixRuntimeSummary {
   loading: boolean;
   canRepair: boolean;
   state: string;
+  /**
+   * Whether the UI should surface the voice status at all. Only a problem
+   * state (`warning`/`danger`) warrants a notification — a ready engine is
+   * used silently, and the transient "checking" state stays quiet too. UI
+   * surfaces should render the status label only when this is true.
+   */
+  needsAttention: boolean;
   refresh: () => Promise<void>;
 }
 
-type OminixRuntimeSnapshot = Omit<OminixRuntimeSummary, "refresh">;
+type OminixRuntimeSnapshot = Omit<
+  OminixRuntimeSummary,
+  "refresh" | "needsAttention"
+>;
 
 const POLL_MS = 10_000;
 
@@ -38,72 +48,69 @@ function emit(summary: OminixRuntimeSnapshot) {
   listeners.forEach((listener) => listener(summary));
 }
 
-export function summarizeOminixRuntime(runtime: OminixRuntimeStatus): OminixRuntimeSnapshot {
-  if (runtime.health.healthy && runtime.voice_models_ready !== false) {
+/**
+ * Collapse the three-leg pipeline readiness into the UI snapshot. The check
+ * confirms the WHOLE voice path is usable under the caller's current config —
+ * ASR (always on-device), LLM, and TTS validated per its effective route
+ * (cloud credentials for Volcano, or the on-device GPT-SoVITS engine). When a
+ * leg blocks, its `detail` becomes the label so the UI names the exact gap
+ * instead of a generic "models not ready".
+ *
+ * `canRepair` is true only for on-device-engine gaps (ASR model / local TTS),
+ * which the OMiniX repair flow can fix; LLM and cloud-credential gaps are a
+ * settings task, not a repair, so they report `canRepair: false`.
+ */
+export function summarizeVoiceReadiness(readiness: VoiceReadiness): OminixRuntimeSnapshot {
+  if (readiness.ready) {
     return {
       label: "Voice engine ready",
       tone: "success",
       ready: true,
       loading: false,
-      canRepair: runtime.can_repair,
-      state: runtime.state,
+      canRepair: false,
+      state: "ready",
     };
   }
 
-  if (
-    runtime.suggested_action === "bootstrap_voice_models" ||
-    (runtime.health.healthy && runtime.voice_models_ready === false)
-  ) {
+  // Report the first failing leg, in pipeline order: ASR → LLM → TTS.
+  if (!readiness.asr.ready) {
     return {
-      label: "Voice models not ready",
+      label: readiness.asr.detail,
       tone: "warning",
       ready: false,
       loading: false,
       canRepair: true,
-      state: runtime.state,
+      state: "asr_not_ready",
     };
   }
 
-  if (runtime.can_repair) {
+  if (!readiness.llm.ready) {
     return {
-      label: "Voice engine needs repair",
+      label: readiness.llm.detail,
       tone: "warning",
       ready: false,
       loading: false,
-      canRepair: true,
-      state: runtime.state,
+      canRepair: false,
+      state: "llm_not_ready",
     };
   }
 
-  if (
-    runtime.suggested_action === "install_ominix_api_binary" ||
-    !runtime.binary_installed
-  ) {
-    return {
-      label: "Voice engine not installed",
-      tone: "warning",
-      ready: false,
-      loading: false,
-      canRepair: true,
-      state: runtime.state,
-    };
-  }
-
+  const localTts = readiness.tts.mode === "local";
   return {
-    label: "Voice engine unavailable",
-    tone: "danger",
+    label: readiness.tts.detail,
+    tone: "warning",
     ready: false,
     loading: false,
-    canRepair: false,
-    state: runtime.state,
+    canRepair: localTts,
+    state: `tts_not_ready_${readiness.tts.mode}`,
   };
 }
 
 export function refreshOminixRuntimeSummary(): Promise<void> {
   if (inFlight) return inFlight;
-  inFlight = fetchOminixRuntimeStatus()
-    .then((runtime) => {
-      emit(summarizeOminixRuntime(runtime));
+  inFlight = fetchVoiceReadiness()
+    .then((readiness) => {
+      emit(summarizeVoiceReadiness(readiness));
     })
     .catch(() => {
       emit({
@@ -143,5 +150,9 @@ export function useOminixRuntimeSummary() {
     };
   }, []);
 
-  return { ...summary, refresh: refreshOminixRuntimeSummary };
+  return {
+    ...summary,
+    needsAttention: summary.tone === "warning" || summary.tone === "danger",
+    refresh: refreshOminixRuntimeSummary,
+  };
 }

--- a/src/home/voice/voice-view.test.tsx
+++ b/src/home/voice/voice-view.test.tsx
@@ -216,4 +216,22 @@ describe("VoiceView", () => {
     render(<VoiceView sessionId="voice-test" onBack={vi.fn()} />);
     expect(screen.queryByText("Voice engine ready")).toBeNull();
   });
+
+  it("stays silent while the runtime is still checking", () => {
+    runtimeMock.label = "Checking voice engine";
+    runtimeMock.tone = "default";
+    runtimeMock.ready = false;
+    runtimeMock.loading = true;
+    runtimeMock.needsAttention = false;
+
+    render(<VoiceView sessionId="voice-test" onBack={vi.fn()} />);
+
+    // No not-ready guidance while still checking — the state is silent. (The
+    // orb keeps its not-ready affordance, but its click is a no-op until the
+    // check resolves, so no explicit settings CTA is shown either.)
+    expect(
+      screen.queryByText("语音引擎未就绪，请先在 Settings 里安装或修复 OMiniX。"),
+    ).toBeNull();
+    expect(screen.queryByText(/打开 OMiniX 设置/)).toBeNull();
+  });
 });

--- a/src/home/voice/voice-view.test.tsx
+++ b/src/home/voice/voice-view.test.tsx
@@ -26,6 +26,7 @@ const runtimeMock = vi.hoisted((): {
   loading: boolean;
   canRepair: boolean;
   state: string;
+  needsAttention: boolean;
   refresh: ReturnType<typeof vi.fn>;
 } => ({
   label: "Voice engine ready",
@@ -34,6 +35,7 @@ const runtimeMock = vi.hoisted((): {
   loading: false,
   canRepair: true,
   state: "healthy",
+  needsAttention: false,
   refresh: vi.fn(),
 }));
 
@@ -111,6 +113,7 @@ describe("VoiceView", () => {
     runtimeMock.loading = false;
     runtimeMock.canRepair = true;
     runtimeMock.state = "healthy";
+    runtimeMock.needsAttention = false;
     runtimeMock.refresh.mockReset();
   });
 
@@ -195,13 +198,22 @@ describe("VoiceView", () => {
     runtimeMock.loading = false;
     runtimeMock.canRepair = true;
     runtimeMock.state = "missing_plist";
+    runtimeMock.needsAttention = true;
 
     render(<VoiceView sessionId="voice-test" onBack={vi.fn()} />);
 
     expect(screen.getByText("语音引擎未就绪，请先在 Settings 里安装或修复 OMiniX。")).toBeTruthy();
+    // The readiness pill surfaces only in a problem state.
+    expect(screen.getByText("Voice engine needs repair")).toBeTruthy();
     fireEvent.click(screen.getByRole("button", { name: "open OMiniX settings" }));
 
     expect(conversationMock.start).not.toHaveBeenCalled();
     expect(navigateMock).toHaveBeenCalledWith("/settings?tab=ominix");
+  });
+
+  it("does not show the readiness pill when the engine is ready", () => {
+    // Defaults from beforeEach: ready + needsAttention=false.
+    render(<VoiceView sessionId="voice-test" onBack={vi.fn()} />);
+    expect(screen.queryByText("Voice engine ready")).toBeNull();
   });
 });

--- a/src/home/voice/voice-view.tsx
+++ b/src/home/voice/voice-view.tsx
@@ -139,7 +139,9 @@ export function VoiceView({ sessionId, historyTopic, onBack }: VoiceViewProps) {
             ? conv.exiting
               ? "再见 👋"
               : STATE_WORD[conv.state]
-            : "语音引擎未就绪，请先在 Settings 里安装或修复 OMiniX。"}
+            : runtime.loading
+              ? /* still checking — stay silent, the pill is hidden too */ ""
+              : "语音引擎未就绪，请先在 Settings 里安装或修复 OMiniX。"}
         </div>
 
         {runtime.ready && conv.error && (

--- a/src/home/voice/voice-view.tsx
+++ b/src/home/voice/voice-view.tsx
@@ -126,9 +126,13 @@ export function VoiceView({ sessionId, historyTopic, onBack }: VoiceViewProps) {
           <VoiceOrb state={runtime.ready ? conv.state : "error"} />
         </div>
 
-        <div className={`voice-runtime-pill is-${runtime.tone}`}>
-          {runtime.label}
-        </div>
+        {/* Surface the readiness pill only when something is wrong; a ready
+            engine is used silently. */}
+        {runtime.needsAttention && (
+          <div className={`voice-runtime-pill is-${runtime.tone}`}>
+            {runtime.label}
+          </div>
+        )}
 
         <div className="mt-6 min-h-[20px] text-sm text-white/55">
           {runtime.ready

--- a/src/pages/home-page.tsx
+++ b/src/pages/home-page.tsx
@@ -223,9 +223,11 @@ function WarmWorkbenchHomePage() {
                   navigate("/voice");
                 }}
                 meta={
-                  <WorkbenchStatusPill tone={voiceRuntime.tone}>
-                    {voiceRuntime.label}
-                  </WorkbenchStatusPill>
+                  voiceRuntime.needsAttention ? (
+                    <WorkbenchStatusPill tone={voiceRuntime.tone}>
+                      {voiceRuntime.label}
+                    </WorkbenchStatusPill>
+                  ) : undefined
                 }
               />
               <WorkbenchRouteCard

--- a/src/settings/settings-api.ts
+++ b/src/settings/settings-api.ts
@@ -927,6 +927,37 @@ export async function fetchOminixRuntimeStatus(): Promise<OminixRuntimeStatus> {
   return await request<OminixRuntimeStatus>(`${OMINIX_RUNTIME_BASE}/runtime`);
 }
 
+/** Readiness of one voice-pipeline leg. */
+export interface VoiceLeg {
+  ready: boolean;
+  /** Human-readable status, surfaced as the label when this leg blocks. */
+  detail: string;
+}
+
+/** Readiness of the TTS leg, plus the effective route for this profile. */
+export interface VoiceTtsLeg {
+  ready: boolean;
+  /** "cloud" (Volcano) or "local" (on-device GPT-SoVITS). */
+  mode: "cloud" | "local" | string;
+  detail: string;
+}
+
+/**
+ * Per-tenant voice-assistant pre-flight: ASR + LLM + (route-aware) TTS.
+ * `ready` is true only when all three legs are usable under the caller's
+ * current config (e.g. cloud TTS counts its credentials, not a local model).
+ */
+export interface VoiceReadiness {
+  ready: boolean;
+  asr: VoiceLeg;
+  llm: VoiceLeg;
+  tts: VoiceTtsLeg;
+}
+
+export async function fetchVoiceReadiness(): Promise<VoiceReadiness> {
+  return await request<VoiceReadiness>("/api/voice/readiness");
+}
+
 export async function repairOminixRuntime(): Promise<OminixRepairResponse> {
   return await request<OminixRepairResponse>(`${OMINIX_RUNTIME_BASE}/repair`, {
     method: "POST",


### PR DESCRIPTION
## Summary

Reworks the voice readiness gate to reflect the **whole pipeline** and to surface status **only when something is wrong**.

Previously the `/voice` page (and other voice surfaces) consumed the OminiX runtime status and blocked on an unused `qwen3-tts` model, so it showed "Voice models not ready" even when voice worked. Now it consumes the new backend endpoint that validates ASR + LLM + (route-aware) TTS, so cloud and local voice both report correctly.

Requires backend: octos-org/octos#1513 (`GET /api/voice/readiness`).

## Changes

- **`settings/settings-api.ts`** — `VoiceReadiness` types + `fetchVoiceReadiness()`.
- **`home/use-ominix-runtime-summary.ts`** — consumes `/api/voice/readiness` instead of the OminiX runtime status. Same hook shape; when a leg blocks, its `detail` becomes the label (e.g. "Cloud TTS selected but credentials missing (appid + VOLC_TTS_TOKEN)") so the UI names the exact gap. New derived `needsAttention` (true only for `warning`/`danger`).
- **Display surfaces silent when ready** — the status label renders only when `needsAttention`, across `voice-view`, `classic-standby-view`, `metro-tiles`, and the home workbench card. A ready engine is used silently; the transient "checking" state stays quiet too (incl. the `/voice` not-ready guidance text, which now has a loading branch).
- `canRepair` is true only for on-device-engine gaps (ASR model / local TTS); LLM and cloud-credential gaps are a settings task, not a repair.

## Testing

- `npx tsc -b` clean.
- `npx vitest run` — 747 pass. Rewrote `use-ominix-runtime-summary.test.ts` for the 3-leg model; added voice-view tests for pill visibility and the silent checking state.
- eslint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)