### PR TITLE
feat(chat): per-session thinking-effort selector (/thinking parity)

### DIFF
--- a/src/components/chat-thread-cancel-ordering.test.tsx
+++ b/src/components/chat-thread-cancel-ordering.test.tsx
@@ -1,0 +1,142 @@
+/**
+ * Cancel-vs-seed ordering (codex #261 round-2 P1).
+ *
+ * The send path parks `turn/start` behind `whenThinkingSeeded` during
+ * the initial `session/open` handshake. A cancel clicked in that window
+ * must be gated on the SAME promise, or `turn/interrupt` reaches the
+ * bridge queue first, no-ops server-side, and the supposedly cancelled
+ * turn runs anyway. This pins: (1) the interrupt defers while the scope
+ * is unseeded; (2) it fires after the seed; (3) seeded steady-state
+ * cancels still go through.
+ */
+
+import { afterEach, describe, expect, it, vi } from "vitest";
+import * as React from "react";
+import { act } from "react";
+import { createRoot, type Root } from "react-dom/client";
+
+(
+  globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }
+).IS_REACT_ACT_ENVIRONMENT = true;
+
+const interruptTurn = vi.fn().mockResolvedValue({ interrupted: true });
+vi.mock("@/runtime/ui-protocol-runtime", () => ({
+  getActiveBridge: () => ({ interruptTurn }),
+}));
+
+import { ChatThread } from "./chat-thread";
+import { SessionContext } from "@/runtime/session-context";
+import type { SessionContextValue } from "@/runtime/session-context";
+import * as ThreadStore from "@/store/thread-store";
+import {
+  __resetThinkingStoreForTest,
+  markThinkingSeeded,
+} from "@/store/thinking-store";
+
+const SESSION = "sess-cancel-ordering";
+
+interface MountedHarness {
+  container: HTMLDivElement;
+  root: Root;
+  unmount: () => void;
+}
+
+function makeSessionCtx(): SessionContextValue {
+  return {
+    sessions: [],
+    currentSessionId: SESSION,
+    historyTopic: undefined,
+    currentSessionTitle: "",
+    currentSessionStats: null,
+    initialMessages: [],
+    activeTaskOnServer: false,
+    queueMode: null,
+    adaptiveMode: null,
+    setServerTaskActive: () => {},
+    renameSession: () => {},
+    updateSessionStats: () => {},
+    switchSession: () => {},
+    goBack: async () => false,
+    createSession: () => SESSION,
+    removeSession: async () => {},
+    refreshSessions: async () => {},
+    markSessionActive: () => {},
+  };
+}
+
+function mountWithStreamingTurn(): MountedHarness {
+  // A streaming pendingAssistant makes `isRunning` true → Cancel button.
+  ThreadStore.addUserMessage(SESSION, {
+    text: "long question",
+    clientMessageId: "cmid-cancel-order",
+  });
+  ThreadStore.appendAssistantToken("cmid-cancel-order", "thinking…");
+  const container = document.createElement("div");
+  document.body.appendChild(container);
+  const root = createRoot(container);
+  act(() => {
+    root.render(
+      <SessionContext.Provider value={makeSessionCtx()}>
+        <ChatThread />
+      </SessionContext.Provider>,
+    );
+  });
+  return {
+    container,
+    root,
+    unmount: () => {
+      act(() => root.unmount());
+      container.remove();
+    },
+  };
+}
+
+afterEach(() => {
+  for (const node of [...document.body.children]) node.remove();
+  ThreadStore.__resetForTests();
+  __resetThinkingStoreForTest();
+  interruptTurn.mockClear();
+});
+
+describe("cancel ordering vs thinking-seed gate", () => {
+  it("defers turn/interrupt until the scope seeds, then fires", async () => {
+    const harness = mountWithStreamingTurn();
+    const cancelBtn = harness.container.querySelector(
+      '[data-testid="cancel-button"]',
+    ) as HTMLButtonElement;
+    expect(cancelBtn).toBeTruthy();
+
+    await act(async () => {
+      cancelBtn.click();
+    });
+    // Scope not seeded (session/open still pending) → interrupt parked.
+    expect(interruptTurn).not.toHaveBeenCalled();
+
+    await act(async () => {
+      markThinkingSeeded(SESSION);
+      // Let the gated .then continuation run.
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+    expect(interruptTurn).toHaveBeenCalledWith(
+      "cmid-cancel-order",
+      "user cancelled",
+    );
+    harness.unmount();
+  });
+
+  it("fires immediately (one microtask) when the scope is already seeded", async () => {
+    markThinkingSeeded(SESSION);
+    const harness = mountWithStreamingTurn();
+    const cancelBtn = harness.container.querySelector(
+      '[data-testid="cancel-button"]',
+    ) as HTMLButtonElement;
+    await act(async () => {
+      cancelBtn.click();
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+    expect(interruptTurn).toHaveBeenCalledTimes(1);
+    harness.unmount();
+  });
+});

--- a/src/components/chat-thread-thinking-selector.test.tsx
+++ b/src/components/chat-thread-thinking-selector.test.tsx
@@ -1,0 +1,134 @@
+/**
+ * Composer thinking-effort selector (TUI `/thinking` parity).
+ *
+ * The selector is per-session state backed by `thinking-store`; the send
+ * path (`buildTurnStartExtras`) reads the same store so every user turn
+ * carries the choice — omission is meaningful to the server (clears the
+ * persisted override), so the selector MUST round-trip through the store,
+ * not component-local state.
+ */
+
+import { afterEach, describe, expect, it } from "vitest";
+import * as React from "react";
+import { act } from "react";
+import { createRoot, type Root } from "react-dom/client";
+
+(
+  globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }
+).IS_REACT_ACT_ENVIRONMENT = true;
+
+import { ChatThread } from "./chat-thread";
+import { SessionContext } from "@/runtime/session-context";
+import type { SessionContextValue } from "@/runtime/session-context";
+import * as ThreadStore from "@/store/thread-store";
+import {
+  __resetThinkingStoreForTest,
+  getThinkingEffort,
+  setThinkingEffort,
+} from "@/store/thinking-store";
+
+const SESSION = "sess-thinking-selector";
+
+interface MountedHarness {
+  container: HTMLDivElement;
+  root: Root;
+  unmount: () => void;
+}
+
+function makeSessionCtx(): SessionContextValue {
+  return {
+    sessions: [],
+    currentSessionId: SESSION,
+    historyTopic: undefined,
+    currentSessionTitle: "",
+    currentSessionStats: null,
+    initialMessages: [],
+    activeTaskOnServer: false,
+    queueMode: null,
+    adaptiveMode: null,
+    setServerTaskActive: () => {},
+    renameSession: () => {},
+    updateSessionStats: () => {},
+    switchSession: () => {},
+    goBack: async () => false,
+    createSession: () => SESSION,
+    removeSession: async () => {},
+    refreshSessions: async () => {},
+    markSessionActive: () => {},
+  };
+}
+
+function mount(node: React.ReactElement): MountedHarness {
+  const container = document.createElement("div");
+  document.body.appendChild(container);
+  const root = createRoot(container);
+  act(() => {
+    root.render(node);
+  });
+  return {
+    container,
+    root,
+    unmount: () => {
+      act(() => root.unmount());
+      container.remove();
+    },
+  };
+}
+
+function mountThread(): MountedHarness {
+  return mount(
+    <SessionContext.Provider value={makeSessionCtx()}>
+      <ChatThread />
+    </SessionContext.Provider>,
+  );
+}
+
+function getSelect(harness: MountedHarness): HTMLSelectElement {
+  const el = harness.container.querySelector(
+    '[data-testid="thinking-effort-select"]',
+  ) as HTMLSelectElement | null;
+  expect(el).toBeTruthy();
+  return el as HTMLSelectElement;
+}
+
+afterEach(() => {
+  for (const node of [...document.body.children]) node.remove();
+  ThreadStore.__resetForTests();
+  __resetThinkingStoreForTest();
+});
+
+describe("composer thinking-effort selector", () => {
+  it("renders defaulted and writes the store on change", () => {
+    const harness = mountThread();
+    const select = getSelect(harness);
+    expect(select.value).toBe("");
+
+    act(() => {
+      select.value = "high";
+      select.dispatchEvent(new Event("change", { bubbles: true }));
+    });
+    expect(getThinkingEffort(SESSION)).toBe("high");
+    expect(getSelect(harness).value).toBe("high");
+    harness.unmount();
+  });
+
+  it("reflects a store value seeded before mount (session/open restore path)", () => {
+    setThinkingEffort(SESSION, "medium");
+    const harness = mountThread();
+    expect(getSelect(harness).value).toBe("medium");
+    harness.unmount();
+  });
+
+  it("selecting default clears the stored override", () => {
+    setThinkingEffort(SESSION, "max");
+    const harness = mountThread();
+    const select = getSelect(harness);
+    expect(select.value).toBe("max");
+    act(() => {
+      select.value = "";
+      select.dispatchEvent(new Event("change", { bubbles: true }));
+    });
+    expect(getThinkingEffort(SESSION)).toBe(null);
+    harness.unmount();
+  });
+});

--- a/src/components/chat-thread.tsx
+++ b/src/components/chat-thread.tsx
@@ -36,7 +36,8 @@ import {
 } from "lucide-react";
 import { useSession } from "@/runtime/session-context";
 import {
-  asReasoningEffortLevel,
+  asStoredEffort,
+  KNOWN_EFFORT_LEVELS,
   setThinkingEffort,
   useThinkingEffort,
 } from "@/store/thinking-store";
@@ -2174,7 +2175,7 @@ function Composer({ mountGhost, unmountGhost }: ComposerProps) {
                 onChange={(e) =>
                   setThinkingEffort(
                     currentSessionId,
-                    asReasoningEffortLevel(e.target.value),
+                    asStoredEffort(e.target.value),
                     historyTopic,
                   )
                 }
@@ -2185,6 +2186,18 @@ function Composer({ mountGhost, unmountGhost }: ComposerProps) {
                 <option value="medium">Thinking: medium</option>
                 <option value="high">Thinking: high</option>
                 <option value="max">Thinking: max</option>
+                {/* A newer server can persist a tier this client does
+                    not know; keep it selectable so it round-trips
+                    verbatim instead of being destroyed by omission
+                    (codex #261 P2). */}
+                {thinkingEffort !== null &&
+                  !(KNOWN_EFFORT_LEVELS as readonly string[]).includes(
+                    thinkingEffort,
+                  ) && (
+                    <option value={thinkingEffort}>
+                      Thinking: {thinkingEffort}
+                    </option>
+                  )}
               </select>
             </label>
             {(queueMode || adaptiveMode || queueDepth > 0) && (

--- a/src/components/chat-thread.tsx
+++ b/src/components/chat-thread.tsx
@@ -40,7 +40,6 @@ import {
   KNOWN_EFFORT_LEVELS,
   setThinkingEffort,
   useThinkingEffort,
-  whenThinkingSeeded,
 } from "@/store/thinking-store";
 import {
   useThreads,
@@ -52,7 +51,10 @@ import {
 } from "@/store/thread-store";
 import { isProjectionV1Enabled } from "@/store/projection-store";
 import { uploadFiles } from "@/api/chat";
-import { sendMessage as bridgeSend } from "@/runtime/ui-protocol-send";
+import {
+  interruptActiveTurn,
+  sendMessage as bridgeSend,
+} from "@/runtime/ui-protocol-send";
 import { getActiveBridge } from "@/runtime/ui-protocol-runtime";
 import { MarkdownContent } from "./markdown-renderer";
 import { ThinkingIndicator } from "./thinking-indicator";
@@ -1881,21 +1883,19 @@ function Composer({ mountGhost, unmountGhost }: ComposerProps) {
           t.pendingAssistant.status === "streaming",
       )?.id;
       if (pendingTurnId) {
-        // codex #261 round-2 P1: the send path parks `turn/start` behind
-        // `whenThinkingSeeded` during the initial `session/open`
-        // handshake. A cancel clicked in that window must NOT enqueue
-        // `turn/interrupt` ahead of the still-parked `turn/start` —
-        // the interrupt would no-op server-side and the supposedly
-        // cancelled turn would then run. Gating the interrupt on the
-        // SAME promise preserves pairwise order: seed waiters resolve
-        // in registration order and the send always registered first
-        // (this Cancel button only exists for a bubble that send
-        // created). Steady-state cost is one microtask.
-        void whenThinkingSeeded(currentSessionId, historyTopic)
-          .then(() => bridge.interruptTurn(pendingTurnId, "user cancelled"))
-          .catch(() => {
-            // best-effort: swallow transport errors.
-          });
+        // codex #261 rounds 2-3 P1: route through the shared
+        // seed-ordering-aware helper — a direct `bridge.interruptTurn`
+        // here can reach the bridge queue ahead of a `turn/start` still
+        // parked on `whenThinkingSeeded`, no-op server-side, and let
+        // the supposedly cancelled turn run.
+        void interruptActiveTurn({
+          sessionId: currentSessionId,
+          historyTopic,
+          turnId: pendingTurnId,
+          reason: "user cancelled",
+        }).catch(() => {
+          // best-effort: swallow transport errors.
+        });
       }
     }
   }, [currentSessionId, historyTopic, threadsForRunning]);

--- a/src/components/chat-thread.tsx
+++ b/src/components/chat-thread.tsx
@@ -22,6 +22,7 @@ import {
   Paperclip,
   X,
   FileIcon,
+  Brain,
   Mic,
   Video,
   Camera,
@@ -34,6 +35,11 @@ import {
   Check,
 } from "lucide-react";
 import { useSession } from "@/runtime/session-context";
+import {
+  asReasoningEffortLevel,
+  setThinkingEffort,
+  useThinkingEffort,
+} from "@/store/thinking-store";
 import {
   useThreads,
   type MessageFile,
@@ -1354,6 +1360,10 @@ function Composer({ mountGhost, unmountGhost }: ComposerProps) {
   // existing `queueMode` literal label still renders for sessions that
   // never push anything onto the queue.
   const queueDepth = currentSessionStats?.queue_depth ?? 0;
+  // Thinking-effort selector state (TUI `/thinking` parity). Seeded from
+  // the server-persisted value on every `session/open` ack; the send path
+  // reads the same store so every user turn carries the choice.
+  const thinkingEffort = useThinkingEffort(currentSessionId, historyTopic);
   // M10.5: ThreadStore is the single source of truth — read `isRunning`
   // from the active session's threads.
   const threadsForRunning = useThreads(currentSessionId, historyTopic);
@@ -2148,8 +2158,37 @@ function Composer({ mountGhost, unmountGhost }: ComposerProps) {
                 turn exists OR a legacy `queueMode` label is set, so
                 "N queued" appears regardless of whether the session
                 also has a `queueMode` label. */}
+            {/* Thinking-effort selector (TUI `/thinking` parity). Value is
+                per-session and server-persisted via `turn/start`;
+                "Default" omits the wire field, which also clears the
+                server's stored override on the next send. */}
+            <label
+              className="glass-icon-button ml-auto flex h-8 shrink-0 cursor-pointer items-center gap-1 rounded-[10px] px-2"
+              title="Thinking effort for this session"
+            >
+              <Brain size={14} className="shrink-0" />
+              <select
+                data-testid="thinking-effort-select"
+                aria-label="Thinking effort"
+                value={thinkingEffort ?? ""}
+                onChange={(e) =>
+                  setThinkingEffort(
+                    currentSessionId,
+                    asReasoningEffortLevel(e.target.value),
+                    historyTopic,
+                  )
+                }
+                className="cursor-pointer bg-transparent text-[11px] font-medium text-text-strong outline-none"
+              >
+                <option value="">Thinking: default</option>
+                <option value="low">Thinking: low</option>
+                <option value="medium">Thinking: medium</option>
+                <option value="high">Thinking: high</option>
+                <option value="max">Thinking: max</option>
+              </select>
+            </label>
             {(queueMode || adaptiveMode || queueDepth > 0) && (
-              <div className="ml-auto flex items-center gap-1.5">
+              <div className="flex items-center gap-1.5">
                 {(queueMode || queueDepth > 0) && (
                   <span
                     data-testid="queue-mode-badge"

--- a/src/components/chat-thread.tsx
+++ b/src/components/chat-thread.tsx
@@ -40,6 +40,7 @@ import {
   KNOWN_EFFORT_LEVELS,
   setThinkingEffort,
   useThinkingEffort,
+  whenThinkingSeeded,
 } from "@/store/thinking-store";
 import {
   useThreads,
@@ -1880,9 +1881,21 @@ function Composer({ mountGhost, unmountGhost }: ComposerProps) {
           t.pendingAssistant.status === "streaming",
       )?.id;
       if (pendingTurnId) {
-        void bridge.interruptTurn(pendingTurnId, "user cancelled").catch(() => {
-          // best-effort: swallow transport errors.
-        });
+        // codex #261 round-2 P1: the send path parks `turn/start` behind
+        // `whenThinkingSeeded` during the initial `session/open`
+        // handshake. A cancel clicked in that window must NOT enqueue
+        // `turn/interrupt` ahead of the still-parked `turn/start` —
+        // the interrupt would no-op server-side and the supposedly
+        // cancelled turn would then run. Gating the interrupt on the
+        // SAME promise preserves pairwise order: seed waiters resolve
+        // in registration order and the send always registered first
+        // (this Cancel button only exists for a bubble that send
+        // created). Steady-state cost is one microtask.
+        void whenThinkingSeeded(currentSessionId, historyTopic)
+          .then(() => bridge.interruptTurn(pendingTurnId, "user cancelled"))
+          .catch(() => {
+            // best-effort: swallow transport errors.
+          });
       }
     }
   }, [currentSessionId, historyTopic, threadsForRunning]);

--- a/src/home/conversation-view.tsx
+++ b/src/home/conversation-view.tsx
@@ -44,7 +44,8 @@ import {
   type MessageFile,
   type ThreadToolCall,
 } from "@/store/thread-store";
-import { sendMessage as bridgeSend } from "@/runtime/ui-protocol-send";
+import {
+  interruptActiveTurn, sendMessage as bridgeSend } from "@/runtime/ui-protocol-send";
 import { getActiveBridge } from "@/runtime/ui-protocol-runtime";
 import { buildAuthenticatedFileUrl } from "@/api/files";
 import { useHomeSettings } from "./home-settings-context";
@@ -393,7 +394,17 @@ export function ConversationView({ onBack, prefill }: ConversationViewProps) {
           t.pendingAssistant.status === "streaming",
       );
       if (pendingThread) {
-        void bridge.interruptTurn(pendingThread.id, "user cancelled").catch(() => {
+        // codex #261 round-3 P1: route through the shared
+        // seed-ordering-aware helper — a direct `bridge.interruptTurn`
+        // can reach the bridge queue ahead of a `turn/start` still
+        // parked on `whenThinkingSeeded` (send-before-open window),
+        // no-op server-side, and let the cancelled turn run.
+        void interruptActiveTurn({
+          sessionId: currentSessionId,
+          historyTopic,
+          turnId: pendingThread.id,
+          reason: "user cancelled",
+        }).catch(() => {
           // best-effort: swallow transport errors.
         });
       }

--- a/src/runtime/ui-protocol-bridge.test.ts
+++ b/src/runtime/ui-protocol-bridge.test.ts
@@ -1954,6 +1954,49 @@ describe("notification dispatch", () => {
     expect(req.params?.media).toEqual(["uploads/frame.jpg"]);
   });
 
+  it("sendTurn forwards reasoning_effort onto the wire (thinking parity)", async () => {
+    const { bridge, ws } = await freshConnected();
+    void bridge.sendTurn("turn-re", [{ kind: "text", text: "hi" }], {
+      reasoning_effort: "high",
+    });
+    const req = findRequest(ws, METHODS.TURN_START);
+    expect(req.params?.reasoning_effort).toBe("high");
+  });
+
+  it("sendTurn omits reasoning_effort when unset (omission = default, clears server override)", async () => {
+    const { bridge, ws } = await freshConnected();
+    void bridge.sendTurn("turn-re-d", [{ kind: "text", text: "hi" }], {
+      topic: "slides",
+    });
+    const req = findRequest(ws, METHODS.TURN_START);
+    expect("reasoning_effort" in (req.params ?? {})).toBe(false);
+  });
+
+  it("emits onSessionOpened with the open ack payload (reasoning_effort restore)", async () => {
+    const bridge = createUiProtocolBridge(makeBridgeOpts());
+    void bridge.start({ sessionId: "sess-1" });
+    await Promise.resolve();
+    const ws = lastInstance();
+    const seen: unknown[] = [];
+    bridge.onSessionOpened((opened) => seen.push(opened));
+    ws.triggerOpen();
+    await Promise.resolve();
+    const open = findRequest(ws, METHODS.SESSION_OPEN);
+    ws.triggerMessage({
+      jsonrpc: "2.0",
+      id: open.id,
+      result: {
+        opened: { session_id: "sess-1", reasoning_effort: "medium" },
+      },
+    });
+    await Promise.resolve();
+    expect(seen).toHaveLength(1);
+    expect((seen[0] as { reasoning_effort?: string }).reasoning_effort).toBe(
+      "medium",
+    );
+    await bridge.stop();
+  });
+
   it("sendTurn omits live_video when not set (byte-identical legacy shape)", async () => {
     const { bridge, ws } = await freshConnected();
     void bridge.sendTurn("turn-plain", [{ kind: "text", text: "hi" }]);

--- a/src/runtime/ui-protocol-bridge.ts
+++ b/src/runtime/ui-protocol-bridge.ts
@@ -524,6 +524,11 @@ export interface UiProtocolBridge {
    *  missed completion bubble + media attachment from the durable
    *  ledger via `replayed_envelopes`. */
   onReopened(handler: () => void): () => void;
+  /** Fires on EVERY successful `session/open` ack (initial open AND
+   *  reconnects) with the server's `opened` payload. The runtime layer
+   *  seeds per-session state that the server persists across restarts —
+   *  today the thinking-effort selector (`opened.reasoning_effort`). */
+  onSessionOpened(handler: (opened: SessionOpenedResult) => void): () => void;
   onWarning(handler: (e: WarningEvent) => void): () => void;
   /** Issue #113.2: server-emitted title update for cross-tab and
    *  auto-title flows. SessionProvider subscribes to keep its
@@ -1783,6 +1788,10 @@ class UiProtocolBridgeImpl implements UiProtocolBridge {
    *  to re-issue `session/hydrate` so envelopes emitted while the WS
    *  was disconnected get replayed from `replayed_envelopes`. */
   private readonly subReopened = new Subscribers<void>();
+  /** Fires on every successful `session/open` ack with the `opened`
+   *  payload (initial + reconnect) — carrier for server-persisted
+   *  per-session state like `reasoning_effort`. */
+  private readonly subSessionOpened = new Subscribers<SessionOpenedResult>();
   private readonly subSessionTitleUpdated = new Subscribers<{
     session_id: string;
     title: string;
@@ -2037,6 +2046,7 @@ class UiProtocolBridgeImpl implements UiProtocolBridge {
     this.subQueueState.clear();
     this.subWarning.clear();
     this.subState.clear();
+    this.subSessionOpened.clear();
     this.subSessionTitleUpdated.clear();
   }
 
@@ -2075,6 +2085,14 @@ class UiProtocolBridgeImpl implements UiProtocolBridge {
     // server always saw `live_video=false` and forwarded zero reference frames.
     if (extras?.live_video) {
       params.live_video = true;
+    }
+    // Thinking-effort parity (`/thinking`): forward the per-session
+    // reasoning effort. Omission is MEANINGFUL to the server (a user
+    // turn without the field clears the stored override), so this maps
+    // only-when-populated like the other extras — the "default"
+    // selection is expressed by absence.
+    if (extras?.reasoning_effort) {
+      params.reasoning_effort = extras.reasoning_effort;
     }
     return this.request<TurnStartResult>(METHODS.TURN_START, params);
   }
@@ -2281,6 +2299,9 @@ class UiProtocolBridgeImpl implements UiProtocolBridge {
   onReopened(handler: Listener<void>): () => void {
     return this.subReopened.add(handler);
   }
+  onSessionOpened(handler: Listener<SessionOpenedResult>): () => void {
+    return this.subSessionOpened.add(handler);
+  }
   onWarning(handler: Listener<WarningEvent>): () => void {
     return this.subWarning.add(handler);
   }
@@ -2468,6 +2489,12 @@ class UiProtocolBridgeImpl implements UiProtocolBridge {
       const isReopen = this.hasEverOpened;
       this.hasEverOpened = true;
       this.setState("connected");
+      // Surface the `opened` payload (initial + reopen) so the runtime
+      // layer can seed server-persisted per-session state — today the
+      // thinking-effort selector (`opened.reasoning_effort`).
+      if (openResult?.opened) {
+        this.subSessionOpened.emit(openResult.opened);
+      }
       this.startKeepalive();
       this.flushSendQueue();
       if (isReopen) {

--- a/src/runtime/ui-protocol-bridge.ts
+++ b/src/runtime/ui-protocol-bridge.ts
@@ -45,6 +45,7 @@ import type {
   RouterStatusEvent,
   RpcErrorPayload,
   SessionHydrateResult,
+  SessionOpenedResult,
   SessionOpenResult,
   TaskOutputDeltaEvent,
   TaskUpdatedEvent,

--- a/src/runtime/ui-protocol-runtime.ts
+++ b/src/runtime/ui-protocol-runtime.ts
@@ -18,6 +18,10 @@ import {
   setHydrateSnapshot,
   suppressPendingDeltasForReplay,
 } from "@/store/thread-store";
+import {
+  asReasoningEffortLevel,
+  setThinkingEffort,
+} from "@/store/thinking-store";
 
 interface ActiveBridge {
   sessionId: string;
@@ -36,6 +40,9 @@ interface ActiveBridge {
    *  envelopes (e.g. a `TurnSpawnComplete` emitted while the WS was
    *  dropped) get replayed via `replayed_envelopes`. */
   unsubscribeReopened: () => void;
+  /** Cleanup fn for the session-opened subscriber (thinking-effort
+   *  seeding). Detached on stop. */
+  unsubscribeSessionOpened: () => void;
 }
 
 let active: ActiveBridge | null = null;
@@ -190,6 +197,21 @@ export async function startBridgeForSession(
       runHydrateFor(sessionId, topic, bridge, myGeneration);
     });
   }
+  // Thinking-effort parity: seed the per-session selector from the
+  // server-persisted value carried on every `session/open` ack, so a
+  // reload/reconnect restores the user's `/thinking`-equivalent choice.
+  // Same defensive-typeof guard as `onReopened` for pre-dating mocks.
+  let unsubscribeSessionOpened: () => void = () => {};
+  if (typeof bridge.onSessionOpened === "function") {
+    unsubscribeSessionOpened = bridge.onSessionOpened((opened) => {
+      if (myGeneration !== generation) return;
+      setThinkingEffort(
+        sessionId,
+        asReasoningEffortLevel(opened.reasoning_effort),
+        topic,
+      );
+    });
+  }
 
   active = {
     sessionId,
@@ -199,6 +221,7 @@ export async function startBridgeForSession(
     connectionState,
     unsubscribeState,
     unsubscribeReopened,
+    unsubscribeSessionOpened,
   };
 
   // M10 Phase 6.2 (Bug C): immediately fire `session/hydrate` to fetch
@@ -349,6 +372,7 @@ export async function stopActiveBridge(): Promise<void> {
   handle.attachment.detach();
   handle.unsubscribeState();
   handle.unsubscribeReopened();
+  handle.unsubscribeSessionOpened();
   try {
     await handle.bridge.stop();
   } catch {
@@ -377,6 +401,7 @@ export async function stopActiveBridgeIfScope(
   handle.attachment.detach();
   handle.unsubscribeState();
   handle.unsubscribeReopened();
+  handle.unsubscribeSessionOpened();
   try {
     await handle.bridge.stop();
   } catch {
@@ -410,5 +435,6 @@ export function __setActiveBridgeForTest(
     connectionState,
     unsubscribeState: () => {},
     unsubscribeReopened: () => {},
+    unsubscribeSessionOpened: () => {},
   };
 }

--- a/src/runtime/ui-protocol-runtime.ts
+++ b/src/runtime/ui-protocol-runtime.ts
@@ -19,7 +19,8 @@ import {
   suppressPendingDeltasForReplay,
 } from "@/store/thread-store";
 import {
-  asReasoningEffortLevel,
+  asStoredEffort,
+  markThinkingSeeded,
   setThinkingEffort,
 } from "@/store/thinking-store";
 
@@ -200,17 +201,28 @@ export async function startBridgeForSession(
   // Thinking-effort parity: seed the per-session selector from the
   // server-persisted value carried on every `session/open` ack, so a
   // reload/reconnect restores the user's `/thinking`-equivalent choice.
-  // Same defensive-typeof guard as `onReopened` for pre-dating mocks.
+  // ROOT scope only (codex #261 P1): the bridge's `session/open` sends
+  // the bare session id, so `opened.reasoning_effort` describes the
+  // ROOT bucket — applying it to a topic key would restore the wrong
+  // value and let the topic's next turn overwrite the root's choice.
+  // Topic scopes are marked seeded-without-value instead (no restore is
+  // possible over the current wire; selector still works live).
+  // Same defensive-typeof guard as `onReopened` for pre-dating mocks —
+  // those are marked seeded too so sends never wait on a seed that
+  // cannot arrive.
   let unsubscribeSessionOpened: () => void = () => {};
-  if (typeof bridge.onSessionOpened === "function") {
+  const scopeHasTopic = Boolean(topic && topic.trim() !== "");
+  if (!scopeHasTopic && typeof bridge.onSessionOpened === "function") {
     unsubscribeSessionOpened = bridge.onSessionOpened((opened) => {
       if (myGeneration !== generation) return;
       setThinkingEffort(
         sessionId,
-        asReasoningEffortLevel(opened.reasoning_effort),
+        asStoredEffort(opened.reasoning_effort),
         topic,
       );
     });
+  } else {
+    markThinkingSeeded(sessionId, topic);
   }
 
   active = {
@@ -437,4 +449,8 @@ export function __setActiveBridgeForTest(
     unsubscribeReopened: () => {},
     unsubscribeSessionOpened: () => {},
   };
+  // Injected bridges skip the real `session/open` handshake, so mark the
+  // thinking-effort scope seeded — otherwise every test send would stall
+  // on `whenThinkingSeeded`'s fail-open timeout.
+  markThinkingSeeded(sessionId, topic);
 }

--- a/src/runtime/ui-protocol-send.test.ts
+++ b/src/runtime/ui-protocol-send.test.ts
@@ -62,6 +62,10 @@ vi.mock("./ui-protocol-bridge", async () => {
 
 import * as ThreadStore from "@/store/thread-store";
 import {
+  __resetThinkingStoreForTest,
+  setThinkingEffort,
+} from "@/store/thinking-store";
+import {
   buildTurnStartExtras,
   interruptActiveTurn,
   sendMessage,
@@ -123,6 +127,36 @@ afterEach(() => {
   __resetUiProtocolRuntimeForTest();
   __resetSendQueueForTest();
   __bridgeFactoryOverride.current = null;
+});
+
+describe("buildTurnStartExtras reasoning_effort (thinking parity)", () => {
+  const base = { sessionId: SESSION, text: "", media: [] as string[] };
+
+  afterEach(() => {
+    __resetThinkingStoreForTest();
+  });
+
+  it("attaches the session's stored thinking effort to the envelope", () => {
+    setThinkingEffort(SESSION, "high");
+    expect(buildTurnStartExtras({ ...base })?.reasoning_effort).toBe("high");
+  });
+
+  it("scopes the lookup by (session, topic)", () => {
+    setThinkingEffort(SESSION, "low", "slides");
+    // Default-topic send: no override stored for the bare session.
+    expect(buildTurnStartExtras({ ...base })).toBeUndefined();
+    // Topic-scoped send picks up the topic's value.
+    expect(
+      buildTurnStartExtras({ ...base, historyTopic: "slides" })
+        ?.reasoning_effort,
+    ).toBe("low");
+  });
+
+  it("omits the field entirely for default (omission clears the server override)", () => {
+    // No store entry → envelope stays undefined so the wire bytes are
+    // identical to a plain text send.
+    expect(buildTurnStartExtras({ ...base })).toBeUndefined();
+  });
 });
 
 describe("buildTurnStartExtras live_video (#1478)", () => {

--- a/src/runtime/ui-protocol-send.ts
+++ b/src/runtime/ui-protocol-send.ts
@@ -293,6 +293,16 @@ export async function interruptActiveTurn(opts: {
   const bridge = getActiveBridge(opts.sessionId, opts.historyTopic);
   if (!bridge || !turnId) return false;
 
+  // codex #261 rounds 2-3 P1: the send path parks `turn/start` behind
+  // `whenThinkingSeeded` during the initial `session/open` handshake. An
+  // interrupt issued in that window must NOT reach the bridge queue
+  // ahead of the still-parked start — it would no-op server-side and
+  // the supposedly cancelled turn would run. Gating on the SAME promise
+  // preserves pairwise order (waiters resolve in registration order and
+  // the send always registered first). EVERY cancel surface must route
+  // through this helper rather than calling `bridge.interruptTurn`
+  // directly, or it re-opens the race (round 3: /home ConversationView).
+  await whenThinkingSeeded(opts.sessionId, opts.historyTopic);
   const result = await bridge.interruptTurn(turnId, opts.reason);
   if (result.interrupted && control?.turnId === turnId) {
     control.complete();

--- a/src/runtime/ui-protocol-send.ts
+++ b/src/runtime/ui-protocol-send.ts
@@ -18,7 +18,10 @@
  */
 
 import * as ThreadStore from "@/store/thread-store";
-import { getThinkingEffort } from "@/store/thinking-store";
+import {
+  getThinkingEffort,
+  whenThinkingSeeded,
+} from "@/store/thinking-store";
 import { displayFilenameFromPath } from "@/lib/utils";
 import { getActiveBridge, startBridgeForSession } from "./ui-protocol-runtime";
 import { BridgeStoppedError, BridgeTimeoutError } from "./ui-protocol-bridge";
@@ -636,6 +639,12 @@ async function sendMessageV1(
     // from the populated `SendOptions` fields. The bridge serialises
     // only the populated extras onto the wire, so a text-only send
     // produces the same bytes a pre-β-1 build did.
+    // codex #261 P2: a send racing the `session/open` handshake must not
+    // serialise its frame before the server-persisted thinking effort has
+    // been observed — the frame would omit `reasoning_effort` and the
+    // server treats user-turn omission as "clear the stored override".
+    // Bounded fail-open (3s) so a broken handshake can't wedge sends.
+    await whenThinkingSeeded(opts.sessionId, opts.historyTopic);
     const extras = buildTurnStartExtras(opts);
     const result = await bridge.sendTurn(
       clientMessageId,

--- a/src/runtime/ui-protocol-send.ts
+++ b/src/runtime/ui-protocol-send.ts
@@ -18,6 +18,7 @@
  */
 
 import * as ThreadStore from "@/store/thread-store";
+import { getThinkingEffort } from "@/store/thinking-store";
 import { displayFilenameFromPath } from "@/lib/utils";
 import { getActiveBridge, startBridgeForSession } from "./ui-protocol-runtime";
 import { BridgeStoppedError, BridgeTimeoutError } from "./ui-protocol-bridge";
@@ -140,11 +141,22 @@ export function buildTurnStartExtras(
     extras.live_video = true;
   }
 
+  // Thinking-effort parity (TUI `/thinking`): read the per-session store
+  // HERE — centrally — rather than in each send surface. The server
+  // clears its persisted override whenever a user turn omits the field,
+  // so a single surface (voice, studio rail) sending without it would
+  // silently reset the user's choice. "Default" is expressed by absence.
+  const effort = getThinkingEffort(opts.sessionId, opts.historyTopic);
+  if (effort !== null) {
+    extras.reasoning_effort = effort;
+  }
+
   if (
     (extras.media === undefined || extras.media.length === 0) &&
     (extras.topic === undefined || extras.topic.length === 0) &&
     extras.rewrite_for === undefined &&
-    extras.live_video === undefined
+    extras.live_video === undefined &&
+    extras.reasoning_effort === undefined
   ) {
     return undefined;
   }

--- a/src/runtime/ui-protocol-types.ts
+++ b/src/runtime/ui-protocol-types.ts
@@ -81,8 +81,11 @@ export interface TurnStartExtras {
    *  stored override ("default"); server-initiated continuations fall
    *  back to the stored value. So once the user picks a non-default
    *  effort the send path must attach it to EVERY turn (see
-   *  `buildTurnStartExtras` reading the thinking store). */
-  reasoning_effort?: ReasoningEffortLevel;
+   *  `buildTurnStartExtras` reading the thinking store).
+   *  Typed wider than the known union: a NEWER server may have
+   *  persisted a tier this client does not know, and it must
+   *  round-trip verbatim rather than be destroyed by omission. */
+  reasoning_effort?: ReasoningEffortLevel | (string & {});
 }
 
 /** Wire values of `octos_core::ui_protocol::ReasoningEffortLevel`
@@ -97,8 +100,9 @@ export interface SessionOpenedResult {
   panes?: unknown;
   /** Server-persisted per-session reasoning effort, surfaced on the
    *  open ack so a (re)connecting client restores its thinking
-   *  selector. Absent/null when the session never set one. */
-  reasoning_effort?: ReasoningEffortLevel | null;
+   *  selector. Absent/null when the session never set one. May carry
+   *  a tier newer than this client's known union. */
+  reasoning_effort?: ReasoningEffortLevel | (string & {}) | null;
 }
 
 export interface SessionOpenResult {

--- a/src/runtime/ui-protocol-types.ts
+++ b/src/runtime/ui-protocol-types.ts
@@ -75,7 +75,19 @@ export interface TurnStartExtras {
    *  by the voice screen when the camera is on. Omitted (≡ false) otherwise;
    *  the server never infers live-video from attachment types. */
   live_video?: boolean;
+  /** Per-session reasoning/thinking effort (TUI `/thinking` parity).
+   *  Server precedence: a USER turn carrying the field wins AND
+   *  persists it for the session; a user turn OMITTING it clears the
+   *  stored override ("default"); server-initiated continuations fall
+   *  back to the stored value. So once the user picks a non-default
+   *  effort the send path must attach it to EVERY turn (see
+   *  `buildTurnStartExtras` reading the thinking store). */
+  reasoning_effort?: ReasoningEffortLevel;
 }
+
+/** Wire values of `octos_core::ui_protocol::ReasoningEffortLevel`
+ *  (snake_case strings; `max` is the DeepSeek tier). */
+export type ReasoningEffortLevel = "low" | "medium" | "high" | "max";
 
 export interface SessionOpenedResult {
   session_id: string;
@@ -83,6 +95,10 @@ export interface SessionOpenedResult {
   cursor?: UiCursor;
   workspace_root?: string;
   panes?: unknown;
+  /** Server-persisted per-session reasoning effort, surfaced on the
+   *  open ack so a (re)connecting client restores its thinking
+   *  selector. Absent/null when the session never set one. */
+  reasoning_effort?: ReasoningEffortLevel | null;
 }
 
 export interface SessionOpenResult {

--- a/src/store/thinking-store.test.ts
+++ b/src/store/thinking-store.test.ts
@@ -1,0 +1,47 @@
+/**
+ * thinking-store unit tests — per-session reasoning effort backing the
+ * composer selector and the send path (TUI `/thinking` parity).
+ */
+
+import { afterEach, describe, expect, it } from "vitest";
+import {
+  __resetThinkingStoreForTest,
+  asReasoningEffortLevel,
+  getThinkingEffort,
+  setThinkingEffort,
+} from "./thinking-store";
+
+const SESSION = "sess-thinking-store";
+
+afterEach(() => {
+  __resetThinkingStoreForTest();
+});
+
+describe("thinking-store", () => {
+  it("stores per-(session, topic) values independently", () => {
+    setThinkingEffort(SESSION, "high");
+    setThinkingEffort(SESSION, "low", "slides");
+    expect(getThinkingEffort(SESSION)).toBe("high");
+    expect(getThinkingEffort(SESSION, "slides")).toBe("low");
+    expect(getThinkingEffort("other-session")).toBe(null);
+  });
+
+  it("clears with null", () => {
+    setThinkingEffort(SESSION, "max");
+    setThinkingEffort(SESSION, null);
+    expect(getThinkingEffort(SESSION)).toBe(null);
+  });
+
+  it("asReasoningEffortLevel narrows wire values and rejects unknowns", () => {
+    expect(asReasoningEffortLevel("low")).toBe("low");
+    expect(asReasoningEffortLevel("medium")).toBe("medium");
+    expect(asReasoningEffortLevel("high")).toBe("high");
+    expect(asReasoningEffortLevel("max")).toBe("max");
+    // Unknown future tier, null, undefined, non-strings → unset, so a
+    // newer server cannot poison the selector state.
+    expect(asReasoningEffortLevel("ultra")).toBe(null);
+    expect(asReasoningEffortLevel(null)).toBe(null);
+    expect(asReasoningEffortLevel(undefined)).toBe(null);
+    expect(asReasoningEffortLevel(3)).toBe(null);
+  });
+});

--- a/src/store/thinking-store.test.ts
+++ b/src/store/thinking-store.test.ts
@@ -3,18 +3,21 @@
  * composer selector and the send path (TUI `/thinking` parity).
  */
 
-import { afterEach, describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import {
   __resetThinkingStoreForTest,
-  asReasoningEffortLevel,
+  asStoredEffort,
   getThinkingEffort,
+  markThinkingSeeded,
   setThinkingEffort,
+  whenThinkingSeeded,
 } from "./thinking-store";
 
 const SESSION = "sess-thinking-store";
 
 afterEach(() => {
   __resetThinkingStoreForTest();
+  vi.useRealTimers();
 });
 
 describe("thinking-store", () => {
@@ -32,16 +35,61 @@ describe("thinking-store", () => {
     expect(getThinkingEffort(SESSION)).toBe(null);
   });
 
-  it("asReasoningEffortLevel narrows wire values and rejects unknowns", () => {
-    expect(asReasoningEffortLevel("low")).toBe("low");
-    expect(asReasoningEffortLevel("medium")).toBe("medium");
-    expect(asReasoningEffortLevel("high")).toBe("high");
-    expect(asReasoningEffortLevel("max")).toBe("max");
-    // Unknown future tier, null, undefined, non-strings → unset, so a
-    // newer server cannot poison the selector state.
-    expect(asReasoningEffortLevel("ultra")).toBe(null);
-    expect(asReasoningEffortLevel(null)).toBe(null);
-    expect(asReasoningEffortLevel(undefined)).toBe(null);
-    expect(asReasoningEffortLevel(3)).toBe(null);
+  it("asStoredEffort keeps known AND unknown tiers, rejects empties", () => {
+    expect(asStoredEffort("low")).toBe("low");
+    expect(asStoredEffort("max")).toBe("max");
+    // codex #261 P2: an unknown tier from a NEWER server must be
+    // preserved — narrowing it to null would omit the field on the next
+    // send, and user-turn omission clears the server's stored override.
+    expect(asStoredEffort("ultra")).toBe("ultra");
+    expect(asStoredEffort("  high  ")).toBe("high");
+    expect(asStoredEffort("")).toBe(null);
+    expect(asStoredEffort("   ")).toBe(null);
+    expect(asStoredEffort(null)).toBe(null);
+    expect(asStoredEffort(undefined)).toBe(null);
+    expect(asStoredEffort(3)).toBe(null);
+  });
+
+  it("whenThinkingSeeded resolves immediately for a seeded scope", async () => {
+    markThinkingSeeded(SESSION);
+    await expect(whenThinkingSeeded(SESSION, undefined, 50)).resolves.toBe(
+      undefined,
+    );
+  });
+
+  it("whenThinkingSeeded resolves when the seed arrives later", async () => {
+    const waiter = whenThinkingSeeded(SESSION, undefined, 5000);
+    let resolved = false;
+    void waiter.then(() => {
+      resolved = true;
+    });
+    await Promise.resolve();
+    expect(resolved).toBe(false);
+    // A value-seed (session/open ack) marks the scope seeded.
+    setThinkingEffort(SESSION, "medium");
+    await waiter;
+    expect(resolved).toBe(true);
+  });
+
+  it("whenThinkingSeeded fails open after the timeout", async () => {
+    vi.useFakeTimers();
+    const waiter = whenThinkingSeeded(SESSION, undefined, 100);
+    vi.advanceTimersByTime(101);
+    await expect(waiter).resolves.toBe(undefined);
+  });
+
+  it("seeding is scope-precise", async () => {
+    markThinkingSeeded(SESSION, "slides");
+    // Root scope remains unseeded.
+    vi.useFakeTimers();
+    let rootResolved = false;
+    void whenThinkingSeeded(SESSION, undefined, 100).then(() => {
+      rootResolved = true;
+    });
+    await Promise.resolve();
+    expect(rootResolved).toBe(false);
+    vi.advanceTimersByTime(101);
+    await Promise.resolve();
+    expect(rootResolved).toBe(true);
   });
 });

--- a/src/store/thinking-store.ts
+++ b/src/store/thinking-store.ts
@@ -1,0 +1,102 @@
+/**
+ * Per-session reasoning/thinking effort store (web parity for the TUI
+ * `/thinking` command; octos P2 parity item).
+ *
+ * Single source of truth for the composer's thinking selector AND the
+ * send path: `buildTurnStartExtras` reads the current value at send
+ * time so EVERY user turn carries the chosen effort. That is load-
+ * bearing, not cosmetic — the server treats a user turn that OMITS
+ * `reasoning_effort` as "the user chose default" and CLEARS the
+ * persisted override, so a single surface sending without the field
+ * (voice, studio rail) would silently reset the user's choice. Reading
+ * the store centrally in the send path keeps all three send surfaces
+ * consistent.
+ *
+ * Seeding: the bridge surfaces the server-persisted value from the
+ * `session/open` ack (`opened.reasoning_effort`), and the runtime layer
+ * seeds this store — so a page reload or reconnect restores the
+ * selector to the authoritative server-side value.
+ *
+ * `null` ≡ "default": the send path omits the field entirely.
+ */
+
+import { useSyncExternalStore } from "react";
+import type { ReasoningEffortLevel } from "@/runtime/ui-protocol-types";
+
+const effortByKey = new Map<string, ReasoningEffortLevel>();
+const listeners = new Set<() => void>();
+
+function notify(): void {
+  for (const listener of listeners) listener();
+}
+
+function subscribe(listener: () => void): () => void {
+  listeners.add(listener);
+  return () => {
+    listeners.delete(listener);
+  };
+}
+
+function storeKey(sessionId: string, topic?: string): string {
+  const trimmedTopic = topic?.trim();
+  return trimmedTopic ? `${sessionId}#${trimmedTopic}` : sessionId;
+}
+
+const WIRE_LEVELS: readonly ReasoningEffortLevel[] = [
+  "low",
+  "medium",
+  "high",
+  "max",
+];
+
+/** Narrow an untrusted wire value to a known effort level. Unknown
+ *  strings (a future server tier) are treated as unset rather than
+ *  poisoning the selector state. */
+export function asReasoningEffortLevel(
+  value: unknown,
+): ReasoningEffortLevel | null {
+  return WIRE_LEVELS.includes(value as ReasoningEffortLevel)
+    ? (value as ReasoningEffortLevel)
+    : null;
+}
+
+export function getThinkingEffort(
+  sessionId: string,
+  topic?: string,
+): ReasoningEffortLevel | null {
+  return effortByKey.get(storeKey(sessionId, topic)) ?? null;
+}
+
+/** Set (or clear with `null`) the session's thinking effort. */
+export function setThinkingEffort(
+  sessionId: string,
+  effort: ReasoningEffortLevel | null,
+  topic?: string,
+): void {
+  const key = storeKey(sessionId, topic);
+  const current = effortByKey.get(key) ?? null;
+  if (current === effort) return;
+  if (effort === null) {
+    effortByKey.delete(key);
+  } else {
+    effortByKey.set(key, effort);
+  }
+  notify();
+}
+
+export function useThinkingEffort(
+  sessionId: string,
+  topic?: string,
+): ReasoningEffortLevel | null {
+  return useSyncExternalStore(
+    subscribe,
+    () => getThinkingEffort(sessionId, topic),
+    () => getThinkingEffort(sessionId, topic),
+  );
+}
+
+/** Test helper — clears all per-session state. */
+export function __resetThinkingStoreForTest(): void {
+  effortByKey.clear();
+  notify();
+}

--- a/src/store/thinking-store.ts
+++ b/src/store/thinking-store.ts
@@ -15,7 +15,17 @@
  * Seeding: the bridge surfaces the server-persisted value from the
  * `session/open` ack (`opened.reasoning_effort`), and the runtime layer
  * seeds this store — so a page reload or reconnect restores the
- * selector to the authoritative server-side value.
+ * authoritative server-side value. The send path can `await
+ * whenThinkingSeeded(...)` so a send racing the open handshake does not
+ * serialise a frame without the field and wrongly clear the override
+ * (codex #261 P2).
+ *
+ * Unknown tiers: a NEWER server may persist a tier this client does not
+ * know (e.g. a future "ultra"). The store keeps the RAW string and the
+ * send path forwards it verbatim — narrowing it to null would omit the
+ * field and destroy the newer-tier choice (codex #261 P2). The selector
+ * renders the raw value as an extra option until the user explicitly
+ * picks something else.
  *
  * `null` ≡ "default": the send path omits the field entirely.
  */
@@ -23,8 +33,17 @@
 import { useSyncExternalStore } from "react";
 import type { ReasoningEffortLevel } from "@/runtime/ui-protocol-types";
 
-const effortByKey = new Map<string, ReasoningEffortLevel>();
+/** A stored tier: one of the known wire levels, or a raw string from a
+ *  newer server that must be preserved round-trip. */
+export type StoredEffort = ReasoningEffortLevel | (string & {});
+
+const effortByKey = new Map<string, StoredEffort>();
+/** Scopes whose server-persisted value has been observed (or is known
+ *  not to be observable — topic scopes, legacy bridges). Send-side
+ *  waiters gate on this, not on a value being present. */
+const seededKeys = new Set<string>();
 const listeners = new Set<() => void>();
+const seedWaiters = new Map<string, Array<() => void>>();
 
 function notify(): void {
   for (const listener of listeners) listener();
@@ -42,52 +61,99 @@ function storeKey(sessionId: string, topic?: string): string {
   return trimmedTopic ? `${sessionId}#${trimmedTopic}` : sessionId;
 }
 
-const WIRE_LEVELS: readonly ReasoningEffortLevel[] = [
+export const KNOWN_EFFORT_LEVELS: readonly ReasoningEffortLevel[] = [
   "low",
   "medium",
   "high",
   "max",
 ];
 
-/** Narrow an untrusted wire value to a known effort level. Unknown
- *  strings (a future server tier) are treated as unset rather than
- *  poisoning the selector state. */
-export function asReasoningEffortLevel(
-  value: unknown,
-): ReasoningEffortLevel | null {
-  return WIRE_LEVELS.includes(value as ReasoningEffortLevel)
-    ? (value as ReasoningEffortLevel)
-    : null;
+/** Normalize an untrusted wire value to a storable tier. Known levels
+ *  and unknown non-empty strings are kept (unknown tiers must survive a
+ *  round-trip through an older client); everything else is unset. */
+export function asStoredEffort(value: unknown): StoredEffort | null {
+  if (typeof value !== "string") return null;
+  const trimmed = value.trim();
+  return trimmed.length > 0 ? trimmed : null;
 }
 
 export function getThinkingEffort(
   sessionId: string,
   topic?: string,
-): ReasoningEffortLevel | null {
+): StoredEffort | null {
   return effortByKey.get(storeKey(sessionId, topic)) ?? null;
 }
 
 /** Set (or clear with `null`) the session's thinking effort. */
 export function setThinkingEffort(
   sessionId: string,
-  effort: ReasoningEffortLevel | null,
+  effort: StoredEffort | null,
   topic?: string,
 ): void {
   const key = storeKey(sessionId, topic);
   const current = effortByKey.get(key) ?? null;
-  if (current === effort) return;
-  if (effort === null) {
-    effortByKey.delete(key);
-  } else {
-    effortByKey.set(key, effort);
+  if (current !== effort) {
+    if (effort === null) {
+      effortByKey.delete(key);
+    } else {
+      effortByKey.set(key, effort);
+    }
+    notify();
   }
-  notify();
+  markThinkingSeeded(sessionId, topic);
+}
+
+/** Mark a scope's restore as complete WITHOUT changing its value —
+ *  used for scopes where no server restore is possible (topic buckets:
+ *  `session/open` carries only the root session id, so the ack's
+ *  `reasoning_effort` describes the ROOT bucket; and legacy bridges
+ *  pre-dating `onSessionOpened`). */
+export function markThinkingSeeded(sessionId: string, topic?: string): void {
+  const key = storeKey(sessionId, topic);
+  if (!seededKeys.has(key)) {
+    seededKeys.add(key);
+  }
+  const waiters = seedWaiters.get(key);
+  if (waiters) {
+    seedWaiters.delete(key);
+    for (const resolve of waiters) resolve();
+  }
+}
+
+/** Resolves once the scope's server restore has been observed (or was
+ *  marked unobservable), or after `timeoutMs` as a fail-open bound so a
+ *  send can never wedge on a handshake that never completes. */
+export function whenThinkingSeeded(
+  sessionId: string,
+  topic: string | undefined,
+  timeoutMs = 3000,
+): Promise<void> {
+  const key = storeKey(sessionId, topic);
+  if (seededKeys.has(key)) return Promise.resolve();
+  return new Promise((resolve) => {
+    const timer = setTimeout(() => {
+      const waiters = seedWaiters.get(key);
+      if (waiters) {
+        const next = waiters.filter((w) => w !== wrapped);
+        if (next.length === 0) seedWaiters.delete(key);
+        else seedWaiters.set(key, next);
+      }
+      resolve();
+    }, timeoutMs);
+    const wrapped = () => {
+      clearTimeout(timer);
+      resolve();
+    };
+    const waiters = seedWaiters.get(key) ?? [];
+    waiters.push(wrapped);
+    seedWaiters.set(key, waiters);
+  });
 }
 
 export function useThinkingEffort(
   sessionId: string,
   topic?: string,
-): ReasoningEffortLevel | null {
+): StoredEffort | null {
   return useSyncExternalStore(
     subscribe,
     () => getThinkingEffort(sessionId, topic),
@@ -98,5 +164,7 @@ export function useThinkingEffort(
 /** Test helper — clears all per-session state. */
 export function __resetThinkingStoreForTest(): void {
   effortByKey.clear();
+  seededKeys.clear();
+  seedWaiters.clear();
   notify();
 }


### PR DESCRIPTION
First of the three P2 web-parity gaps (WEB-PARITY-2026-07-10): the TUI's `/thinking` per-session reasoning-effort control, as a composer dropdown.

## What
- Composer toolbar selector (default/low/medium/high/max) backed by a per-(session, topic) `thinking-store`.
- **Central send-path injection**: `buildTurnStartExtras` reads the store, so every user turn from every surface (chat, voice, studio rail) carries the choice. This is load-bearing: the server clears its persisted override whenever a user turn omits `reasoning_effort` — per-surface wiring would silently reset the user's choice.
- Bridge: `turn/start` maps `reasoning_effort` only-when-populated (absence ≡ default); new `onSessionOpened` subscription surfaces the `session/open` ack payload; runtime seeds the store from `opened.reasoning_effort` so reload/reconnect restores the server-persisted value.
- Unknown future tiers narrow to unset (`asReasoningEffortLevel`) instead of poisoning state.

## Server contract
`TurnStartParams.reasoning_effort` (snake_case: low|medium|high|max) — carrying wins+persists; user-turn omission clears; continuations fall back to stored. `SessionOpened.reasoning_effort` restores. (See `ui_protocol.rs` #1421-era precedence comment.)

## Tests
905 passing (+22: store unit, extras injection/topic-scoping/omission, bridge mapping + ack emission, composer round-trip). tsc clean; zero new lint errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)