### PR TITLE
feat(ui): compaction indicator + context.lifecycle.v1 negotiation (UPCR-2026-026)

### DIFF
--- a/src/components/chat-thread.tsx
+++ b/src/components/chat-thread.tsx
@@ -924,9 +924,14 @@ export const ThreadAssistantBubble = memo(function ThreadAssistantBubble({
             `inline-flex` indicator sits cleanly below the tool-card row
             instead of overlapping it (reported on dspfac 2026-05-22:
             "渡劫中…(13s) is overlapped on task status bubble"). */}
+        {/* Mounted OUTSIDE the live-indicators gate: with projection_v1
+            (skipOptimisticUserMessage) the server's preflight compaction
+            events arrive before any live bubble exists — a gated mount
+            would miss the one-shot crew:compaction events entirely. The
+            component renders null when idle. */}
+        <CompactionIndicator />
         {showLiveIndicators && (
           <div className="mt-2 block">
-            <CompactionIndicator />
             <ThinkingIndicator />
           </div>
         )}

--- a/src/components/chat-thread.tsx
+++ b/src/components/chat-thread.tsx
@@ -48,6 +48,7 @@ import { sendMessage as bridgeSend } from "@/runtime/ui-protocol-send";
 import { getActiveBridge } from "@/runtime/ui-protocol-runtime";
 import { MarkdownContent } from "./markdown-renderer";
 import { ThinkingIndicator } from "./thinking-indicator";
+import { CompactionIndicator } from "./compaction-indicator";
 import { ToolProgressIndicator } from "./tool-progress-indicator";
 import { useTasks } from "@/store/task-store";
 import { SPAWN_ONLY_TOOL_NAMES } from "@/runtime/spawn-only-tools";
@@ -925,6 +926,7 @@ export const ThreadAssistantBubble = memo(function ThreadAssistantBubble({
             "渡劫中…(13s) is overlapped on task status bubble"). */}
         {showLiveIndicators && (
           <div className="mt-2 block">
+            <CompactionIndicator />
             <ThinkingIndicator />
           </div>
         )}

--- a/src/components/chat-thread.tsx
+++ b/src/components/chat-thread.tsx
@@ -924,12 +924,6 @@ export const ThreadAssistantBubble = memo(function ThreadAssistantBubble({
             `inline-flex` indicator sits cleanly below the tool-card row
             instead of overlapping it (reported on dspfac 2026-05-22:
             "渡劫中…(13s) is overlapped on task status bubble"). */}
-        {/* Mounted OUTSIDE the live-indicators gate: with projection_v1
-            (skipOptimisticUserMessage) the server's preflight compaction
-            events arrive before any live bubble exists — a gated mount
-            would miss the one-shot crew:compaction events entirely. The
-            component renders null when idle. */}
-        <CompactionIndicator />
         {showLiveIndicators && (
           <div className="mt-2 block">
             <ThinkingIndicator />
@@ -1247,6 +1241,11 @@ function ChatThreadV2({
 
   return (
     <div className="flex h-full min-h-0 flex-col bg-transparent">
+      {/* Mounted ONCE at thread level (codex R3): a per-bubble mount
+          duplicated the listener/timer per assistant message, and with
+          projection_v1 the preflight compaction events can arrive before
+          any bubble exists at all. Renders null when idle. */}
+      <CompactionIndicator />
       {hasThreads || hasGhosts ? (
         <ThreadList
           threads={threads}

--- a/src/components/compaction-indicator.test.tsx
+++ b/src/components/compaction-indicator.test.tsx
@@ -1,0 +1,160 @@
+/**
+ * CompactionIndicator (UPCR-2026-026) — the SPA sibling of octos-tui#253.
+ *
+ * Covers:
+ *  1. `crew:compaction phase:"started"` renders the in-progress block with
+ *     the honest threshold-relative bar + percent.
+ *  2. `phase:"completed"` swaps it for the `before → after` notice and
+ *     auto-clears after the timeout.
+ *  3. Cross-session events are dropped by the scope filter.
+ *  4. Hang safety: a `crew:thinking thinking:false` falling edge clears a
+ *     dangling started-block (lost completed event) but leaves a
+ *     completed notice to its own timer.
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import * as React from "react";
+import { act } from "react";
+import { createRoot, type Root } from "react-dom/client";
+
+(
+  globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }
+).IS_REACT_ACT_ENVIRONMENT = true;
+
+import { CompactionIndicator } from "./compaction-indicator";
+import { progressBar } from "@/lib/progress-bar";
+import { SessionContext } from "@/runtime/session-context";
+import type { SessionContextValue } from "@/runtime/session-context";
+
+const SESSION = "sess-compaction";
+
+function makeSessionCtx(): SessionContextValue {
+  return {
+    sessions: [],
+    currentSessionId: SESSION,
+    historyTopic: undefined,
+    currentSessionTitle: "",
+    currentSessionStats: null,
+    initialMessages: [],
+    activeTaskOnServer: false,
+    queueMode: null,
+    adaptiveMode: null,
+    setServerTaskActive: () => {},
+    renameSession: () => {},
+    updateSessionStats: () => {},
+    switchSession: () => {},
+    goBack: async () => false,
+    createSession: () => SESSION,
+    removeSession: async () => {},
+    refreshSessions: async () => {},
+    markSessionActive: () => {},
+  };
+}
+
+let container: HTMLDivElement;
+let root: Root;
+
+function mount() {
+  container = document.createElement("div");
+  document.body.appendChild(container);
+  root = createRoot(container);
+  act(() => {
+    root.render(
+      <SessionContext.Provider value={makeSessionCtx()}>
+        <CompactionIndicator />
+      </SessionContext.Provider>,
+    );
+  });
+}
+
+function fire(name: string, detail: Record<string, unknown>) {
+  act(() => {
+    window.dispatchEvent(new CustomEvent(name, { detail }));
+  });
+}
+
+beforeEach(() => {
+  vi.useFakeTimers();
+});
+
+afterEach(() => {
+  act(() => {
+    root.unmount();
+  });
+  container.remove();
+  vi.useRealTimers();
+});
+
+describe("CompactionIndicator", () => {
+  it("renders the honest bar on started and the notice on completed", () => {
+    mount();
+    expect(container.querySelector("[data-testid='compaction-indicator']")).toBeNull();
+
+    fire("crew:compaction", {
+      session_id: SESSION,
+      phase: "started",
+      token_estimate: 48000,
+      threshold_tokens: 96000,
+      trigger: "preflight",
+    });
+    const block = container.querySelector("[data-testid='compaction-indicator']");
+    expect(block).not.toBeNull();
+    expect(block!.textContent).toContain("Compacting conversation");
+    expect(block!.textContent).toContain("48.0k tokens");
+    const bar = container.querySelector("[data-testid='compaction-bar']");
+    expect(bar!.textContent).toContain("50% of compact threshold");
+    // 50% of a 40-cell bar = 20 filled.
+    expect(bar!.textContent).toContain("▰".repeat(20) + "▱".repeat(20));
+
+    fire("crew:compaction", {
+      session_id: SESSION,
+      phase: "completed",
+      token_estimate_before: 48000,
+      token_estimate_after: 12000,
+      retained_count: 8,
+      dropped_count: 42,
+      error: null,
+    });
+    const notice = container.querySelector("[data-testid='compaction-indicator']");
+    expect(notice!.textContent).toContain("context compacted 48.0k → 12.0k tokens");
+
+    // Auto-clears after the timeout.
+    act(() => {
+      vi.advanceTimersByTime(9000);
+    });
+    expect(container.querySelector("[data-testid='compaction-indicator']")).toBeNull();
+  });
+
+  it("drops cross-session events", () => {
+    mount();
+    fire("crew:compaction", {
+      session_id: "other-session",
+      phase: "started",
+      token_estimate: 1000,
+      threshold_tokens: 2000,
+      trigger: "preflight",
+    });
+    expect(container.querySelector("[data-testid='compaction-indicator']")).toBeNull();
+  });
+
+  it("clears a dangling started-block on the thinking falling edge", () => {
+    mount();
+    fire("crew:compaction", {
+      session_id: SESSION,
+      phase: "started",
+      token_estimate: 1000,
+      threshold_tokens: 2000,
+      trigger: "preflight",
+    });
+    expect(container.querySelector("[data-testid='compaction-indicator']")).not.toBeNull();
+
+    fire("crew:thinking", { session_id: SESSION, thinking: false });
+    expect(container.querySelector("[data-testid='compaction-indicator']")).toBeNull();
+  });
+
+  it("progressBar clamps and rounds", () => {
+    expect(progressBar(0, 8)).toBe("▱▱▱▱▱▱▱▱");
+    expect(progressBar(0.5, 8)).toBe("▰▰▰▰▱▱▱▱");
+    expect(progressBar(4.2, 8)).toBe("▰▰▰▰▰▰▰▰");
+  });
+});

--- a/src/components/compaction-indicator.test.tsx
+++ b/src/components/compaction-indicator.test.tsx
@@ -159,6 +159,32 @@ describe("CompactionIndicator", () => {
     expect(container!.querySelector("[data-testid='compaction-indicator']")).toBeNull();
   });
 
+  it("clears state when the session scope changes", () => {
+    mount();
+    fire("crew:compaction", {
+      session_id: SESSION,
+      phase: "completed",
+      token_estimate_before: 48000,
+      token_estimate_after: 12000,
+      retained_count: 8,
+      dropped_count: 42,
+      error: null,
+    });
+    expect(container!.querySelector("[data-testid='compaction-indicator']")).not.toBeNull();
+
+    // Re-render under a DIFFERENT session — the notice must not bleed.
+    act(() => {
+      root!.render(
+        <SessionContext.Provider
+          value={{ ...makeSessionCtx(), currentSessionId: "another-session" }}
+        >
+          <CompactionIndicator />
+        </SessionContext.Provider>,
+      );
+    });
+    expect(container!.querySelector("[data-testid='compaction-indicator']")).toBeNull();
+  });
+
   it("progressBar clamps and rounds", () => {
     expect(progressBar(0, 8)).toBe("▱▱▱▱▱▱▱▱");
     expect(progressBar(0.5, 8)).toBe("▰▰▰▰▱▱▱▱");

--- a/src/components/compaction-indicator.test.tsx
+++ b/src/components/compaction-indicator.test.tsx
@@ -51,8 +51,8 @@ function makeSessionCtx(): SessionContextValue {
   };
 }
 
-let container: HTMLDivElement;
-let root: Root;
+let container: HTMLDivElement | null = null;
+let root: Root | null = null;
 
 function mount() {
   container = document.createElement("div");
@@ -78,17 +78,24 @@ beforeEach(() => {
 });
 
 afterEach(() => {
-  act(() => {
-    root.unmount();
-  });
-  container.remove();
+  // Guarded: the pure-utility test never mounts (codex P3 — a solo
+  // `vitest -t progressBar` run would crash cleanup otherwise).
+  if (root) {
+    const mounted = root;
+    act(() => {
+      mounted.unmount();
+    });
+    root = null;
+  }
+  container?.remove();
+  container = null;
   vi.useRealTimers();
 });
 
 describe("CompactionIndicator", () => {
   it("renders the honest bar on started and the notice on completed", () => {
     mount();
-    expect(container.querySelector("[data-testid='compaction-indicator']")).toBeNull();
+    expect(container!.querySelector("[data-testid='compaction-indicator']")).toBeNull();
 
     fire("crew:compaction", {
       session_id: SESSION,
@@ -97,11 +104,11 @@ describe("CompactionIndicator", () => {
       threshold_tokens: 96000,
       trigger: "preflight",
     });
-    const block = container.querySelector("[data-testid='compaction-indicator']");
+    const block = container!.querySelector("[data-testid='compaction-indicator']");
     expect(block).not.toBeNull();
     expect(block!.textContent).toContain("Compacting conversation");
     expect(block!.textContent).toContain("48.0k tokens");
-    const bar = container.querySelector("[data-testid='compaction-bar']");
+    const bar = container!.querySelector("[data-testid='compaction-bar']");
     expect(bar!.textContent).toContain("50% of compact threshold");
     // 50% of a 40-cell bar = 20 filled.
     expect(bar!.textContent).toContain("▰".repeat(20) + "▱".repeat(20));
@@ -115,14 +122,14 @@ describe("CompactionIndicator", () => {
       dropped_count: 42,
       error: null,
     });
-    const notice = container.querySelector("[data-testid='compaction-indicator']");
+    const notice = container!.querySelector("[data-testid='compaction-indicator']");
     expect(notice!.textContent).toContain("context compacted 48.0k → 12.0k tokens");
 
     // Auto-clears after the timeout.
     act(() => {
       vi.advanceTimersByTime(9000);
     });
-    expect(container.querySelector("[data-testid='compaction-indicator']")).toBeNull();
+    expect(container!.querySelector("[data-testid='compaction-indicator']")).toBeNull();
   });
 
   it("drops cross-session events", () => {
@@ -134,7 +141,7 @@ describe("CompactionIndicator", () => {
       threshold_tokens: 2000,
       trigger: "preflight",
     });
-    expect(container.querySelector("[data-testid='compaction-indicator']")).toBeNull();
+    expect(container!.querySelector("[data-testid='compaction-indicator']")).toBeNull();
   });
 
   it("clears a dangling started-block on the thinking falling edge", () => {
@@ -146,10 +153,10 @@ describe("CompactionIndicator", () => {
       threshold_tokens: 2000,
       trigger: "preflight",
     });
-    expect(container.querySelector("[data-testid='compaction-indicator']")).not.toBeNull();
+    expect(container!.querySelector("[data-testid='compaction-indicator']")).not.toBeNull();
 
     fire("crew:thinking", { session_id: SESSION, thinking: false });
-    expect(container.querySelector("[data-testid='compaction-indicator']")).toBeNull();
+    expect(container!.querySelector("[data-testid='compaction-indicator']")).toBeNull();
   });
 
   it("progressBar clamps and rounds", () => {

--- a/src/components/compaction-indicator.tsx
+++ b/src/components/compaction-indicator.tsx
@@ -1,0 +1,165 @@
+import { useEffect, useRef, useState } from "react";
+import { useSession } from "@/runtime/session-context";
+import { eventMatchesScope } from "@/runtime/event-scope";
+import { progressBar } from "@/lib/progress-bar";
+
+/**
+ * Context-compaction indicator (UPCR-2026-026), the SPA sibling of
+ * octos-tui#253's block:
+ *
+ * ```text
+ * ✶ Compacting conversation… (12s · 87.4k tokens)
+ *   ▰▰▰▰▰▰▰▰▰▰▰▰▰▰▰▰▰▰▰▰▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱▱ 91%
+ * ```
+ *
+ * Consumes the scoped `crew:compaction` DOM event fanned out by the
+ * ui-protocol event router. `phase: "started"` arms the in-progress
+ * block; `phase: "completed"` swaps it for a transient success notice
+ * (`✓ context compacted 87.4k → 31.2k tokens`) that auto-clears. The
+ * serve pass is synchronous today, so started/completed usually arrive
+ * in one batch — the in-progress state may only flash; the notice is
+ * the durable part of the UX.
+ *
+ * The percentage is HONEST: pre-compaction tokens over the threshold
+ * that tripped the pass (the started event carries it). We deliberately
+ * do not invent a percentage on completed-only flows.
+ */
+
+const BAR_WIDTH = 40;
+const NOTICE_AUTO_CLEAR_MS = 8000;
+
+function formatTokens(n: number): string {
+  if (n >= 1000) return `${(n / 1000).toFixed(1)}k`;
+  return String(n);
+}
+
+type CompactionState =
+  | {
+      phase: "started";
+      tokenEstimate: number;
+      thresholdTokens: number;
+      startedAt: number;
+    }
+  | {
+      phase: "completed";
+      before: number;
+      after: number | null;
+      error: string | null;
+    };
+
+export function CompactionIndicator() {
+  const { currentSessionId, historyTopic } = useSession();
+  const [state, setState] = useState<CompactionState | null>(null);
+  const [elapsed, setElapsed] = useState(0);
+  const clearTimer = useRef<number | null>(null);
+
+  useEffect(() => {
+    function handler(e: Event) {
+      const detail = (e as CustomEvent).detail;
+      if (!eventMatchesScope(detail, currentSessionId, historyTopic)) return;
+      if (clearTimer.current != null) {
+        window.clearTimeout(clearTimer.current);
+        clearTimer.current = null;
+      }
+      if (detail.phase === "started") {
+        setState({
+          phase: "started",
+          tokenEstimate: detail.token_estimate ?? 0,
+          thresholdTokens: detail.threshold_tokens ?? 0,
+          startedAt: Date.now(),
+        });
+        setElapsed(0);
+        return;
+      }
+      if (detail.phase === "completed") {
+        setState({
+          phase: "completed",
+          before: detail.token_estimate_before ?? 0,
+          after:
+            typeof detail.token_estimate_after === "number"
+              ? detail.token_estimate_after
+              : null,
+          error: detail.error ?? null,
+        });
+        clearTimer.current = window.setTimeout(() => {
+          setState(null);
+          clearTimer.current = null;
+        }, NOTICE_AUTO_CLEAR_MS);
+      }
+    }
+    // Hang safety (the octos-tui#253 lesson): a compaction block must
+    // never outlive its turn. `crew:thinking` falls at every turn
+    // terminal, so a started-block whose completed event was lost is
+    // cleared there; a completed notice keeps its own auto-clear timer.
+    function thinkingHandler(e: Event) {
+      const detail = (e as CustomEvent).detail;
+      if (!eventMatchesScope(detail, currentSessionId, historyTopic)) return;
+      if (!detail.thinking) {
+        setState((prev) => (prev?.phase === "started" ? null : prev));
+      }
+    }
+    window.addEventListener("crew:compaction", handler);
+    window.addEventListener("crew:thinking", thinkingHandler);
+    return () => {
+      window.removeEventListener("crew:compaction", handler);
+      window.removeEventListener("crew:thinking", thinkingHandler);
+      if (clearTimer.current != null) {
+        window.clearTimeout(clearTimer.current);
+        clearTimer.current = null;
+      }
+    };
+  }, [currentSessionId, historyTopic]);
+
+  useEffect(() => {
+    if (state?.phase !== "started") return;
+    const startedAt = state.startedAt;
+    const tick = () =>
+      setElapsed(Math.floor((Date.now() - startedAt) / 1000));
+    tick();
+    const id = window.setInterval(tick, 1000);
+    return () => window.clearInterval(id);
+  }, [state]);
+
+  if (!state) return null;
+
+  if (state.phase === "started") {
+    const frac =
+      state.thresholdTokens > 0 ? state.tokenEstimate / state.thresholdTokens : 0;
+    const pct = Math.round(Math.min(1, Math.max(0, frac)) * 100);
+    return (
+      <div
+        data-testid="compaction-indicator"
+        className="mx-4 my-2 rounded-lg border border-border bg-surface px-3 py-2 text-sm text-muted"
+      >
+        <div>
+          ✶ Compacting conversation…
+          {elapsed >= 1 ? ` (${elapsed}s · ${formatTokens(state.tokenEstimate)} tokens)` : ` (${formatTokens(state.tokenEstimate)} tokens)`}
+        </div>
+        <div className="font-mono text-xs" data-testid="compaction-bar">
+          {progressBar(frac, BAR_WIDTH)} {pct}% of compact threshold
+        </div>
+      </div>
+    );
+  }
+
+  if (state.error) {
+    return (
+      <div
+        data-testid="compaction-indicator"
+        className="mx-4 my-2 rounded-lg border border-border bg-surface px-3 py-2 text-sm text-muted"
+      >
+        ✗ context compaction failed: {state.error}
+      </div>
+    );
+  }
+
+  const after = state.after ?? state.before;
+  return (
+    <div
+      data-testid="compaction-indicator"
+      className="mx-4 my-2 rounded-lg border border-border bg-surface px-3 py-2 text-sm text-muted"
+    >
+      ✓ context compacted {formatTokens(state.before)} → {formatTokens(after)} tokens
+    </div>
+  );
+}

--- a/src/components/compaction-indicator.tsx
+++ b/src/components/compaction-indicator.tsx
@@ -54,6 +54,11 @@ export function CompactionIndicator() {
   const clearTimer = useRef<number | null>(null);
 
   useEffect(() => {
+    // Scope change (session/topic switch): the previous conversation's
+    // block must not bleed into the new one — reset local state whenever
+    // the effect re-binds (codex R4).
+    setState(null);
+    setElapsed(0);
     function handler(e: Event) {
       const detail = (e as CustomEvent).detail;
       if (!eventMatchesScope(detail, currentSessionId, historyTopic)) return;

--- a/src/lib/progress-bar.ts
+++ b/src/lib/progress-bar.ts
@@ -1,0 +1,7 @@
+/** `▰▰▰▰▱▱▱▱` fixed-width fraction bar (UPCR-2026-026 compaction UX —
+ * shared with the indicator's tests). */
+export function progressBar(frac: number, width: number): string {
+  const clamped = Math.min(1, Math.max(0, frac));
+  const filled = Math.min(width, Math.round(clamped * width));
+  return "▰".repeat(filled) + "▱".repeat(width - filled);
+}

--- a/src/runtime/ui-protocol-bridge.test.ts
+++ b/src/runtime/ui-protocol-bridge.test.ts
@@ -901,6 +901,11 @@ describe("connection lifecycle", () => {
     // notifications on this feature, so dropping it would silently
     // disable spawn_only attachment delivery.
     expect(ws.url).toContain("ui_feature=event.message_persisted.v1");
+    // Regression-pin for UPCR-2026-026: the server filters the whole
+    // context lifecycle family (compaction started/completed,
+    // normalization) for clients that did not negotiate this capability
+    // — the same silent-filter gap octos-tui#253 hit.
+    expect(ws.url).toContain("ui_feature=context.lifecycle.v1");
     // Regression-pin for the M10 Phase 1 capability negotiation
     // (server PR #772): server only emits the new
     // `turn/spawn_complete` envelope when this capability is in the
@@ -1773,6 +1778,71 @@ describe("notification dispatch", () => {
     await Promise.resolve();
     return { bridge, ws };
   }
+
+  it("routes context compaction lifecycle with flattened payloads", async () => {
+    const { bridge, ws } = await freshConnected();
+    const seen: unknown[] = [];
+    bridge.onContextCompaction((e) => seen.push(e));
+
+    ws.triggerMessage({
+      jsonrpc: "2.0",
+      method: METHODS.CONTEXT_COMPACTION_STARTED,
+      params: {
+        session_id: "sess-1",
+        context_state: { session_id: "sess-1", token_estimate: 91000 },
+        trigger: "preflight",
+        threshold_tokens: 96000,
+      },
+    });
+    ws.triggerMessage({
+      jsonrpc: "2.0",
+      method: METHODS.CONTEXT_COMPACTION_COMPLETED,
+      params: {
+        session_id: "sess-1",
+        context_state: { session_id: "sess-1", token_estimate: 31000 },
+        compaction: {
+          compaction_id: "c-1",
+          token_estimate_before: 91000,
+          token_estimate_after: 31000,
+          retained_count: 8,
+          dropped_count: 42,
+        },
+      },
+    });
+
+    expect(seen).toHaveLength(2);
+    expect(seen[0]).toMatchObject({
+      session_id: "sess-1",
+      token_estimate: 91000,
+      threshold_tokens: 96000,
+      trigger: "preflight",
+    });
+    expect(seen[1]).toMatchObject({
+      session_id: "sess-1",
+      token_estimate_before: 91000,
+      token_estimate_after: 31000,
+      retained_count: 8,
+      dropped_count: 42,
+      error: null,
+    });
+  });
+
+  it("drops malformed compaction payloads at the guard", async () => {
+    const { bridge, ws } = await freshConnected();
+    const seen: unknown[] = [];
+    bridge.onContextCompaction((e) => seen.push(e));
+    ws.triggerMessage({
+      jsonrpc: "2.0",
+      method: METHODS.CONTEXT_COMPACTION_STARTED,
+      params: { session_id: "sess-1" },
+    });
+    ws.triggerMessage({
+      jsonrpc: "2.0",
+      method: METHODS.CONTEXT_COMPACTION_COMPLETED,
+      params: { session_id: "sess-1", compaction: {} },
+    });
+    expect(seen).toHaveLength(0);
+  });
 
   it("routes message/delta to its handler", async () => {
     const { bridge, ws } = await freshConnected();

--- a/src/runtime/ui-protocol-bridge.ts
+++ b/src/runtime/ui-protocol-bridge.ts
@@ -1826,6 +1826,7 @@ class UiProtocolBridgeImpl implements UiProtocolBridge {
     this.subTaskUpdated.clear();
     this.subTaskOutputDelta.clear();
     this.subTurnLifecycle.clear();
+    this.subContextCompaction.clear();
     this.subApprovalRequested.clear();
     this.subToolStarted.clear();
     this.subToolProgress.clear();

--- a/src/runtime/ui-protocol-bridge.ts
+++ b/src/runtime/ui-protocol-bridge.ts
@@ -45,6 +45,8 @@ import type {
   ToolCompletedEvent,
   ToolProgressEvent,
   ToolStartedEvent,
+  ContextCompactionStartedEvent,
+  ContextCompactionCompletedEvent,
   TurnCompletedEvent,
   TurnErrorEvent,
   TurnInterruptResult,
@@ -84,6 +86,8 @@ export type {
   ToolCompletedEvent,
   ToolProgressEvent,
   ToolStartedEvent,
+  ContextCompactionStartedEvent,
+  ContextCompactionCompletedEvent,
   TurnCompletedEvent,
   TurnErrorEvent,
   TurnInterruptResult,
@@ -173,6 +177,12 @@ export const METHODS = {
   // (`ToolProgressIndicator`) lights up — the SSE bridge predecessor of
   // this surface was the sole dispatcher prior to PR #96. See
   // `crates/octos-cli/src/api/ui_protocol_progress.rs:99-363`.
+  // UPCR-2026-026 context-compaction lifecycle: `started` fires
+  // immediately before a server-owned compaction pass (may arrive in the
+  // same batch as `completed` — the pass is synchronous today);
+  // `completed` carries the before/after token estimates.
+  CONTEXT_COMPACTION_STARTED: "context/compaction_started",
+  CONTEXT_COMPACTION_COMPLETED: "context/compaction_completed",
   TOOL_STARTED: "tool/started",
   TOOL_PROGRESS: "tool/progress",
   TOOL_COMPLETED: "tool/completed",
@@ -251,6 +261,13 @@ export const UI_PROTOCOL_FEATURES = [
   // populated post-`session/open` from the negotiated `replayed_envelopes`
   // is what eliminates the N+1 bubble render after page reload.
   "state.session_hydrate.v1",
+  // UPCR-2026-026 (octos #1558) + UPCR-2026-022: the server filters the
+  // context lifecycle family (context/compaction_started,
+  // context/compaction_completed, context/normalization_reported) for
+  // clients that did not negotiate this capability — without the token
+  // the SPA's compaction indicator is unreachable in production (the
+  // same gap octos-tui#253 fixed for the TUI).
+  "context.lifecycle.v1",
 ] as const;
 
 /**
@@ -419,6 +436,13 @@ export interface UiProtocolBridge {
   onTurnLifecycle(
     handler: (
       e: TurnStartedEvent | TurnCompletedEvent | TurnErrorEvent,
+    ) => void,
+  ): () => void;
+  /** UPCR-2026-026 context-compaction lifecycle (started | completed);
+   *  discriminate by `threshold_tokens` (present only on started). */
+  onContextCompaction(
+    handler: (
+      e: ContextCompactionStartedEvent | ContextCompactionCompletedEvent,
     ) => void,
   ): () => void;
   onApprovalRequested(handler: (e: ApprovalRequestedEvent) => void): () => void;
@@ -1055,6 +1079,41 @@ function guardTaskOutputDelta(p: unknown): TaskOutputDeltaEvent | null {
   };
 }
 
+function guardContextCompactionStarted(p: unknown): ContextCompactionStartedEvent | null {
+  if (!isPlainObject(p)) return null;
+  if (!isString(p.session_id)) return null;
+  const contextState = isPlainObject(p.context_state) ? p.context_state : null;
+  const tokenEstimate =
+    contextState && typeof contextState.token_estimate === "number"
+      ? contextState.token_estimate
+      : null;
+  if (tokenEstimate == null || typeof p.threshold_tokens !== "number") return null;
+  return {
+    session_id: p.session_id,
+    token_estimate: tokenEstimate,
+    threshold_tokens: p.threshold_tokens,
+    trigger: isString(p.trigger) ? p.trigger : "",
+  };
+}
+
+function guardContextCompactionCompleted(p: unknown): ContextCompactionCompletedEvent | null {
+  if (!isPlainObject(p)) return null;
+  if (!isString(p.session_id)) return null;
+  const compaction = isPlainObject(p.compaction) ? p.compaction : null;
+  if (!compaction || typeof compaction.token_estimate_before !== "number") return null;
+  return {
+    session_id: p.session_id,
+    token_estimate_before: compaction.token_estimate_before,
+    token_estimate_after:
+      typeof compaction.token_estimate_after === "number"
+        ? compaction.token_estimate_after
+        : null,
+    retained_count: typeof compaction.retained_count === "number" ? compaction.retained_count : 0,
+    dropped_count: typeof compaction.dropped_count === "number" ? compaction.dropped_count : 0,
+    error: isString(compaction.error) ? compaction.error : null,
+  };
+}
+
 function guardTurnStarted(p: unknown): TurnStartedEvent | null {
   if (!isPlainObject(p)) return null;
   if (!isString(p.session_id) || !isString(p.turn_id)) return null;
@@ -1514,6 +1573,9 @@ class UiProtocolBridgeImpl implements UiProtocolBridge {
   private readonly subVoiceExit = new Subscribers<VoiceExitEvent>();
   private readonly subTaskUpdated = new Subscribers<TaskUpdatedEvent>();
   private readonly subTaskOutputDelta = new Subscribers<TaskOutputDeltaEvent>();
+  private readonly subContextCompaction = new Subscribers<
+    ContextCompactionStartedEvent | ContextCompactionCompletedEvent
+  >();
   private readonly subTurnLifecycle = new Subscribers<
     TurnStartedEvent | TurnCompletedEvent | TurnErrorEvent
   >();
@@ -1584,6 +1646,14 @@ class UiProtocolBridgeImpl implements UiProtocolBridge {
     [METHODS.TASK_OUTPUT_DELTA]: {
       guard: guardTaskOutputDelta,
       emit: (v) => this.subTaskOutputDelta.emit(v as TaskOutputDeltaEvent),
+    },
+    [METHODS.CONTEXT_COMPACTION_STARTED]: {
+      guard: guardContextCompactionStarted,
+      emit: (v) => this.subContextCompaction.emit(v as ContextCompactionStartedEvent),
+    },
+    [METHODS.CONTEXT_COMPACTION_COMPLETED]: {
+      guard: guardContextCompactionCompleted,
+      emit: (v) => this.subContextCompaction.emit(v as ContextCompactionCompletedEvent),
     },
     [METHODS.TURN_STARTED]: {
       guard: guardTurnStarted,
@@ -1923,6 +1993,11 @@ class UiProtocolBridgeImpl implements UiProtocolBridge {
     handler: Listener<TurnStartedEvent | TurnCompletedEvent | TurnErrorEvent>,
   ): () => void {
     return this.subTurnLifecycle.add(handler);
+  }
+  onContextCompaction(
+    handler: Listener<ContextCompactionStartedEvent | ContextCompactionCompletedEvent>,
+  ): () => void {
+    return this.subContextCompaction.add(handler);
   }
   onApprovalRequested(handler: Listener<ApprovalRequestedEvent>): () => void {
     return this.subApprovalRequested.add(handler);

--- a/src/runtime/ui-protocol-event-router.ts
+++ b/src/runtime/ui-protocol-event-router.ts
@@ -1910,6 +1910,33 @@ export function attachRouter(
   const offApprovalRequested = bridge.onApprovalRequested((e) =>
     handleApprovalRequested(cfg, e),
   );
+  // UPCR-2026-026: fan the context-compaction lifecycle out as a scoped
+  // `crew:compaction` DOM event; `CompactionIndicator` consumes it the
+  // same way ThinkingIndicator consumes `crew:thinking`. Discriminate by
+  // the field unique per variant (`threshold_tokens` only on started).
+  // Optional-call: older bridge mocks/instances may predate the method
+  // (same defensive rule as `onReopened` in the runtime).
+  const offContextCompaction = bridge.onContextCompaction?.((e) => {
+    const detail =
+      "threshold_tokens" in e
+        ? {
+            session_id: e.session_id,
+            phase: "started" as const,
+            token_estimate: e.token_estimate,
+            threshold_tokens: e.threshold_tokens,
+            trigger: e.trigger,
+          }
+        : {
+            session_id: e.session_id,
+            phase: "completed" as const,
+            token_estimate_before: e.token_estimate_before,
+            token_estimate_after: e.token_estimate_after,
+            retained_count: e.retained_count,
+            dropped_count: e.dropped_count,
+            error: e.error,
+          };
+    dispatch(cfg, new CustomEvent("crew:compaction", { detail }));
+  });
   const offToolStarted = bridge.onToolStarted((e) => handleToolStarted(cfg, e));
   const offToolProgress = bridge.onToolProgress((e) =>
     handleToolProgress(cfg, e),
@@ -1967,6 +1994,7 @@ export function attachRouter(
       offToolProgress();
       offToolCompleted();
       offProgressUpdated();
+      offContextCompaction?.();
       offRouterStatus();
       offRouterFailover();
       offQueueState();

--- a/src/runtime/ui-protocol-event-router.ts
+++ b/src/runtime/ui-protocol-event-router.ts
@@ -1917,10 +1917,13 @@ export function attachRouter(
   // Optional-call: older bridge mocks/instances may predate the method
   // (same defensive rule as `onReopened` in the runtime).
   const offContextCompaction = bridge.onContextCompaction?.((e) => {
+    // `topic` rides every detail so `eventMatchesScope` accepts the
+    // event in topic-scoped chats (`/new <topic>` sessions) too.
     const detail =
       "threshold_tokens" in e
         ? {
             session_id: e.session_id,
+            topic: cfg.topic,
             phase: "started" as const,
             token_estimate: e.token_estimate,
             threshold_tokens: e.threshold_tokens,
@@ -1928,6 +1931,7 @@ export function attachRouter(
           }
         : {
             session_id: e.session_id,
+            topic: cfg.topic,
             phase: "completed" as const,
             token_estimate_before: e.token_estimate_before,
             token_estimate_after: e.token_estimate_after,

--- a/src/runtime/ui-protocol-types.ts
+++ b/src/runtime/ui-protocol-types.ts
@@ -408,6 +408,32 @@ export interface TurnStartedEvent {
   turn_id: string;
 }
 
+/** UPCR-2026-026: emitted immediately BEFORE a server-owned context
+ * compaction pass. `token_estimate` is the PRE-compaction size (flattened
+ * from the wire's `context_state.token_estimate` by the bridge guard);
+ * `threshold_tokens` is the limit that tripped the pass — an honest
+ * fullness denominator for the indicator bar. May arrive in the same
+ * delivery batch as the completed event (the pass is synchronous today).
+ */
+export interface ContextCompactionStartedEvent {
+  session_id: string;
+  token_estimate: number;
+  threshold_tokens: number;
+  trigger: string;
+}
+
+/** Completion record for a compaction pass (flattened from the wire's
+ * `compaction` object by the bridge guard). `token_estimate_after` is
+ * absent on failed passes (`error` set). */
+export interface ContextCompactionCompletedEvent {
+  session_id: string;
+  token_estimate_before: number;
+  token_estimate_after: number | null;
+  retained_count: number;
+  dropped_count: number;
+  error: string | null;
+}
+
 export interface TurnCompletedEvent {
   session_id: string;
   turn_id: string;


### PR DESCRIPTION
Web-app half of the compaction UX (server: octos#1558, TUI: octos-tui#253).

Adds `context.lifecycle.v1` to the negotiated feature list (the server silently filters the whole lifecycle family without it — same gap the TUI had), bridges `context/compaction_started|completed` with flattening guards, fans them out as scoped `crew:compaction` DOM events, and renders the mockup-style indicator beside ThinkingIndicator with an honest threshold-relative bar, transient completed notice, and thinking-edge hang safety.

🤖 Generated with [Claude Code](https://claude.com/claude-code)