### PR TITLE
fix: send after-cursor on reconnect session/open + lossless mid-turn replay (#245 P2 #4)

### DIFF
--- a/src/runtime/ui-protocol-bridge.test.ts
+++ b/src/runtime/ui-protocol-bridge.test.ts
@@ -2445,6 +2445,88 @@ describe("rpc correlation", () => {
     await Promise.resolve();
     expect(deltas).toHaveLength(1);
   });
+
+  it("sends the last-seen cursor as `after` on reopen, but not on the initial open", async () => {
+    // #245 P2: the initial session/open is cursorless (server serves live /
+    // full snapshot); a REOPEN sends `after` = the highest durable cursor
+    // seen, so the server replays only the disconnect gap.
+    vi.useFakeTimers();
+    const bridge = createUiProtocolBridge(makeBridgeOpts());
+    void bridge.start({ sessionId: "sess-1" });
+    await Promise.resolve();
+    const ws1 = lastInstance();
+    ws1.triggerOpen();
+    await Promise.resolve();
+    const open1 = findRequest(ws1, METHODS.SESSION_OPEN);
+    // The initial open must NOT carry `after`.
+    expect((open1.params as Record<string, unknown>).after).toBeUndefined();
+    // Ack seeds the cursor from the server's authoritative head.
+    ws1.triggerMessage({
+      jsonrpc: "2.0",
+      id: open1.id,
+      result: { opened: { session_id: "sess-1", cursor: { stream: "sess-1", seq: 5 } } },
+    });
+    await Promise.resolve();
+
+    // A durable frame advances the cursor to seq 18.
+    ws1.triggerMessage({
+      jsonrpc: "2.0",
+      method: METHODS.MESSAGE_PERSISTED,
+      params: {
+        session_id: "sess-1",
+        turn_id: "t1",
+        thread_id: "th1",
+        seq: 18,
+        role: "assistant",
+        message_id: "m1",
+        source: "assistant",
+        cursor: { stream: "sess-1", seq: 18 },
+        persisted_at: "2026-05-04T00:00:00Z",
+        text: "hello",
+      },
+    });
+    await Promise.resolve();
+
+    // Reconnect → the reopen's session/open must carry after = {sess-1, 18}.
+    ws1.triggerClose(1006, "abnormal");
+    await vi.advanceTimersByTimeAsync(1000);
+    const ws2 = lastInstance();
+    expect(ws2).not.toBe(ws1);
+    ws2.triggerOpen();
+    await Promise.resolve();
+    const open2 = findRequest(ws2, METHODS.SESSION_OPEN);
+    expect((open2.params as Record<string, unknown>).after).toEqual({
+      stream: "sess-1",
+      seq: 18,
+    });
+  });
+
+  it("seeds the reopen `after` from the open ack even with no durable frames", async () => {
+    // #245 P2: even a session that saw no cursor-bearing live frames still
+    // has an `after` for its next reopen — seeded from the open ack's head.
+    vi.useFakeTimers();
+    const bridge = createUiProtocolBridge(makeBridgeOpts());
+    void bridge.start({ sessionId: "sess-1" });
+    await Promise.resolve();
+    const ws1 = lastInstance();
+    ws1.triggerOpen();
+    await Promise.resolve();
+    ws1.triggerMessage({
+      jsonrpc: "2.0",
+      id: findRequest(ws1, METHODS.SESSION_OPEN).id,
+      result: { opened: { session_id: "sess-1", cursor: { stream: "sess-1", seq: 3 } } },
+    });
+    await Promise.resolve();
+
+    ws1.triggerClose(1006, "abnormal");
+    await vi.advanceTimersByTimeAsync(1000);
+    const ws2 = lastInstance();
+    ws2.triggerOpen();
+    await Promise.resolve();
+    expect(
+      (findRequest(ws2, METHODS.SESSION_OPEN).params as Record<string, unknown>).after,
+    ).toEqual({ stream: "sess-1", seq: 3 });
+  });
 });
 
 // ---------------------------------------------------------------------------

--- a/src/runtime/ui-protocol-bridge.test.ts
+++ b/src/runtime/ui-protocol-bridge.test.ts
@@ -2501,6 +2501,59 @@ describe("rpc correlation", () => {
     });
   });
 
