### PR TITLE
Fix chat refresh media and tool rehydration

### DIFF
--- a/src/api/files.test.ts
+++ b/src/api/files.test.ts
@@ -1,0 +1,38 @@
+import { afterEach, describe, expect, it } from "vitest";
+
+import { buildAuthenticatedFileUrl, buildFileUrl } from "@/api/files";
+import { TOKEN_KEY } from "@/lib/constants";
+
+afterEach(() => {
+  localStorage.removeItem(TOKEN_KEY);
+});
+
+describe("buildFileUrl", () => {
+  it("includes session context for workspace-relative upload paths", () => {
+    expect(
+      buildFileUrl("uploads/video-1782874133859.webm", {
+        sessionId: "web-1782873684428-f5emdc",
+      }),
+    ).toBe(
+      "/api/files?path=uploads%2Fvideo-1782874133859.webm&session=web-1782873684428-f5emdc",
+    );
+  });
+
+  it("keeps legacy file paths on the path endpoint", () => {
+    expect(
+      buildFileUrl("skill-output/report.md", {
+        sessionId: "web-1782873684428-f5emdc",
+      }),
+    ).toBe("/api/files/skill-output%2Freport.md");
+  });
+
+  it("appends auth tokens after existing session query parameters", () => {
+    localStorage.setItem(TOKEN_KEY, "abc 123");
+
+    expect(
+      buildAuthenticatedFileUrl("uploads/video.webm", {
+        sessionId: "web-1",
+      }),
+    ).toBe("/api/files?path=uploads%2Fvideo.webm&session=web-1&token=abc%20123");
+  });
+});

--- a/src/api/files.ts
+++ b/src/api/files.ts
@@ -1,12 +1,33 @@
 import { getToken } from "@/api/client";
 import { API_BASE } from "@/lib/constants";
 
