### PR TITLE
feat(tasks): cancel background tasks from the web dock

### DIFF
--- a/src/components/session-task-dock.test.tsx
+++ b/src/components/session-task-dock.test.tsx
@@ -12,7 +12,7 @@
  * arithmetic.
  */
 
-import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import * as React from "react";
 import { act } from "react";
 import { createRoot, type Root } from "react-dom/client";
@@ -20,6 +20,11 @@ import { createRoot, type Root } from "react-dom/client";
 (
   globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }
 ).IS_REACT_ACT_ENVIRONMENT = true;
+
+const cancelTask = vi.fn();
+vi.mock("@/runtime/ui-protocol-runtime", () => ({
+  getActiveBridge: () => ({ cancelTask }),
+}));
 
 import { SessionTaskIndicator } from "./session-task-dock";
 import { SessionContext } from "@/runtime/session-context";
@@ -96,11 +101,84 @@ function seedTasks(n: number): void {
 
 beforeEach(() => {
   TaskStore.clearTasks(SESSION);
+  cancelTask.mockReset();
 });
 
 afterEach(() => {
   for (const node of [...document.body.children]) node.remove();
   TaskStore.clearTasks(SESSION);
+});
+
+describe("SessionTaskIndicator — cancel", () => {
+  it("opens a cancel menu and cancels a running task, dropping it from active", async () => {
+    cancelTask.mockResolvedValue({ task_id: "task-0", status: "cancelled" });
+    seedTasks(1);
+    const harness = mount(
+      <SessionContext.Provider value={makeSessionCtx()}>
+        <SessionTaskIndicator />
+      </SessionContext.Provider>,
+    );
+
+    // Indicator is a button; no menu until opened.
+    const indicator = harness.container.querySelector(
+      '[data-testid="session-task-indicator"]',
+    ) as HTMLButtonElement;
+    expect(indicator).toBeTruthy();
+    expect(
+      harness.container.querySelector(
+        '[data-testid="session-task-cancel-menu"]',
+      ),
+    ).toBeNull();
+
+    act(() => indicator.click());
+    const cancelBtn = harness.container.querySelector(
+      '[data-testid="cancel-task-task-0"]',
+    ) as HTMLButtonElement;
+    expect(cancelBtn).toBeTruthy();
+
+    await act(async () => {
+      cancelBtn.click();
+    });
+
+    expect(cancelTask).toHaveBeenCalledWith("task-0");
+    // Cancelled → mapped to a terminal status → no longer active → indicator
+    // (which only shows for active/failed) disappears.
+    expect(
+      harness.container.querySelector(
+        '[data-testid="session-task-indicator"]',
+      ),
+    ).toBeNull();
+
+    harness.unmount();
+  });
+
+  it("keeps the task active when the server reports it still running", async () => {
+    cancelTask.mockResolvedValue({ task_id: "task-0", status: "running" });
+    seedTasks(1);
+    const harness = mount(
+      <SessionContext.Provider value={makeSessionCtx()}>
+        <SessionTaskIndicator />
+      </SessionContext.Provider>,
+    );
+    const indicator = harness.container.querySelector(
+      '[data-testid="session-task-indicator"]',
+    ) as HTMLButtonElement;
+    act(() => indicator.click());
+    await act(async () => {
+      (
+        harness.container.querySelector(
+          '[data-testid="cancel-task-task-0"]',
+        ) as HTMLButtonElement
+      ).click();
+    });
+    // Still running → indicator remains.
+    expect(
+      harness.container.querySelector(
+        '[data-testid="session-task-indicator"]',
+      ),
+    ).toBeTruthy();
+    harness.unmount();
+  });
 });
 
 describe("SessionTaskIndicator — constellation dot cap", () => {

--- a/src/components/session-task-dock.test.tsx
+++ b/src/components/session-task-dock.test.tsx
@@ -267,6 +267,68 @@ describe("SessionTaskIndicator — cancel", () => {
     harness.unmount();
   });
 
+  it("ignores a retained terminal pipeline row when classifying the cancel group", async () => {
+    // codex round 3: `buildSummary` rolls up the ACTIVE subset only, so a
+    // completed pipeline row retained in the store must not re-classify
+    // its call id as a pipeline family — the renderer showed the two
+    // active non-pipeline rows separately, so Cancel stays per-row.
+    cancelTask.mockResolvedValue({ task_id: "x", status: "cancelled" });
+    const shared = "tc-retained";
+    TaskStore.replaceTasks(SESSION, [
+      {
+        id: "old-pipe",
+        tool_name: "pipeline:analyze",
+        tool_call_id: shared,
+        status: "completed",
+        started_at: new Date(2026, 0, 1, 0, 0, 0).toISOString(),
+        completed_at: new Date(2026, 0, 1, 0, 1, 0).toISOString(),
+        output_files: [],
+        error: null,
+      },
+      {
+        id: "podcast-a",
+        tool_name: "podcast_generate",
+        tool_call_id: shared,
+        status: "running",
+        started_at: new Date(2026, 0, 1, 0, 2, 0).toISOString(),
+        completed_at: null,
+        output_files: [],
+        error: null,
+      },
+      {
+        id: "voice-b",
+        tool_name: "fm_tts",
+        tool_call_id: shared,
+        status: "running",
+        started_at: new Date(2026, 0, 1, 0, 2, 1).toISOString(),
+        completed_at: null,
+        output_files: [],
+        error: null,
+      },
+    ]);
+    const harness = mount(
+      <SessionContext.Provider value={makeSessionCtx()}>
+        <SessionTaskIndicator />
+      </SessionContext.Provider>,
+    );
+    const indicator = harness.container.querySelector(
+      '[data-testid="session-task-indicator"]',
+    ) as HTMLButtonElement;
+    // Active rollup input excludes the terminal row → two separate rows.
+    expect(indicator.getAttribute("data-task-count")).toBe("2");
+    act(() => indicator.click());
+    const cancelBtn = harness.container.querySelector(
+      '[data-testid="cancel-task-podcast-a"]',
+    ) as HTMLButtonElement;
+    expect(cancelBtn).toBeTruthy();
+    await act(async () => {
+      cancelBtn.click();
+    });
+    // The stale pipeline row must not expand the group: one cancel only.
+    expect(cancelTask.mock.calls.map((c) => c[0])).toEqual(["podcast-a"]);
+    harness.unmount();
+  });
+
   it("keeps the task active when the server reports it still running", async () => {
     cancelTask.mockResolvedValue({ task_id: "task-0", status: "running" });
     seedTasks(1);

--- a/src/components/session-task-dock.test.tsx
+++ b/src/components/session-task-dock.test.tsx
@@ -152,6 +152,66 @@ describe("SessionTaskIndicator — cancel", () => {
     harness.unmount();
   });
 
+  it("cancels every member of a rolled-up pipeline group, not just the representative", async () => {
+    cancelTask.mockResolvedValue({ task_id: "x", status: "cancelled" });
+    // A run_pipeline parent + two pipeline children sharing one tool_call_id
+    // collapse to a single menu row; Cancel must hit all three.
+    const shared = "tc-pipe";
+    TaskStore.replaceTasks(SESSION, [
+      {
+        id: "p-parent",
+        tool_name: "run_pipeline",
+        tool_call_id: shared,
+        status: "running",
+        started_at: new Date(2026, 0, 1, 0, 0, 0).toISOString(),
+        completed_at: null,
+        output_files: [],
+        error: null,
+      },
+      {
+        id: "p-child-1",
+        tool_name: "pipeline:analyze",
+        tool_call_id: shared,
+        status: "running",
+        started_at: new Date(2026, 0, 1, 0, 0, 1).toISOString(),
+        completed_at: null,
+        output_files: [],
+        error: null,
+      },
+      {
+        id: "p-child-2",
+        tool_name: "pipeline:synthesize",
+        tool_call_id: shared,
+        status: "running",
+        started_at: new Date(2026, 0, 1, 0, 0, 2).toISOString(),
+        completed_at: null,
+        output_files: [],
+        error: null,
+      },
+    ]);
+    const harness = mount(
+      <SessionContext.Provider value={makeSessionCtx()}>
+        <SessionTaskIndicator />
+      </SessionContext.Provider>,
+    );
+    const indicator = harness.container.querySelector(
+      '[data-testid="session-task-indicator"]',
+    ) as HTMLButtonElement;
+    act(() => indicator.click());
+    // One collapsed row for the group.
+    const cancelBtn = harness.container.querySelector(
+      '[data-testid="cancel-task-p-parent"]',
+    ) as HTMLButtonElement;
+    expect(cancelBtn).toBeTruthy();
+    await act(async () => {
+      cancelBtn.click();
+    });
+    // All three raw task ids were cancelled.
+    const cancelledIds = cancelTask.mock.calls.map((c) => c[0]).sort();
+    expect(cancelledIds).toEqual(["p-child-1", "p-child-2", "p-parent"]);
+    harness.unmount();
+  });
+
   it("keeps the task active when the server reports it still running", async () => {
     cancelTask.mockResolvedValue({ task_id: "task-0", status: "running" });
     seedTasks(1);

--- a/src/components/session-task-dock.test.tsx
+++ b/src/components/session-task-dock.test.tsx
@@ -212,6 +212,61 @@ describe("SessionTaskIndicator — cancel", () => {
     harness.unmount();
   });
 
+  it("cancels only the clicked row when unrelated tasks share a tool_call_id", async () => {
+    // codex round 2 P1: `rollupTasksByCall` deliberately renders unrelated
+    // NON-pipeline tasks as separate rows even when they share a
+    // `tool_call_id`. Cancel on one row must not destroy the other row's
+    // task — group expansion applies to pipeline families only.
+    cancelTask.mockResolvedValue({ task_id: "x", status: "cancelled" });
+    const shared = "tc-shared";
+    TaskStore.replaceTasks(SESSION, [
+      {
+        id: "podcast-a",
+        tool_name: "podcast_generate",
+        tool_call_id: shared,
+        status: "running",
+        started_at: new Date(2026, 0, 1, 0, 0, 0).toISOString(),
+        completed_at: null,
+        output_files: [],
+        error: null,
+      },
+      {
+        id: "voice-b",
+        tool_name: "fm_tts",
+        tool_call_id: shared,
+        status: "running",
+        started_at: new Date(2026, 0, 1, 0, 0, 1).toISOString(),
+        completed_at: null,
+        output_files: [],
+        error: null,
+      },
+    ]);
+    const harness = mount(
+      <SessionContext.Provider value={makeSessionCtx()}>
+        <SessionTaskIndicator />
+      </SessionContext.Provider>,
+    );
+    const indicator = harness.container.querySelector(
+      '[data-testid="session-task-indicator"]',
+    ) as HTMLButtonElement;
+    // Non-pipeline group does NOT collapse: both rows visible.
+    expect(indicator.getAttribute("data-task-count")).toBe("2");
+    act(() => indicator.click());
+    const cancelBtn = harness.container.querySelector(
+      '[data-testid="cancel-task-podcast-a"]',
+    ) as HTMLButtonElement;
+    expect(cancelBtn).toBeTruthy();
+    expect(
+      harness.container.querySelector('[data-testid="cancel-task-voice-b"]'),
+    ).toBeTruthy();
+    await act(async () => {
+      cancelBtn.click();
+    });
+    // ONLY the clicked row's task was cancelled.
+    expect(cancelTask.mock.calls.map((c) => c[0])).toEqual(["podcast-a"]);
+    harness.unmount();
+  });
+
   it("keeps the task active when the server reports it still running", async () => {
     cancelTask.mockResolvedValue({ task_id: "task-0", status: "running" });
     seedTasks(1);

--- a/src/components/session-task-dock.tsx
+++ b/src/components/session-task-dock.tsx
@@ -1,7 +1,8 @@
-import { useMemo, type ReactElement } from "react";
+import { useMemo, useState, type ReactElement } from "react";
 import type { BackgroundTaskInfo as TaskInfo } from "@/api/types";
-import { useTasks } from "@/store/task-store";
+import { mergeTask, useTasks } from "@/store/task-store";
 import { useSession } from "@/runtime/session-context";
+import { getActiveBridge } from "@/runtime/ui-protocol-runtime";
 import {
   displayLabelForRolled,
   rollupTasksByCall,
@@ -87,10 +88,50 @@ const DOT_PALETTE = ["bg-accent", "bg-accent/70", "bg-accent/40"] as const;
 export function SessionTaskIndicator() {
   const { currentSessionId, historyTopic } = useSession();
   const currentTasks = useTasks(currentSessionId, historyTopic);
+  const [open, setOpen] = useState(false);
+  // Task ids with an in-flight cancel request, so the row shows "Cancelling…"
+  // until the authoritative `task/updated` flips it to a terminal state.
+  const [cancelling, setCancelling] = useState<Record<string, boolean>>({});
 
   const summary = useMemo(() => buildSummary(currentTasks), [currentTasks]);
 
-  if (!summary) return null;
+  async function cancelTask(task: TaskInfo) {
+    setCancelling((prev) => ({ ...prev, [task.id]: true }));
+    try {
+      const bridge = getActiveBridge(currentSessionId, historyTopic);
+      if (!bridge) throw new Error("bridge not connected");
+      const result = await bridge.cancelTask(task.id);
+      // Optimistically reflect the authoritative post-cancel state; the
+      // server's own `task/updated` confirms it moments later. The web status
+      // union has no `cancelled`, so a cancelled/pending task maps to a
+      // terminal `completed` (drops from the active set, no red flash); a task
+      // that had already finished comes back completed/failed unchanged; a
+      // still-`running` result means the cancel didn't take, so keep it active.
+      const status: TaskInfo["status"] =
+        result.status === "cancelled" || result.status === "pending"
+          ? "completed"
+          : result.status === "running"
+            ? "running"
+            : result.status === "failed"
+              ? "failed"
+              : "completed";
+      mergeTask(currentSessionId, { ...task, status }, historyTopic);
+    } catch {
+      // Leave the task as-is; drop the optimistic "Cancelling…" flag so the
+      // user can retry.
+    } finally {
+      setCancelling((prev) => {
+        const next = { ...prev };
+        delete next[task.id];
+        return next;
+      });
+    }
+  }
+
+  if (!summary) {
+    if (open) setOpen(false);
+    return null;
+  }
 
   // Header constellation (M9 follow-up, 2026-05-22). Inline dot-per-task
   // visualisation that scales with count, replacing the "glass-pill"
@@ -153,24 +194,61 @@ export function SessionTaskIndicator() {
   }
 
   const count = summary.state === "failed" ? 1 : summary.active.length;
+  // Only running/spawned tasks are cancellable; a failed-only summary has none.
+  const cancellable = summary.active;
 
   return (
-    <div
-      data-testid="session-task-indicator"
-      data-task-count={count}
-      data-task-state={summary.state}
-      className="session-task-indicator inline-flex items-center gap-2"
-      title={summary.detail}
-    >
-      <span
-        className="inline-flex items-center gap-1"
-        aria-hidden="true"
+    <div className="relative inline-flex">
+      <button
+        type="button"
+        data-testid="session-task-indicator"
+        data-task-count={count}
+        data-task-state={summary.state}
+        className="session-task-indicator inline-flex items-center gap-2 rounded-[8px] px-1 py-0.5 hover:bg-surface-container disabled:cursor-default"
+        title={summary.detail}
+        aria-haspopup={cancellable.length > 0 ? "menu" : undefined}
+        aria-expanded={cancellable.length > 0 ? open : undefined}
+        disabled={cancellable.length === 0}
+        onClick={() => setOpen((v) => !v)}
       >
-        {dots}
-      </span>
-      <span className="truncate text-[12px] font-medium text-text-strong">
-        {summary.label}
-      </span>
+        <span className="inline-flex items-center gap-1" aria-hidden="true">
+          {dots}
+        </span>
+        <span className="truncate text-[12px] font-medium text-text-strong">
+          {summary.label}
+        </span>
+      </button>
+
+      {open && cancellable.length > 0 && (
+        <div
+          role="menu"
+          data-testid="session-task-cancel-menu"
+          className="absolute right-0 top-full z-50 mt-1 w-64 rounded-[10px] border border-border bg-surface-container p-1 shadow-lg"
+        >
+          {cancellable.map((task) => {
+            const busy = cancelling[task.id] === true;
+            return (
+              <div
+                key={task.id}
+                className="flex items-center justify-between gap-2 rounded-[8px] px-2 py-1.5 hover:bg-surface"
+              >
+                <span className="truncate text-[12px] text-text">
+                  {taskDisplayName(task)}
+                </span>
+                <button
+                  type="button"
+                  data-testid={`cancel-task-${task.id}`}
+                  className="shrink-0 rounded-[6px] border border-border px-2 py-0.5 text-[11px] font-medium text-muted hover:border-rose-400 hover:text-rose-300 disabled:opacity-60"
+                  disabled={busy}
+                  onClick={() => void cancelTask(task)}
+                >
+                  {busy ? "Cancelling…" : "Cancel"}
+                </button>
+              </div>
+            );
+          })}
+        </div>
+      )}
     </div>
   );
 }

--- a/src/components/session-task-dock.tsx
+++ b/src/components/session-task-dock.tsx
@@ -5,7 +5,7 @@ import { useSession } from "@/runtime/session-context";
 import { getActiveBridge } from "@/runtime/ui-protocol-runtime";
 import {
   displayLabelForRolled,
-  rollupKey,
+  expandRolledGroup,
   rollupTasksByCall,
 } from "@/runtime/task-rollup";
 
@@ -109,10 +109,12 @@ export function SessionTaskIndicator() {
   // Cancel EVERY active raw task in the representative's group, not just the
   // representative — otherwise a sibling immediately becomes the next
   // representative and one Cancel doesn't clear the row (codex review).
+  // `expandRolledGroup` mirrors the rollup's collapse rule: ONLY pipeline
+  // families expand; unrelated tasks sharing a `tool_call_id` render as
+  // separate rows, so their Cancel must stay per-row (codex round 2).
   async function cancelGroup(representative: TaskInfo) {
-    const key = rollupKey(representative);
-    const members = currentTasks.filter(
-      (t) => isTaskActive(t) && rollupKey(t) === key,
+    const members = expandRolledGroup(representative, currentTasks).filter(
+      isTaskActive,
     );
     const ids = members.length > 0 ? members : [representative];
     setCancelling((prev) => {

--- a/src/components/session-task-dock.tsx
+++ b/src/components/session-task-dock.tsx
@@ -1,10 +1,11 @@
-import { useMemo, useState, type ReactElement } from "react";
+import { useEffect, useMemo, useState, type ReactElement } from "react";
 import type { BackgroundTaskInfo as TaskInfo } from "@/api/types";
 import { mergeTask, useTasks } from "@/store/task-store";
 import { useSession } from "@/runtime/session-context";
 import { getActiveBridge } from "@/runtime/ui-protocol-runtime";
 import {
   displayLabelForRolled,
+  rollupKey,
   rollupTasksByCall,
 } from "@/runtime/task-rollup";
 
@@ -93,45 +94,67 @@ export function SessionTaskIndicator() {
   // until the authoritative `task/updated` flips it to a terminal state.
   const [cancelling, setCancelling] = useState<Record<string, boolean>>({});
 
+  // The indicator stays mounted across session/topic switches, so a menu left
+  // open in one session must not render already-open (and destructive) over a
+  // different cached session's tasks (codex review).
+  useEffect(() => {
+    setOpen(false);
+    setCancelling({});
+  }, [currentSessionId, historyTopic]);
+
   const summary = useMemo(() => buildSummary(currentTasks), [currentTasks]);
 
-  async function cancelTask(task: TaskInfo) {
-    setCancelling((prev) => ({ ...prev, [task.id]: true }));
-    try {
-      const bridge = getActiveBridge(currentSessionId, historyTopic);
-      if (!bridge) throw new Error("bridge not connected");
-      const result = await bridge.cancelTask(task.id);
-      // Optimistically reflect the authoritative post-cancel state; the
-      // server's own `task/updated` confirms it moments later. The web status
-      // union has no `cancelled`, so a cancelled/pending task maps to a
-      // terminal `completed` (drops from the active set, no red flash); a task
-      // that had already finished comes back completed/failed unchanged; a
-      // still-`running` result means the cancel didn't take, so keep it active.
-      const status: TaskInfo["status"] =
-        result.status === "cancelled" || result.status === "pending"
-          ? "completed"
-          : result.status === "running"
-            ? "running"
-            : result.status === "failed"
-              ? "failed"
-              : "completed";
-      mergeTask(currentSessionId, { ...task, status }, historyTopic);
-    } catch {
-      // Leave the task as-is; drop the optimistic "Cancelling…" flag so the
-      // user can retry.
-    } finally {
-      setCancelling((prev) => {
-        const next = { ...prev };
-        delete next[task.id];
-        return next;
-      });
-    }
+  // A menu row is a rolled-up representative (a `run_pipeline` parent can
+  // stand in for several `pipeline:*` children sharing its tool_call_id).
+  // Cancel EVERY active raw task in the representative's group, not just the
+  // representative — otherwise a sibling immediately becomes the next
+  // representative and one Cancel doesn't clear the row (codex review).
+  async function cancelGroup(representative: TaskInfo) {
+    const key = rollupKey(representative);
+    const members = currentTasks.filter(
+      (t) => isTaskActive(t) && rollupKey(t) === key,
+    );
+    const ids = members.length > 0 ? members : [representative];
+    setCancelling((prev) => {
+      const next = { ...prev };
+      for (const m of ids) next[m.id] = true;
+      return next;
+    });
+    const bridge = getActiveBridge(currentSessionId, historyTopic);
+    await Promise.all(
+      ids.map(async (task) => {
+        try {
+          if (!bridge) throw new Error("bridge not connected");
+          const result = await bridge.cancelTask(task.id);
+          // Optimistically reflect the authoritative post-cancel state; the
+          // server's `task/updated` confirms it moments later. The web status
+          // union has no `cancelled`, so cancelled/pending → terminal
+          // `completed` (drops from active, no red flash); an already-finished
+          // task comes back completed/failed; a still-`running` result means
+          // the cancel didn't take, so keep it active.
+          const status: TaskInfo["status"] =
+            result.status === "cancelled" || result.status === "pending"
+              ? "completed"
+              : result.status === "running"
+                ? "running"
+                : result.status === "failed"
+                  ? "failed"
+                  : "completed";
+          mergeTask(currentSessionId, { ...task, status }, historyTopic);
+        } catch {
+          // Leave the task as-is so the user can retry.
+        } finally {
+          setCancelling((prev) => {
+            const next = { ...prev };
+            delete next[task.id];
+            return next;
+          });
+        }
+      }),
+    );
   }
 
-  if (!summary) {
-    if (open) setOpen(false);
-    return null;
-  }
+  if (!summary) return null;
 
   // Header constellation (M9 follow-up, 2026-05-22). Inline dot-per-task
   // visualisation that scales with count, replacing the "glass-pill"
@@ -240,7 +263,7 @@ export function SessionTaskIndicator() {
                   data-testid={`cancel-task-${task.id}`}
                   className="shrink-0 rounded-[6px] border border-border px-2 py-0.5 text-[11px] font-medium text-muted hover:border-rose-400 hover:text-rose-300 disabled:opacity-60"
                   disabled={busy}
-                  onClick={() => void cancelTask(task)}
+                  onClick={() => void cancelGroup(task)}
                 >
                   {busy ? "Cancelling…" : "Cancel"}
                 </button>

--- a/src/components/session-task-dock.tsx
+++ b/src/components/session-task-dock.tsx
@@ -112,9 +112,13 @@ export function SessionTaskIndicator() {
   // `expandRolledGroup` mirrors the rollup's collapse rule: ONLY pipeline
   // families expand; unrelated tasks sharing a `tool_call_id` render as
   // separate rows, so their Cancel must stay per-row (codex round 2).
+  // Expand over the SAME active subset `buildSummary` rolled up — a
+  // retained terminal pipeline row must not re-classify a key that the
+  // renderer treated as non-pipeline rows (codex round 3).
   async function cancelGroup(representative: TaskInfo) {
-    const members = expandRolledGroup(representative, currentTasks).filter(
-      isTaskActive,
+    const members = expandRolledGroup(
+      representative,
+      currentTasks.filter(isTaskActive),
     );
     const ids = members.length > 0 ? members : [representative];
     setCancelling((prev) => {

--- a/src/runtime/task-rollup.test.ts
+++ b/src/runtime/task-rollup.test.ts
@@ -367,22 +367,67 @@ describe("aggregateCallStatus", () => {
     expect(aggregateCallStatus(tasks, CALL)).toBe("failed");
   });
 
-  it("the latest parent wins over a failed predecessor sharing the call id (relaunch)", () => {
+  it("the newest parent by started_at wins over a failed predecessor, regardless of list order", () => {
+    // codex round 5 P1: TaskStore.getTasks orders newest-first, so list
+    // position must not decide — a relaunched parent must supersede its
+    // failed predecessor under BOTH orderings.
+    const older = makeTask({
+      id: "parent-old",
+      tool_name: "run_pipeline",
+      tool_call_id: CALL,
+      status: "failed",
+      started_at: "2026-07-10T00:00:00Z",
+    });
+    const newer = makeTask({
+      id: "parent-new",
+      tool_name: "run_pipeline",
+      tool_call_id: CALL,
+      status: "completed",
+      started_at: "2026-07-10T01:00:00Z",
+    });
+    // Production (store) ordering: newest first.
+    expect(aggregateCallStatus([newer, older], CALL)).toBe("settled");
+    // Chronological ordering: oldest first.
+    expect(aggregateCallStatus([older, newer], CALL)).toBe("settled");
+    // Inverse case: the RELAUNCH failed while the predecessor succeeded.
+    const newerFailed = makeTask({
+      id: "parent-new-f",
+      tool_name: "run_pipeline",
+      tool_call_id: CALL,
+      status: "failed",
+      started_at: "2026-07-10T01:00:00Z",
+    });
+    const olderOk = makeTask({
+      id: "parent-old-ok",
+      tool_name: "run_pipeline",
+      tool_call_id: CALL,
+      status: "completed",
+      started_at: "2026-07-10T00:00:00Z",
+    });
+    expect(aggregateCallStatus([newerFailed, olderOk], CALL)).toBe("failed");
+  });
+
+  it("keeps any-failure aggregation for non-pipeline groups (no parent masking)", () => {
+    // codex round 5 P2: unrelated ordinary tasks sharing a call id have
+    // no parent/child relationship — one member's success must not mask
+    // another member's failure.
     const tasks = [
       makeTask({
-        id: "parent-old",
-        tool_name: "run_pipeline",
-        tool_call_id: CALL,
-        status: "failed",
-      }),
-      makeTask({
-        id: "parent-new",
-        tool_name: "run_pipeline",
+        id: "ord-ok",
+        tool_name: "podcast_generate",
         tool_call_id: CALL,
         status: "completed",
+        started_at: "2026-07-10T01:00:00Z",
+      }),
+      makeTask({
+        id: "ord-fail",
+        tool_name: "fm_tts",
+        tool_call_id: CALL,
+        status: "failed",
+        started_at: "2026-07-10T00:00:00Z",
       }),
     ];
-    expect(aggregateCallStatus(tasks, CALL)).toBe("settled");
+    expect(aggregateCallStatus(tasks, CALL)).toBe("failed");
   });
 
   it("returns null when no member carries the call id", () => {

--- a/src/runtime/task-rollup.test.ts
+++ b/src/runtime/task-rollup.test.ts
@@ -13,7 +13,11 @@
  */
 
 import { describe, expect, it } from "vitest";
-import { displayLabelForRolled, rollupTasksByCall } from "./task-rollup";
+import {
+  aggregateCallStatus,
+  displayLabelForRolled,
+  rollupTasksByCall,
+} from "./task-rollup";
 import type { BackgroundTaskInfo } from "@/api/types";
 
 function makeTask(
@@ -281,5 +285,112 @@ describe("displayLabelForRolled", () => {
     expect(displayLabelForRolled(t("podcast_generate"))).toBe(
       "podcast generate",
     );
+  });
+});
+
+describe("aggregateCallStatus", () => {
+  const CALL = "tc-agg";
+
+  it("reports active while any member is spawned/running", () => {
+    const tasks = [
+      makeTask({
+        id: "a",
+        tool_name: "pipeline:analyze",
+        tool_call_id: CALL,
+        status: "failed",
+      }),
+      makeTask({
+        id: "b",
+        tool_name: "pipeline:synthesize",
+        tool_call_id: CALL,
+        status: "running",
+      }),
+    ];
+    expect(aggregateCallStatus(tasks, CALL)).toBe("active");
+  });
+
+  it("honors the parent's successful outcome over a retained failed child (recovered pipeline)", () => {
+    // codex round 4: a pipeline can recover from a node failure (failure
+    // edges, retries, continue_on_error) — the failed child row remains
+    // in the store while the parent completes successfully. The parent's
+    // outcome must win, or a successful run renders as an error.
+    const tasks = [
+      makeTask({
+        id: "child-f",
+        tool_name: "pipeline:analyze",
+        tool_call_id: CALL,
+        status: "failed",
+      }),
+      makeTask({
+        id: "parent",
+        tool_name: "run_pipeline",
+        tool_call_id: CALL,
+        status: "completed",
+      }),
+    ];
+    expect(aggregateCallStatus(tasks, CALL)).toBe("settled");
+  });
+
+  it("reports failed when the parent itself failed", () => {
+    const tasks = [
+      makeTask({
+        id: "child-ok",
+        tool_name: "pipeline:analyze",
+        tool_call_id: CALL,
+        status: "completed",
+      }),
+      makeTask({
+        id: "parent",
+        tool_name: "run_pipeline",
+        tool_call_id: CALL,
+        status: "failed",
+      }),
+    ];
+    expect(aggregateCallStatus(tasks, CALL)).toBe("failed");
+  });
+
+  it("falls back to child aggregation when no parent remains (orphan case)", () => {
+    const tasks = [
+      makeTask({
+        id: "c1",
+        tool_name: "pipeline:analyze",
+        tool_call_id: CALL,
+        status: "completed",
+      }),
+      makeTask({
+        id: "c2",
+        tool_name: "pipeline:synthesize",
+        tool_call_id: CALL,
+        status: "failed",
+      }),
+    ];
+    expect(aggregateCallStatus(tasks, CALL)).toBe("failed");
+  });
+
+  it("the latest parent wins over a failed predecessor sharing the call id (relaunch)", () => {
+    const tasks = [
+      makeTask({
+        id: "parent-old",
+        tool_name: "run_pipeline",
+        tool_call_id: CALL,
+        status: "failed",
+      }),
+      makeTask({
+        id: "parent-new",
+        tool_name: "run_pipeline",
+        tool_call_id: CALL,
+        status: "completed",
+      }),
+    ];
+    expect(aggregateCallStatus(tasks, CALL)).toBe("settled");
+  });
+
+  it("returns null when no member carries the call id", () => {
+    expect(
+      aggregateCallStatus(
+        [makeTask({ id: "x", tool_name: "podcast_generate" })],
+        CALL,
+      ),
+    ).toBe(null);
   });
 });

--- a/src/runtime/task-rollup.test.ts
+++ b/src/runtime/task-rollup.test.ts
@@ -407,9 +407,9 @@ describe("aggregateCallStatus", () => {
     expect(aggregateCallStatus([newerFailed, olderOk], CALL)).toBe("failed");
   });
 
-  it("keeps any-failure aggregation for non-pipeline groups (no parent masking)", () => {
-    // codex round 5 P2: unrelated ordinary tasks sharing a call id have
-    // no parent/child relationship — one member's success must not mask
+  it("keeps any-failure aggregation for mixed-tool non-pipeline groups (no member masking)", () => {
+    // codex round 5 P2: DIFFERENT ordinary tools sharing a call id have
+    // no lineage relationship — one member's success must not mask
     // another member's failure.
     const tasks = [
       makeTask({
@@ -428,6 +428,45 @@ describe("aggregateCallStatus", () => {
       }),
     ];
     expect(aggregateCallStatus(tasks, CALL)).toBe("failed");
+  });
+
+  it("a successful same-tool relaunch supersedes its failed predecessor (newest wins)", () => {
+    // codex round 6 P2: TaskSupervisor::relaunch registers the successor
+    // with the SAME tool_call_id and tool_name. The retained failed
+    // predecessor must not fail the card once the relaunch settles.
+    const failedOld = makeTask({
+      id: "tts-old",
+      tool_name: "fm_tts",
+      tool_call_id: CALL,
+      status: "failed",
+      started_at: "2026-07-10T00:00:00Z",
+    });
+    const relaunchOk = makeTask({
+      id: "tts-new",
+      tool_name: "fm_tts",
+      tool_call_id: CALL,
+      status: "completed",
+      started_at: "2026-07-10T01:00:00Z",
+    });
+    // Both store (newest-first) and chronological orderings.
+    expect(aggregateCallStatus([relaunchOk, failedOld], CALL)).toBe("settled");
+    expect(aggregateCallStatus([failedOld, relaunchOk], CALL)).toBe("settled");
+    // Inverse: the relaunch itself failed after a completed predecessor.
+    const relaunchBad = makeTask({
+      id: "tts-new-f",
+      tool_name: "fm_tts",
+      tool_call_id: CALL,
+      status: "failed",
+      started_at: "2026-07-10T02:00:00Z",
+    });
+    const okOld = makeTask({
+      id: "tts-old-ok",
+      tool_name: "fm_tts",
+      tool_call_id: CALL,
+      status: "completed",
+      started_at: "2026-07-10T00:30:00Z",
+    });
+    expect(aggregateCallStatus([relaunchBad, okOld], CALL)).toBe("failed");
   });
 
   it("returns null when no member carries the call id", () => {

--- a/src/runtime/task-rollup.ts
+++ b/src/runtime/task-rollup.ts
@@ -89,19 +89,35 @@ export function expandRolledGroup(
  *   - null      → no member carries this call id (store not hydrated);
  *                 caller falls back to the event's own state.
  *
- * Outcome rule (codex rounds 4–5): a pipeline can RECOVER from a node
- * failure (failure edges, retries, `continue_on_error`) — the failed
- * `pipeline:*` child row is retained in the store while the parent
- * settles successfully. Within a pipeline FAMILY the parent's outcome
- * is therefore authoritative, and the NEWEST parent by `started_at`
- * wins so a relaunch sharing the call id supersedes its failed
- * predecessor (`TaskStore.getTasks` orders newest-first, so list
- * position must NOT be trusted — round-5 P1). Child aggregation — any
- * failed member fails the call — covers the orphan case where only
- * children remain. NON-pipeline groups (unrelated tasks sharing a call
- * id, explicitly supported by the rollup) keep any-failure
- * aggregation: no member is a "parent" that can mask another member's
- * failure (round-5 P2).
+ * Outcome rule (codex rounds 4–6), matching the two REAL server flows
+ * that share a `tool_call_id` (elsewhere tcids are process-unique, see
+ * octos #1412):
+ *
+ *   1. Pipeline family (run_pipeline parent + pipeline:* children): the
+ *      parent's outcome is authoritative — a pipeline can RECOVER from
+ *      a node failure (failure edges, retries, `continue_on_error`), so
+ *      a retained failed child must not fail a successfully-settled
+ *      parent. The NEWEST parent by `started_at` wins so a relaunched
+ *      parent supersedes its failed predecessor. Orphan children (no
+ *      parent row) aggregate any-failure.
+ *   2. Relaunch chain (`TaskSupervisor::relaunch` registers a successor
+ *      with the SAME tool_call_id AND tool_name): the newest member's
+ *      outcome wins, so a successful relaunch clears its failed
+ *      predecessor. Detected as a non-pipeline group whose members all
+ *      share one tool_name.
+ *
+ * A non-pipeline group with MIXED tool names is the defensive
+ * unrelated-tasks case the rollup renders as separate rows — no member
+ * is a "parent" that can mask another member's failure, so any failure
+ * fails the call.
+ *
+ * Timestamp caveat: rows hydrated live by `mergeLiveTask` carry client
+ * receipt time (the `task/updated` wire has no server `started_at`), so
+ * a reconnect replay can momentarily misorder a relaunch chain; the
+ * task watcher's poll rewrites the store with server-authoritative
+ * timestamps within one tick. Ties (and unparseable timestamps) keep
+ * the FIRST seen member, which is the newest under
+ * `TaskStore.getTasks`'s newest-first ordering.
  */
 export function aggregateCallStatus(
   tasks: BackgroundTaskInfo[],
@@ -110,24 +126,35 @@ export function aggregateCallStatus(
   let sawMember = false;
   let sawFailed = false;
   let sawPipeline = false;
+  let sameToolName = true;
+  let firstToolName: string | null = null;
   let parent: BackgroundTaskInfo | null = null;
+  let newest: BackgroundTaskInfo | null = null;
   for (const t of tasks) {
     if (t.tool_call_id !== toolCallId) continue;
     sawMember = true;
     if (t.status === "spawned" || t.status === "running") return "active";
     if (t.status === "failed") sawFailed = true;
+    if (firstToolName === null) firstToolName = t.tool_name;
+    else if (t.tool_name !== firstToolName) sameToolName = false;
     const child = isPipelineChild(t);
     if (child || isPipelineParent(t)) sawPipeline = true;
-    // Track the newest parent-capable member by timestamp. Ties (and
-    // unparseable timestamps) keep the FIRST seen, which is the newest
-    // under the store's newest-first ordering.
     if (!child && (parent === null || startedAtMs(t) > startedAtMs(parent))) {
       parent = t;
     }
+    if (newest === null || startedAtMs(t) > startedAtMs(newest)) {
+      newest = t;
+    }
   }
   if (!sawMember) return null;
-  if (sawPipeline && parent !== null) {
-    return parent.status === "failed" ? "failed" : "settled";
+  if (sawPipeline) {
+    if (parent !== null) {
+      return parent.status === "failed" ? "failed" : "settled";
+    }
+    return sawFailed ? "failed" : "settled";
+  }
+  if (sameToolName && newest !== null) {
+    return newest.status === "failed" ? "failed" : "settled";
   }
   return sawFailed ? "failed" : "settled";
 }

--- a/src/runtime/task-rollup.ts
+++ b/src/runtime/task-rollup.ts
@@ -84,13 +84,19 @@ export function expandRolledGroup(
  * applier) consult this before flipping the card:
  *
  *   - "active"  → at least one member still spawned/running; defer.
- *   - "failed"  → all settled, at least one member failed; settle error.
- *                 The store retains earlier failed rows, so the failure
- *                 outcome survives until the last sibling ends without
- *                 any extra bookkeeping.
- *   - "settled" → all settled, none failed; settle complete.
+ *   - "failed"  → all settled with a failure outcome; settle error.
+ *   - "settled" → all settled successfully; settle complete.
  *   - null      → no member carries this call id (store not hydrated);
  *                 caller falls back to the event's own state.
+ *
+ * Outcome rule (codex round 4): a pipeline can RECOVER from a node
+ * failure (failure edges, retries, `continue_on_error`) — the failed
+ * `pipeline:*` child row is retained in the store while the parent
+ * settles successfully. The parent's outcome is therefore authoritative
+ * when a parent member exists (the LAST parent in list order wins, so a
+ * relaunch sharing the call id supersedes its failed predecessor);
+ * child aggregation — any failed member fails the call — is the
+ * fallback for the orphan case where only children remain.
  */
 export function aggregateCallStatus(
   tasks: BackgroundTaskInfo[],
@@ -98,13 +104,18 @@ export function aggregateCallStatus(
 ): "active" | "failed" | "settled" | null {
   let sawMember = false;
   let sawFailed = false;
+  let parent: BackgroundTaskInfo | null = null;
   for (const t of tasks) {
     if (t.tool_call_id !== toolCallId) continue;
     sawMember = true;
     if (t.status === "spawned" || t.status === "running") return "active";
+    if (!isPipelineChild(t)) parent = t;
     if (t.status === "failed") sawFailed = true;
   }
   if (!sawMember) return null;
+  if (parent !== null) {
+    return parent.status === "failed" ? "failed" : "settled";
+  }
   return sawFailed ? "failed" : "settled";
 }
 

--- a/src/runtime/task-rollup.ts
+++ b/src/runtime/task-rollup.ts
@@ -45,14 +45,32 @@ function isPipelineParent(task: BackgroundTaskInfo): boolean {
 }
 
 /**
- * Synthesize a rollup key that never collides across null entries. Exported
- * so a caller can recover every raw member behind a rolled-up representative
- * (e.g. to cancel a whole pipeline group, not just its representative).
+ * Synthesize a rollup key that never collides across null entries.
  */
 export function rollupKey(task: BackgroundTaskInfo): string {
   return task.tool_call_id != null
     ? `${CALL_TAG}${task.tool_call_id}`
     : `${NULL_CALL_TAG}${task.id}`;
+}
+
+/**
+ * Recover the raw tasks behind a rendered row. Mirrors the collapse rule
+ * in `rollupTasksByCall` exactly: only pipeline families fold into one
+ * representative, so only they expand back out. A non-pipeline task
+ * renders 1:1 even when it shares a `tool_call_id` with unrelated work —
+ * expanding those by key alone would let one row act on another visible
+ * row's task (codex review: Cancel on either row destroyed both).
+ */
+export function expandRolledGroup(
+  representative: BackgroundTaskInfo,
+  tasks: BackgroundTaskInfo[],
+): BackgroundTaskInfo[] {
+  const key = rollupKey(representative);
+  const members = tasks.filter((t) => rollupKey(t) === key);
+  const isPipelineGroup = members.some(
+    (t) => isPipelineParent(t) || isPipelineChild(t),
+  );
+  return isPipelineGroup ? members : [representative];
 }
 
 /**

--- a/src/runtime/task-rollup.ts
+++ b/src/runtime/task-rollup.ts
@@ -89,14 +89,19 @@ export function expandRolledGroup(
  *   - null      → no member carries this call id (store not hydrated);
  *                 caller falls back to the event's own state.
  *
- * Outcome rule (codex round 4): a pipeline can RECOVER from a node
+ * Outcome rule (codex rounds 4–5): a pipeline can RECOVER from a node
  * failure (failure edges, retries, `continue_on_error`) — the failed
  * `pipeline:*` child row is retained in the store while the parent
- * settles successfully. The parent's outcome is therefore authoritative
- * when a parent member exists (the LAST parent in list order wins, so a
- * relaunch sharing the call id supersedes its failed predecessor);
- * child aggregation — any failed member fails the call — is the
- * fallback for the orphan case where only children remain.
+ * settles successfully. Within a pipeline FAMILY the parent's outcome
+ * is therefore authoritative, and the NEWEST parent by `started_at`
+ * wins so a relaunch sharing the call id supersedes its failed
+ * predecessor (`TaskStore.getTasks` orders newest-first, so list
+ * position must NOT be trusted — round-5 P1). Child aggregation — any
+ * failed member fails the call — covers the orphan case where only
+ * children remain. NON-pipeline groups (unrelated tasks sharing a call
+ * id, explicitly supported by the rollup) keep any-failure
+ * aggregation: no member is a "parent" that can mask another member's
+ * failure (round-5 P2).
  */
 export function aggregateCallStatus(
   tasks: BackgroundTaskInfo[],
@@ -104,19 +109,32 @@ export function aggregateCallStatus(
 ): "active" | "failed" | "settled" | null {
   let sawMember = false;
   let sawFailed = false;
+  let sawPipeline = false;
   let parent: BackgroundTaskInfo | null = null;
   for (const t of tasks) {
     if (t.tool_call_id !== toolCallId) continue;
     sawMember = true;
     if (t.status === "spawned" || t.status === "running") return "active";
-    if (!isPipelineChild(t)) parent = t;
     if (t.status === "failed") sawFailed = true;
+    const child = isPipelineChild(t);
+    if (child || isPipelineParent(t)) sawPipeline = true;
+    // Track the newest parent-capable member by timestamp. Ties (and
+    // unparseable timestamps) keep the FIRST seen, which is the newest
+    // under the store's newest-first ordering.
+    if (!child && (parent === null || startedAtMs(t) > startedAtMs(parent))) {
+      parent = t;
+    }
   }
   if (!sawMember) return null;
-  if (parent !== null) {
+  if (sawPipeline && parent !== null) {
     return parent.status === "failed" ? "failed" : "settled";
   }
   return sawFailed ? "failed" : "settled";
+}
+
+function startedAtMs(task: BackgroundTaskInfo): number {
+  const ms = Date.parse(task.started_at);
+  return Number.isNaN(ms) ? 0 : ms;
 }
 
 /**

--- a/src/runtime/task-rollup.ts
+++ b/src/runtime/task-rollup.ts
@@ -44,8 +44,12 @@ function isPipelineParent(task: BackgroundTaskInfo): boolean {
   return task.tool_name === "run_pipeline";
 }
 
-/** Synthesize a rollup key that never collides across null entries. */
-function rollupKey(task: BackgroundTaskInfo): string {
+/**
+ * Synthesize a rollup key that never collides across null entries. Exported
+ * so a caller can recover every raw member behind a rolled-up representative
+ * (e.g. to cancel a whole pipeline group, not just its representative).
+ */
+export function rollupKey(task: BackgroundTaskInfo): string {
   return task.tool_call_id != null
     ? `${CALL_TAG}${task.tool_call_id}`
     : `${NULL_CALL_TAG}${task.id}`;

--- a/src/runtime/task-rollup.ts
+++ b/src/runtime/task-rollup.ts
@@ -74,6 +74,41 @@ export function expandRolledGroup(
 }
 
 /**
+ * Aggregate status of every raw task sharing one tool call (codex round 3).
+ *
+ * Pipeline members emit per-task terminal transitions, but the thread's
+ * tool card is keyed by the shared `tool_call_id` — settling the card on
+ * the FIRST terminal member freezes it while siblings still run, and
+ * later running frames never restore it. Both terminal paths (the live
+ * `task/updated` router branch and the polling `crew:task_status`
+ * applier) consult this before flipping the card:
+ *
+ *   - "active"  → at least one member still spawned/running; defer.
+ *   - "failed"  → all settled, at least one member failed; settle error.
+ *                 The store retains earlier failed rows, so the failure
+ *                 outcome survives until the last sibling ends without
+ *                 any extra bookkeeping.
+ *   - "settled" → all settled, none failed; settle complete.
+ *   - null      → no member carries this call id (store not hydrated);
+ *                 caller falls back to the event's own state.
+ */
+export function aggregateCallStatus(
+  tasks: BackgroundTaskInfo[],
+  toolCallId: string,
+): "active" | "failed" | "settled" | null {
+  let sawMember = false;
+  let sawFailed = false;
+  for (const t of tasks) {
+    if (t.tool_call_id !== toolCallId) continue;
+    sawMember = true;
+    if (t.status === "spawned" || t.status === "running") return "active";
+    if (t.status === "failed") sawFailed = true;
+  }
+  if (!sawMember) return null;
+  return sawFailed ? "failed" : "settled";
+}
+
+/**
  * Fold pipeline children under the parent `run_pipeline` task by
  * `tool_call_id`. The returned list preserves the input order of each
  * group's representative (parent first, else first child seen).

--- a/src/runtime/task-status-applier.test.ts
+++ b/src/runtime/task-status-applier.test.ts
@@ -145,6 +145,65 @@ describe("applyTaskStatusToThreadStore", () => {
     expect(tc?.status).toBe("error");
   });
 
+  it("re-polled deferred terminal rows do not re-narrate duplicate progress lines", () => {
+    // codex round 4: two terminal members waiting on an active sibling
+    // are re-dispatched by the watcher every poll tick. Their distinct
+    // lines alternate, bypassing appendToolProgress's consecutive-only
+    // dedupe — the narration dedupe must record on first landing even
+    // though the terminal flip stays retryable.
+    const cmid = "cmid-live-spam";
+    const callId = "tc-pipe-spam";
+    seedToolCall(cmid, callId, "run_pipeline");
+
+    const base = { started_at: "2026-07-10T00:00:00Z", error: null };
+    const memberA: BackgroundTaskInfo = {
+      id: "sp-a",
+      tool_name: "pipeline:analyze",
+      tool_call_id: callId,
+      status: "completed",
+      ...base,
+    };
+    const memberB: BackgroundTaskInfo = {
+      id: "sp-b",
+      tool_name: "pipeline:plan",
+      tool_call_id: callId,
+      status: "failed",
+      ...base,
+      error: "boom",
+    };
+    const memberC: BackgroundTaskInfo = {
+      id: "sp-c",
+      tool_name: "pipeline:synthesize",
+      tool_call_id: callId,
+      status: "running",
+      ...base,
+    };
+    TaskStore.replaceTasks(SESSION, [memberA, memberB, memberC]);
+
+    const toolCall = () => {
+      const [thread] = ThreadStore.getThreads(SESSION);
+      return thread.responses[0].toolCalls.find((c) => c.id === callId);
+    };
+
+    // Tick 1: both terminal rows land their lines, flips deferred on C.
+    applyTaskStatusToThreadStore(SESSION, undefined, memberA);
+    applyTaskStatusToThreadStore(SESSION, undefined, memberB);
+    const afterTick1 = toolCall()?.progress.length ?? 0;
+    expect(toolCall()?.status).toBe("running");
+
+    // Tick 2: watcher re-dispatches the same rows — no new narration.
+    applyTaskStatusToThreadStore(SESSION, undefined, memberA);
+    applyTaskStatusToThreadStore(SESSION, undefined, memberB);
+    expect(toolCall()?.progress.length ?? 0).toBe(afterTick1);
+    expect(toolCall()?.status).toBe("running");
+
+    // Tick 3: C settles → orphan child aggregation (B failed) → error.
+    const memberCDone: BackgroundTaskInfo = { ...memberC, status: "completed" };
+    TaskStore.replaceTasks(SESSION, [memberA, memberB, memberCDone]);
+    applyTaskStatusToThreadStore(SESSION, undefined, memberCDone);
+    expect(toolCall()?.status).toBe("error");
+  });
+
   it("task.status=running does NOT flip status (the chip is correctly running)", () => {
     const cmid = "cmid-live-3";
     const taskId = "task_pipeline_3";

--- a/src/runtime/task-status-applier.test.ts
+++ b/src/runtime/task-status-applier.test.ts
@@ -14,6 +14,7 @@
 
 import { afterEach, describe, expect, it } from "vitest";
 import * as ThreadStore from "@/store/thread-store";
+import * as TaskStore from "@/store/task-store";
 import {
   __resetTaskStatusDedupForTest,
   applyTaskStatusToThreadStore,
@@ -25,6 +26,7 @@ const SESSION = "sess-runtime-provider";
 
 afterEach(() => {
   ThreadStore.__resetForTests();
+  TaskStore.clearTasks(SESSION);
   __resetTaskStatusDedupForTest();
   __resetTurnMetaForTest();
 });
@@ -97,6 +99,49 @@ describe("applyTaskStatusToThreadStore", () => {
 
     const [thread] = ThreadStore.getThreads(SESSION);
     const tc = thread.responses[0].toolCalls.find((c) => c.id === taskId);
+    expect(tc?.status).toBe("error");
+  });
+
+  it("defers the terminal flip while a pipeline sibling is active, then settles with the aggregate outcome", () => {
+    // codex round 3: the watcher dispatches each raw pipeline row
+    // separately — flipping the shared card on the FIRST terminal member
+    // froze it while siblings still ran. The flip must wait for the last
+    // sibling, and an earlier failed row (retained by TaskStore) must
+    // win the final outcome.
+    const cmid = "cmid-live-sib";
+    const callId = "tc-pipe-live";
+    seedToolCall(cmid, callId, "run_pipeline");
+
+    const memberA: BackgroundTaskInfo = {
+      id: "sib-live-a",
+      tool_name: "pipeline:analyze",
+      tool_call_id: callId,
+      status: "failed",
+      started_at: "2026-07-10T00:00:00Z",
+      error: "boom",
+    };
+    const memberB: BackgroundTaskInfo = {
+      id: "sib-live-b",
+      tool_name: "pipeline:synthesize",
+      tool_call_id: callId,
+      status: "running",
+      started_at: "2026-07-10T00:00:00Z",
+      error: null,
+    };
+    // The watcher writes the poll snapshot BEFORE dispatching each row.
+    TaskStore.replaceTasks(SESSION, [memberA, memberB]);
+    applyTaskStatusToThreadStore(SESSION, undefined, memberA);
+    let [thread] = ThreadStore.getThreads(SESSION);
+    let tc = thread.responses[0].toolCalls.find((c) => c.id === callId);
+    // Sibling B still running → the shared card must NOT settle yet.
+    expect(tc?.status).toBe("running");
+
+    // Next poll: B completed. All members settled, one failed → error.
+    const memberBDone: BackgroundTaskInfo = { ...memberB, status: "completed" };
+    TaskStore.replaceTasks(SESSION, [memberA, memberBDone]);
+    applyTaskStatusToThreadStore(SESSION, undefined, memberBDone);
+    [thread] = ThreadStore.getThreads(SESSION);
+    tc = thread.responses[0].toolCalls.find((c) => c.id === callId);
     expect(tc?.status).toBe("error");
   });
 

--- a/src/runtime/task-status-applier.ts
+++ b/src/runtime/task-status-applier.ts
@@ -19,14 +19,29 @@ import * as TaskStore from "@/store/task-store";
 import { aggregateCallStatus } from "@/runtime/task-rollup";
 import type { BackgroundTaskInfo } from "@/api/types";
 
-/** Last task_status seen per `task.id`. Used to suppress synthesizing a
- *  duplicate progress line on replays/oscillations — only emit a line
- *  when the status actually changes for that task. Per-task scoping
- *  also means two unrelated tasks sharing one `tool_call_id` (rare but
- *  possible across reconnects) each contribute exactly one entry per
- *  transition rather than collapsing into the previous task's line.
- */
-const lastTaskStatusById = new Map<string, BackgroundTaskInfo["status"]>();
+/** Narration dedupe: last task_status whose progress LINE landed, per
+ *  `task.id`. Suppresses re-synthesizing the same line on replays /
+ *  poll re-dispatches — only emit a line when the status actually
+ *  changes for that task. Per-task scoping also means two unrelated
+ *  tasks sharing one `tool_call_id` (rare but possible across
+ *  reconnects) each contribute exactly one entry per transition rather
+ *  than collapsing into the previous task's line.
+ *
+ *  codex round 4: this is deliberately a SEPARATE map from the flip
+ *  dedupe below. A terminal row deferred on an active pipeline sibling
+ *  must keep re-evaluating the aggregate every poll tick (flip map not
+ *  recorded) WITHOUT re-narrating its line each tick — two deferred
+ *  terminal rows alternate lines that bypass `appendToolProgress`'s
+ *  consecutive-only dedupe and would evict real progress from the
+ *  bounded timeline. */
+const lastNarratedStatusById = new Map<string, BackgroundTaskInfo["status"]>();
+
+/** Flip dedupe: last task_status whose terminal status flip (or
+ *  non-terminal pass-through) fully APPLIED, per `task.id`. Recorded
+ *  only after `setToolCallStatus` confirms application (or on
+ *  non-terminal frames), so a no-oped or deferred flip retries on the
+ *  next poll tick. */
+const lastAppliedStatusById = new Map<string, BackgroundTaskInfo["status"]>();
 
 /** Cap individual task labels and error suffixes so a pathological
  *  payload cannot bloat the in-bubble timeline. The bubble renders
@@ -52,19 +67,18 @@ function displayTaskName(tool: string): string {
 /** Build a human-readable progress line for a task_status transition.
  *  Returns null when the status carries no useful narration (e.g. the
  *  daemon emitted an unknown status string), or when this exact status
- *  was already seen for this task and a duplicate line should be
+ *  was already seen (`previous`) and a duplicate line should be
  *  suppressed at the source.
  *
  *  Bug 2026-05-15 (codex final-3 gap 3): does NOT record the dedupe
- *  entry here — the caller MUST record only AFTER the lookup +
- *  `setToolCallStatus` actually applied. Pre-fix this function wrote
- *  the dedupe before the lookup at the call site succeeded, so a
- *  later retry of the same terminal task was silently suppressed and
- *  the status flip never got another chance. */
+ *  entry here — the caller MUST record only AFTER the append actually
+ *  landed on a resolved thread. Pre-fix this function wrote the dedupe
+ *  before the lookup at the call site succeeded, so a later retry of
+ *  the same terminal task was silently suppressed. */
 function synthesizeTaskProgressLine(
   task: BackgroundTaskInfo,
+  previous: BackgroundTaskInfo["status"] | undefined,
 ): string | null {
-  const previous = lastTaskStatusById.get(task.id);
   if (previous === task.status) return null;
 
   const label = displayTaskName(task.tool_name);
@@ -89,10 +103,11 @@ function synthesizeTaskProgressLine(
   }
 }
 
-/** Reset the per-task status-dedupe map. Tests call this between
+/** Reset the per-task status-dedupe maps. Tests call this between
  *  cases so a transition seen in one case can re-fire in the next. */
 export function __resetTaskStatusDedupForTest(): void {
-  lastTaskStatusById.clear();
+  lastNarratedStatusById.clear();
+  lastAppliedStatusById.clear();
 }
 
 /** Apply a `crew:task_status` payload to ThreadStore: synthesize a
@@ -109,8 +124,17 @@ export function applyTaskStatusToThreadStore(
   topic: string | undefined,
   task: BackgroundTaskInfo,
 ): void {
-  const progressLine = synthesizeTaskProgressLine(task);
-  if (!progressLine || !task.tool_call_id) return;
+  if (!task.tool_call_id) return;
+  const previousNarrated = lastNarratedStatusById.get(task.id);
+  const lineIsNew = previousNarrated !== task.status;
+  const progressLine = lineIsNew
+    ? synthesizeTaskProgressLine(task, previousNarrated)
+    : null;
+  // A fresh status that synthesizes NO line is an unknown status string —
+  // nothing to narrate or flip (pre-split behavior preserved).
+  if (lineIsNew && progressLine === null) return;
+  const flipIsNew = lastAppliedStatusById.get(task.id) !== task.status;
+  if (!lineIsNew && !flipIsNew) return;
   // Mirror into the thread store when it already knows about this
   // tool_call_id (i.e. tool_start arrived before task_status). When
   // the lookup misses we deliberately drop the synthetic progress
@@ -123,7 +147,7 @@ export function applyTaskStatusToThreadStore(
     task.tool_call_id,
   );
   if (!threadId) {
-    // Bug 2026-05-15 (codex final-3 gap 3): DO NOT record the dedupe
+    // Bug 2026-05-15 (codex final-3 gap 3): DO NOT record any dedupe
     // entry — the lookup missed, so a later retry of the same
     // `completed`/`failed` task MUST be allowed to try again. The
     // task watcher's poll loop re-fires the same row on every tick,
@@ -131,13 +155,19 @@ export function applyTaskStatusToThreadStore(
     // the first attempt arrived.
     return;
   }
-  ThreadStore.appendToolProgress(threadId, task.tool_call_id, progressLine);
+  if (progressLine !== null) {
+    ThreadStore.appendToolProgress(threadId, task.tool_call_id, progressLine);
+    // Narration dedupe records as soon as the line lands — even when the
+    // terminal flip below defers — so re-polled deferred rows do not
+    // re-narrate every tick (codex round 4).
+    lastNarratedStatusById.set(task.id, task.status);
+  }
   // Mirror the terminal status into ThreadStore so the spinner clears
   // on the same tick the progress line says "done". Non-terminal
   // `spawned`/`running` lines do NOT flip status (the chip is
   // correctly running during those frames).
   //
-  // Bug 2026-05-15 (codex final-3 gap 3): record the dedupe entry
+  // Bug 2026-05-15 (codex final-3 gap 3): record the flip dedupe entry
   // ONLY AFTER `setToolCallStatus` confirms it actually applied.
   // `setToolCallStatus` returns `true` when it found the target tool
   // call and flipped its status, `false` when the lookup no-oped. If
@@ -161,11 +191,11 @@ export function applyTaskStatusToThreadStore(
         task.tool_call_id,
       ) ?? (task.status === "failed" ? "failed" : "settled");
     if (aggregate === "active") {
-      // Do NOT record the dedupe entry: the next poll tick re-fires this
+      // Do NOT record the flip dedupe: the next poll tick re-fires this
       // terminal row and re-evaluates the aggregate, so the card still
       // settles even if the last sibling's own terminal row is never
-      // observed (self-healing). The re-synthesized progress line is
-      // swallowed by `appendToolProgress`'s consecutive-duplicate dedupe.
+      // observed (self-healing). The narration dedupe above already
+      // recorded, so the retry is silent.
       return;
     }
     applied = ThreadStore.setToolCallStatus(
@@ -177,6 +207,6 @@ export function applyTaskStatusToThreadStore(
   // Non-terminal `spawned`/`running` lines always count as applied
   // (the progress line itself landed; no status flip required).
   if (applied) {
-    lastTaskStatusById.set(task.id, task.status);
+    lastAppliedStatusById.set(task.id, task.status);
   }
 }

--- a/src/runtime/task-status-applier.ts
+++ b/src/runtime/task-status-applier.ts
@@ -15,6 +15,8 @@
  */
 
 import * as ThreadStore from "@/store/thread-store";
+import * as TaskStore from "@/store/task-store";
+import { aggregateCallStatus } from "@/runtime/task-rollup";
 import type { BackgroundTaskInfo } from "@/api/types";
 
 /** Last task_status seen per `task.id`. Used to suppress synthesizing a
@@ -142,17 +144,34 @@ export function applyTaskStatusToThreadStore(
   // the status flip no-ops (tool call not in store yet, picker
   // missed, etc.) the next retry should be allowed to try again.
   let applied = true;
-  if (task.status === "completed") {
+  if (task.status === "completed" || task.status === "failed") {
+    // codex round 3: pipeline members share this tool_call_id but the
+    // watcher dispatches each raw row separately — flipping the card on
+    // the FIRST terminal member freezes it while siblings still run
+    // (same deferral the live `task/updated` router path applies). The
+    // watcher calls `TaskStore.replaceTasks` BEFORE dispatching
+    // `crew:task_status`, so the store reflects this poll's snapshot.
+    // While a sibling is active, skip the flip; the LAST member's
+    // transition settles the card with the aggregate outcome (an
+    // earlier failed row is retained by the store, so the failure
+    // outcome survives the deferral).
+    const aggregate =
+      aggregateCallStatus(
+        TaskStore.getTasks(sessionId, topic),
+        task.tool_call_id,
+      ) ?? (task.status === "failed" ? "failed" : "settled");
+    if (aggregate === "active") {
+      // Do NOT record the dedupe entry: the next poll tick re-fires this
+      // terminal row and re-evaluates the aggregate, so the card still
+      // settles even if the last sibling's own terminal row is never
+      // observed (self-healing). The re-synthesized progress line is
+      // swallowed by `appendToolProgress`'s consecutive-duplicate dedupe.
+      return;
+    }
     applied = ThreadStore.setToolCallStatus(
       threadId,
       task.tool_call_id,
-      "complete",
-    );
-  } else if (task.status === "failed") {
-    applied = ThreadStore.setToolCallStatus(
-      threadId,
-      task.tool_call_id,
-      "error",
+      aggregate === "failed" ? "error" : "complete",
     );
   }
   // Non-terminal `spawned`/`running` lines always count as applied

--- a/src/runtime/ui-protocol-bridge.ts
+++ b/src/runtime/ui-protocol-bridge.ts
@@ -26,6 +26,7 @@ import type {
   UserQuestionRespondResult,
   UserQuestionAnswer,
   ApprovalRespondResult,
+  TaskCancelResult,
   ApprovalScope,
   ConnectionState,
   Envelope,
@@ -74,6 +75,7 @@ export type {
   UserQuestionRespondResult,
   UserQuestionAnswer,
   ApprovalRespondResult,
+  TaskCancelResult,
   ApprovalScope,
   ConnectionState,
   HydratedMessage,
@@ -132,9 +134,7 @@ export const METHODS = {
   APPROVAL_RESPOND: "approval/respond",
   USER_QUESTION_RESPOND: "user_question/respond",
   USER_QUESTION_REQUESTED: "user_question/requested",
-  TASK_OUTPUT_READ: "task/output/read",
   DIFF_PREVIEW_GET: "diff/preview/get",
-  TURN_STATE_GET: "turn/state/get",
   PING: "ping",
   // M12 Phase D-1 (octos PR #912): auxiliary.rest_to_ws.v1 methods.
   // Each mirrors the JSON body of the corresponding REST handler so
@@ -146,6 +146,7 @@ export const METHODS = {
   SESSION_STATUS_GET: "session/status.get",
   SESSION_FILES_LIST: "session/files.list",
   SESSION_TASKS_LIST: "session/tasks.list",
+  TASK_CANCEL: "task/cancel",
   SESSION_WORKSPACE_GET: "session/workspace.get",
   SESSION_TITLE_SET: "session/title.set",
   SESSION_DELETE: "session/delete",
@@ -236,6 +237,7 @@ export const UI_PROTOCOL_FEATURES = [
   "approval.typed.v1",
   "user_question.v1",
   "pane.snapshots.v1",
+  "harness.task_control.v1",
   // P1.3 (server PR #767, web PR aligning the wire shape): the server
   // explicitly filters both live broadcast and cursor replay of
   // `message/persisted` notifications unless this capability was
@@ -382,6 +384,7 @@ export interface UiProtocolBridge {
     scope?: ApprovalScope,
     client_note?: string,
   ): Promise<ApprovalRespondResult>;
+  cancelTask(task_id: string): Promise<TaskCancelResult>;
 
   /**
    * Issue a `session/hydrate` RPC for the active session. M10 Phase 6.2
@@ -2073,6 +2076,18 @@ class UiProtocolBridgeImpl implements UiProtocolBridge {
       METHODS.APPROVAL_RESPOND,
       params,
     );
+  }
+
+  cancelTask(task_id: string): Promise<TaskCancelResult> {
+    if (!isString(task_id)) {
+      return Promise.reject(
+        new Error("ui-protocol-bridge: cancelTask requires task_id"),
+      );
+    }
+    return this.request<TaskCancelResult>(METHODS.TASK_CANCEL, {
+      task_id,
+      session_id: this.requireScopedSessionId(),
+    });
   }
 
   onUserQuestionRequested(

--- a/src/runtime/ui-protocol-event-router.test.ts
+++ b/src/runtime/ui-protocol-event-router.test.ts
@@ -13,6 +13,7 @@
 
 import { afterEach, describe, expect, it, vi } from "vitest";
 import * as ThreadStore from "@/store/thread-store";
+import * as TaskStore from "@/store/task-store";
 import {
   __resetProjectionForTests,
   __setProjectionV1ForTests,
@@ -497,6 +498,38 @@ describe("router event mapping", () => {
     expect(progressEvt!.detail.message).toBe("deep_research");
     expect(progressEvt!.detail.turnId).toBe("cmid-3");
     expect(progressEvt!.detail.terminal).toBeUndefined();
+  });
+
+  it("task/updated cancelled drops the task from the active store (mapped to completed)", () => {
+    // The web BackgroundTaskInfo status union has no `cancelled`; pre-fix the
+    // router dropped a `cancelled` update entirely, leaving a cancelled task
+    // stuck showing as running. It must map to a terminal status so the task
+    // leaves the active set.
+    const cfg = {
+      sessionId: SESSION,
+      dispatchEvent: () => {},
+    };
+    TaskStore.replaceTasks(SESSION, [
+      {
+        id: "task-cxl",
+        tool_name: "deep_search",
+        tool_call_id: "tc-cxl",
+        status: "running",
+        started_at: new Date(2026, 0, 1).toISOString(),
+        completed_at: null,
+        output_files: [],
+        error: null,
+      },
+    ]);
+    handleTaskUpdated(cfg, {
+      session_id: SESSION,
+      task_id: "task-cxl",
+      state: "cancelled",
+      title: "deep_search",
+    } as TaskUpdatedEvent);
+    const task = TaskStore.getTasks(SESSION).find((t) => t.id === "task-cxl");
+    expect(task?.status).toBe("completed"); // terminal, not "running", not dropped-update
+    expect(task?.error).toBeNull(); // cancelled is not an error
   });
 
   it("task/updated completed fans out a terminal crew:tool_progress (spawn_only spinner clear)", () => {

--- a/src/runtime/ui-protocol-event-router.test.ts
+++ b/src/runtime/ui-protocol-event-router.test.ts
@@ -597,6 +597,71 @@ describe("router event mapping", () => {
     expect(terminalEvt!.detail.message).toBe("done");
   });
 
+  it("task/updated cancelled for one pipeline member defers card terminalization until the last sibling ends", () => {
+    // codex round 2 P2: pipeline members share one tool call, but
+    // `task/updated` fires per raw task. Cancelling one member while a
+    // sibling keeps running (a supported task/cancel outcome) must NOT
+    // settle the shared card — later running frames never restore it.
+    // Terminalize only when no active sibling remains on the call.
+    seedThread("cmid-sib");
+    const dispatched: Event[] = [];
+    const cfg = {
+      sessionId: SESSION,
+      dispatchEvent: (e: Event) => dispatched.push(e),
+    };
+    const shared = "tc-pipe-sib";
+    const base = {
+      started_at: new Date(2026, 0, 1).toISOString(),
+      completed_at: null,
+      output_files: [],
+      error: null,
+    };
+    TaskStore.replaceTasks(SESSION, [
+      {
+        id: "sib-a",
+        tool_name: "pipeline:analyze",
+        tool_call_id: shared,
+        status: "running",
+        ...base,
+      },
+      {
+        id: "sib-b",
+        tool_name: "pipeline:synthesize",
+        tool_call_id: shared,
+        status: "running",
+        ...base,
+      },
+    ]);
+    const terminalFrames = () =>
+      dispatched
+        .filter((e) => e.type === "crew:tool_progress")
+        .map((e) => e as CustomEvent)
+        .filter((e) => e.detail.terminal === true);
+    handleTaskUpdated(cfg, {
+      session_id: SESSION,
+      turn_id: "cmid-sib",
+      task_id: "sib-a",
+      tool_call_id: shared,
+      state: "cancelled",
+    } as TaskUpdatedEvent);
+    // Sibling sib-b still running on the same call — no terminal frame yet.
+    expect(terminalFrames()).toHaveLength(0);
+    // The cancelled member's OWN store row still went terminal (its dock
+    // row clears); only the shared card transition is deferred.
+    expect(
+      TaskStore.getTasks(SESSION).find((t) => t.id === "sib-a")?.status,
+    ).toBe("completed");
+    handleTaskUpdated(cfg, {
+      session_id: SESSION,
+      turn_id: "cmid-sib",
+      task_id: "sib-b",
+      tool_call_id: shared,
+      state: "cancelled",
+    } as TaskUpdatedEvent);
+    // Last active member gone → the shared card terminalizes now.
+    expect(terminalFrames()).toHaveLength(1);
+  });
+
   it("task/updated running passes through new labels (state-only dedupe would suppress spinner refresh)", () => {
     // Codex round-3: a stream of `running` updates with refreshed
     // `title`/`runtime_detail` values must reach the lifted spinner.

--- a/src/runtime/ui-protocol-event-router.test.ts
+++ b/src/runtime/ui-protocol-event-router.test.ts
@@ -567,6 +567,36 @@ describe("router event mapping", () => {
     expect(terminalEvt!.detail.message).toBe("done");
   });
 
+  it("task/updated cancelled fires a terminal crew:tool_progress (tool card stops spinning)", () => {
+    // Codex P1: `cancelled` must share the completed terminal path, else the
+    // tool card + spinner keep animating after the dock row disappears.
+    seedThread("cmid-cxl");
+    const dispatched: Event[] = [];
+    const cfg = {
+      sessionId: SESSION,
+      dispatchEvent: (e: Event) => dispatched.push(e),
+    };
+    handleTaskUpdated(cfg, {
+      session_id: SESSION,
+      turn_id: "cmid-cxl",
+      task_id: "task-cxl2",
+      state: "running",
+      title: "deep_search",
+    });
+    handleTaskUpdated(cfg, {
+      session_id: SESSION,
+      turn_id: "cmid-cxl",
+      task_id: "task-cxl2",
+      state: "cancelled",
+    });
+    const terminalEvt = dispatched
+      .filter((e) => e.type === "crew:tool_progress")
+      .map((e) => e as CustomEvent)
+      .find((e) => e.detail.terminal === true);
+    expect(terminalEvt).toBeDefined();
+    expect(terminalEvt!.detail.message).toBe("done");
+  });
+
   it("task/updated running passes through new labels (state-only dedupe would suppress spinner refresh)", () => {
     // Codex round-3: a stream of `running` updates with refreshed
     // `title`/`runtime_detail` values must reach the lifted spinner.

--- a/src/runtime/ui-protocol-event-router.test.ts
+++ b/src/runtime/ui-protocol-event-router.test.ts
@@ -662,6 +662,69 @@ describe("router event mapping", () => {
     expect(terminalFrames()).toHaveLength(1);
   });
 
+  it("task/updated failed for one pipeline member defers, and the failure outcome wins when the last sibling completes", () => {
+    // codex round 3: the failed/errored branch bypassed the sibling
+    // deferral — one member's failure settled the shared card while the
+    // other member kept running. The failure must defer like the other
+    // terminals, and its store row must carry the error outcome to the
+    // final settle.
+    seedThread("cmid-sibfail");
+    const dispatched: Event[] = [];
+    const cfg = {
+      sessionId: SESSION,
+      dispatchEvent: (e: Event) => dispatched.push(e),
+    };
+    const shared = "tc-pipe-fail";
+    const base = {
+      started_at: new Date(2026, 0, 1).toISOString(),
+      completed_at: null,
+      output_files: [],
+      error: null,
+    };
+    TaskStore.replaceTasks(SESSION, [
+      {
+        id: "sf-a",
+        tool_name: "pipeline:analyze",
+        tool_call_id: shared,
+        status: "running",
+        ...base,
+      },
+      {
+        id: "sf-b",
+        tool_name: "pipeline:synthesize",
+        tool_call_id: shared,
+        status: "running",
+        ...base,
+      },
+    ]);
+    const terminalFrames = () =>
+      dispatched
+        .filter((e) => e.type === "crew:tool_progress")
+        .map((e) => e as CustomEvent)
+        .filter((e) => e.detail.terminal === true);
+    handleTaskUpdated(cfg, {
+      session_id: SESSION,
+      turn_id: "cmid-sibfail",
+      task_id: "sf-a",
+      tool_call_id: shared,
+      state: "failed",
+      runtime_detail: "boom",
+    } as TaskUpdatedEvent);
+    // Sibling still running → even a failure defers the shared card.
+    expect(terminalFrames()).toHaveLength(0);
+    handleTaskUpdated(cfg, {
+      session_id: SESSION,
+      turn_id: "cmid-sibfail",
+      task_id: "sf-b",
+      tool_call_id: shared,
+      state: "completed",
+    } as TaskUpdatedEvent);
+    // All settled; sf-a's retained failed row decides the outcome.
+    const frames = terminalFrames();
+    expect(frames).toHaveLength(1);
+    expect(frames[0].detail.message).toBe("error");
+  });
+
   it("task/updated running passes through new labels (state-only dedupe would suppress spinner refresh)", () => {
     // Codex round-3: a stream of `running` updates with refreshed
     // `title`/`runtime_detail` values must reach the lifted spinner.

--- a/src/runtime/ui-protocol-event-router.ts
+++ b/src/runtime/ui-protocol-event-router.ts
@@ -941,6 +941,25 @@ export function handleTaskUpdated(
     case "completed":
     case "cancelled":
     case "canceled": {
+      // Pipeline members share one tool card (`resolvedToolCallId`) but
+      // `task/updated` fires per raw task, and a cancel can terminate one
+      // member while siblings keep running — an explicitly supported
+      // task/cancel outcome. Settling the card on the FIRST terminal
+      // member freezes it "complete" while the dock still shows active
+      // work, and later running frames never restore it (codex round 2).
+      // Defer the terminal transition until no active sibling shares the
+      // call id. `mergeLiveTask` above already flipped THIS task's store
+      // row terminal, so an active match is a different, still-live member.
+      const hasActiveSibling = TaskStore.getTasks(
+        cfg.sessionId,
+        cfg.topic,
+      ).some(
+        (t) =>
+          t.id !== event.task_id &&
+          t.tool_call_id === resolvedToolCallId &&
+          (t.status === "spawned" || t.status === "running"),
+      );
+      if (hasActiveSibling) break;
       if (hostThreadId) {
         ThreadStore.setToolCallStatus(
           hostThreadId,

--- a/src/runtime/ui-protocol-event-router.ts
+++ b/src/runtime/ui-protocol-event-router.ts
@@ -53,6 +53,7 @@ import type { MessageMeta } from "@/store/thread-store";
 import type { MessageInfo } from "@/api/types";
 import { recordRuntimeCounter } from "./observability";
 import { isSpawnOnlyToolName } from "./spawn-only-tools";
+import { aggregateCallStatus } from "./task-rollup";
 
 // ---------------------------------------------------------------------------
 // Per-turn meta snapshot
@@ -933,72 +934,55 @@ export function handleTaskUpdated(
       dispatchToolProgressEvent(cfg, hostThreadId, toolLabel, label);
       break;
     }
-    // `cancelled` shares the completed terminal path: the tool card must
-    // stop animating, a terminal progress frame must fire, and the cache
-    // entry dropped — otherwise the tool card + spinner keep spinning after
-    // the dock row disappears (codex review). `mergeLiveTask` above already
-    // maps its store status to `completed`.
+    // All terminal states share one path: the tool card must stop
+    // animating, a terminal progress frame must fire, and the cache
+    // entry dropped — otherwise the tool card + spinner keep spinning
+    // after the dock row disappears (codex review). `cancelled` maps its
+    // store status to `completed` in `mergeLiveTask`.
+    //
+    // Pipeline members share one tool card (`resolvedToolCallId`) but
+    // `task/updated` fires per raw task, and a cancel or failure can
+    // terminate one member while siblings keep running — an explicitly
+    // supported task/cancel outcome. Settling the card on the FIRST
+    // terminal member freezes it while the dock still shows active work,
+    // and later running frames never restore it (codex rounds 2–3).
+    // Defer the card's terminal transition while any active member
+    // shares the call id — `mergeLiveTask` above already flipped THIS
+    // task's store row terminal, so an active match is a different,
+    // still-live member. A deferred failure is retained by its store
+    // row: when the last sibling settles, the aggregate reports
+    // "failed" and the card lands on error.
     case "completed":
     case "cancelled":
-    case "canceled": {
-      // Pipeline members share one tool card (`resolvedToolCallId`) but
-      // `task/updated` fires per raw task, and a cancel can terminate one
-      // member while siblings keep running — an explicitly supported
-      // task/cancel outcome. Settling the card on the FIRST terminal
-      // member freezes it "complete" while the dock still shows active
-      // work, and later running frames never restore it (codex round 2).
-      // Defer the terminal transition until no active sibling shares the
-      // call id. `mergeLiveTask` above already flipped THIS task's store
-      // row terminal, so an active match is a different, still-live member.
-      const hasActiveSibling = TaskStore.getTasks(
-        cfg.sessionId,
-        cfg.topic,
-      ).some(
-        (t) =>
-          t.id !== event.task_id &&
-          t.tool_call_id === resolvedToolCallId &&
-          (t.status === "spawned" || t.status === "running"),
-      );
-      if (hasActiveSibling) break;
-      if (hostThreadId) {
-        ThreadStore.setToolCallStatus(
-          hostThreadId,
-          resolvedToolCallId,
-          "complete",
-        );
-      }
-      dispatchToolProgressEvent(
-        cfg,
-        hostThreadId,
-        toolLabel,
-        "done",
-        /* terminal */ true,
-      );
-      // Drop the cache entry — the task is done, no further frames
-      // should land on this id (mirrors `handleToolCompleted`). Drop
-      // both identifier shapes.
-      toolNameByCallId.delete(event.task_id);
-      if (resolvedToolCallId !== event.task_id) {
-        toolNameByCallId.delete(resolvedToolCallId);
-      }
-      break;
-    }
+    case "canceled":
     case "failed":
     case "errored": {
+      const isFailureEvent =
+        event.state === "failed" || event.state === "errored";
+      const aggregate =
+        aggregateCallStatus(
+          TaskStore.getTasks(cfg.sessionId, cfg.topic),
+          resolvedToolCallId,
+        ) ?? (isFailureEvent ? "failed" : "settled");
+      if (aggregate === "active") break;
+      const isError = aggregate === "failed";
       if (hostThreadId) {
         ThreadStore.setToolCallStatus(
           hostThreadId,
           resolvedToolCallId,
-          "error",
+          isError ? "error" : "complete",
         );
       }
       dispatchToolProgressEvent(
         cfg,
         hostThreadId,
         toolLabel,
-        "error",
+        isError ? "error" : "done",
         /* terminal */ true,
       );
+      // Drop the cache entry — the call is done, no further frames
+      // should land on this id (mirrors `handleToolCompleted`). Drop
+      // both identifier shapes.
       toolNameByCallId.delete(event.task_id);
       if (resolvedToolCallId !== event.task_id) {
         toolNameByCallId.delete(resolvedToolCallId);

--- a/src/runtime/ui-protocol-event-router.ts
+++ b/src/runtime/ui-protocol-event-router.ts
@@ -1052,7 +1052,15 @@ function mergeLiveTask(
           ? "completed"
           : state === "failed" || state === "errored"
             ? "failed"
-            : null;
+            : // A `cancelled` task (harness.task_control.v1 task/cancel, or a
+              // channel-side cancel) is terminal-and-not-an-error. The web
+              // `BackgroundTaskInfo` status union has no `cancelled`, and
+              // dropping the update here (the pre-fix behavior) left a
+              // cancelled task stuck showing as running forever. Map it to
+              // `completed` so it leaves the active set without flashing red.
+              state === "cancelled" || state === "canceled"
+              ? "completed"
+              : null;
   if (!status) return;
 
   const existing = TaskStore.getTasks(sessionId, topic).find(

--- a/src/runtime/ui-protocol-event-router.ts
+++ b/src/runtime/ui-protocol-event-router.ts
@@ -933,7 +933,14 @@ export function handleTaskUpdated(
       dispatchToolProgressEvent(cfg, hostThreadId, toolLabel, label);
       break;
     }
-    case "completed": {
+    // `cancelled` shares the completed terminal path: the tool card must
+    // stop animating, a terminal progress frame must fire, and the cache
+    // entry dropped — otherwise the tool card + spinner keep spinning after
+    // the dock row disappears (codex review). `mergeLiveTask` above already
+    // maps its store status to `completed`.
+    case "completed":
+    case "cancelled":
+    case "canceled": {
       if (hostThreadId) {
         ThreadStore.setToolCallStatus(
           hostThreadId,

--- a/src/runtime/ui-protocol-types.ts
+++ b/src/runtime/ui-protocol-types.ts
@@ -105,6 +105,17 @@ export interface ApprovalRespondResult {
 }
 
 /**
+ * Result of `task/cancel` (harness.task_control.v1). `status` is the task's
+ * authoritative post-cancel runtime state — a task that had already finished
+ * comes back `completed`/`failed` rather than `cancelled`, so the caller
+ * renders truth instead of assuming the cancel took.
+ */
+export interface TaskCancelResult {
+  task_id: string;
+  status: "pending" | "running" | "completed" | "failed" | "cancelled";
+}
+
+/**
  * `message/delta` notification per UI Protocol v1 spec § 6 / § 9.
  *
  * The wire payload's text-bearing field is named `text` to match


### PR DESCRIPTION
Second of the two P1 web-parity gaps (`harness.task_control.v1`): background tasks shown in the header dock can now be cancelled from the web UI.

## What

- **Dock cancel menu** — the task constellation indicator is now a button; it opens a per-row cancel menu. Cancelling a rolled-up pipeline row cancels every active raw member of that family (`expandRolledGroup` mirrors `rollupTasksByCall`'s collapse rule exactly, over the same active subset the renderer saw).
- **Bridge** — `task/cancel` RPC + `harness.task_control.v1` negotiated; removed two dead method constants.
- **Terminal correctness** (pre-existing latent bugs surfaced by review):
  - `cancelled`/`canceled` task states were silently DROPPED by the event router (task stuck "running" forever) and missing from the terminal switch (tool card spun forever). Both fixed.
  - Shared tool cards (pipeline members share one `tool_call_id`) no longer settle on the FIRST terminal member: `aggregateCallStatus` defers the card until no member is active, on **both** the live `task/updated` path and the `crew:task_status` poll path.
  - Outcome rules match the two real server flows sharing a tcid: pipeline families (newest parent authoritative — recovered pipelines settle complete) and relaunch chains (same tool_name; newest wins — a successful relaunch clears its failed predecessor). Mixed-tool groups keep any-failure.
  - Applier dedupe split into narration vs flip maps so deferred terminal rows stay retryable without re-narrating duplicate progress lines every poll tick.

## Review

7 codex rounds; all findings folded except one known edge, deliberately deferred:

- **Known edge (documented in `aggregateCallStatus` doc):** rows hydrated live by `mergeLiveTask` carry client receipt-time `started_at` (the `task/updated` wire has no server timestamp), so an exotic reconnect replay could misorder a relaunch chain's outcome. Not a regression — pre-PR the card settled last-event-wins unconditionally, which misrenders in strictly more cases. Root fix is server-side; follow-up filed in octos to carry `started_at` + `relaunched_from` on `task/updated`.

## Tests

883 passing (14 new: group cancel, per-row cancel for unrelated/retained-terminal groups, sibling deferral incl. failure retention, relaunch chains under both orderings, no-spam re-poll, aggregate unit coverage). tsc + eslint clean on touched files.
