### PR TITLE
fix(voice): playback interrupt hang, post-unmount mic re-acquire, false turn-error on RPC timeout

### DIFF
--- a/src/home/voice/audio-playback.test.ts
+++ b/src/home/voice/audio-playback.test.ts
@@ -1,0 +1,118 @@
+/**
+ * audio-playback unit tests.
+ *
+ * The load-bearing contract: `playAudioBlob(blob, onEnded)`'s `onEnded`
+ * callback fires EXACTLY ONCE for every started clip — on natural end,
+ * on interrupt via `stopAudio()`, and on supersede by a newer clip.
+ * `use-voice-conversation.ts`'s `playOne` resolves its await inside that
+ * callback; if an interrupt orphans it, the reply drain loop's
+ * `playingRef` stays latched true and every later reply is silenced
+ * until the user leaves /voice.
+ */
+
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { playAudioBlob, stopAudio } from "./audio-playback";
+
+class FakeSource {
+  buffer: unknown = null;
+  onended: ((ev: Event) => void) | null = null;
+  connect = vi.fn();
+  start = vi.fn();
+  stop = vi.fn();
+}
+
+const sources: FakeSource[] = [];
+
+class FakeAudioContext {
+  state = "running";
+  destination = {};
+  resume = vi.fn(async () => {});
+  decodeAudioData = vi.fn(async () => ({}) as AudioBuffer);
+  createBufferSource() {
+    const s = new FakeSource();
+    sources.push(s);
+    return s;
+  }
+}
+
+// NB: audio-playback caches its module-level AudioContext on first use, so
+// the stub must be in place before the first `playAudioBlob` call and the
+// same fake instance is shared by every test in this file (it is stateless;
+// per-clip state lives on the FakeSource entries in `sources`).
+vi.stubGlobal("AudioContext", FakeAudioContext);
+
+function makeBlob(): Blob {
+  const blob = new Blob(["x"]);
+  if (typeof blob.arrayBuffer !== "function") {
+    // Older jsdom Blobs lack arrayBuffer(); provide the minimal surface.
+    (blob as unknown as { arrayBuffer: () => Promise<ArrayBuffer> }).arrayBuffer =
+      async () => new ArrayBuffer(1);
+  }
+  return blob;
+}
+
+beforeEach(() => {
+  // Drain any clip a previous test left playing, THEN forget its source.
+  stopAudio();
+  sources.length = 0;
+});
+
+describe("playAudioBlob / stopAudio", () => {
+  it("fires onEnded when the clip ends naturally, and a later stopAudio does not re-fire it", async () => {
+    const onEnded = vi.fn();
+    await expect(playAudioBlob(makeBlob(), onEnded)).resolves.toBe(true);
+    expect(sources).toHaveLength(1);
+    expect(onEnded).not.toHaveBeenCalled();
+
+    // Browser fires `ended` when playback finishes.
+    sources[0].onended?.(new Event("ended"));
+    expect(onEnded).toHaveBeenCalledTimes(1);
+
+    stopAudio();
+    expect(onEnded).toHaveBeenCalledTimes(1);
+  });
+
+  it("stopAudio (interrupt) fires the in-flight clip's onEnded so awaiting callers resolve", async () => {
+    // THE bug: an interrupt mid-playback nulled `onended` before stop(), so
+    // `playOne`'s promise never resolved and the voice drain loop wedged —
+    // no subsequent reply audio ever played.
+    const onEnded = vi.fn();
+    await playAudioBlob(makeBlob(), onEnded);
+
+    stopAudio();
+    expect(sources[0].stop).toHaveBeenCalledTimes(1);
+    expect(onEnded).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not double-fire onEnded when the browser's late `ended` event lands after an interrupt", async () => {
+    const onEnded = vi.fn();
+    await playAudioBlob(makeBlob(), onEnded);
+
+    stopAudio();
+    expect(onEnded).toHaveBeenCalledTimes(1);
+
+    // Per spec, stop() makes the source fire `ended` asynchronously — the
+    // handler must have been detached so the interrupt's own invocation
+    // stays the only one.
+    sources[0].onended?.(new Event("ended"));
+    expect(onEnded).toHaveBeenCalledTimes(1);
+  });
+
+  it("starting a new clip supersedes the previous one and fires its onEnded exactly once", async () => {
+    const first = vi.fn();
+    const second = vi.fn();
+    await playAudioBlob(makeBlob(), first);
+    await playAudioBlob(makeBlob(), second);
+
+    expect(first).toHaveBeenCalledTimes(1);
+    expect(second).not.toHaveBeenCalled();
+
+    // The second clip still completes normally.
+    sources[1].onended?.(new Event("ended"));
+    expect(second).toHaveBeenCalledTimes(1);
+  });
+
+  it("stopAudio is a no-op when nothing is playing", () => {
+    expect(() => stopAudio()).not.toThrow();
+  });
+});