-export function buildFileUrl(filePath: string): string {
+export interface BuildFileUrlOptions {
+  sessionId?: string;
+}
+
+function shouldUseSessionScopedFileUrl(filePath: string, sessionId?: string): boolean {
+  return Boolean(sessionId && filePath.startsWith("uploads/"));
+}
+
+export function buildFileUrl(
+  filePath: string,
+  options: BuildFileUrlOptions = {},
+): string {
+  if (shouldUseSessionScopedFileUrl(filePath, options.sessionId)) {
+    const params = new URLSearchParams();
+    params.set("path", filePath);
+    params.set("session", options.sessionId!);
+    return `${API_BASE}/api/files?${params.toString()}`;
+  }
   return `${API_BASE}/api/files/${encodeURIComponent(filePath)}`;
 }
 
-export function buildAuthenticatedFileUrl(filePath: string): string {
+export function buildAuthenticatedFileUrl(
+  filePath: string,
+  options: BuildFileUrlOptions = {},
+): string {
   const token = getToken();
-  const base = buildFileUrl(filePath);
-  return token ? `${base}?token=${encodeURIComponent(token)}` : base;
+  const base = buildFileUrl(filePath, options);
+  const separator = base.includes("?") ? "&" : "?";
+  return token ? `${base}${separator}token=${encodeURIComponent(token)}` : base;
 }

--- a/src/components/chat-thread-hydrate-replay.test.tsx
+++ b/src/components/chat-thread-hydrate-replay.test.tsx
@@ -45,10 +45,11 @@
  * shell in between.
  */
 
-import { afterEach, describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import * as React from "react";
 import { act } from "react";
 import { createRoot, type Root } from "react-dom/client";
+import { waitFor } from "@testing-library/react";
 
 (
   globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }
@@ -61,6 +62,9 @@ import * as ThreadStore from "@/store/thread-store";
 import { __resetRouterStateForTest } from "@/runtime/ui-protocol-event-router";
 
 const SESSION = "sess-hydrate-replay";
+const originalFetch = globalThis.fetch;
+const originalCreateObjectURL = URL.createObjectURL;
+const originalRevokeObjectURL = URL.revokeObjectURL;
 
 interface MountedHarness {
   container: HTMLDivElement;
@@ -110,6 +114,19 @@ function mount(node: React.ReactElement): MountedHarness {
 
 afterEach(() => {
   for (const node of [...document.body.children]) node.remove();
+  globalThis.fetch = originalFetch;
+  if (originalCreateObjectURL) {
+    URL.createObjectURL = originalCreateObjectURL;
+  } else {
+    delete (URL as unknown as { createObjectURL?: typeof URL.createObjectURL })
+      .createObjectURL;
+  }
+  if (originalRevokeObjectURL) {
+    URL.revokeObjectURL = originalRevokeObjectURL;
+  } else {
+    delete (URL as unknown as { revokeObjectURL?: typeof URL.revokeObjectURL })
+      .revokeObjectURL;
+  }
   ThreadStore.__resetForTests();
   __resetRouterStateForTest();
 });
@@ -304,5 +321,48 @@ describe("hard-refresh replay for a completed run_pipeline turn", () => {
     expect(toolCallBubble!.textContent ?? "").toContain("run_pipeline");
 
     harness.unmount();
+  });
+});
+
+describe("hard-refresh replay for workspace upload media", () => {
+  it("loads refreshed upload videos through the session-scoped file endpoint", async () => {
+    const fetchMock = vi.fn(async () =>
+      new Response(new Blob(["video"], { type: "video/webm" })),
+    );
+    globalThis.fetch = fetchMock as typeof fetch;
+    URL.createObjectURL = vi.fn(() => "blob:video");
+    URL.revokeObjectURL = vi.fn();
+
+    act(() => {
+      ThreadStore.replayHistory(SESSION, [
+        {
+          seq: 0,
+          role: "user",
+          content: "[Attached: video-1782874133859.webm]",
+          client_message_id: "cmid-video",
+          thread_id: "cmid-video",
+          timestamp: "2026-07-01T02:53:53Z",
+          media: ["uploads/video-1782874133859.webm"],
+        },
+      ]);
+    });
+
+    const harness = mount(
+      <SessionContext.Provider value={makeSessionCtx()}>
+        <ChatThread />
+      </SessionContext.Provider>,
+    );
+
+    await waitFor(() => {
+      expect(fetchMock).toHaveBeenCalledWith(
+        "/api/files?path=uploads%2Fvideo-1782874133859.webm&session=sess-hydrate-replay",
+        { headers: {} },
+      );
+    });
+    await waitFor(() => {
+      expect(harness.container.querySelector("video")?.getAttribute("src")).toBe(
+        "blob:video",
+      );
+    });
   });
 });

--- a/src/components/chat-thread.tsx
+++ b/src/components/chat-thread.tsx
@@ -178,13 +178,20 @@ function toolArgumentSummary(
 // File attachment renderer
 // ---------------------------------------------------------------------------
 
+type BlobUrlState = {
+  status: "loading" | "ready" | "error";
+  url?: string;
+};
+
 /** Fetch a file with auth and return an object URL. */
-function useBlobUrl(filePath: string): string | undefined {
+function useBlobUrl(filePath: string, sessionId?: string): BlobUrlState {
   const isExternal = filePath.startsWith("http");
   const [blobState, setBlobState] = useState<{
     filePath: string;
+    sessionId?: string;
+    status: "loading" | "ready" | "error";
     url?: string;
-  }>({ filePath: "" });
+  }>({ filePath: "", status: "loading" });
 
   useEffect(() => {
     if (isExternal) return;
@@ -192,8 +199,9 @@ function useBlobUrl(filePath: string): string | undefined {
     let revoked = false;
     let url: string | undefined;
 
+    setBlobState({ filePath, sessionId, status: "loading" });
     const token = getToken();
-    const apiUrl = buildFileUrl(filePath);
+    const apiUrl = buildFileUrl(filePath, { sessionId });
     fetch(apiUrl, {
       headers: token ? { Authorization: `Bearer ${token}` } : {},
     })
@@ -204,26 +212,30 @@ function useBlobUrl(filePath: string): string | undefined {
       .then((blob) => {
         if (revoked) return;
         url = URL.createObjectURL(blob);
-        setBlobState({ filePath, url });
+        setBlobState({ filePath, sessionId, status: "ready", url });
       })
       .catch(() => {
-        // Fallback: leave undefined, media element will show broken state
+        if (!revoked) setBlobState({ filePath, sessionId, status: "error" });
       });
 
     return () => {
       revoked = true;
       if (url) URL.revokeObjectURL(url);
     };
-  }, [filePath, isExternal]);
+  }, [filePath, isExternal, sessionId]);
 
-  if (isExternal) return filePath;
-  return blobState.filePath === filePath ? blobState.url : undefined;
+  if (isExternal) return { status: "ready", url: filePath };
+  if (blobState.filePath === filePath && blobState.sessionId === sessionId) {
+    return { status: blobState.status, url: blobState.url };
+  }
+  return { status: "loading" };
 }
 
-function FileAttachment({ file }: { file: MessageFile }) {
-  const blobUrl = useBlobUrl(file.path);
-  const isAudio = /\.(mp3|wav|ogg|webm|m4a|aac|flac|opus)$/i.test(file.filename);
+function FileAttachment({ file, sessionId }: { file: MessageFile; sessionId?: string }) {
+  const blob = useBlobUrl(file.path, sessionId);
+  const blobUrl = blob.url;
   const isVideo = /\.(mp4|webm|mov)$/i.test(file.filename);
+  const isAudio = !isVideo && /\.(mp3|wav|ogg|m4a|aac|flac|opus)$/i.test(file.filename);
   const isImage = /\.(png|jpg|jpeg|gif|webp|svg|bmp)$/i.test(file.filename);
   const visibleCaption = visibleAttachmentCaption(file.caption);
 
@@ -238,7 +250,7 @@ function FileAttachment({ file }: { file: MessageFile }) {
   }, [blobUrl, file.filename]);
 
   if (isAudio) {
-    return <AudioAttachment file={file} blobUrl={blobUrl} />;
+    return <AudioAttachment file={file} blobUrl={blobUrl} loadStatus={blob.status} />;
   }
 
   if (isVideo) {
@@ -246,6 +258,8 @@ function FileAttachment({ file }: { file: MessageFile }) {
       <div className="message-attachment-card rounded-[10px] p-2">
         {blobUrl ? (
           <video controls preload="metadata" className="w-full max-w-sm rounded-[8px]" src={blobUrl} />
+        ) : blob.status === "error" ? (
+          <div className="flex h-24 items-center justify-center text-xs text-muted">Failed to load</div>
         ) : (
           <div className="flex h-24 items-center justify-center text-xs text-muted">Loading...</div>
         )}
@@ -295,7 +309,7 @@ function FileAttachment({ file }: { file: MessageFile }) {
   const isExternalUrl = /^https?:\/\//i.test(file.path);
   const directHref = isExternalUrl
     ? file.path
-    : buildAuthenticatedFileUrl(file.path);
+    : buildAuthenticatedFileUrl(file.path, { sessionId });
   return blobUrl ? (
     <a
       href={directHref}
@@ -321,7 +335,15 @@ function FileAttachment({ file }: { file: MessageFile }) {
 }
 
 /** Audio attachment — <audio> element only created on first play click. */
-function AudioAttachment({ file, blobUrl }: { file: MessageFile; blobUrl?: string }) {
+function AudioAttachment({
+  file,
+  blobUrl,
+  loadStatus,
+}: {
+  file: MessageFile;
+  blobUrl?: string;
+  loadStatus: BlobUrlState["status"];
+}) {
   const [activated, setActivated] = useState(false);
   const [playing, setPlaying] = useState(false);
   const audioRef = useRef<HTMLAudioElement>(null);
@@ -383,7 +405,9 @@ function AudioAttachment({ file, blobUrl }: { file: MessageFile; blobUrl?: strin
           </div>
         </div>
       ) : (
-        <div className="flex h-8 items-center justify-center text-xs text-muted">Loading...</div>
+        <div className="flex h-8 items-center justify-center text-xs text-muted">
+          {loadStatus === "error" ? "Failed to load" : "Loading..."}
+        </div>
       )}
     </div>
   );
@@ -539,9 +563,11 @@ function threadMessageVisibleText(message: ThreadMessage): string {
 const ThreadUserBubble = memo(function ThreadUserBubble({
   message,
   threadId,
+  sessionId,
 }: {
   message: ThreadMessage;
   threadId: string;
+  sessionId?: string;
 }) {
   const visibleText = threadMessageVisibleText(message);
   // Visual layout is shared with `<GhostBubble>` via `<UserBubbleShell>`
@@ -553,7 +579,7 @@ const ThreadUserBubble = memo(function ThreadUserBubble({
     message.files.length > 0 ? (
       <>
         {message.files.map((f) => (
-          <FileAttachment key={f.path} file={f} />
+          <FileAttachment key={f.path} file={f} sessionId={sessionId} />
         ))}
       </>
     ) : null;
@@ -815,11 +841,13 @@ export const ThreadAssistantBubble = memo(function ThreadAssistantBubble({
   isStreaming,
   showLiveIndicators,
   threadId,
+  sessionId,
 }: {
   message: ThreadMessage;
   isStreaming: boolean;
   showLiveIndicators: boolean;
   threadId: string;
+  sessionId?: string;
 }) {
   // Prefer the explicit thread.id passed by the renderer over the
   // message's own backref so a finalized assistant whose origin tid
@@ -901,7 +929,7 @@ export const ThreadAssistantBubble = memo(function ThreadAssistantBubble({
         {message.files.length > 0 && (
           <div className="mt-3 flex flex-col gap-2">
             {message.files.map((f) => (
-              <FileAttachment key={f.path} file={f} />
+              <FileAttachment key={f.path} file={f} sessionId={sessionId} />
             ))}
           </div>
         )}
@@ -1080,7 +1108,11 @@ function ThreadView({
   );
   return (
     <div data-testid="chat-thread-bundle" data-thread-id={thread.id}>
-      <ThreadUserBubble message={thread.userMsg} threadId={thread.id} />
+      <ThreadUserBubble
+        message={thread.userMsg}
+        threadId={thread.id}
+        sessionId={currentSessionId}
+      />
       {visibleResponses.map((response) => (
         <ThreadAssistantBubble
           key={response.id}
@@ -1088,6 +1120,7 @@ function ThreadView({
           isStreaming={false}
           showLiveIndicators={false}
           threadId={thread.id}
+          sessionId={currentSessionId}
         />
       ))}
       {thread.pendingAssistant && (
@@ -1100,6 +1133,7 @@ function ThreadView({
             hasRunningBackgroundTask
           }
           threadId={thread.id}
+          sessionId={currentSessionId}
         />
       )}
     </div>

--- a/src/runtime/ui-protocol-bridge.test.ts
+++ b/src/runtime/ui-protocol-bridge.test.ts
@@ -482,6 +482,16 @@ describe("type guards (fail-closed)", () => {
           media: ["pf/file.md"],
         },
       ],
+      replayed_tool_envelopes: [
+        {
+          thread_id: "synth_0",
+          seq: 7,
+          payload: {
+            type: "tool_start",
+            data: { tool_call_id: "tc-shell-1", name: "shell" },
+          },
+        },
+      ],
     });
     expect(result).not.toBeNull();
     expect(result?.messages).toHaveLength(3);
@@ -492,6 +502,8 @@ describe("type guards (fail-closed)", () => {
     expect(result?.messages?.[0].message_id).toBeUndefined();
     expect(result?.replayed_envelopes).toHaveLength(1);
     expect(result?.replayed_envelopes?.[0].task_id).toBe("task_abc");
+    expect(result?.replayed_tool_envelopes).toHaveLength(1);
+    expect(result?.replayed_tool_envelopes?.[0].payload.type).toBe("tool_start");
   });
 
   it("guardSessionHydrate accepts a back-compat result without new fields (older server)", () => {

--- a/src/runtime/ui-protocol-bridge.ts
+++ b/src/runtime/ui-protocol-bridge.ts
@@ -25,6 +25,7 @@ import type {
   ApprovalRespondResult,
   ApprovalScope,
   ConnectionState,
+  Envelope,
   HydratedMessage,
   MessageDeltaEvent,
   FileAttachedEvent,
@@ -603,6 +604,71 @@ interface ProjectionEnvelope {
   };
 }
 
+function guardHydrateToolEnvelope(p: unknown): Envelope | null {
+  if (!isPlainObject(p)) return null;
+  if (!isString(p.thread_id)) return null;
+  if (typeof p.seq !== "number" || !Number.isFinite(p.seq) || p.seq < 0) {
+    return null;
+  }
+  if (!isPlainObject(p.payload)) return null;
+  const payloadType = p.payload.type;
+  if (
+    payloadType !== "tool_start" &&
+    payloadType !== "tool_progress" &&
+    payloadType !== "tool_end"
+  ) {
+    return null;
+  }
+  if (!isPlainObject(p.payload.data)) return null;
+  const data = p.payload.data;
+  if (!isString(data.tool_call_id)) return null;
+  if (payloadType === "tool_start") {
+    if (!isString(data.name)) return null;
+    return {
+      thread_id: p.thread_id,
+      seq: p.seq,
+      client_message_id:
+        typeof p.client_message_id === "string" ? p.client_message_id : undefined,
+      payload: {
+        type: "tool_start",
+        data: {
+          tool_call_id: data.tool_call_id,
+          name: data.name,
+          ...(data.arguments !== undefined ? { arguments: data.arguments } : {}),
+        },
+      },
+    };
+  }
+  if (payloadType === "tool_progress") {
+    if (typeof data.message !== "string") return null;
+    return {
+      thread_id: p.thread_id,
+      seq: p.seq,
+      client_message_id:
+        typeof p.client_message_id === "string" ? p.client_message_id : undefined,
+      payload: {
+        type: "tool_progress",
+        data: { tool_call_id: data.tool_call_id, message: data.message },
+      },
+    };
+  }
+  if (data.status !== "complete" && data.status !== "error") return null;
+  return {
+    thread_id: p.thread_id,
+    seq: p.seq,
+    client_message_id:
+      typeof p.client_message_id === "string" ? p.client_message_id : undefined,
+    payload: {
+      type: "tool_end",
+      data: {
+        tool_call_id: data.tool_call_id,
+        status: data.status,
+        ...(typeof data.error === "string" ? { error: data.error } : {}),
+      },
+    },
+  };
+}
+
 function guardProjectionEnvelope(p: unknown): ProjectionEnvelope | null {
   if (!isPlainObject(p)) return null;
   if (!isString(p.turn_id)) return null;
@@ -985,11 +1051,21 @@ export function guardSessionHydrate(p: unknown): SessionHydrateResult | null {
     }
   }
 
+  let replayedToolEnvelopes: Envelope[] | undefined;
+  if (Array.isArray(p.replayed_tool_envelopes)) {
+    replayedToolEnvelopes = [];
+    for (const e of p.replayed_tool_envelopes) {
+      const guarded = guardHydrateToolEnvelope(e);
+      if (guarded) replayedToolEnvelopes.push(guarded);
+    }
+  }
+
   return {
     session_id: p.session_id,
     cursor,
     messages,
     replayed_envelopes: replayedEnvelopes,
+    replayed_tool_envelopes: replayedToolEnvelopes,
   };
 }
 

--- a/src/runtime/ui-protocol-runtime.ts
+++ b/src/runtime/ui-protocol-runtime.ts
@@ -251,6 +251,7 @@ function runHydrateFor(
     setHydrateSnapshot(sessionId, topic, {
       messages: hydrate.messages,
       replayed_envelopes: hydrate.replayed_envelopes,
+      replayed_tool_envelopes: hydrate.replayed_tool_envelopes,
     });
   })();
 }

--- a/src/runtime/ui-protocol-types.ts
+++ b/src/runtime/ui-protocol-types.ts
@@ -796,6 +796,7 @@ export interface SessionHydrateResult {
   turns?: unknown[];
   pending_approvals?: unknown[];
   replayed_envelopes?: TurnSpawnCompleteEvent[];
+  replayed_tool_envelopes?: Envelope[];
 }
 
 // ─── M9-γ canonical projection envelope (UPCR-2026-014) ────────────────────

--- a/src/store/thread-store.test.ts
+++ b/src/store/thread-store.test.ts
@@ -2808,6 +2808,97 @@ describe.each(FLAG_STATES)(
     }
   });
 
+  it("merges hydrate media into an existing REST-seeded user message", () => {
+    ThreadStore.replayHistory(SID, [
+      {
+        role: "user",
+        content: "describe this image",
+        timestamp: "2026-07-01T02:53:00Z",
+        thread_id: "cmid-image",
+        client_message_id: "cmid-image",
+      },
+    ]);
+
+    ThreadStore.setHydrateSnapshot(SID, undefined, {
+      messages: [
+        {
+          seq: 0,
+          role: "user",
+          content: "describe this image",
+          thread_id: "cmid-image",
+          client_message_id: "cmid-image",
+          persisted_at: "2026-07-01T02:53:00Z",
+          media: ["uploads/pasted-photo.jpg"],
+        },
+      ],
+    });
+
+    const threads = ThreadStore.getThreads(SID);
+    expect(threads).toHaveLength(1);
+    expect(threads[0].userMsg.text).toBe("describe this image");
+    expect(threads[0].userMsg.files.map((f) => f.path)).toEqual([
+      "uploads/pasted-photo.jpg",
+    ]);
+  });
+
+  it("replays hydrate tool envelopes onto the existing assistant bubble", () => {
+    ThreadStore.replayHistory(SID, [
+      {
+        seq: 0,
+        role: "user",
+        content: "run a shell command",
+        timestamp: "2026-07-01T02:53:00Z",
+        thread_id: "cmid-tools",
+        client_message_id: "cmid-tools",
+      },
+      {
+        seq: 4,
+        role: "assistant",
+        content: "The command finished.",
+        timestamp: "2026-07-01T02:53:05Z",
+        thread_id: "cmid-tools",
+      },
+    ]);
+
+    ThreadStore.setHydrateSnapshot(SID, undefined, {
+      replayed_tool_envelopes: [
+        {
+          thread_id: "cmid-tools",
+          seq: 1,
+          payload: {
+            type: "tool_start",
+            data: { tool_call_id: "tc-shell-1", name: "shell" },
+          },
+        },
+        {
+          thread_id: "cmid-tools",
+          seq: 2,
+          payload: {
+            type: "tool_progress",
+            data: { tool_call_id: "tc-shell-1", message: "running" },
+          },
+        },
+        {
+          thread_id: "cmid-tools",
+          seq: 3,
+          payload: {
+            type: "tool_end",
+            data: { tool_call_id: "tc-shell-1", status: "complete" },
+          },
+        },
+      ],
+    });
+
+    const response = ThreadStore.getThreads(SID)[0].responses[0];
+    expect(response.toolCalls).toHaveLength(1);
+    expect(response.toolCalls[0].id).toBe("tc-shell-1");
+    expect(response.toolCalls[0].name).toBe("shell");
+    expect(response.toolCalls[0].status).toBe("complete");
+    expect(response.toolCalls[0].progress.map((entry) => entry.message)).toEqual([
+      "running",
+    ]);
+  });
+
   /**
    * Confirm the seed is idempotent: a subsequent `replayHistory` call
    * (REST retries fire at 2s/5s/12s) replaces state wholesale, so a

--- a/src/store/thread-store.test.ts
+++ b/src/store/thread-store.test.ts
@@ -2900,6 +2900,88 @@ describe.each(FLAG_STATES)(
   });
 
   /**
+   * PR #243 follow-up (P2): `ThreadUserBubble` / `ThreadAssistantBubble`
+   * are `React.memo` components whose shallow comparison keys on the
+   * `message` object reference. Merging hydrate media into an existing
+   * (REST-seeded) message by pushing into `files` in place mutated
+   * store state WITHOUT changing that reference — the store notified,
+   * the parent re-rendered, but the memoized bubble skipped its repaint
+   * and the rehydrated media silently didn't display. Pin the store
+   * contract: a media merge must REPLACE the containing message object
+   * (same convention as `replaceAssistantSlot`).
+   */
+  it("replaces the message object reference when hydrate media merges into an existing message", () => {
+    ThreadStore.replayHistory(SID, [
+      {
+        seq: 0,
+        role: "user",
+        content: "describe this image",
+        timestamp: "2026-07-01T02:53:00Z",
+        thread_id: "cmid-ref",
+        client_message_id: "cmid-ref",
+      },
+      {
+        seq: 5,
+        role: "assistant",
+        content: "Here is the report.",
+        timestamp: "2026-07-01T02:53:05Z",
+        thread_id: "cmid-ref",
+      },
+    ]);
+    const before = ThreadStore.getThreads(SID)[0];
+    const userBefore = before.userMsg;
+    const responseBefore = before.responses[0];
+
+    const snapshot = {
+      messages: [
+        {
+          seq: 0,
+          role: "user",
+          content: "describe this image",
+          thread_id: "cmid-ref",
+          client_message_id: "cmid-ref",
+          persisted_at: "2026-07-01T02:53:00Z",
+          media: ["uploads/pasted-photo.jpg"],
+        },
+        {
+          seq: 5,
+          role: "assistant",
+          content: "Here is the report.",
+          thread_id: "cmid-ref",
+          persisted_at: "2026-07-01T02:53:05Z",
+          media: ["outputs/report.pdf"],
+        },
+      ],
+    };
+    ThreadStore.setHydrateSnapshot(SID, undefined, snapshot);
+
+    const after = ThreadStore.getThreads(SID)[0];
+    // The memo-visibility contract: new object references, not just
+    // new contents inside the same objects.
+    expect(after.userMsg).not.toBe(userBefore);
+    expect(after.responses[0]).not.toBe(responseBefore);
+    expect(after.userMsg.files.map((f) => f.path)).toEqual([
+      "uploads/pasted-photo.jpg",
+    ]);
+    expect(after.responses[0].files.map((f) => f.path)).toEqual([
+      "outputs/report.pdf",
+    ]);
+    // Untouched fields carry over onto the replacement objects.
+    expect(after.userMsg.text).toBe("describe this image");
+    expect(after.responses[0].text).toBe("Here is the report.");
+
+    // No-op re-merge (same snapshot replayed, e.g. WS reconnect) must
+    // NOT mint fresh objects — that would churn memoized bubbles on
+    // every reconnect.
+    ThreadStore.setHydrateSnapshot(SID, undefined, snapshot);
+    const again = ThreadStore.getThreads(SID)[0];
+    expect(again.userMsg).toBe(after.userMsg);
+    expect(again.responses[0]).toBe(after.responses[0]);
+    expect(again.userMsg.files).toHaveLength(1);
+    expect(again.responses[0].files).toHaveLength(1);
+  });
+
+  /**
    * Confirm the seed is idempotent: a subsequent `replayHistory` call
    * (REST retries fire at 2s/5s/12s) replaces state wholesale, so a
    * real REST response that lands later WINS for any overlap with the

--- a/src/store/thread-store.test.ts
+++ b/src/store/thread-store.test.ts
@@ -2982,6 +2982,235 @@ describe.each(FLAG_STATES)(
   });
 
   /**
+   * PR #243 follow-up (P2): the hydrate tool replay re-runs on every
+   * WS reconnect (`setHydrateSnapshot` per `session/hydrate`) and
+   * after every `replayHistory` rebuild (cached-hydrate
+   * re-application), but `appendToolProgress` only suppresses
+   * *consecutive* duplicate lines — so replaying the same envelope set
+   * against unchanged state duplicated every progress line
+   * (["step 1","step 2"] became ["step 1","step 2","step 1","step 2"]).
+   */
+  it("does not duplicate tool progress when the same hydrate tool envelopes replay again", () => {
+    const restRows = [
+      {
+        seq: 0,
+        role: "user",
+        content: "run a shell command",
+        timestamp: "2026-07-01T02:53:00Z",
+        thread_id: "cmid-replay",
+        client_message_id: "cmid-replay",
+      },
+      {
+        seq: 5,
+        role: "assistant",
+        content: "The command finished.",
+        timestamp: "2026-07-01T02:53:05Z",
+        thread_id: "cmid-replay",
+      },
+    ];
+    ThreadStore.replayHistory(SID, restRows);
+
+    const toolEnvelopes = [
+      {
+        thread_id: "cmid-replay",
+        seq: 1,
+        payload: {
+          type: "tool_start" as const,
+          data: { tool_call_id: "tc-shell-1", name: "shell" },
+        },
+      },
+      {
+        thread_id: "cmid-replay",
+        seq: 2,
+        payload: {
+          type: "tool_progress" as const,
+          data: { tool_call_id: "tc-shell-1", message: "step 1" },
+        },
+      },
+      {
+        thread_id: "cmid-replay",
+        seq: 3,
+        payload: {
+          type: "tool_progress" as const,
+          data: { tool_call_id: "tc-shell-1", message: "step 2" },
+        },
+      },
+      {
+        thread_id: "cmid-replay",
+        seq: 4,
+        payload: {
+          type: "tool_end" as const,
+          data: { tool_call_id: "tc-shell-1", status: "complete" as const },
+        },
+      },
+    ];
+    ThreadStore.setHydrateSnapshot(SID, undefined, {
+      replayed_tool_envelopes: toolEnvelopes,
+    });
+    // WS reconnect: the server replays the SAME retained envelopes.
+    ThreadStore.setHydrateSnapshot(SID, undefined, {
+      replayed_tool_envelopes: toolEnvelopes,
+    });
+
+    let response = ThreadStore.getThreads(SID)[0].responses[0];
+    expect(response.toolCalls).toHaveLength(1);
+    expect(response.toolCalls[0].progress.map((e) => e.message)).toEqual([
+      "step 1",
+      "step 2",
+    ]);
+
+    // A later hydrate carrying a NEW envelope (higher seq) still
+    // applies — the ledger only skips (thread_id, seq) pairs already
+    // applied, not the whole thread.
+    ThreadStore.setHydrateSnapshot(SID, undefined, {
+      replayed_tool_envelopes: [
+        ...toolEnvelopes,
+        {
+          thread_id: "cmid-replay",
+          seq: 6,
+          payload: {
+            type: "tool_progress" as const,
+            data: { tool_call_id: "tc-shell-1", message: "step 3" },
+          },
+        },
+      ],
+    });
+    response = ThreadStore.getThreads(SID)[0].responses[0];
+    expect(response.toolCalls[0].progress.map((e) => e.message)).toEqual([
+      "step 1",
+      "step 2",
+      "step 3",
+    ]);
+
+    // REST retry: `replayHistory` rebuilds state wholesale (rebuilt
+    // rows carry no progress timelines) and re-applies the cached
+    // hydrate — the replayed tool state must come back exactly once.
+    ThreadStore.replayHistory(SID, restRows);
+    response = ThreadStore.getThreads(SID)[0].responses[0];
+    expect(response.toolCalls).toHaveLength(1);
+    expect(response.toolCalls[0].status).toBe("complete");
+    expect(response.toolCalls[0].progress.map((e) => e.message)).toEqual([
+      "step 1",
+      "step 2",
+      "step 3",
+    ]);
+  });
+
+  /**
+   * PR #243 follow-up (P2): the replay lane routed by `thread_id`
+   * alone — `ensureOrphanThread`'s `pickHostSessionForOrphan()`
+   * fallback attached tool cards for unknown threads to an ARBITRARY
+   * other session. A hydrate is scoped to one (sessionId, topic);
+   * envelopes that cannot be resolved within that scope are skipped.
+   */
+  it("skips hydrate tool envelopes for unknown threads instead of attaching to another session", () => {
+    // Session A has real thread state; the hydrate below is for a
+    // DIFFERENT session that has none.
+    ThreadStore.replayHistory(SID, [
+      {
+        seq: 0,
+        role: "user",
+        content: "unrelated conversation",
+        timestamp: "2026-07-01T02:53:00Z",
+        thread_id: "cmid-a",
+        client_message_id: "cmid-a",
+      },
+      {
+        seq: 1,
+        role: "assistant",
+        content: "sure",
+        timestamp: "2026-07-01T02:53:01Z",
+        thread_id: "cmid-a",
+      },
+    ]);
+
+    const OTHER_SID = "sess-hydrate-scope-other";
+    ThreadStore.setHydrateSnapshot(OTHER_SID, undefined, {
+      replayed_tool_envelopes: [
+        {
+          thread_id: "cmid-ghost",
+          seq: 1,
+          payload: {
+            type: "tool_start" as const,
+            data: { tool_call_id: "tc-ghost-1", name: "shell" },
+          },
+        },
+        {
+          thread_id: "cmid-ghost",
+          seq: 2,
+          payload: {
+            type: "tool_progress" as const,
+            data: { tool_call_id: "tc-ghost-1", message: "leaked" },
+          },
+        },
+      ],
+    });
+
+    // Pre-fix: `pickHostSessionForOrphan()` minted an orphan thread in
+    // session A hosting the foreign tool card.
+    const threadsA = ThreadStore.getThreads(SID);
+    expect(threadsA).toHaveLength(1);
+    expect(threadsA[0].responses[0].toolCalls).toEqual([]);
+    expect(threadsA[0].pendingAssistant).toBeNull();
+    expect(ThreadStore.getThreads(OTHER_SID)).toHaveLength(0);
+  });
+
+  it("does not replay tool envelopes onto another session's thread with the same id", () => {
+    ThreadStore.replayHistory(SID, [
+      {
+        seq: 0,
+        role: "user",
+        content: "session A prompt",
+        timestamp: "2026-07-01T02:53:00Z",
+        thread_id: "cmid-a",
+        client_message_id: "cmid-a",
+      },
+      {
+        seq: 1,
+        role: "assistant",
+        content: "session A reply",
+        timestamp: "2026-07-01T02:53:01Z",
+        thread_id: "cmid-a",
+      },
+    ]);
+    const OTHER_SID = "sess-hydrate-scope-b";
+    ThreadStore.replayHistory(OTHER_SID, [
+      {
+        seq: 0,
+        role: "user",
+        content: "session B prompt",
+        timestamp: "2026-07-01T02:54:00Z",
+        thread_id: "cmid-b",
+        client_message_id: "cmid-b",
+      },
+    ]);
+
+    // Session B's hydrate names session A's thread — a server-side
+    // mixup. Pre-fix the cross-session `findThreadById` walk attached
+    // the tool card to session A's bubble.
+    ThreadStore.setHydrateSnapshot(OTHER_SID, undefined, {
+      replayed_tool_envelopes: [
+        {
+          thread_id: "cmid-a",
+          seq: 1,
+          payload: {
+            type: "tool_start" as const,
+            data: { tool_call_id: "tc-cross-1", name: "shell" },
+          },
+        },
+      ],
+    });
+
+    const threadsA = ThreadStore.getThreads(SID);
+    expect(threadsA).toHaveLength(1);
+    expect(threadsA[0].responses[0].toolCalls).toEqual([]);
+    const threadsB = ThreadStore.getThreads(OTHER_SID);
+    expect(threadsB).toHaveLength(1);
+    expect(threadsB[0].responses).toEqual([]);
+    expect(threadsB[0].pendingAssistant).toBeNull();
+  });
+
+  /**
    * Confirm the seed is idempotent: a subsequent `replayHistory` call
    * (REST retries fire at 2s/5s/12s) replaces state wholesale, so a
    * real REST response that lands later WINS for any overlap with the

--- a/src/store/thread-store.ts
+++ b/src/store/thread-store.ts
@@ -2586,17 +2586,35 @@ function hydrateRowToMessageInfo(row: HydrateMessageRow): MessageInfo | null {
   };
 }
 
-function mergeMediaIntoMessage(target: ThreadMessage, media?: string[]): boolean {
-  if (!media || media.length === 0) return false;
+/**
+ * Merge hydrate media paths into `target`, returning a NEW
+ * `ThreadMessage` (fresh object + fresh `files` array) when anything
+ * was added, or `null` when the merge is a no-op.
+ *
+ * PR #243 follow-up (P2): the first cut pushed into `target.files` in
+ * place. `ThreadUserBubble` / `ThreadAssistantBubble` are `React.memo`
+ * components whose shallow comparison keys on the `message` object
+ * reference, so an in-place push updated store state without ever
+ * repainting the bubble — media merged into an EXISTING (REST-seeded)
+ * message silently didn't display. Same convention as
+ * `replaceAssistantSlot` (see the 2026-05-15 bug note there): every
+ * mutation that changes a message's data MUST replace the containing
+ * `ThreadMessage` object.
+ */
+function mergeMediaIntoMessage(
+  target: ThreadMessage,
+  media?: string[],
+): ThreadMessage | null {
+  if (!media || media.length === 0) return null;
   const seen = new Set(target.files.map((file) => file.path));
-  let changed = false;
+  const added: MessageFile[] = [];
   for (const path of media) {
     if (seen.has(path)) continue;
-    target.files.push(fileFromMediaPath(path));
+    added.push(fileFromMediaPath(path));
     seen.add(path);
-    changed = true;
   }
-  return changed;
+  if (added.length === 0) return null;
+  return { ...target, files: [...target.files, ...added] };
 }
 
 function rowTimestampMs(row: HydrateMessageRow): number | null {
@@ -2633,15 +2651,23 @@ function mergeHydrateMediaIntoExisting(
       const anchor = row.client_message_id ?? row.thread_id;
       const thread = anchor ? state.byId.get(anchor) : undefined;
       if (!thread) continue;
-      changed = mergeMediaIntoMessage(thread.userMsg, row.media) || changed;
+      const mergedUser = mergeMediaIntoMessage(thread.userMsg, row.media);
+      if (mergedUser) {
+        thread.userMsg = mergedUser;
+        changed = true;
+      }
       continue;
     }
 
     const thread = row.thread_id ? state.byId.get(row.thread_id) : undefined;
     if (!thread) continue;
-    for (const response of thread.responses) {
-      if (hydrateRowMatchesResponse(row, response)) {
-        changed = mergeMediaIntoMessage(response, row.media) || changed;
+    for (let i = 0; i < thread.responses.length; i += 1) {
+      if (hydrateRowMatchesResponse(row, thread.responses[i])) {
+        const merged = mergeMediaIntoMessage(thread.responses[i], row.media);
+        if (merged) {
+          thread.responses[i] = merged;
+          changed = true;
+        }
         break;
       }
     }

--- a/src/store/thread-store.ts
+++ b/src/store/thread-store.ts
@@ -189,6 +189,30 @@ function hasSeenSeq(key: string, seq: number): boolean {
 }
 
 /**
+ * PR #243 follow-up (P2): `${thread_id}:${seq}` identities of hydrate
+ * `replayed_tool_envelopes` already applied to the CURRENT thread
+ * state for a store key. `(thread_id, seq)` is the canonical envelope
+ * identity (see `Envelope` in `ui-protocol-types.ts`).
+ *
+ * Why: `applyHydrateDedup` re-runs the tool replay on every WS
+ * `session/hydrate` (initial connect + every reconnect) and after
+ * every `replayHistory` rebuild (the cached-hydrate re-application) —
+ * even twice within ONE hydrate on the M10.5 seed path
+ * (`seedFromHydrateMessages` → `replayHistory` → nested
+ * `applyHydrateDedup`, then the outer pass's own tail call). But
+ * `appendToolProgress` only suppresses *consecutive* duplicate lines,
+ * so replaying the same `tool_progress` envelopes against unchanged
+ * state duplicated every progress line per re-run.
+ *
+ * Lifecycle: an entry is added when the envelope is actually applied.
+ * `replayHistory` drops the key's ledger when it replaces state
+ * wholesale — rebuilt REST rows carry no progress timelines, so the
+ * cached-hydrate re-application MUST re-attach. `clearSession` /
+ * `__resetForTests` release it with the rest of the session state.
+ */
+const appliedHydrateToolEnvelopesByKey = new Map<string, Set<string>>();
+
+/**
  * M10 Phase 6.2 (Bug C): per-session WS `session/hydrate` snapshot
  * cached so that subsequent `replayHistory` calls (the forced retries
  * in chat-thread.tsx fire at 2s/5s/12s) can replay the dedup pass on
@@ -2449,6 +2473,12 @@ export function replayHistory(
   state.threads.sort((a, b) => a.userMsg.timestamp - b.userMsg.timestamp);
   for (const thread of state.threads) sortResponsesInThread(thread);
 
+  // PR #243 follow-up (P2): state for `key` is replaced wholesale and
+  // the rebuilt rows carry no tool progress timelines — drop the
+  // applied-tool-envelope ledger so the cached-hydrate re-application
+  // below is allowed to re-attach the replayed tool state to the
+  // fresh objects.
+  appliedHydrateToolEnvelopesByKey.delete(key);
   sessionsByKey.set(key, state);
   loadedSessions.add(key);
 
@@ -2676,14 +2706,53 @@ function mergeHydrateMediaIntoExisting(
   return changed;
 }
 
-function replayHydrateToolEnvelopes(envelopes: Envelope[] | undefined): void {
+function replayHydrateToolEnvelopes(
+  sessionId: string,
+  topic: string | undefined,
+  envelopes: Envelope[] | undefined,
+): void {
   if (!envelopes || envelopes.length === 0) return;
+  const key = storeKey(sessionId, topic);
+  // PR #243 follow-up (P2): scope the replay to the hydrating session.
+  // The tool mutators below route by `thread_id` alone — for an
+  // unknown thread `ensureOrphanThread` falls through to
+  // `pickHostSessionForOrphan()`, which would attach the replayed tool
+  // card to an ARBITRARY other session. A hydrate is scoped to ONE
+  // (sessionId, topic); skip envelopes whose thread cannot be resolved
+  // within that scope's own state (the `messages[]` seed pass runs
+  // before us, so any thread the snapshot carries rows for already
+  // exists here).
+  const state = sessionsByKey.get(key);
+  if (!state) return;
+  let applied = appliedHydrateToolEnvelopesByKey.get(key);
   const ordered = [...envelopes].sort((a, b) => {
     if (a.thread_id === b.thread_id) return a.seq - b.seq;
     return a.thread_id.localeCompare(b.thread_id);
   });
 
   for (const envelope of ordered) {
+    if (!state.byId.has(envelope.thread_id)) {
+      recordRuntimeCounter("octos_hydrate_tool_envelope_unresolved_total", {
+        surface: "thread_store",
+      });
+      continue;
+    }
+    // PR #243 follow-up (P2): idempotency. This replay re-runs on every
+    // WS reconnect and after every `replayHistory` rebuild, but
+    // `appendToolProgress` only skips *consecutive* duplicate lines —
+    // re-applying the same `tool_progress` envelopes against unchanged
+    // state duplicated every progress line. Skip `(thread_id, seq)`
+    // pairs already applied to the current state generation (see
+    // `appliedHydrateToolEnvelopesByKey`); envelopes skipped above as
+    // unresolved are NOT marked, so a later hydrate that seeds their
+    // thread can still apply them.
+    const envelopeKey = `${envelope.thread_id}:${envelope.seq}`;
+    if (applied?.has(envelopeKey)) continue;
+    if (!applied) {
+      applied = new Set();
+      appliedHydrateToolEnvelopesByKey.set(key, applied);
+    }
+    applied.add(envelopeKey);
     const payload = envelope.payload;
     if (payload.type === "tool_start") {
       addToolCall(
@@ -2966,7 +3035,7 @@ export function applyHydrateDedup(
     notify();
   }
   if (envelopes.length === 0) {
-    replayHydrateToolEnvelopes(hydrate.replayed_tool_envelopes);
+    replayHydrateToolEnvelopes(sessionId, topic, hydrate.replayed_tool_envelopes);
     return;
   }
 
@@ -3163,7 +3232,7 @@ export function applyHydrateDedup(
       topic,
     });
   }
-  replayHydrateToolEnvelopes(hydrate.replayed_tool_envelopes);
+  replayHydrateToolEnvelopes(sessionId, topic, hydrate.replayed_tool_envelopes);
   notify();
 }
 
@@ -3588,6 +3657,7 @@ export function clearSession(sessionId: string, topic?: string): void {
     hydrateSnapshotByKey.delete(key);
     pendingClientMessageIds.delete(key);
     seenSeqsByKey.delete(key);
+    appliedHydrateToolEnvelopesByKey.delete(key);
   } else {
     for (const k of [...sessionsByKey.keys()]) {
       if (k === sessionId || k.startsWith(`${sessionId}#`)) {
@@ -3597,6 +3667,7 @@ export function clearSession(sessionId: string, topic?: string): void {
         hydrateSnapshotByKey.delete(k);
         pendingClientMessageIds.delete(k);
         seenSeqsByKey.delete(k);
+        appliedHydrateToolEnvelopesByKey.delete(k);
       }
     }
     // Codex round-5 P3: a hydrate snapshot may exist without a
@@ -3612,10 +3683,17 @@ export function clearSession(sessionId: string, topic?: string): void {
     }
     // WEB-NEW-17: same orphan-key concern for the seen-seqs cache —
     // sweep it independently so a clear-then-stream sequence doesn't
-    // suppress a fresh re-fired live row.
+    // suppress a fresh re-fired live row. Same for the applied
+    // tool-envelope ledger (PR #243 follow-up): a clear-then-hydrate
+    // sequence must be allowed to re-apply the replayed tool state.
     for (const k of [...seenSeqsByKey.keys()]) {
       if (k === sessionId || k.startsWith(`${sessionId}#`)) {
         seenSeqsByKey.delete(k);
+      }
+    }
+    for (const k of [...appliedHydrateToolEnvelopesByKey.keys()]) {
+      if (k === sessionId || k.startsWith(`${sessionId}#`)) {
+        appliedHydrateToolEnvelopesByKey.delete(k);
       }
     }
   }
@@ -3717,6 +3795,7 @@ export function __resetForTests(): void {
   hydrateSnapshotByKey.clear();
   pendingClientMessageIds.clear();
   seenSeqsByKey.clear();
+  appliedHydrateToolEnvelopesByKey.clear();
   version = 0;
   idCounter = 0;
 }

--- a/src/store/thread-store.ts
+++ b/src/store/thread-store.ts
@@ -2551,6 +2551,7 @@ export interface HydrateEnvelope {
 export interface HydrateSnapshot {
   messages?: HydrateMessageRow[];
   replayed_envelopes?: HydrateEnvelope[];
+  replayed_tool_envelopes?: Envelope[];
 }
 
 /**
@@ -2583,6 +2584,106 @@ function hydrateRowToMessageInfo(row: HydrateMessageRow): MessageInfo | null {
     timestamp,
     media: row.media,
   };
+}
+
+function mergeMediaIntoMessage(target: ThreadMessage, media?: string[]): boolean {
+  if (!media || media.length === 0) return false;
+  const seen = new Set(target.files.map((file) => file.path));
+  let changed = false;
+  for (const path of media) {
+    if (seen.has(path)) continue;
+    target.files.push(fileFromMediaPath(path));
+    seen.add(path);
+    changed = true;
+  }
+  return changed;
+}
+
+function rowTimestampMs(row: HydrateMessageRow): number | null {
+  if (!row.persisted_at) return null;
+  const timestamp = new Date(row.persisted_at).getTime();
+  return Number.isFinite(timestamp) ? timestamp : null;
+}
+
+function hydrateRowMatchesResponse(
+  row: HydrateMessageRow,
+  response: ThreadMessage,
+): boolean {
+  if (typeof row.seq === "number" && response.historySeq === row.seq) {
+    return true;
+  }
+  if (row.content === undefined || response.text !== row.content) return false;
+  const timestamp = rowTimestampMs(row);
+  return timestamp === null || response.timestamp === timestamp;
+}
+
+function mergeHydrateMediaIntoExisting(
+  sessionId: string,
+  topic: string | undefined,
+  rows: HydrateMessageRow[],
+): boolean {
+  if (rows.length === 0) return false;
+  const state = sessionsByKey.get(storeKey(sessionId, topic));
+  if (!state) return false;
+  let changed = false;
+
+  for (const row of rows) {
+    if (!row.media || row.media.length === 0) continue;
+    if (row.role === "user") {
+      const anchor = row.client_message_id ?? row.thread_id;
+      const thread = anchor ? state.byId.get(anchor) : undefined;
+      if (!thread) continue;
+      changed = mergeMediaIntoMessage(thread.userMsg, row.media) || changed;
+      continue;
+    }
+
+    const thread = row.thread_id ? state.byId.get(row.thread_id) : undefined;
+    if (!thread) continue;
+    for (const response of thread.responses) {
+      if (hydrateRowMatchesResponse(row, response)) {
+        changed = mergeMediaIntoMessage(response, row.media) || changed;
+        break;
+      }
+    }
+  }
+
+  return changed;
+}
+
+function replayHydrateToolEnvelopes(envelopes: Envelope[] | undefined): void {
+  if (!envelopes || envelopes.length === 0) return;
+  const ordered = [...envelopes].sort((a, b) => {
+    if (a.thread_id === b.thread_id) return a.seq - b.seq;
+    return a.thread_id.localeCompare(b.thread_id);
+  });
+
+  for (const envelope of ordered) {
+    const payload = envelope.payload;
+    if (payload.type === "tool_start") {
+      addToolCall(
+        envelope.thread_id,
+        payload.data.tool_call_id,
+        payload.data.name,
+        payload.data.arguments,
+      );
+      continue;
+    }
+    if (payload.type === "tool_progress") {
+      appendToolProgress(
+        envelope.thread_id,
+        payload.data.tool_call_id,
+        payload.data.message,
+      );
+      continue;
+    }
+    if (payload.type === "tool_end") {
+      setToolCallStatus(
+        envelope.thread_id,
+        payload.data.tool_call_id,
+        payload.data.status === "error" ? "error" : "complete",
+      );
+    }
+  }
 }
 
 /**
@@ -2835,7 +2936,13 @@ export function applyHydrateDedup(
   // `m10-harden-reload-midstream` catches when both the legacy
   // companion AND the envelope land in the same hydrate response.
   seedFromHydrateMessages(sessionId, topic, messages, envelopes);
-  if (envelopes.length === 0) return;
+  if (mergeHydrateMediaIntoExisting(sessionId, topic, messages)) {
+    notify();
+  }
+  if (envelopes.length === 0) {
+    replayHydrateToolEnvelopes(hydrate.replayed_tool_envelopes);
+    return;
+  }
 
   // Build the seq → row metadata index, including media so we can
   // identify per-file companion rows by media-subset against an
@@ -3030,6 +3137,7 @@ export function applyHydrateDedup(
       topic,
     });
   }
+  replayHydrateToolEnvelopes(hydrate.replayed_tool_envelopes);
   notify();
 }
 


### PR DESCRIPTION
## Summary

- Rehydrate uploaded media into refreshed chat bubbles by carrying persisted `media` rows into the thread store.
- Replay hydrate tool envelopes into existing assistant bubbles so tool cards, model metadata, and timing-related UI survive refresh.
- Load refreshed workspace upload media through the session-scoped file endpoint.
- Treat refreshed `.webm` uploads as videos and surface a clear failed-load state instead of leaving media stuck on `Loading...`.

## Root Cause

Live chat rendering received media attachments and tool-call UI state from websocket notifications, but the refresh path rebuilt the UI from persisted/hydrated data that previously did not carry the same frontend facts. After the backend exposed persisted media and replayable tool envelopes, the frontend also needed to merge those facts into existing thread bubbles and resolve `uploads/...` media paths with the active session context.

For recorded videos, refreshed messages contained workspace-relative paths such as `uploads/video-*.webm`. The existing file loader requested `/api/files/<path>` without a session, which the backend cannot resolve for session workspace uploads. The blob fetch failed, and the UI stayed in a loading state.

## Impact

After a page refresh, chat history can now restore:

- image/video upload bubbles
- tool-call indicators and progress cards
- session-scoped recorded media playback

The file URL change is scoped to workspace upload paths and preserves the legacy `/api/files/<path>` behavior for other file references.

## Validation

- `npm run test:unit -- src/api/files.test.ts src/components/chat-thread-hydrate-replay.test.tsx src/store/thread-store.test.ts`
- `npm run test:unit -- src/components/chat-thread-hydrate-replay.test.tsx src/components/chat-thread-copy.test.tsx src/components/chat-thread-heartbeat.test.tsx src/components/chat-thread-bg-spinner.test.tsx src/components/chat-thread-tool-failure-preserves-user-prompt.test.tsx src/components/chat-thread-tool-call-status-icon.test.tsx src/components/chat-thread-tool-call-args.test.tsx src/components/chat-thread-tool-call-no-trailing-spinner.test.tsx src/components/chat-thread-progress-toggle.test.tsx`
- `git diff --check`
