### PR TITLE
fix: 3 of 4 P2s from the tri-repo review (octos-web #245)

### DIFF
--- a/src/components/chat-thread-video-recording-preview.test.tsx
+++ b/src/components/chat-thread-video-recording-preview.test.tsx
@@ -65,10 +65,14 @@ class FakeMediaRecorder {
   onstop: (() => void) | null = null;
   state: RecordingState = "inactive";
 
+  static instances: FakeMediaRecorder[] = [];
+
   constructor(
     public stream: MediaStream,
     public options?: MediaRecorderOptions,
-  ) {}
+  ) {
+    FakeMediaRecorder.instances.push(this);
+  }
 
   static isTypeSupported = vi.fn(() => true);
 
@@ -80,6 +84,13 @@ class FakeMediaRecorder {
     this.state = "inactive";
     this.onstop?.();
   });
+
+  /** Test helper: deliver a chunk of `size` bytes to this recorder. */
+  emitChunk(size: number): void {
+    this.ondataavailable?.({
+      data: new Blob(["x".repeat(size)]),
+    } as unknown as BlobEvent);
+  }
 }
 
 afterEach(() => {
@@ -87,6 +98,9 @@ afterEach(() => {
   vi.restoreAllMocks();
   for (const node of [...document.body.children]) node.remove();
   ThreadStore.__resetForTests();
+  FakeMediaRecorder.instances = [];
+  delete (URL as unknown as { createObjectURL?: unknown }).createObjectURL;
+  delete (URL as unknown as { revokeObjectURL?: unknown }).revokeObjectURL;
 });
 
 describe("video recording preview", () => {
@@ -124,6 +138,89 @@ describe("video recording preview", () => {
     expect(preview).not.toBeNull();
     expect(preview!.srcObject).toBe(stream);
     expect(play).toHaveBeenCalled();
+
+    harness.unmount();
+  });
+
+  it("a trailing chunk from a stopped recorder does not contaminate the next recording", async () => {
+    // #245 P2: the recorder chunk buffer must be per-recorder. A shared
+    // `chunksRef` (reset at the start of each recording) let a late
+    // `dataavailable` from a just-stopped recorder push into the NEW
+    // recording's buffer, so the second recording's blob contained the first
+    // recording's trailing audio/video.
+    const stream = {
+      getTracks: () => [{ stop: vi.fn() }],
+    } as unknown as MediaStream;
+    Object.defineProperty(navigator, "mediaDevices", {
+      configurable: true,
+      value: { getUserMedia: vi.fn().mockResolvedValue(stream) },
+    });
+    vi.stubGlobal("MediaRecorder", FakeMediaRecorder);
+    vi.spyOn(HTMLMediaElement.prototype, "play").mockResolvedValue(undefined);
+    // Capture the blob each recording produces (video mode → createObjectURL).
+    // jsdom has no URL.createObjectURL, so define it (configurable → afterEach
+    // deletes it).
+    const blobs: Blob[] = [];
+    Object.defineProperty(URL, "createObjectURL", {
+      configurable: true,
+      writable: true,
+      value: (obj: Blob) => {
+        blobs.push(obj);
+        return "blob:mock";
+      },
+    });
+    Object.defineProperty(URL, "revokeObjectURL", {
+      configurable: true,
+      writable: true,
+      value: () => {},
+    });
+
+    const harness = mount(
+      <SessionContext.Provider value={makeSessionCtx()}>
+        <ChatThread />
+      </SessionContext.Provider>,
+    );
+    const button = () =>
+      harness.container.querySelector<HTMLButtonElement>(
+        "[data-testid='video-button']",
+      )!;
+
+    // Recording A: start, one 200-byte chunk, then stop (builds A's blob).
+    await act(async () => {
+      button().click();
+      await Promise.resolve();
+    });
+    const recA = FakeMediaRecorder.instances[0];
+    await act(async () => {
+      recA.emitChunk(200);
+    });
+    await act(async () => {
+      button().click(); // stop A
+      await Promise.resolve();
+    });
+
+    // Recording B starts (resets any shared buffer)...
+    await act(async () => {
+      button().click();
+      await Promise.resolve();
+    });
+    const recB = FakeMediaRecorder.instances[1];
+    expect(recB).not.toBe(recA);
+    // ...then A's TRAILING chunk lands late, and B records its own 50 bytes.
+    await act(async () => {
+      recA.emitChunk(999); // stale trailing chunk from the stopped recorder
+      recB.emitChunk(50);
+    });
+    await act(async () => {
+      button().click(); // stop B (builds B's blob)
+      await Promise.resolve();
+    });
+
+    // Two recordings produced two blobs; B's must be its own 50 bytes only —
+    // NOT 50 + 999 (contaminated by A's trailing chunk).
+    expect(blobs.length).toBeGreaterThanOrEqual(2);
+    const blobB = blobs[blobs.length - 1];
+    expect(blobB.size).toBe(50);
 
     harness.unmount();
   });

--- a/src/components/chat-thread.tsx
+++ b/src/components/chat-thread.tsx
@@ -1340,7 +1340,6 @@ function Composer({ mountGhost, unmountGhost }: ComposerProps) {
   const [recordingTime, setRecordingTime] = useState(0);
   const mediaRecorderRef = useRef<MediaRecorder | null>(null);
   const mediaStreamRef = useRef<MediaStream | null>(null);
-  const chunksRef = useRef<Blob[]>([]);
   const timerRef = useRef<ReturnType<typeof setInterval> | null>(null);
   const videoPreviewRef = useRef<HTMLVideoElement>(null);
 
@@ -1389,12 +1388,20 @@ function Composer({ mountGhost, unmountGhost }: ComposerProps) {
             ? "video/webm;codecs=vp9,opus"
             : "video/webm";
       const recorder = new MediaRecorder(stream, { mimeType: recordMime });
-      chunksRef.current = [];
+      // Per-recorder chunk buffer captured in this closure (#245 P2). A
+      // shared `chunksRef` raced teardown: `stopRecording` nulls the recorder
+      // ref synchronously, but `stop()`'s trailing `dataavailable` fires
+      // asynchronously afterwards — if the user started a NEW recording in
+      // between (which would have reset the shared buffer), that stale chunk
+      // contaminated the new recording's blob. A local array isolates each
+      // recording: a late chunk from an old recorder lands in ITS OWN (now
+      // unused) buffer, and this recorder's `onstop` builds only from its own.
+      const chunks: Blob[] = [];
       recorder.ondataavailable = (e) => {
-        if (e.data.size > 0) chunksRef.current.push(e.data);
+        if (e.data.size > 0) chunks.push(e.data);
       };
       recorder.onstop = async () => {
-        const rawBlob = new Blob(chunksRef.current, { type: recordMime });
+        const rawBlob = new Blob(chunks, { type: recordMime });
         let blob: Blob;
         let ext: string;
         let fileType: string;

--- a/src/runtime/ui-protocol-bridge.test.ts
+++ b/src/runtime/ui-protocol-bridge.test.ts
@@ -2322,6 +2322,75 @@ describe("rpc correlation", () => {
     await vi.advanceTimersByTimeAsync(5001);
     expect(captured).toBeInstanceOf(BridgeTimeoutError);
   });
+
+  it("does not time out an RPC queued during reconnect before it is sent", async () => {
+    // #245 P2: the RPC timeout must start at SEND time, not enqueue time.
+    // A turn queued while the socket is down (waiting for reconnect) must not
+    // time out while parked in `sendQueue` — its clock only starts once the
+    // frame goes on the wire after the reconnect handshake.
+    vi.useFakeTimers();
+    const bridge = createUiProtocolBridge(
+      makeBridgeOpts({ rpcTimeoutMs: 5000 }),
+    );
+    void bridge.start({ sessionId: "sess-1" });
+    await Promise.resolve();
+    const ws1 = lastInstance();
+    ws1.triggerOpen();
+    await Promise.resolve();
+    ws1.triggerMessage({
+      jsonrpc: "2.0",
+      id: findRequest(ws1, METHODS.SESSION_OPEN).id,
+      result: { opened: { session_id: "sess-1" } },
+    });
+    await Promise.resolve();
+
+    // Socket drops → the bridge is reconnecting; this send is QUEUED.
+    ws1.triggerClose(1006, "abnormal");
+    await Promise.resolve();
+    const promise = bridge.sendTurn("turn-1", [{ kind: "text", text: "hi" }]);
+    let captured: unknown;
+    let resolved = false;
+    promise.then(
+      () => {
+        resolved = true;
+      },
+      (err) => {
+        captured = err;
+      },
+    );
+
+    // Wait well past rpcTimeoutMs while still disconnected (the reconnect
+    // backoff creates ws2 at ~1000ms but it never gets to open). The queued
+    // turn must NOT have timed out — pre-fix the request-time timer fired here.
+    await vi.advanceTimersByTimeAsync(6000);
+    expect(captured).toBeUndefined();
+    expect(resolved).toBe(false);
+
+    // Complete the reconnect handshake — the queued turn now goes on the wire.
+    const ws2 = lastInstance();
+    expect(ws2).not.toBe(ws1);
+    ws2.triggerOpen();
+    await Promise.resolve();
+    ws2.triggerMessage({
+      jsonrpc: "2.0",
+      id: findRequest(ws2, METHODS.SESSION_OPEN).id,
+      result: { opened: { session_id: "sess-1" } },
+    });
+    await Promise.resolve();
+    const turnReq = findRequest(ws2, METHODS.TURN_START);
+    expect(turnReq).toBeDefined();
+
+    // The server acks the (now-sent) turn → the Promise resolves; it never
+    // spuriously timed out.
+    ws2.triggerMessage({
+      jsonrpc: "2.0",
+      id: turnReq.id,
+      result: { turn_id: "turn-1" },
+    });
+    await Promise.resolve();
+    expect(captured).toBeUndefined();
+    expect(resolved).toBe(true);
+  });
 });
 
 // ---------------------------------------------------------------------------

--- a/src/runtime/ui-protocol-bridge.test.ts
+++ b/src/runtime/ui-protocol-bridge.test.ts
@@ -2391,6 +2391,60 @@ describe("rpc correlation", () => {
     expect(captured).toBeUndefined();
     expect(resolved).toBe(true);
   });
+
+  it("a superseded socket does not dispatch late frames after reconnect", async () => {
+    // #245 P2: after a reconnect the PRIOR socket must go silent. A late or
+    // buffered frame arriving on the old socket used to still reach
+    // `onWsMessage` (its handler was never detached / identity-checked), so
+    // the same envelope the new socket also replays got dispatched twice.
+    vi.useFakeTimers();
+    const bridge = createUiProtocolBridge(makeBridgeOpts());
+    const deltas: unknown[] = [];
+    bridge.onMessageDelta((e) => deltas.push(e));
+    void bridge.start({ sessionId: "sess-1" });
+    await Promise.resolve();
+    const ws1 = lastInstance();
+    ws1.triggerOpen();
+    await Promise.resolve();
+    ws1.triggerMessage({
+      jsonrpc: "2.0",
+      id: findRequest(ws1, METHODS.SESSION_OPEN).id,
+      result: { opened: { session_id: "sess-1" } },
+    });
+    await Promise.resolve();
+
+    // Reconnect: ws1 drops, ws2 comes up and re-opens the session.
+    ws1.triggerClose(1006, "abnormal");
+    await vi.advanceTimersByTimeAsync(1000);
+    const ws2 = lastInstance();
+    expect(ws2).not.toBe(ws1);
+    ws2.triggerOpen();
+    await Promise.resolve();
+    ws2.triggerMessage({
+      jsonrpc: "2.0",
+      id: findRequest(ws2, METHODS.SESSION_OPEN).id,
+      result: { opened: { session_id: "sess-1" } },
+    });
+    await Promise.resolve();
+
+    // A late/buffered frame on the OLD socket must NOT dispatch.
+    ws1.triggerMessage({
+      jsonrpc: "2.0",
+      method: METHODS.MESSAGE_DELTA,
+      params: { session_id: "sess-1", turn_id: "t1", text: "orphan" },
+    });
+    await Promise.resolve();
+    expect(deltas).toHaveLength(0);
+
+    // The live socket still dispatches normally.
+    ws2.triggerMessage({
+      jsonrpc: "2.0",
+      method: METHODS.MESSAGE_DELTA,
+      params: { session_id: "sess-1", turn_id: "t1", text: "live" },
+    });
+    await Promise.resolve();
+    expect(deltas).toHaveLength(1);
+  });
 });
 
 // ---------------------------------------------------------------------------

--- a/src/runtime/ui-protocol-bridge.ts
+++ b/src/runtime/ui-protocol-bridge.ts
@@ -2033,19 +2033,53 @@ class UiProtocolBridgeImpl implements UiProtocolBridge {
       throw err instanceof Error ? err : new Error(String(err));
     }
 
+    // Supersede any prior socket BEFORE adopting the new one (#245 P2). A
+    // reconnect (or a visibility-driven reopen that bypasses `onWsClose`)
+    // could leave the previous socket attached: its live `onmessage` would
+    // double-dispatch frames the new socket also replays, its late `onclose`
+    // would null the CURRENT `this.ws` and re-enter `scheduleReconnect`, and
+    // its `onopen` would re-run `startKeepalive` and clobber the live
+    // keepalive timer (single-slot field). Detaching the old socket's
+    // handlers + closing it (and cancelling the keepalive) makes it silent.
+    this.detachSocket(this.ws);
+    this.cancelKeepalive();
+
     this.ws = ws;
+    // Every handler is identity-guarded: if `this.ws` has moved on to a newer
+    // socket by the time a late event fires, this (now-superseded) socket must
+    // not dispatch, re-null the live socket, or touch the keepalive.
     ws.onopen = () => {
+      if (this.ws !== ws) return;
       void this.onWsOpen();
     };
     ws.onmessage = (ev) => {
+      if (this.ws !== ws) return;
       this.onWsMessage(ev);
     };
     ws.onerror = () => {
+      if (this.ws !== ws) return;
       this.onWsError();
     };
     ws.onclose = (ev) => {
+      if (this.ws !== ws) return;
       this.onWsClose(ev);
     };
+  }
+
+  /** Detach a socket's handlers and close it so a late event from a
+   *  superseded generation cannot reach the bridge (#245 P2). Safe on
+   *  `null` and on an already-closing socket. */
+  private detachSocket(ws: WebSocket | null): void {
+    if (!ws) return;
+    ws.onopen = null;
+    ws.onmessage = null;
+    ws.onerror = null;
+    ws.onclose = null;
+    try {
+      ws.close(4001, "superseded");
+    } catch {
+      // ignore — the socket may already be closing/closed.
+    }
   }
 
   private async onWsOpen(): Promise<void> {

--- a/src/runtime/ui-protocol-bridge.ts
+++ b/src/runtime/ui-protocol-bridge.ts
@@ -551,7 +551,14 @@ interface PendingRpc {
   method: string;
   resolve: (value: unknown) => void;
   reject: (err: Error) => void;
+  /** Timeout handle, or `null` until the frame is actually sent. The RPC
+   *  timeout clock starts at SEND time (armed by `armPendingTimeout`), not
+   *  when the request was enqueued — otherwise a frame parked in `sendQueue`
+   *  during a slow reconnect could time out before it ever went on the wire
+   *  (#245 P2). */
   timer: unknown;
+  /** Timeout duration, retained so the timer can be armed later, at send. */
+  timeoutMs: number;
 }
 
 type Listener<T> = (value: T) => void;
@@ -2528,47 +2535,64 @@ class UiProtocolBridgeImpl implements UiProtocolBridge {
     const timeoutMs = opts?.timeoutMs ?? this.cfg.rpcTimeoutMs;
 
     return new Promise<T>((resolve, reject) => {
-      const timer = this.cfg.setTimeout(() => {
-        if (!this.pending.delete(id)) return;
-        // Issue #109.2: drop the matching queued frame so a late
-        // reconnect-flush does not re-send a request whose Promise we
-        // just rejected with `BridgeTimeoutError`. Pre-fix, the
-        // `pending[id]` entry was deleted but the raw frame in
-        // `sendQueue` survived — after reconnect, the frame fired,
-        // the server processed it, but the client had no pending
-        // resolver. Worst case: a duplicate `turn/start` materialised
-        // on the server seconds after the user's UI gave up.
-        this.dropQueuedRpc(id);
-        reject(new BridgeTimeoutError(method, timeoutMs));
-      }, timeoutMs);
+      // The timeout is NOT armed here — only once the frame actually goes on
+      // the wire (`armPendingTimeout`). A frame that has to wait in
+      // `sendQueue` for a reconnect must not burn its timeout budget while
+      // parked (#245 P2). If the reconnect is ultimately abandoned,
+      // `rejectAllPending` settles this entry, so a never-sent frame does not
+      // hang forever.
       this.pending.set(id, {
         method,
         resolve: resolve as (v: unknown) => void,
         reject,
-        timer,
+        timer: null,
+        timeoutMs,
       });
 
       if (opts?.bypassQueue) {
         // session/open during onopen needs to bypass the queue — at that
         // moment state is still `connecting` so the queue path would defer
         // it forever, blocking the handshake completion.
-        const sent = this.rawSend(text);
-        if (!sent) {
+        if (this.rawSend(text)) {
+          this.armPendingTimeout(id);
+        } else {
           this.pending.delete(id);
-          this.cfg.clearTimeout(timer);
           reject(new BridgeStoppedError("socket not open for handshake"));
         }
         return;
       }
 
       if (this.state === "connected") {
-        if (!this.rawSend(text)) {
+        if (this.rawSend(text)) {
+          this.armPendingTimeout(id);
+        } else {
           this.enqueueFrame({ text, rpcId: id });
         }
         return;
       }
       this.enqueueFrame({ text, rpcId: id });
     });
+  }
+
+  /**
+   * Arm the RPC timeout for a pending request AT SEND TIME (idempotent —
+   * a no-op if the entry is gone or the timer is already running). Keeping
+   * the clock off until the frame leaves `sendQueue` is what stops a request
+   * from timing out during a long reconnect before it was ever transmitted
+   * (#245 P2). The timeout callback drops the queued frame (Issue #109.2) so
+   * a late flush cannot re-send a request whose Promise we already rejected.
+   */
+  private armPendingTimeout(id: string): void {
+    const pending = this.pending.get(id);
+    if (!pending || pending.timer !== null) return;
+    const { method, timeoutMs } = pending;
+    pending.timer = this.cfg.setTimeout(() => {
+      const p = this.pending.get(id);
+      if (!p) return;
+      this.pending.delete(id);
+      this.dropQueuedRpc(id);
+      p.reject(new BridgeTimeoutError(method, timeoutMs));
+    }, timeoutMs);
   }
 
   private sendNotification(method: string, params: unknown): void {
@@ -2638,6 +2662,11 @@ class UiProtocolBridgeImpl implements UiProtocolBridge {
       const next = this.sendQueue[0];
       if (!this.rawSend(next.text)) return;
       this.sendQueue.shift();
+      // The frame just went on the wire — start its RPC timeout NOW, not
+      // when it was originally enqueued (#245 P2).
+      if (next.rpcId !== undefined) {
+        this.armPendingTimeout(next.rpcId);
+      }
     }
   }
 }


### PR DESCRIPTION
Fixes 3 of the 4 **P2** findings in octos-web #245 — the self-contained, active-bug ones. Each is RED→GREEN (failing test written/verified first). The 4th (reconnect `after` cursor) is deferred pending a decision — see below.

## Fixes

**RPC timeout starts at send-time, not enqueue-time** (`ui-protocol-bridge.ts`)
The per-request timer armed in `request()` at enqueue. A turn queued in `sendQueue` while the socket was down burned its timeout budget while parked, so a reconnect slower than `rpcTimeoutMs` rejected it before its frame ever went on the wire. Now `PendingRpc.timer` starts `null` and is armed by `armPendingTimeout` only when the frame is actually sent (immediate send, handshake send, or `flushSendQueue` drain). A never-sent frame still settles via `rejectAllPending` on an abandoned reconnect. *RED+GREEN:* a turn queued during reconnect no longer times out while parked past `rpcTimeoutMs`; it flushes on reconnect and resolves.

**Silence superseded WebSockets on reconnect** (`ui-protocol-bridge.ts`)
A reconnect (or visibility-driven reopen bypassing `onWsClose`) could leave the prior socket attached — its `onmessage` double-dispatched frames the new socket also replayed, its late `onclose` nulled the live `this.ws` + re-entered `scheduleReconnect`, and its `onopen` clobbered the single-slot keepalive timer. `openSocket` now supersedes the prior socket (`detachSocket` nulls handlers + closes, `cancelKeepalive`), and every new-socket handler is identity-guarded (`if (this.ws !== ws) return`). *RED+GREEN:* a buffered frame on the old socket after reconnect no longer dispatches; the live socket still delivers.

**Isolate recorder chunk buffers per recording** (`chat-thread.tsx`)
The shared `chunksRef` (reset per recording) let a trailing `dataavailable` from a just-stopped recorder push into the NEXT recording's buffer, contaminating its blob. Each `startRecording` now captures a per-recorder `chunks` array; its `onstop` builds only from that. *RED+GREEN:* with a 200-byte chunk in A, A stopped, B started, A's 999-byte trailing chunk delivered late, and B's own 50 bytes, B's blob is 50 bytes (was 1049 under the shared buffer).

## Deferred: reconnect `session/open` sends no `after` cursor

The 4th P2. The server **does** support `after` on `session/open` (`replay_after_with_head`), so passing the last-seen cursor is the "proper" fix. But: (a) there is already a mitigation — on reopen the bridge emits `subReopened`, and the runtime re-fetches `session/hydrate` to recover missed envelopes, so this is not an active data-loss bug today; and (b) the server delivers the cursor replay as separate notifications, which would **double-deliver** against that hydrate refetch unless the runtime's `message_id` dedup is verified to cover it and/or the workaround is reconciled/removed. That's a cross-layer change (bridge + runtime dedup + server delivery-mode) warranting a focused, separately-reviewed follow-up rather than risking a double-delivery regression in this batch.

## Verification
Full web unit suite green: 761 tests / 76 files. `tsc -b` clean, `eslint` clean on the changed files.

Fixes 3 of the 4 P2 checkboxes in #245.

🤖 Generated with [Claude Code](https://claude.com/claude-code)