--- a/src/home/voice/audio-playback.ts
+++ b/src/home/voice/audio-playback.ts
@@ -14,6 +14,11 @@
 
 let ctx: AudioContext | null = null;
 let current: AudioBufferSourceNode | null = null;
+// Completion callback for `current`, kept alongside it so `stopAudio` can
+// fire it on interrupt. `playOne` (use-voice-conversation.ts) awaits this
+// callback; orphaning it wedges the reply drain loop's `playingRef` latch
+// and permanently silences every later reply.
+let currentOnEnded: (() => void) | null = null;
 
 function getCtx(): AudioContext | null {
   if (ctx) return ctx;
@@ -33,23 +38,33 @@ export function unlockAudio(): void {
   if (c && c.state === "suspended") void c.resume();
 }
 
-/** Stop whatever is currently playing. */
+/** Stop whatever is currently playing. Fires the interrupted clip's
+ *  `onEnded` callback (exactly once) so callers awaiting playback
+ *  completion resolve — nulling the handler without invoking it left
+ *  `playOne`'s promise pending forever and no later reply ever played. */
 export function stopAudio(): void {
-  if (current) {
-    try {
-      current.onended = null;
-      current.stop();
-    } catch {
-      // already stopped / ended
-    }
-    current = null;
+  if (!current) return;
+  const src = current;
+  const onEnded = currentOnEnded;
+  current = null;
+  currentOnEnded = null;
+  // Detach the DOM handler first: stop() makes the source fire `ended`
+  // asynchronously, and we invoke the completion callback ourselves below —
+  // detaching keeps it to exactly one invocation.
+  src.onended = null;
+  try {
+    src.stop();
+  } catch {
+    // already stopped / ended
   }
+  onEnded?.();
 }
 
 /** Decode + play an audio blob through the unlocked context. Resolves true if
- *  playback started, false if Web Audio is unavailable. `onEnded` fires when
- *  the clip finishes (not when interrupted via `stopAudio`). Throws if decode
- *  or start fails — caller handles fallback. */
+ *  playback started, false if Web Audio is unavailable. `onEnded` fires
+ *  exactly once per started clip — when it finishes, when it is interrupted
+ *  via `stopAudio`, or when a newer clip supersedes it. Throws if decode or
+ *  start fails — caller handles fallback. */
 export async function playAudioBlob(
   blob: Blob,
   onEnded: () => void,
@@ -70,10 +85,14 @@ export async function playAudioBlob(
   src.buffer = audioBuf;
   src.connect(c.destination);
   src.onended = () => {
-    if (current === src) current = null;
+    if (current === src) {
+      current = null;
+      currentOnEnded = null;
+    }
     onEnded();
   };
   current = src;
+  currentOnEnded = onEnded;
   src.start();
   return true;
 }

--- a/src/home/voice/use-voice-conversation.test.ts
+++ b/src/home/voice/use-voice-conversation.test.ts
@@ -1,4 +1,5 @@
-import { describe, it, expect, vi } from "vitest";
+import { describe, it, expect, vi, afterEach } from "vitest";
+import { act, renderHook } from "@testing-library/react";
 import {
   assembleTurnFiles,
   collectFreshAudio,
@@ -8,8 +9,103 @@ import {
   pickFreshAudio,
   shouldHandleExitEvent,
   stripVisualMarker,
+  useVoiceConversation,
 } from "./use-voice-conversation";
 import type { Thread } from "@/store/thread-store";
+
+// ---------------------------------------------------------------------------
+// Hook-level harness (start() cancellation — post-unmount mic re-acquire).
+// The pure-function suites below don't touch these mocks.
+// ---------------------------------------------------------------------------
+
+const {
+  captureStartMock,
+  captureStopMock,
+  getActiveBridgeMock,
+} = vi.hoisted(() => ({
+  captureStartMock: vi.fn(async () => {}),
+  captureStopMock: vi.fn(async () => {}),
+  getActiveBridgeMock: vi.fn((): unknown => undefined),
+}));
+
+vi.mock("./use-voice-capture", () => ({
+  // Stable object — the hook destructures start/stop and depends on their
+  // identity staying constant across renders (mirrors the real hook's
+  // useCallback([])-stable fns).
+  useVoiceCapture: () => ({
+    capturing: false,
+    start: captureStartMock,
+    stop: captureStopMock,
+    error: null,
+  }),
+}));
+
+const cameraMock = vi.hoisted(() => ({
+  active: false,
+  stream: null,
+  error: null,
+  start: vi.fn(async () => {}),
+  stop: vi.fn(),
+  grabFrame: vi.fn(async () => null),
+}));
+
+vi.mock("./use-camera-frame", () => ({
+  useCameraFrame: () => cameraMock,
+}));
+
+// Behavioural audio-playback mock mirroring the real module's contract:
+// `playAudioBlob` parks the clip's completion callback (playback "runs" until
+// something fires it); `stopAudio` fires it exactly once, so `playOne`'s
+// await resolves on interrupt just like the real implementation.
+const audioMock = vi.hoisted(() => {
+  const state = { onEnded: null as null | (() => void) };
+  return {
+    state,
+    playAudioBlob: vi.fn(async (_blob: Blob, onEnded: () => void) => {
+      state.onEnded = onEnded;
+      return true;
+    }),
+    stopAudio: vi.fn(() => {
+      const f = state.onEnded;
+      state.onEnded = null;
+      f?.();
+    }),
+    unlockAudio: vi.fn(),
+  };
+});
+
+vi.mock("./audio-playback", () => ({
+  playAudioBlob: audioMock.playAudioBlob,
+  stopAudio: audioMock.stopAudio,
+  unlockAudio: audioMock.unlockAudio,
+}));
+
+const threadsMock = vi.hoisted(() => ({ value: [] as unknown[] }));
+
+vi.mock("@/store/thread-store", () => ({
+  useThreads: () => threadsMock.value,
+}));
+
+vi.mock("@/runtime/ui-protocol-send", () => ({
+  interruptActiveTurn: vi.fn(async () => true),
+  sendMessage: vi.fn(),
+}));
+
+vi.mock("@/runtime/ui-protocol-runtime", () => ({
+  getActiveBridge: getActiveBridgeMock,
+}));
+
+vi.mock("@/api/chat", () => ({
+  uploadFiles: vi.fn(async () => []),
+}));
+
+vi.mock("@/api/files", () => ({
+  buildFileUrl: (p: string) => p,
+}));
+
+vi.mock("@/api/client", () => ({
+  buildApiHeaders: () => ({}),
+}));
 
 describe("assembleTurnFiles", () => {
   const audio = new File(["a"], "utterance.wav", { type: "audio/wav" });
@@ -203,5 +299,164 @@ describe("farewellAudioActive (fallback must not cut off the goodbye)", () => {
     // A turn that produced no farewell audio sits in `thinking`; the fallback
     // timer must be allowed to leave rather than hang forever.
     expect(farewellAudioActive(false, 0, "thinking")).toBe(false);
+  });
+});
+
+describe("start() cancellation (post-unmount mic re-acquire)", () => {
+  afterEach(() => {
+    vi.useRealTimers();
+    captureStartMock.mockClear();
+    captureStopMock.mockClear();
+    getActiveBridgeMock.mockReset();
+    getActiveBridgeMock.mockReturnValue(undefined);
+  });
+
+  it("does NOT re-acquire the microphone when the hook unmounts during the bridge-connect wait", async () => {
+    vi.useFakeTimers();
+    // /voice mints a fresh session per entry, so the bridge is still
+    // connecting at mount — start() sits in its ~12s poll.
+    getActiveBridgeMock.mockReturnValue(undefined);
+
+    const { result, unmount } = renderHook(() =>
+      useVoiceConversation("voice-cancel-test"),
+    );
+
+    let startPromise!: Promise<void>;
+    act(() => {
+      startPromise = result.current.start();
+    });
+    // A few poll iterations pass, then the user leaves /voice mid-wait.
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(600);
+    });
+    unmount(); // unmount cleanup runs stop()
+
+    // Ride out the rest of the poll + the 12s ceiling. Pre-fix,
+    // beginListening() ran here — re-acquiring the mic under a fresh VAD
+    // generation that nothing tears down.
+    await vi.advanceTimersByTimeAsync(13000);
+    await startPromise;
+
+    expect(captureStartMock).not.toHaveBeenCalled();
+  });
+
+  it("still begins listening once the bridge connects when start() was not cancelled", async () => {
+    getActiveBridgeMock.mockReturnValue({
+      getConnectionState: () => "connected",
+    });
+
+    const { result, unmount } = renderHook(() =>
+      useVoiceConversation("voice-happy-test"),
+    );
+
+    await act(async () => {
+      await result.current.start();
+    });
+
+    expect(captureStartMock).toHaveBeenCalledTimes(1);
+    unmount();
+  });
+});
+
+describe("interrupt() supersedes the drain loop (stale grace timer)", () => {
+  // codex P2 on the playback-interrupt fix: resolving the interrupted clip's
+  // promise lets the old drainQueue() continuation run to completion — it
+  // must NOT then schedule its return-to-listening grace timer, because
+  // interrupt() already chose the next state. Pre-fix the stale timer could
+  // fire ~1.5s later, see the user's follow-up turn in `thinking`, and knock
+  // it back to `listening` (disrupting the in-flight turn).
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.unstubAllGlobals();
+    threadsMock.value = [];
+    audioMock.state.onEnded = null;
+    audioMock.playAudioBlob.mockClear();
+    audioMock.stopAudio.mockClear();
+    captureStartMock.mockClear();
+    captureStopMock.mockClear();
+    getActiveBridgeMock.mockReset();
+    getActiveBridgeMock.mockReturnValue(undefined);
+  });
+
+  const flushMicrotasks = async () => {
+    for (let i = 0; i < 8; i++) await Promise.resolve();
+  };
+
+  it("a stale post-interrupt grace timer must not knock the next turn back to listening", async () => {
+    vi.useFakeTimers();
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => ({
+        ok: true,
+        blob: async () => new Blob(["a"]),
+      })),
+    );
+    getActiveBridgeMock.mockReturnValue({
+      getConnectionState: () => "connected",
+    });
+
+    const { result, rerender } = renderHook(() =>
+      useVoiceConversation("voice-interrupt-test"),
+    );
+
+    // Enter listening (bridge already connected → no poll wait).
+    await act(async () => {
+      await result.current.start();
+    });
+    expect(result.current.state).toBe("listening");
+
+    // First utterance → thinking.
+    const onUtterance1 = captureStartMock.mock.calls[0][0] as (
+      wav: Blob,
+    ) => void;
+    await act(async () => {
+      onUtterance1(new Blob(["u1"]));
+      await flushMicrotasks();
+    });
+    expect(result.current.state).toBe("thinking");
+
+    // Reply audio lands → the drain loop starts playing it (the mock parks
+    // the clip's completion callback, i.e. playback is in flight).
+    threadsMock.value = [
+      {
+        id: "turn-1",
+        userMsg: { text: "hi" },
+        pendingAssistant: null,
+        responses: [
+          { role: "assistant", text: "reply", files: [{ path: "w/r1.wav" }] },
+        ],
+      },
+    ];
+    rerender();
+    await act(async () => {
+      await flushMicrotasks();
+    });
+    expect(result.current.state).toBe("speaking");
+
+    // User taps the orb mid-playback: discard the clip, back to listening.
+    const listenCallsBeforeInterrupt = captureStartMock.mock.calls.length;
+    await act(async () => {
+      result.current.interrupt();
+      await flushMicrotasks();
+    });
+    expect(result.current.state).toBe("listening");
+
+    // The user immediately speaks again — the follow-up turn is `thinking`
+    // well inside the superseded drain's 1.5s grace window.
+    const onUtterance2 = captureStartMock.mock.calls[
+      listenCallsBeforeInterrupt
+    ][0] as (wav: Blob) => void;
+    await act(async () => {
+      onUtterance2(new Blob(["u2"]));
+      await flushMicrotasks();
+    });
+    expect(result.current.state).toBe("thinking");
+
+    // Ride past the grace window: the stale timer must not fire
+    // beginListening() against the in-flight turn.
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(2000);
+    });
+    expect(result.current.state).toBe("thinking");
   });
 });