+  it("a bridge restarted for another session does not send the stale cursor", async () => {
+    // #245 P2 (codex): `lastCursor` must not survive start → stop → start.
+    // The server rejects an `after` whose stream doesn't match the session
+    // (cursor_stream_mismatch), so a reused bridge would wedge its reopen.
+    vi.useFakeTimers();
+    const bridge = createUiProtocolBridge(makeBridgeOpts());
+    void bridge.start({ sessionId: "sess-1" });
+    await Promise.resolve();
+    const ws1 = lastInstance();
+    ws1.triggerOpen();
+    await Promise.resolve();
+    ws1.triggerMessage({
+      jsonrpc: "2.0",
+      id: findRequest(ws1, METHODS.SESSION_OPEN).id,
+      result: { opened: { session_id: "sess-1", cursor: { stream: "sess-1", seq: 42 } } },
+    });
+    await Promise.resolve();
+    await bridge.stop();
+
+    // Restart the SAME instance on a different session. Its open ack seeds a
+    // LOWER seq than the stale sess-1 cursor (42) — the max-seq comparison
+    // alone would keep the stale one.
+    void bridge.start({ sessionId: "sess-2" });
+    await Promise.resolve();
+    const ws2 = lastInstance();
+    ws2.triggerOpen();
+    await Promise.resolve();
+    const open2 = findRequest(ws2, METHODS.SESSION_OPEN);
+    expect((open2.params as Record<string, unknown>).session_id).toBe("sess-2");
+    // Fresh lifecycle → no `after` on its initial open (and never sess-1's).
+    expect((open2.params as Record<string, unknown>).after).toBeUndefined();
+    ws2.triggerMessage({
+      jsonrpc: "2.0",
+      id: open2.id,
+      result: { opened: { session_id: "sess-2", cursor: { stream: "sess-2", seq: 3 } } },
+    });
+    await Promise.resolve();
+
+    // The restarted lifecycle's REOPEN must send sess-2's cursor — never the
+    // higher-seq sess-1 leftover (the server would reject the stream
+    // mismatch and wedge the reconnect).
+    ws2.triggerClose(1006, "abnormal");
+    await vi.advanceTimersByTimeAsync(1000);
+    const ws3 = lastInstance();
+    ws3.triggerOpen();
+    await Promise.resolve();
+    const open3 = findRequest(ws3, METHODS.SESSION_OPEN);
+    expect((open3.params as Record<string, unknown>).after).toEqual({
+      stream: "sess-2",
+      seq: 3,
+    });
+  });
+
   it("seeds the reopen `after` from the open ack even with no durable frames", async () => {
     // #245 P2: even a session that saw no cursor-bearing live frames still
     // has an `after` for its next reopen — seeded from the open ack's head.

--- a/src/runtime/ui-protocol-bridge.ts
+++ b/src/runtime/ui-protocol-bridge.ts
@@ -1718,6 +1718,12 @@ class UiProtocolBridgeImpl implements UiProtocolBridge {
     this.visibilityReconnectInFlight = false;
     this.hasEverOpened = false;
     this.authExpiredDispatched = false;
+    // #245 P2 (codex): a bridge reused via start → stop → start must not
+    // carry the previous lifecycle's cursor — the server rejects an `after`
+    // whose stream doesn't match the (new) session, and a same-session
+    // restart wants the fresh open ack to reseed. `advanceCursor` also
+    // replaces on stream change as a second line of defense.
+    this.lastCursor = null;
     this.installVisibilityListener();
     await this.openSocket();
   }
@@ -2302,7 +2308,14 @@ class UiProtocolBridgeImpl implements UiProtocolBridge {
     ) {
       return;
     }
-    if (this.lastCursor === null || seq > this.lastCursor.seq) {
+    if (
+      this.lastCursor === null ||
+      // A different stream means a different session/topic scope (one
+      // monotonic stream per session) — replace outright rather than
+      // comparing seqs across unrelated streams (#245 P2, codex).
+      this.lastCursor.stream !== stream ||
+      seq > this.lastCursor.seq
+    ) {
       this.lastCursor = { stream, seq };
     }
   }

--- a/src/runtime/ui-protocol-bridge.ts
+++ b/src/runtime/ui-protocol-bridge.ts
@@ -53,6 +53,7 @@ import type {
   TurnStartInput,
   TurnStartResult,
   TurnStartedEvent,
+  UiCursor,
   UiProgressMetadata,
   UiRetryBackoff,
   UiTokenCostUpdate,
@@ -1466,6 +1467,17 @@ class UiProtocolBridgeImpl implements UiProtocolBridge {
    *  resets the flag in `onWsOpen`) or fails (the bounded reconnect
    *  loop takes over and eventually re-latches the abandonment). */
   private visibilityReconnectInFlight = false;
+  /** #245 P2: the highest durable ledger cursor we have seen for this
+   *  session — seeded from the `session/open` ack's `opened.cursor` and
+   *  advanced by the cursor-bearing live frames (`message/persisted`,
+   *  `turn/completed`, `turn/spawn_complete`). Sent back as `after` on a
+   *  REOPEN so the server replays only what happened during the gap
+   *  (`replay_after_with_head`), instead of the reconnect relying solely on
+   *  a full `session/hydrate` refetch. One monotonic stream per session, so
+   *  the highest `seq` wins. Null until the first open acks — a cursorless
+   *  open is "live only / full snapshot" server-side, which is exactly what
+   *  the initial open wants. */
+  private lastCursor: UiCursor | null = null;
   /** Issue #137: bound visibilitychange listener. Stashed so `stop()`
    *  can remove it; React strict-mode and SPA session-switch flows
    *  call start() → stop() → start() back-to-back. */
@@ -2090,13 +2102,28 @@ class UiProtocolBridgeImpl implements UiProtocolBridge {
         session_id: this.requireSessionId(),
       };
       if (this.profileId) params.profile_id = this.profileId;
+      // #245 P2: on a REOPEN (not the initial open), ask the server to replay
+      // everything after the last durable cursor we saw, so events emitted
+      // during the disconnect stream back through the normal live path. The
+      // initial open sends no `after` — a cursorless open is "live only /
+      // full snapshot" server-side. `hasEverOpened` is still the pre-open
+      // value here (it flips after the ack below).
+      if (this.hasEverOpened && this.lastCursor !== null) {
+        params.after = this.lastCursor;
+      }
       // session/open is the lifecycle gate: state stays at `connecting`
       // until the server acks. Failure here forces a reconnect so the next
       // attempt re-runs the handshake with a fresh socket.
-      await this.request<SessionOpenResult>(METHODS.SESSION_OPEN, params, {
-        bypassQueue: true,
-      });
+      const openResult = await this.request<SessionOpenResult>(
+        METHODS.SESSION_OPEN,
+        params,
+        { bypassQueue: true },
+      );
       if (this.stopped) return;
+      // Seed/advance the cursor from the open ack — the server stamps
+      // `opened.cursor` with the authoritative head, so even a session with
+      // no cursor-bearing live frames yet has an `after` for its next reopen.
+      this.advanceCursor(openResult?.opened?.cursor);
       this.reconnectAttempts = 0;
       this.reconnectAbandoned = false;
       // Issue #137: a successful (re)open clears the latch reason and
@@ -2253,6 +2280,31 @@ class UiProtocolBridgeImpl implements UiProtocolBridge {
       return;
     }
     handler.emit(result);
+    // #245 P2: advance the reconnect cursor from any cursor-bearing frame
+    // (message/persisted, turn/completed, turn/spawn_complete). Deltas carry
+    // no cursor, so this tracks the last DURABLE position — exactly what the
+    // server's `after` replay filters on (`entry.seq > after.seq`).
+    this.advanceCursor((result as { cursor?: unknown }).cursor);
+  }
+
+  /** Advance `lastCursor` to the highest durable ledger position seen
+   *  (#245 P2). Ignores malformed cursors and any that don't move forward;
+   *  a single monotonic stream per session means the highest `seq` wins. */
+  private advanceCursor(cursor: unknown): void {
+    if (!isPlainObject(cursor)) return;
+    const { stream, seq } = cursor as { stream?: unknown; seq?: unknown };
+    if (
+      typeof stream !== "string" ||
+      stream.length === 0 ||
+      typeof seq !== "number" ||
+      !Number.isFinite(seq) ||
+      seq < 0
+    ) {
+      return;
+    }
+    if (this.lastCursor === null || seq > this.lastCursor.seq) {
+      this.lastCursor = { stream, seq };
+    }
   }
 
   private onWsError(): void {

--- a/src/runtime/ui-protocol-event-router.test.ts
+++ b/src/runtime/ui-protocol-event-router.test.ts
@@ -14,6 +14,13 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
 import * as ThreadStore from "@/store/thread-store";
 import {
+  __resetProjectionForTests,
+  __setProjectionV1ForTests,
+  getEnvelopes,
+  projectionStoreKey,
+} from "@/store/projection-store";
+import { project } from "@/store/projection";
+import {
   __resetRouterStateForTest,
   __resetTurnMetaForTest,
   attachRouter,
@@ -73,6 +80,8 @@ afterEach(() => {
   ThreadStore.__resetForTests();
   __resetRouterStateForTest();
   __resetTurnMetaForTest();
+  __setProjectionV1ForTests(false);
+  __resetProjectionForTests();
 });
 
 describe("router event mapping", () => {
@@ -293,6 +302,45 @@ describe("router event mapping", () => {
     // finalized thread drops late tokens via the ordinary phantom-chunk
     // guard, same as any completed turn.
     expect(thread.suppressDeltasUntilDurable).toBeFalsy();
+  });
+
+  it("frozen promotion does not corrupt projection-mode text (codex fold 3)", () => {
+    // With octos_projection_v1 on, `replaceAssistantText` dual-writes an
+    // appended `assistant_delta` — on top of the pre-freeze delta already in
+    // the projection log that projected "partial anspartial answer…", and
+    // nothing overwrote it afterwards. The frozen branch must emit the
+    // replacement as `assistant_persisted` (overwrite semantics) instead.
+    __setProjectionV1ForTests(true);
+    const cmid = "cmid-frozen-projection";
+    seedThread(cmid, "ask");
+    ThreadStore.appendAssistantToken(cmid, "partial ans"); // pre-freeze delta
+    ThreadStore.suppressPendingDeltasForReplay(SESSION);
+    handleMessagePersisted(
+      { sessionId: SESSION },
+      {
+        session_id: SESSION,
+        turn_id: cmid,
+        thread_id: cmid,
+        seq: 61,
+        role: "assistant",
+        message_id: "msg-frozen-proj",
+        source: "assistant",
+        cursor: { stream: SESSION, seq: 61 },
+        persisted_at: "2026-07-08T00:00:00Z",
+        content: "partial answer continues to the real end.",
+      },
+    );
+    // Legacy store finalized canonically…
+    const [thread] = ThreadStore.getThreads(SESSION);
+    expect(thread.responses[0].text).toBe(
+      "partial answer continues to the real end.",
+    );
+    // …and the projection agrees (no "partial anspartial answer…" concat).
+    const vm = project(getEnvelopes(projectionStoreKey(SESSION)));
+    const projThread = vm.threads.find((t) => t.thread_id === cmid);
+    expect(projThread?.assistant?.text).toBe(
+      "partial answer continues to the real end.",
+    );
   });
 
   it("message/persisted (assistant, no media, empty pending) leaves pending alive for the late delta", () => {

--- a/src/runtime/ui-protocol-event-router.test.ts
+++ b/src/runtime/ui-protocol-event-router.test.ts
@@ -250,6 +250,51 @@ describe("router event mapping", () => {
     expect(thread.responses[0].historySeq).toBe(50);
   });
 
+  it("tryPromote replaces a replay-frozen pending with the wire content", () => {
+    // #245 P2 (codex fold 2): after a mid-turn reconnect the store freezes
+    // the pending's delta stream (replayed deltas have no identity), so its
+    // text is known-stale. "Streamed text is authoritative" must NOT apply —
+    // pre-fix, promotion finalised the truncated pre-reconnect partial and
+    // the canonical wire content was discarded.
+    const cmid = "cmid-frozen-promote";
+    seedThread(cmid, "ask");
+    ThreadStore.appendAssistantToken(cmid, "partial ans");
+    // Mid-turn reconnect: the runtime freezes threads with in-flight text.
+    ThreadStore.suppressPendingDeltasForReplay(SESSION);
+    // New deltas streamed during/after the gap are dropped by the freeze…
+    ThreadStore.appendAssistantToken(cmid, "wer continues");
+    expect(ThreadStore.getThreads(SESSION)[0].pendingAssistant?.text).toBe(
+      "partial ans",
+    );
+    // …and the durable persisted row carries the canonical full text.
+    handleMessagePersisted(
+      { sessionId: SESSION },
+      {
+        session_id: SESSION,
+        turn_id: cmid,
+        thread_id: cmid,
+        seq: 51,
+        role: "assistant",
+        message_id: "msg-frozen",
+        source: "assistant",
+        cursor: { stream: SESSION, seq: 51 },
+        persisted_at: "2026-07-08T00:00:00Z",
+        content: "partial answer continues to the real end.",
+      },
+    );
+    const [thread] = ThreadStore.getThreads(SESSION);
+    expect(thread.pendingAssistant).toBeNull(); // finalised
+    expect(thread.responses).toHaveLength(1);
+    // The canonical wire content wins over the frozen stale partial.
+    expect(thread.responses[0].text).toBe(
+      "partial answer continues to the real end.",
+    );
+    // Freeze lifted by the durable frame (finalize cleared the flag); the
+    // finalized thread drops late tokens via the ordinary phantom-chunk
+    // guard, same as any completed turn.
+    expect(thread.suppressDeltasUntilDurable).toBeFalsy();
+  });
+
   it("message/persisted (assistant, no media, empty pending) leaves pending alive for the late delta", () => {
     // M10 Phase 5b empty-placeholder fix: when an assistant
     // `message/persisted` lands BEFORE the streamed `message/delta`

--- a/src/runtime/ui-protocol-event-router.test.ts
+++ b/src/runtime/ui-protocol-event-router.test.ts
@@ -328,6 +328,7 @@ describe("router event mapping", () => {
         cursor: { stream: SESSION, seq: 61 },
         persisted_at: "2026-07-08T00:00:00Z",
         content: "partial answer continues to the real end.",
+        media: ["/files/chart.png"],
       },
     );
     // Legacy store finalized canonically…
@@ -341,6 +342,9 @@ describe("router event mapping", () => {
     expect(projThread?.assistant?.text).toBe(
       "partial answer continues to the real end.",
     );
+    // Media-bearing persisted rows keep their file association in the
+    // projection (codex fold 4) — like the normal persisted-row shim.
+    expect(projThread?.assistant?.meta?.media).toEqual(["/files/chart.png"]);
   });
 
   it("message/persisted (assistant, no media, empty pending) leaves pending alive for the late delta", () => {

--- a/src/runtime/ui-protocol-event-router.ts
+++ b/src/runtime/ui-protocol-event-router.ts
@@ -462,8 +462,18 @@ function tryPromotePendingFromPersisted(
   // Phase 5b empty-placeholder fix's intent — keep the bubble alive
   // until something renders — while shortcutting the "delta never
   // shows up" failure mode now that the wire carries text directly.
+  //
+  // #245 P2 (codex fold 2): EXCEPT for a thread frozen by the
+  // post-reopen delta suppression. Its pending text is known-stale —
+  // deltas were deliberately dropped after the reconnect — so here the
+  // wire content is the authoritative text and must REPLACE the frozen
+  // partial before finalisation ("streamed text is authoritative" only
+  // holds when the stream was actually applied). Without this, the
+  // durable frame finalises the truncated pre-reconnect text.
   const wireContent = (event.content ?? "").trim();
-  if (
+  if (thread.suppressDeltasUntilDurable && wireContent.length > 0) {
+    ThreadStore.replaceAssistantText(threadId, event.content ?? "");
+  } else if (
     thread.pendingAssistant.text.trim().length === 0 &&
     wireContent.length > 0
   ) {

--- a/src/runtime/ui-protocol-event-router.ts
+++ b/src/runtime/ui-protocol-event-router.ts
@@ -472,7 +472,17 @@ function tryPromotePendingFromPersisted(
   // durable frame finalises the truncated pre-reconnect text.
   const wireContent = (event.content ?? "").trim();
   if (thread.suppressDeltasUntilDurable && wireContent.length > 0) {
-    ThreadStore.replaceAssistantText(threadId, event.content ?? "");
+    // Projection-safe variant (codex fold 3): `replaceAssistantText`
+    // would dual-write the replacement as an appended `assistant_delta`
+    // and corrupt projection-mode text on top of the pre-freeze delta.
+    ThreadStore.replaceFrozenPendingFromPersisted(
+      threadId,
+      event.content ?? "",
+      {
+        messageId: event.message_id,
+        persistedAt: event.persisted_at,
+      },
+    );
   } else if (
     thread.pendingAssistant.text.trim().length === 0 &&
     wireContent.length > 0

--- a/src/runtime/ui-protocol-event-router.ts
+++ b/src/runtime/ui-protocol-event-router.ts
@@ -481,6 +481,7 @@ function tryPromotePendingFromPersisted(
       {
         messageId: event.message_id,
         persistedAt: event.persisted_at,
+        media: eventMedia,
       },
     );
   } else if (

--- a/src/runtime/ui-protocol-runtime.test.ts
+++ b/src/runtime/ui-protocol-runtime.test.ts
@@ -39,6 +39,7 @@ import {
   startBridgeForSession,
   stopActiveBridge,
 } from "./ui-protocol-runtime";
+import * as ThreadStore from "@/store/thread-store";
 import type { UiProtocolBridge } from "./ui-protocol-bridge";
 import type { ConnectionState } from "./ui-protocol-types";
 
@@ -151,6 +152,7 @@ beforeEach(() => {
 
 afterEach(() => {
   __resetUiProtocolRuntimeForTest();
+  ThreadStore.__resetForTests();
 });
 
 describe("startBridgeForSession race safety", () => {
@@ -340,6 +342,37 @@ describe("reload-bug fix: re-hydrate session on WS reconnect", () => {
       .mock.calls;
     expect(calls[0]).toEqual([["messages"]]);
     expect(calls[1]).toEqual([["messages"]]);
+  });
+
+  it("clears in-flight streamed text on reopen so the after-replay rebuilds it once", async () => {
+    // #245 P2: the bridge sends an `after` cursor on reopen, so the server
+    // replays the disconnect gap as live frames — including message/delta,
+    // which the client does not dedup. The runtime must clear the pending
+    // streamed text on reopen so the replayed deltas rebuild it once instead
+    // of doubling ("partial" -> "partialpartial").
+    const a = makeDeferredBridge();
+    createBridgeSpy.mockReturnValueOnce(a.bridge);
+    const startA = startBridgeForSession("sess-A");
+    a.resolveStart();
+    await startA;
+    a.setConnected();
+    await Promise.resolve();
+    await Promise.resolve();
+
+    // A turn is mid-stream when the socket drops: pending holds partial text.
+    ThreadStore.addUserMessage("sess-A", { text: "hi", clientMessageId: "cmid-1" });
+    ThreadStore.appendAssistantToken("cmid-1", "partial");
+    expect(ThreadStore.getThreads("sess-A")[0].pendingAssistant?.text).toBe(
+      "partial",
+    );
+
+    // Post-reconnect session/open ack → runtime resets the streamed text.
+    a.fireReopened();
+    await Promise.resolve();
+    const pending = ThreadStore.getThreads("sess-A")[0].pendingAssistant;
+    expect(pending?.text).toBe("");
+    // Slot preserved and still streaming (replayed deltas won't be dropped).
+    expect(pending?.status).toBe("streaming");
   });
 
   it("applies the post-reopen hydrate result to ThreadStore for replay dedup", async () => {

--- a/src/runtime/ui-protocol-runtime.test.ts
+++ b/src/runtime/ui-protocol-runtime.test.ts
@@ -344,12 +344,13 @@ describe("reload-bug fix: re-hydrate session on WS reconnect", () => {
     expect(calls[1]).toEqual([["messages"]]);
   });
 
-  it("clears in-flight streamed text on reopen so the after-replay rebuilds it once", async () => {
+  it("freezes in-flight streamed text on reopen so replayed deltas cannot double it", async () => {
     // #245 P2: the bridge sends an `after` cursor on reopen, so the server
     // replays the disconnect gap as live frames — including message/delta,
-    // which the client does not dedup. The runtime must clear the pending
-    // streamed text on reopen so the replayed deltas rebuild it once instead
-    // of doubling ("partial" -> "partialpartial").
+    // which carries no client-side identity. The runtime must freeze the
+    // pending bubble on reopen: text preserved (a clear would truncate when
+    // the replay doesn't cover it — codex review), replayed duplicates
+    // dropped ("partial" must not become "partialpartial").
     const a = makeDeferredBridge();
     createBridgeSpy.mockReturnValueOnce(a.bridge);
     const startA = startBridgeForSession("sess-A");
@@ -366,12 +367,13 @@ describe("reload-bug fix: re-hydrate session on WS reconnect", () => {
       "partial",
     );
 
-    // Post-reconnect session/open ack → runtime resets the streamed text.
+    // Post-reconnect session/open ack → runtime freezes the delta stream.
     a.fireReopened();
     await Promise.resolve();
+    // The replay re-emits the same delta — it must NOT double.
+    ThreadStore.appendAssistantToken("cmid-1", "partial");
     const pending = ThreadStore.getThreads("sess-A")[0].pendingAssistant;
-    expect(pending?.text).toBe("");
-    // Slot preserved and still streaming (replayed deltas won't be dropped).
+    expect(pending?.text).toBe("partial");
     expect(pending?.status).toBe("streaming");
   });
 

--- a/src/runtime/ui-protocol-runtime.ts
+++ b/src/runtime/ui-protocol-runtime.ts
@@ -14,7 +14,10 @@ import {
 } from "./ui-protocol-bridge";
 import type { ConnectionState } from "./ui-protocol-types";
 import { attachRouter, type RouterAttachment } from "./ui-protocol-event-router";
-import { setHydrateSnapshot } from "@/store/thread-store";
+import {
+  resetPendingAssistantForReplay,
+  setHydrateSnapshot,
+} from "@/store/thread-store";
 
 interface ActiveBridge {
   sessionId: string;
@@ -176,6 +179,13 @@ export async function startBridgeForSession(
       // bridge down before publishing its own. Use the same generation
       // guard the initial hydrate uses.
       if (myGeneration !== generation) return;
+      // #245 P2: the bridge now sends an `after` cursor on reopen, so the
+      // server replays the gap as live frames — including `message/delta`,
+      // which has no client dedup. Clear the in-flight streamed text FIRST so
+      // the replayed deltas rebuild the pending bubble once instead of
+      // doubling it. Runs for ALL reopens (topic-scoped bridges included),
+      // unlike the topic-gated hydrate below.
+      resetPendingAssistantForReplay(sessionId, topic);
       runHydrateFor(sessionId, topic, bridge, myGeneration);
     });
   }

--- a/src/runtime/ui-protocol-runtime.ts
+++ b/src/runtime/ui-protocol-runtime.ts
@@ -15,8 +15,8 @@ import {
 import type { ConnectionState } from "./ui-protocol-types";
 import { attachRouter, type RouterAttachment } from "./ui-protocol-event-router";
 import {
-  resetPendingAssistantForReplay,
   setHydrateSnapshot,
+  suppressPendingDeltasForReplay,
 } from "@/store/thread-store";
 
 interface ActiveBridge {
@@ -181,11 +181,12 @@ export async function startBridgeForSession(
       if (myGeneration !== generation) return;
       // #245 P2: the bridge now sends an `after` cursor on reopen, so the
       // server replays the gap as live frames — including `message/delta`,
-      // which has no client dedup. Clear the in-flight streamed text FIRST so
-      // the replayed deltas rebuild the pending bubble once instead of
-      // doubling it. Runs for ALL reopens (topic-scoped bridges included),
-      // unlike the topic-gated hydrate below.
-      resetPendingAssistantForReplay(sessionId, topic);
+      // which has no client-side identity. Freeze each in-flight bubble's
+      // delta stream FIRST (replayed deltas would double it; clearing would
+      // truncate it) — the turn's durable frames deliver canonical text and
+      // lift the freeze. Runs for ALL reopens (topic-scoped bridges
+      // included), unlike the topic-gated hydrate below.
+      suppressPendingDeltasForReplay(sessionId, topic);
       runHydrateFor(sessionId, topic, bridge, myGeneration);
     });
   }

--- a/src/store/thread-store.test.ts
+++ b/src/store/thread-store.test.ts
@@ -124,10 +124,13 @@ describe.each(FLAG_STATES)("thread-store [$label]", ({ projectionV1 }) => {
     expect(thread.pendingAssistant?.text).toBe("Hello, world");
   });
 
-  it("reset_pending_for_replay_clears_streamed_text_so_replayed_deltas_do_not_double", () => {
-    // #245 P2: on a reconnect reopen the server's `after` replay re-emits the
-    // in-flight turn's deltas (no client dedup on message/delta). Clearing the
-    // pending streamed text first lets the replay rebuild it ONCE.
+  it("suppress_pending_deltas_for_replay_freezes_text_until_a_durable_frame", () => {
+    // #245 P2: on a reconnect reopen the server's `after` replay re-emits
+    // deltas with no client-side identity. Appending would double the text;
+    // clearing would truncate it whenever the replay window doesn't reach
+    // back to the earlier deltas (codex review, both directions). The store
+    // freezes the bubble instead: tokens are dropped until a durable frame
+    // (persisted assistant row / finalize) delivers canonical text.
     makeUser("hi", "cmid-1");
     ThreadStore.appendAssistantToken("cmid-1", "Hello");
     ThreadStore.appendAssistantToken("cmid-1", ", world");
@@ -135,18 +138,48 @@ describe.each(FLAG_STATES)("thread-store [$label]", ({ projectionV1 }) => {
       "Hello, world",
     );
 
-    // Mid-turn reconnect: reset clears the streamed text but keeps the slot
-    // streaming (so replayed deltas are not dropped as phantom chunks).
-    ThreadStore.resetPendingAssistantForReplay(SESSION);
-    const afterReset = ThreadStore.getThreads(SESSION)[0].pendingAssistant;
-    expect(afterReset?.text).toBe("");
-    expect(afterReset?.status).toBe("streaming");
-
-    // The server replays the same two deltas → rebuild once, not doubled.
+    // Mid-turn reconnect: the pending text is PRESERVED (not cleared, not
+    // blanked), and replayed duplicate deltas do not double it.
+    ThreadStore.suppressPendingDeltasForReplay(SESSION);
     ThreadStore.appendAssistantToken("cmid-1", "Hello");
     ThreadStore.appendAssistantToken("cmid-1", ", world");
+    const frozen = ThreadStore.getThreads(SESSION)[0].pendingAssistant;
+    expect(frozen?.text).toBe("Hello, world");
+    expect(frozen?.status).toBe("streaming");
+
+    // The durable persisted assistant row lifts the freeze and carries the
+    // canonical full text.
+    ThreadStore.appendPersistedMessage(SESSION, undefined, {
+      role: "assistant",
+      content: "Hello, world — and more streamed during the gap",
+      thread_id: "cmid-1",
+      seq: 7,
+      message_id: "m-canonical",
+      timestamp: new Date().toISOString(),
+    } as never);
+    const thread = ThreadStore.getThreads(SESSION)[0];
+    expect(
+      thread.responses.some((r) =>
+        r.text.includes("more streamed during the gap"),
+      ),
+    ).toBe(true);
+    // Freeze lifted: the still-pending slot streams again.
+    ThreadStore.appendAssistantToken("cmid-1", " tail");
     expect(ThreadStore.getThreads(SESSION)[0].pendingAssistant?.text).toBe(
-      "Hello, world",
+      "Hello, world tail",
+    );
+  });
+
+  it("suppress_without_replay_coverage_does_not_blank_or_truncate_the_bubble", () => {
+    // Codex P2 scenario: a cursorless reopen (or a cursor past this thread's
+    // deltas) replays NOTHING for this thread. The old clear-based approach
+    // left the bubble blank; the freeze must keep the text visible.
+    makeUser("hi", "cmid-1");
+    ThreadStore.appendAssistantToken("cmid-1", "partial answer");
+    ThreadStore.suppressPendingDeltasForReplay(SESSION);
+    // No replay arrives at all — text stays.
+    expect(ThreadStore.getThreads(SESSION)[0].pendingAssistant?.text).toBe(
+      "partial answer",
     );
   });
 

--- a/src/store/thread-store.test.ts
+++ b/src/store/thread-store.test.ts
@@ -124,6 +124,32 @@ describe.each(FLAG_STATES)("thread-store [$label]", ({ projectionV1 }) => {
     expect(thread.pendingAssistant?.text).toBe("Hello, world");
   });
 
+  it("reset_pending_for_replay_clears_streamed_text_so_replayed_deltas_do_not_double", () => {
+    // #245 P2: on a reconnect reopen the server's `after` replay re-emits the
+    // in-flight turn's deltas (no client dedup on message/delta). Clearing the
+    // pending streamed text first lets the replay rebuild it ONCE.
+    makeUser("hi", "cmid-1");
+    ThreadStore.appendAssistantToken("cmid-1", "Hello");
+    ThreadStore.appendAssistantToken("cmid-1", ", world");
+    expect(ThreadStore.getThreads(SESSION)[0].pendingAssistant?.text).toBe(
+      "Hello, world",
+    );
+
+    // Mid-turn reconnect: reset clears the streamed text but keeps the slot
+    // streaming (so replayed deltas are not dropped as phantom chunks).
+    ThreadStore.resetPendingAssistantForReplay(SESSION);
+    const afterReset = ThreadStore.getThreads(SESSION)[0].pendingAssistant;
+    expect(afterReset?.text).toBe("");
+    expect(afterReset?.status).toBe("streaming");
+
+    // The server replays the same two deltas → rebuild once, not doubled.
+    ThreadStore.appendAssistantToken("cmid-1", "Hello");
+    ThreadStore.appendAssistantToken("cmid-1", ", world");
+    expect(ThreadStore.getThreads(SESSION)[0].pendingAssistant?.text).toBe(
+      "Hello, world",
+    );
+  });
+
   it("routes_tool_progress_to_correct_tool_call_via_tool_id", () => {
     makeUser("search", "cmid-1");
     ThreadStore.addToolCall("cmid-1", "tc_a", "deep_search");

--- a/src/store/thread-store.ts
+++ b/src/store/thread-store.ts
@@ -125,6 +125,15 @@ export interface Thread {
   /** In-flight assistant message for the current turn (becomes part of
    *  `responses` when `finalizeAssistant` is called). */
   pendingAssistant: ThreadMessage | null;
+  /** #245 P2: set on a reconnect reopen while this thread had in-flight
+   *  streamed text. While set, `appendAssistantToken` drops tokens for this
+   *  thread — the server's `after` replay re-emits deltas with no client
+   *  identity, so appending would double text, and clearing instead would
+   *  truncate whenever the replay window doesn't reach back to the thread's
+   *  earlier deltas. Freezing the bubble is the only lossless option; the
+   *  turn's durable frames (message/persisted, finalize, spawn-complete)
+   *  deliver the canonical text and clear the flag. */
+  suppressDeltasUntilDurable?: boolean;
 }
 
 // ---------------------------------------------------------------------------
@@ -756,6 +765,16 @@ export function appendAssistantToken(threadId: string, token: string): void {
     });
     return;
   }
+  // #245 P2: post-reopen delta freeze — replayed deltas have no identity,
+  // so until a durable frame re-anchors this thread, appending would
+  // double the text (see `suppressPendingDeltasForReplay`).
+  if (found.thread.suppressDeltasUntilDurable) {
+    recordRuntimeCounter("octos_thread_phantom_chunk_dropped_total", {
+      surface: "thread_store",
+      kind: "replay_suppressed_token",
+    });
+    return;
+  }
   const slot = ensurePendingAssistant(found.thread);
   slot.text += token;
   notify();
@@ -773,40 +792,51 @@ export function appendAssistantToken(threadId: string, token: string): void {
 }
 
 /**
- * #245 P2 (part 2/2): clear the in-flight streamed assistant text on a
- * reconnect REOPEN so the server's `after` replay can rebuild it exactly once.
+ * #245 P2 (part 2/2): freeze in-flight streamed text on a reconnect REOPEN.
  *
- * The bridge now sends an `after` cursor on reopen, so the server replays the
+ * The bridge sends an `after` cursor on reopen, so the server replays the
  * disconnect gap as live-shaped frames. Durable frames dedup on the client
  * (`message/persisted` by seq, `turn/spawn_complete` by message_id) and tool
  * frames are idempotent (`addToolCall` on `(turn_id, tool_call_id)`), but
- * `message/delta` has NO identity dedup — `appendAssistantToken` blindly
- * appends. A mid-turn reconnect would therefore re-stream the already-seen
- * deltas into the surviving `pendingAssistant`, doubling its text
- * ("abc" -> "abcabc"). Clearing just the streamed text (the slot and its tool
- * calls are kept, so the pending stays un-finalized and the phantom-chunk
- * guard does not fire) lets the replayed deltas rebuild it once. If the turn
- * completed during the gap, no deltas replay and the empty pending is
- * finalized by the replayed `turn/completed` / covered by the hydrate refetch.
+ * `message/delta` carries NO identity on the wire — the client cannot tell a
+ * replayed delta from a new one. Appending replayed deltas doubles the text;
+ * clearing the text and rebuilding from the replay truncates it whenever the
+ * replay window does not reach back to the thread's earlier deltas (the
+ * cursor is session-wide, so any durable frame that landed mid-stream —
+ * a tool row, a background spawn-complete — moves it past them; a cursorless
+ * reopen replays nothing at all). Codex review, both directions.
+ *
+ * So: neither append nor clear. Mark each thread that has in-flight streamed
+ * text and DROP its delta tokens (replayed and live alike) until the next
+ * durable frame for that thread — `message/persisted`, `finalizeAssistant`,
+ * or a spawn-complete envelope — which carries the canonical full text and
+ * clears the flag via `clearReplayDeltaSuppression`. The bubble freezes at
+ * its pre-disconnect text instead of doubling, blanking, or truncating, and
+ * snaps to the authoritative text when the turn persists.
  *
  * Runs for EVERY reopen, including topic-scoped bridges (which the hydrate
  * refetch skips) — the bridge sends `after` regardless of topic.
  */
-export function resetPendingAssistantForReplay(
+export function suppressPendingDeltasForReplay(
   sessionId: string,
   topic?: string,
 ): void {
   const state = sessionsByKey.get(storeKey(sessionId, topic));
   if (!state) return;
-  let changed = false;
   for (const thread of state.threads) {
     const pending = thread.pendingAssistant;
     if (pending && pending.text.length > 0) {
-      pending.text = "";
-      changed = true;
+      thread.suppressDeltasUntilDurable = true;
     }
   }
-  if (changed) notify();
+}
+
+/** Lift the post-reopen delta freeze for a thread once a durable frame
+ *  (persisted row, finalize, spawn-complete) has delivered canonical text. */
+function clearReplayDeltaSuppression(thread: Thread): void {
+  if (thread.suppressDeltasUntilDurable) {
+    thread.suppressDeltasUntilDurable = false;
+  }
 }
 
 export function replaceAssistantText(threadId: string, text: string): void {
@@ -1413,6 +1443,10 @@ export function appendCompletionBubble(
     return false;
   }
   const { thread } = host;
+
+  // #245 P2: a spawn-complete envelope is a durable frame — lift the
+  // post-reopen delta freeze for its host thread.
+  clearReplayDeltaSuppression(thread);
 
   // Identity / upgrade-in-place. A replayed envelope on reconnect
   // MUST NOT produce a duplicate row. Two stable identities exist:
@@ -2084,6 +2118,9 @@ export function finalizeAssistant(
     thread.responses.push(finalized);
     sortResponsesInThread(thread);
     thread.pendingAssistant = null;
+    // #245 P2: the turn reached a durable end — lift the post-reopen
+    // delta freeze so the next turn on this thread streams normally.
+    clearReplayDeltaSuppression(thread);
     // WEB-NEW-17: mark the finalised row's seq so a follow-up
     // `message/persisted` with the same seq (re-emitted on reconnect or
     // through `session/hydrate` replay) is suppressed at the dedup gate
@@ -3158,6 +3195,13 @@ export function appendPersistedMessage(
       pendingAssistant: null,
     };
     insertThreadInTimestampOrder(state, thread);
+  }
+
+  // #245 P2: a persisted row IS the durable frame the post-reopen delta
+  // freeze waits for (even when the row dedups below — canonical text is
+  // already present in that case).
+  if (message.role === "assistant") {
+    clearReplayDeltaSuppression(thread);
   }
 
   if (message.role === "user") {

--- a/src/store/thread-store.ts
+++ b/src/store/thread-store.ts
@@ -873,6 +873,56 @@ export function replaceAssistantText(threadId: string, text: string): void {
 }
 
 /**
+ * #245 P2 (codex fold 3): replace a replay-frozen pending's text with the
+ * canonical content of its persisted row — projection-safely.
+ *
+ * `replaceAssistantText` dual-writes its replacement as an `assistant_delta`,
+ * which the projection APPENDS; on the frozen-reconnect path a pre-freeze
+ * delta is already in the projection log, so the append corrupts
+ * projection-mode text ("partial anspartial answer…") and nothing overwrites
+ * it afterwards (`finalizeAssistant` emits only tool_end/turn_completed, and
+ * the promotion path skips `appendPersistedMessage`'s assistant_persisted
+ * emission) — the corruption would be permanent. This variant emits the
+ * replacement as the `assistant_persisted` it actually is: the projection
+ * reducer OVERWRITES `assistantText` on that payload, and the caller's
+ * follow-up `finalizeAssistant` emits `turn_completed`, matching the normal
+ * wire order (persisted → completed).
+ */
+export function replaceFrozenPendingFromPersisted(
+  threadId: string,
+  text: string,
+  meta: { messageId: string; persistedAt: string },
+): void {
+  const found = ensureOrphanThread(threadId);
+  if (!found) return;
+  if (isFinalizedAndIdle(found.thread)) return;
+  const slot = ensurePendingAssistant(found.thread);
+  slot.text = text;
+  notify();
+  if (isProjectionV1Enabled()) {
+    const key = shimResolveKey(threadId);
+    if (key) {
+      // Deliberately uses the shim's contiguous local seq (NOT the wire
+      // seq): the projection buffers out-of-order envelopes per thread,
+      // so a sparse wire seq would park this overwrite in the buffer
+      // forever. Replay dedup is already handled upstream — a re-emitted
+      // persisted row for the same wire seq is dropped by the store's
+      // seq gate before any shim emission happens.
+      shimIngest(key, threadId, {
+        type: "assistant_persisted",
+        data: {
+          text,
+          meta: {
+            message_id: meta.messageId,
+            persisted_at: meta.persistedAt,
+          },
+        },
+      });
+    }
+  }
+}
+
+/**
  * Add or update a tool call on the in-flight assistant bubble.
  *
  * Tool retries collapse: if the most recent toolCall on this thread shares

--- a/src/store/thread-store.ts
+++ b/src/store/thread-store.ts
@@ -891,7 +891,7 @@ export function replaceAssistantText(threadId: string, text: string): void {
 export function replaceFrozenPendingFromPersisted(
   threadId: string,
   text: string,
-  meta: { messageId: string; persistedAt: string },
+  meta: { messageId: string; persistedAt: string; media?: string[] },
 ): void {
   const found = ensureOrphanThread(threadId);
   if (!found) return;
@@ -908,6 +908,7 @@ export function replaceFrozenPendingFromPersisted(
       // forever. Replay dedup is already handled upstream — a re-emitted
       // persisted row for the same wire seq is dropped by the store's
       // seq gate before any shim emission happens.
+      const media = meta.media ?? [];
       shimIngest(key, threadId, {
         type: "assistant_persisted",
         data: {
@@ -915,6 +916,10 @@ export function replaceFrozenPendingFromPersisted(
           meta: {
             message_id: meta.messageId,
             persisted_at: meta.persistedAt,
+            // Mirror the normal persisted-row shim: media-bearing rows
+            // keep their file association in projection mode (codex
+            // fold 4).
+            ...(media.length > 0 ? { media: media.slice() } : {}),
           },
         },
       });

--- a/src/store/thread-store.ts
+++ b/src/store/thread-store.ts
@@ -772,6 +772,43 @@ export function appendAssistantToken(threadId: string, token: string): void {
   }
 }
 
+/**
+ * #245 P2 (part 2/2): clear the in-flight streamed assistant text on a
+ * reconnect REOPEN so the server's `after` replay can rebuild it exactly once.
+ *
+ * The bridge now sends an `after` cursor on reopen, so the server replays the
+ * disconnect gap as live-shaped frames. Durable frames dedup on the client
+ * (`message/persisted` by seq, `turn/spawn_complete` by message_id) and tool
+ * frames are idempotent (`addToolCall` on `(turn_id, tool_call_id)`), but
+ * `message/delta` has NO identity dedup — `appendAssistantToken` blindly
+ * appends. A mid-turn reconnect would therefore re-stream the already-seen
+ * deltas into the surviving `pendingAssistant`, doubling its text
+ * ("abc" -> "abcabc"). Clearing just the streamed text (the slot and its tool
+ * calls are kept, so the pending stays un-finalized and the phantom-chunk
+ * guard does not fire) lets the replayed deltas rebuild it once. If the turn
+ * completed during the gap, no deltas replay and the empty pending is
+ * finalized by the replayed `turn/completed` / covered by the hydrate refetch.
+ *
+ * Runs for EVERY reopen, including topic-scoped bridges (which the hydrate
+ * refetch skips) — the bridge sends `after` regardless of topic.
+ */
+export function resetPendingAssistantForReplay(
+  sessionId: string,
+  topic?: string,
+): void {
+  const state = sessionsByKey.get(storeKey(sessionId, topic));
+  if (!state) return;
+  let changed = false;
+  for (const thread of state.threads) {
+    const pending = thread.pendingAssistant;
+    if (pending && pending.text.length > 0) {
+      pending.text = "";
+      changed = true;
+    }
+  }
+  if (changed) notify();
+}
+
 export function replaceAssistantText(threadId: string, text: string): void {
   const found = ensureOrphanThread(threadId);
   if (!found) return;


### PR DESCRIPTION
The 4th and final P2 from octos-web #245 — deferred from #246 pending cross-layer verification; this is the "proper" version, built after mapping the server's replay delivery and the client's dedup surfaces.

## What it does

**Bridge** — tracks `lastCursor` (highest durable ledger position: seeded from the `session/open` ack, advanced by `message/persisted` / `turn/completed` / `turn/spawn_complete` cursors) and sends it as `after` on every REOPEN. The server replays exactly the disconnect gap (`replay_after_with_head`, `entry.seq > after.seq`) as live-shaped frames. Cursor lifecycle is generation-safe: reset on `start()`, replaced on stream change.

**Mid-turn replay is lossless by design.** `message/delta` frames carry no identity on the wire, so a mid-turn reconnect cannot dedup them: appending replayed deltas doubles the bubble text; clearing-and-rebuilding truncates whenever the session-wide cursor moved past the thread's earlier deltas (any mid-stream durable frame does that; a cursorless reopen replays nothing). Instead the store **freezes** each in-flight bubble on reopen — tokens dropped, text preserved — and the turn's durable frame lifts the freeze with canonical content:
- promotion (`tryPromotePendingFromPersisted`) **replaces** the frozen stale text with the wire content (streamed-text-is-authoritative only holds when the stream was actually applied)
- the replacement reaches the projection as the `assistant_persisted` it is (overwrite semantics, contiguous local seq), not an appended delta — with `media` threaded through

**Kept the hydrate refetch** as the stateless durable safety net — its cross-path dedup (seq-set, message_id) absorbs the durable-frame overlap; only the delta path needed the freeze.

## Codex fold history (each RED-verified with the predicted symptom)
1. P2×2 initial: cursor survived bridge reuse (`sess-1/42` sent as sess-2's `after` → server `cursor_stream_mismatch` wedge); clear-based reset truncated
2. P1: freeze dropped live deltas but promotion finalized the stale partial (`'partial ans'` finalized permanently) → wire-content-wins-over-frozen
3. P2: `replaceAssistantText`'s delta-shaped dual-write corrupted projection-mode text (`partial anspartial answer…`) → `assistant_persisted` overwrite emission
4. P2: media meta dropped in the synthesized envelope → threaded through
5. Final re-review: **clean**

## Verification
815 vitest tests green (80 files), `tsc -b` + eslint clean. Every defense RED-verified by disabling it: stale-cursor leak, `partialpartial` doubling, blank/truncated bubble, projection concat, missing media.

Server contract verified in the octos repo: `handle_session_open` → `send_ledger_event_durable` per replay event; `UiCursor{stream=session_id, seq}` single monotonic stream; `validate_cursor_stream` rejects cross-stream cursors; MessageDelta is ledger-replayed (`ledger_replays_notifications_after_cursor_in_order`).

Closes the last P2 checkbox in #245.

🤖 Generated with [Claude Code](https://claude.com/claude-code)