### PR TITLE
docs: replace Vite template stub with a real README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,73 +1,95 @@
-# React + TypeScript + Vite
+# octos-web
 
-This template provides a minimal setup to get React working in Vite with HMR and some ESLint rules.
+The web client for [octos](https://github.com/octos-org/octos) — a React SPA that talks to an `octos serve` backend over **UI Protocol v1** (JSON-RPC over WebSocket). Chat with your agent, talk to it by voice or video, build slide decks and sites with it, and administer the whole server — from a browser.
 
-Currently, two official plugins are available:
+octos-web is one of two first-party clients for the octos server; the other is [octos-tui](https://github.com/octos-org/octos-tui) for the terminal. Both speak the same protocol.
 
-- [@vitejs/plugin-react](https://github.com/vitejs/vite-plugin-react/blob/main/packages/plugin-react) uses [Babel](https://babeljs.io/) (or [oxc](https://oxc.rs) when used in [rolldown-vite](https://vite.dev/guide/rolldown)) for Fast Refresh
-- [@vitejs/plugin-react-swc](https://github.com/vitejs/vite-plugin-react/blob/main/packages/plugin-react-swc) uses [SWC](https://swc.rs/) for Fast Refresh
+**Stack:** React 19 · TypeScript · Vite 7 · Tailwind CSS 4 · react-router 7 · Vitest + Playwright.
 
-## React Compiler
+## Surfaces
 
-The React Compiler is not enabled on this template because of its impact on dev & build performances. To add it, see [this documentation](https://react.dev/learn/react-compiler/installation).
+| Route | What it is |
+|---|---|
+| `/` | Project launcher — every chat, deck, and site as a project card (Ivory Obsidian design system) |
+| `/home` | Home-assistant standby — clock, weather/news/calendar/photo/smart-home widgets, night mode, wake-word |
+| `/voice` | Voice assistant — on-device VAD, streamed TTS with barge-in, user-selectable voices, live video chat |
+| `/chat` | The chat workbench — streaming turns, tool activity, approvals, file uploads, rich media |
+| `/studio/:projectId` | Studio — three-pane grounded workspace (sources · chat · skills) pinned to a project session |
+| `/slides`, `/slides/:id/present` | Slide-deck gallery, editor, and full-screen present mode |
+| `/sites`, `/sites/:id` | Generated-site gallery and editor with signed previews |
+| `/settings` | Admin dashboard — LLM providers & failover, users, channels, sandbox, tools, system metrics & live logs, server watchdog, skills hub, voice, appearance |
+| `/login` | Email-code login, or password-free solo login against `octos serve --solo` |
 
-## Expanding the ESLint configuration
+## Quickstart
 
-If you are developing a production application, we recommend updating the configuration to enable type-aware lint rules:
+Prereqs: Node 20+, and an octos server.
 
-```js
-export default defineConfig([
-  globalIgnores(['dist']),
-  {
-    files: ['**/*.{ts,tsx}'],
-    extends: [
-      // Other configs...
+```bash
+# 1. Run the backend on :50080 (from the octos repo)
+octos serve                 # or: octos serve --solo   (password-free local login)
 
-      // Remove tseslint.configs.recommended and replace with this
-      tseslint.configs.recommendedTypeChecked,
-      // Alternatively, use this for stricter rules
-      tseslint.configs.strictTypeChecked,
-      // Optionally, add this for stylistic rules
-      tseslint.configs.stylisticTypeChecked,
-
-      // Other configs...
-    ],
-    languageOptions: {
-      parserOptions: {
-        project: ['./tsconfig.node.json', './tsconfig.app.json'],
-        tsconfigRootDir: import.meta.dirname,
-      },
-      // other options...
-    },
-  },
-])
+# 2. Run the web client
+npm ci
+npm run dev                 # Vite dev server on http://localhost:5173
 ```
 
-You can also install [eslint-plugin-react-x](https://github.com/Rel1cx/eslint-react/tree/main/packages/plugins/eslint-plugin-react-x) and [eslint-plugin-react-dom](https://github.com/Rel1cx/eslint-react/tree/main/packages/plugins/eslint-plugin-react-dom) for React-specific lint rules:
+The dev server proxies `/api` (including the WebSocket upgrade) to `http://localhost:50080`, so the app is same-origin out of the box. Sign in with an email code, or one click on the solo button when the server runs `--solo`.
 
-```js
-// eslint.config.js
-import reactX from 'eslint-plugin-react-x'
-import reactDom from 'eslint-plugin-react-dom'
+`predev` copies the VAD/onnx wasm assets (`scripts/copy-vad-assets.mjs`) — it runs automatically before `dev` and `build`.
 
-export default defineConfig([
-  globalIgnores(['dist']),
-  {
-    files: ['**/*.{ts,tsx}'],
-    extends: [
-      // Other configs...
-      // Enable lint rules for React
-      reactX.configs['recommended-typescript'],
-      // Enable lint rules for React DOM
-      reactDom.configs.recommended,
-    ],
-    languageOptions: {
-      parserOptions: {
-        project: ['./tsconfig.node.json', './tsconfig.app.json'],
-        tsconfigRootDir: import.meta.dirname,
-      },
-      // other options...
-    },
-  },
-])
+## Build, lint, test
+
+```bash
+npm run build          # tsc -b && vite build  → dist/
+npm run preview        # serve the production build locally
+npm run lint           # eslint
+
+npm run test:unit      # Vitest unit suite (~800 tests, jsdom, no server needed)
+npm test               # Playwright e2e — needs the app + a LIVE octos server
+npm run test:live:smoke   # fast live smoke subset
+npm run test:live:long    # long-running live scenarios (deep research, TTS)
 ```
+
+The unit suite is the merge gate. Playwright specs (in `tests/`) drive a real browser against `http://localhost:5174` and exercise live server behavior — run them when touching transport, voice, or session flows.
+
+## How it connects
+
+- **Transport** — `src/runtime/ui-protocol-bridge.ts`: a strict, fail-closed JSON-RPC bridge over WebSocket at `/api/ui-protocol/ws`. Reconnects with exponential backoff, resumes with an `after` cursor + `session/hydrate`, and queues outbound RPCs while offline. This is the *only* chat transport (the legacy SSE/REST bridge is gone).
+- **Events → state** — `src/runtime/ui-protocol-event-router.ts` routes typed notifications (`message/delta`, `message/persisted`, `turn/spawn_complete`, `tool/*`, approvals, …) into `src/store/thread-store.ts`, the single source of truth keyed by `client_message_id`. A pure projection layer (`src/store/projection.ts`, envelopes → view-model) runs behind the `octos_projection_v1` flag.
+- **Auth** — session token (`octos_session_token`) and optional admin token in localStorage; the WS handshake carries the token as a query parameter.
+
+The protocol contract lives in the octos repo (`crates/octos-core/src/ui_protocol.rs` and the API docs). Server merges do not wait for client releases — the spec is the contract.
+
+## Configuration
+
+| Env var | Purpose |
+|---|---|
+| `BASE_URL` | Vite base path for subpath deploys (e.g. `/octos-web/`) |
+| `VITE_SKIP_AUTH` | Skip the auth guard — static/demo deploys only |
+| `VITE_PUBLIC_API_ORIGIN` | Absolute API origin when not same-origin |
+| `VITE_WEBHOOK_ORIGIN` | Origin shown for channel webhook URLs |
+| `VITE_SMART_HOME_API_BASE` | Smart-home widget backend (dev proxy: `/smart-home-api` → `:8787`) |
+
+## Deploying
+
+- **Static canary** — `.github/workflows/deploy.yml` publishes the app to GitHub Pages (`BASE_URL=/octos-web/`, SPA `404.html` fallback) with auth skipped, plus the `book/` mdBook of sample research reports under `/book`.
+- **Production** — build with `npm run build` and serve `dist/` from any static host or reverse proxy in front of `octos serve` (the octos repo's deploy docs cover the fleet setup). The app is a pure static bundle; all state lives in the server.
+
+## Repository layout
+
+```
+src/
+  runtime/     UI Protocol bridge, event router, runtime provider
+  store/       thread-store, projection, voice/task/file/content/project stores
+  components/  chat workbench, thread, composer, media
+  home/        home-assistant surface, widget registry, voice assistant
+  studio/      three-pane studio workspace
+  settings/    admin dashboard tabs
+  slides/  sites/  pages/  remaining surface modules
+tests/         Playwright e2e specs
+book/          mdBook sample reports (published to /book)
+```
+
+## License
+
+MIT — see [LICENSE](LICENSE).

--- a/README.md
+++ b/README.md
@@ -65,14 +65,17 @@ The protocol contract lives in the octos repo (`crates/octos-core/src/ui_protoco
 | Env var | Purpose |
 |---|---|
 | `BASE_URL` | Vite base path for subpath deploys (e.g. `/octos-web/`) |
-| `VITE_SKIP_AUTH` | Skip the auth guard — static/demo deploys only |
-| `VITE_PUBLIC_API_ORIGIN` | Absolute API origin when not same-origin |
-| `VITE_WEBHOOK_ORIGIN` | Origin shown for channel webhook URLs |
+| `VITE_SKIP_AUTH` | Build-time: skip the auth guard — static/demo builds only |
+| `VITE_WEBHOOK_ORIGIN` / `VITE_PUBLIC_API_ORIGIN` | Origin used when displaying channel webhook URLs in settings (fallback order) |
 | `VITE_SMART_HOME_API_BASE` | Smart-home widget backend (dev proxy: `/smart-home-api` → `:8787`) |
+
+API and WebSocket traffic is always **same-origin** (`/api/...`) — serve the
+bundle behind the same host as `octos serve` (or a reverse proxy to it);
+there is no env var that repoints the API.
 
 ## Deploying
 
-- **Static canary** — `.github/workflows/deploy.yml` publishes the app to GitHub Pages (`BASE_URL=/octos-web/`, SPA `404.html` fallback) with auth skipped, plus the `book/` mdBook of sample research reports under `/book`.
+- **Static canary** — `.github/workflows/deploy.yml` publishes the app to GitHub Pages (`BASE_URL=/octos-web/`, SPA `404.html` fallback), plus the `book/` mdBook of sample research reports under `/book`. The workflow does not set `VITE_SKIP_AUTH`, so the Pages build still shows the login screen; export it yourself for an auth-free demo build.
 - **Production** — build with `npm run build` and serve `dist/` from any static host or reverse proxy in front of `octos serve` (the octos repo's deploy docs cover the fleet setup). The app is a pure static bundle; all state lives in the server.
 
 ## Repository layout


### PR DESCRIPTION
The README was still the \`npm create vite\` boilerplate from the 2026-03-15 initial commit — 352 commits later it described nothing about the app.

Full rewrite covering:
- **What it is**: the UI Protocol v1 web client for [octos](https://github.com/octos-org/octos); cross-links octos-tui as the sibling client
- **Surfaces table**: `/` launcher · `/home` assistant · `/voice` · `/chat` · `/studio/:id` (Ivory Obsidian, #247) · `/slides` · `/sites` · `/settings` · `/login`
- **Quickstart**: `octos serve` on :50080 (or `--solo`) + `npm run dev` (:5173 proxy, predev VAD assets)
- **Build/test**: vitest unit gate (~800 tests) vs Playwright live suites (:5174)
- **Architecture**: bridge (fail-closed WS JSON-RPC, reconnect + after-cursor + hydrate) → event router → thread-store/projection
- **Config/deploy**: env-var table; GH-Pages canary vs static production build
- License corrected to the actual MIT LICENSE file

Every claim verified against the tree (routes from `src/App.tsx`, proxy from `vite.config.ts`, scripts from `package.json`, ports from `playwright.config.ts`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)