--- a/src/home/voice/use-voice-conversation.ts
+++ b/src/home/voice/use-voice-conversation.ts
@@ -301,6 +301,13 @@ export function useVoiceConversation(
   const audioQueueRef = useRef<string[]>([]);
   const playingRef = useRef(false);
   const graceTimerRef = useRef<ReturnType<typeof setTimeout> | undefined>(undefined);
+  // Drain-loop supersession token. interrupt()/stop() bump it after clearing
+  // the queue; a drain loop whose generation no longer matches was superseded
+  // mid-clip (its playOne resolved via stopAudio) and must NOT schedule the
+  // return-to-listening grace timer — the interrupt path has already chosen
+  // the next state, and a stale 1.5s timer could otherwise catch the user's
+  // follow-up turn in `thinking` and knock it back to listening.
+  const drainGenRef = useRef(0);
 
   // Voice exit intent (UPCR-2026-025): a `crew:voice_exit` DOM event sets
   // `exitPendingRef`; the drainQueue grace-timer then leaves /voice AFTER the
@@ -317,6 +324,13 @@ export function useVoiceConversation(
   const onExitRef = useRef<(() => void) | undefined>(undefined);
   onExitRef.current = onExit;
   const performExitRef = useRef<() => void>(() => {});
+
+  // Cancellation token for start()'s async bridge-connect wait (same idiom
+  // as use-voice-capture's startGenRef). stop() bumps it; start() re-checks
+  // after every await, so leaving /voice mid-poll can never reach
+  // beginListening() after teardown — that re-acquired the microphone under
+  // a fresh VAD generation nothing tears down (post-unmount mic leak).
+  const startGenRef = useRef(0);
 
   // Stable refs that break the circular dependency between beginListening ↔
   // drainQueue. Each stores itself into its own ref every render.
@@ -497,6 +511,7 @@ export function useVoiceConversation(
   // for late sentences before returning to listening.
   const drainQueue = useCallback(async (): Promise<void> => {
     if (playingRef.current) return; // a drain loop is already running
+    const drainGen = drainGenRef.current;
     playingRef.current = true;
     try {
       while (audioQueueRef.current.length > 0) {
@@ -506,6 +521,11 @@ export function useVoiceConversation(
     } finally {
       playingRef.current = false;
     }
+    // interrupt()/stop() superseded this drain while a clip was in flight —
+    // they already chose the next state (listening / idle), so scheduling the
+    // grace timer here would be stale (and could later beginListening() into
+    // the follow-up turn's `thinking`).
+    if (drainGenRef.current !== drainGen) return;
     clearTimeout(graceTimerRef.current);
     graceTimerRef.current = setTimeout(() => {
       if (
@@ -531,6 +551,10 @@ export function useVoiceConversation(
   drainQueueRef.current = drainQueue;
 
   const start = useCallback(async () => {
+    // Capture this start's generation. A later stop() (unmount, exit) or a
+    // newer start() bumps the counter; every await below re-checks it and
+    // abandons, so a stale start can never re-acquire the microphone.
+    const gen = ++startGenRef.current;
     // Unlock audio playback now, while we're still close to the user's entry
     // gesture (the click that mounted the voice view). Replies arrive tens of
     // seconds later and would otherwise be blocked by the autoplay policy.
@@ -582,11 +606,21 @@ export function useVoiceConversation(
       const b = getActiveBridge(sessionId, historyTopic);
       if (b?.getConnectionState?.() === "connected") break;
       await new Promise((r) => setTimeout(r, 200));
+      // stop() ran while we were waiting (the user left /voice) — abandon
+      // before beginListening() re-acquires the mic with no owner left to
+      // tear it down.
+      if (startGenRef.current !== gen) return;
     }
+    if (startGenRef.current !== gen) return;
     await beginListening();
   }, [beginListening, sessionId, historyTopic]);
 
   const stop = useCallback(() => {
+    // Invalidate any in-flight start() (it re-checks this after each await).
+    startGenRef.current++;
+    // Supersede any suspended drain loop so it exits without scheduling a
+    // stale grace timer (releaseAudio() below resolves its awaited clip).
+    drainGenRef.current++;
     clearTimeout(replyTimerRef.current);
     clearTimeout(graceTimerRef.current);
     activeTurnIdRef.current = null;
@@ -631,6 +665,10 @@ export function useVoiceConversation(
   const interrupt = useCallback(() => {
     if (stateRef.current === "speaking") {
       audioQueueRef.current = [];
+      // Supersede the drain loop BEFORE releaseAudio() resolves its awaited
+      // clip: when it resumes it must exit without scheduling a stale grace
+      // timer — we return to listening right here.
+      drainGenRef.current++;
       clearTimeout(graceTimerRef.current);
       releaseAudio();
       void beginListeningRef.current();
@@ -638,6 +676,9 @@ export function useVoiceConversation(
       clearTimeout(replyTimerRef.current);
       clearTimeout(graceTimerRef.current);
       audioQueueRef.current = [];
+      // A drain loop can be alive in `thinking` too (its first clip is still
+      // in the fetch phase) — supersede it the same way.
+      drainGenRef.current++;
       speechInterruptArmedRef.current = false;
       requestTurnInterrupt("user tapped orb while thinking");
       void captureStop();

--- a/src/runtime/ui-protocol-send.test.ts
+++ b/src/runtime/ui-protocol-send.test.ts
@@ -71,6 +71,7 @@ import {
   __resetUiProtocolRuntimeForTest,
   __setActiveBridgeForTest,
 } from "./ui-protocol-runtime";
+import { BridgeTimeoutError } from "./ui-protocol-bridge";
 import type { UiProtocolBridge } from "./ui-protocol-bridge";
 
 const SESSION = "sess-send";
@@ -489,6 +490,98 @@ describe("sendMessage", () => {
     expect(threads).toHaveLength(1);
     expect(threads[0].pendingAssistant).toBeNull();
     expect(threads[0].responses[0]?.status).toBe("error");
+  });
+
+  // WS blip false-error: a `BridgeTimeoutError` on the turn/start RPC
+  // (response frame lost mid-blip) must NOT finalize the bubble as error
+  // when `turn/started` was ALREADY observed — the server is still
+  // running the turn, and the live lifecycle stream is the source of
+  // truth. Pre-fix, only `BridgeStoppedError` honoured `turnStartedSeen`;
+  // the timeout path finalized-as-error and released the send queue early.
+  it("BridgeTimeoutError after turn/started does NOT finalize the turn as error", async () => {
+    const bridge = makeBridge();
+    __setActiveBridgeForTest(SESSION, bridge);
+    const onComplete = vi.fn();
+
+    let lifecycleHandler:
+      | ((e: { turn_id: string; reason?: string; error?: unknown }) => void)
+      | undefined;
+    (bridge.onTurnLifecycle as ReturnType<typeof vi.fn>).mockImplementation(
+      (h: (e: { turn_id: string; reason?: string; error?: unknown }) => void) => {
+        lifecycleHandler = h;
+        return () => {
+          lifecycleHandler = undefined;
+        };
+      },
+    );
+
+    let rejectSendTurn: ((err: unknown) => void) | null = null;
+    (bridge.sendTurn as ReturnType<typeof vi.fn>).mockImplementation(
+      () =>
+        new Promise((_res, rej) => {
+          rejectSendTurn = rej;
+        }),
+    );
+
+    sendMessage({
+      sessionId: SESSION,
+      text: "long turn",
+      media: [],
+      clientMessageId: "cmid-blip",
+      onComplete,
+    });
+    for (let i = 0; i < 12; i++) await Promise.resolve();
+    expect(lifecycleHandler).toBeDefined();
+
+    // Server accepted the turn: bare `turn/started` (no reason/error keys).
+    lifecycleHandler?.({ turn_id: "cmid-blip" });
+
+    // WS blip: the RPC reply is lost; the per-RPC timeout rejects sendTurn.
+    rejectSendTurn?.(new BridgeTimeoutError("turn/start", 30000));
+    for (let i = 0; i < 12; i++) await Promise.resolve();
+
+    // The still-running turn is NOT finalized as error, and the per-session
+    // queue gate stays held for the live lifecycle stream.
+    const threads = ThreadStore.getThreads(SESSION);
+    expect(threads[0].responses[0]?.status).not.toBe("error");
+    expect(onComplete).not.toHaveBeenCalled();
+
+    // The live event stream drives the bubble to completion.
+    lifecycleHandler?.({ turn_id: "cmid-blip", reason: "stop" });
+    expect(onComplete).toHaveBeenCalledTimes(1);
+  });
+
+  // Counterpart guard: with NO `turn/started` observed, an RPC timeout has
+  // no evidence the server ever accepted the turn — it must keep finalizing
+  // as error immediately (the pre-existing behaviour).
+  it("BridgeTimeoutError with no turn/started still finalizes as error", async () => {
+    const bridge = makeBridge();
+    __setActiveBridgeForTest(SESSION, bridge);
+    const onComplete = vi.fn();
+
+    let rejectSendTurn: ((err: unknown) => void) | null = null;
+    (bridge.sendTurn as ReturnType<typeof vi.fn>).mockImplementation(
+      () =>
+        new Promise((_res, rej) => {
+          rejectSendTurn = rej;
+        }),
+    );
+
+    sendMessage({
+      sessionId: SESSION,
+      text: "never started",
+      media: [],
+      clientMessageId: "cmid-timeout-dead",
+      onComplete,
+    });
+    for (let i = 0; i < 12; i++) await Promise.resolve();
+
+    rejectSendTurn?.(new BridgeTimeoutError("turn/start", 30000));
+    for (let i = 0; i < 12; i++) await Promise.resolve();
+
+    const threads = ThreadStore.getThreads(SESSION);
+    expect(threads[0].responses[0]?.status).toBe("error");
+    expect(onComplete).toHaveBeenCalledTimes(1);
   });
 
   // M10 follow-up Bug B: 3 rapid sends serialise behind the prior turn's

--- a/src/runtime/ui-protocol-send.ts
+++ b/src/runtime/ui-protocol-send.ts
@@ -20,7 +20,7 @@
 import * as ThreadStore from "@/store/thread-store";
 import { displayFilenameFromPath } from "@/lib/utils";
 import { getActiveBridge, startBridgeForSession } from "./ui-protocol-runtime";
-import { BridgeStoppedError } from "./ui-protocol-bridge";
+import { BridgeStoppedError, BridgeTimeoutError } from "./ui-protocol-bridge";
 import type { TurnStartExtras, TurnStartMediaRef } from "./ui-protocol-types";
 import { request } from "@/api/client";
 
@@ -661,10 +661,15 @@ async function sendMessageV1(
     //
     //  - `turn/started` already seen: do NOT impose any grace
     //    ceiling. The server accepted the turn; the lifecycle
-    //    channel is the source of truth.
+    //    channel is the source of truth. This covers BOTH the
+    //    transport-drop path AND a `BridgeTimeoutError` on the RPC
+    //    reply (WS blip lost the response frame while the turn keeps
+    //    running server-side) — pre-fix the timeout path finalized
+    //    the bubble as error and released the send queue early.
     //
-    //  - Non-`BridgeStoppedError` (RPC permission_denied,
-    //    validation error, etc.): finalize immediately.
+    //  - Other errors (RPC permission_denied, validation error, a
+    //    timeout with no `turn/started` evidence, etc.): finalize
+    //    immediately.
     const finalizeAsError = () => {
       if (completed) return;
       ThreadStore.finalizeAssistant(clientMessageId, { status: "error" });
@@ -672,20 +677,21 @@ async function sendMessageV1(
       fireComplete();
     };
     const isTransportClose = err instanceof BridgeStoppedError;
+    const isRpcTimeout = err instanceof BridgeTimeoutError;
     const terminalConnState =
       lastConnState === "closed" || lastConnState === "error";
-    if (isTransportClose && !turnStartedSeen && !terminalConnState) {
+    if ((isTransportClose || isRpcTimeout) && turnStartedSeen) {
+      // Server accepted the turn before the transport dropped / the
+      // RPC reply went missing. Don't finalize — the 15-min safety
+      // timer + the lifecycle channel will handle completion (or
+      // release the gate on bridge teardown via offState).
+    } else if (isTransportClose && !terminalConnState) {
       // Reconnectable mid-flight drop: give the bridge a chance to
       // reconnect and deliver `turn/started` via lifecycle.
       graceTimer = setTimeout(() => {
         graceTimer = null;
         finalizeAsError();
       }, 45_000);
-    } else if (isTransportClose && turnStartedSeen) {
-      // Server accepted the turn before the transport dropped.
-      // Don't finalize — the 15-min safety timer + the lifecycle
-      // channel will handle completion (or release the gate on
-      // bridge teardown via offState).
     } else {
       finalizeAsError();
     }


### PR DESCRIPTION
Three P1s in the voice pipeline, each verified on origin/main before fixing.

## 1. One orb-tap interrupt permanently silenced all later replies
`stopAudio()` nulled the source's `onended` before `stop()`, but `playOne`'s promise resolves only inside that callback — so an interrupt mid-clip left the promise pending forever, `drainQueue`'s `playingRef` latched true, and every later reply was enqueued but never played. `stopAudio` now fires the clip's completion callback exactly once (finish, interrupt, or supersede), and `interrupt()`/`stop()` bump a drain supersession token (`drainGenRef`) so the resumed drain loop cannot schedule a stale return-to-listening grace timer into the user's follow-up turn (that consequence was caught by codex review of the initial fix and folded in).

## 2. Exiting /voice mid-connect re-acquired the mic after unmount (privacy leak)
`start()`'s ~12s bridge-connect poll had no cancel guard; leaving /voice during it let `beginListening()` run after `stop()`, re-acquiring the microphone under a fresh VAD generation nothing tears down — capturing ambient speech and ghost-sending it. A `startGenRef` generation (same idiom as `use-voice-capture`) is bumped by `stop()` and re-checked after every await.

## 3. A WS blip finalized a still-running turn as error
A `BridgeTimeoutError` on the turn/start RPC finalized the bubble as error and released the send queue even when `turn/started` had already been observed — the server was still running the turn; only the reply frame was lost. The timeout path now honors `turnStartedSeen` exactly like the transport-drop path; the lifecycle stream (with the existing 15-min safety timer) drives completion. A timeout with no `turn/started` evidence still finalizes immediately.

## Verification
- 758 unit tests pass (baseline 748; +10 new, 6 of them RED pre-fix, including a renderHook repro of the stale-grace-timer timeline and an unmount-mid-poll mic test).
- `tsc -b` exit 0; lint diff byte-identical to the origin/main baseline (all pre-existing).
- codex-reviewed; its one P2 finding (stale grace timer) is fixed and regression-tested.