### PR TITLE
feat(chat): session rewind — per-bubble rollback UI (session/rollback parity)

### DIFF
--- a/src/components/chat-thread-rewind.test.tsx
+++ b/src/components/chat-thread-rewind.test.tsx
@@ -171,26 +171,36 @@ describe("user-bubble rewind affordance", () => {
     harness.unmount();
   });
 
-  it("excludes orphan placeholder threads from the affordance and the count", async () => {
-    // codex #262 P1: a late-event orphan bucket (empty placeholder user
-    // message) is NOT a persisted user turn — it must get no Rewind
-    // button, and rewinding the real turn BEFORE it must not count it.
-    rollbackSessionTurns.mockResolvedValue({ ok: true, droppedTurns: 1 });
-    const { secondThreadId } = seedTwoTurns();
+  it("withholds ALL rewind affordances while an orphan placeholder exists, restores after adoption", async () => {
+    // codex #262 round 2: while ANY orphan placeholder bucket exists,
+    // the local turn list is KNOWN-incomplete — the orphan may be a
+    // real persisted turn whose user message hasn't hydrated, so every
+    // relative index computed from the list is untrustworthy. No
+    // bubble may offer Rewind until the orphan resolves.
+    rollbackSessionTurns.mockResolvedValue({ ok: true, droppedTurns: 2 });
+    const { firstThreadId, secondThreadId } = seedTwoTurns();
     // Mint an orphan bucket the way the store does for late events:
     // a tool progress line for an unknown thread id.
     ThreadStore.appendToolProgress("orphan-thread-1", "tc-orphan", "late");
-    const threads = ThreadStore.getThreads(SESSION);
-    expect(threads.length).toBe(3);
+    expect(ThreadStore.getThreads(SESSION).length).toBe(3);
     const harness = mountThread();
-    // The orphan bubble renders no rewind button.
-    expect(
-      harness.container.querySelector(
-        '[data-testid="rewind-to-orphan-thread-1"]',
-      ),
-    ).toBeNull();
-    // Rewinding the newest REAL turn still sends num_turns = 1 — the
-    // trailing orphan does not inflate the count.
+    // NO bubble renders a rewind button — not the orphan, not the
+    // real turns.
+    for (const id of ["orphan-thread-1", firstThreadId, secondThreadId]) {
+      expect(
+        harness.container.querySelector(`[data-testid="rewind-to-${id}"]`),
+      ).toBeNull();
+    }
+    // The real user message for the orphan arrives (adoption) — the
+    // bucket is a known turn now, so affordances return with indices
+    // counting it as a REAL turn.
+    act(() => {
+      ThreadStore.addUserMessage(SESSION, {
+        text: "third prompt",
+        clientMessageId: "orphan-thread-1",
+      });
+    });
+    // secondThreadId is now 2 turns from the end (adopted turn is 1).
     const btn = harness.container.querySelector(
       `[data-testid="rewind-to-${secondThreadId}"]`,
     ) as HTMLButtonElement;
@@ -203,7 +213,7 @@ describe("user-bubble rewind affordance", () => {
         ) as HTMLButtonElement
       ).click();
     });
-    expect(rollbackSessionTurns).toHaveBeenCalledWith(SESSION, undefined, 1);
+    expect(rollbackSessionTurns).toHaveBeenCalledWith(SESSION, undefined, 2);
     harness.unmount();
   });
 

--- a/src/components/chat-thread-rewind.test.tsx
+++ b/src/components/chat-thread-rewind.test.tsx
@@ -19,6 +19,8 @@ import { createRoot, type Root } from "react-dom/client";
 const rollbackSessionTurns = vi.fn();
 vi.mock("@/runtime/session-rollback", () => ({
   rollbackSessionTurns: (...args: unknown[]) => rollbackSessionTurns(...args),
+  // The bubble also reads the scope-busy flag; never busy in these tests.
+  useRollbackBusy: () => false,
 }));
 
 import { ChatThread } from "./chat-thread";
@@ -166,6 +168,42 @@ describe("user-bubble rewind affordance", () => {
     expect(prefills).toHaveLength(1);
     expect(prefills[0].text).toBe("second prompt");
     expect(prefills[0].sessionId).toBe(SESSION);
+    harness.unmount();
+  });
+
+  it("excludes orphan placeholder threads from the affordance and the count", async () => {
+    // codex #262 P1: a late-event orphan bucket (empty placeholder user
+    // message) is NOT a persisted user turn — it must get no Rewind
+    // button, and rewinding the real turn BEFORE it must not count it.
+    rollbackSessionTurns.mockResolvedValue({ ok: true, droppedTurns: 1 });
+    const { secondThreadId } = seedTwoTurns();
+    // Mint an orphan bucket the way the store does for late events:
+    // a tool progress line for an unknown thread id.
+    ThreadStore.appendToolProgress("orphan-thread-1", "tc-orphan", "late");
+    const threads = ThreadStore.getThreads(SESSION);
+    expect(threads.length).toBe(3);
+    const harness = mountThread();
+    // The orphan bubble renders no rewind button.
+    expect(
+      harness.container.querySelector(
+        '[data-testid="rewind-to-orphan-thread-1"]',
+      ),
+    ).toBeNull();
+    // Rewinding the newest REAL turn still sends num_turns = 1 — the
+    // trailing orphan does not inflate the count.
+    const btn = harness.container.querySelector(
+      `[data-testid="rewind-to-${secondThreadId}"]`,
+    ) as HTMLButtonElement;
+    expect(btn).toBeTruthy();
+    act(() => btn.click());
+    await act(async () => {
+      (
+        harness.container.querySelector(
+          `[data-testid="rewind-to-${secondThreadId}"]`,
+        ) as HTMLButtonElement
+      ).click();
+    });
+    expect(rollbackSessionTurns).toHaveBeenCalledWith(SESSION, undefined, 1);
     harness.unmount();
   });
 

--- a/src/components/chat-thread-rewind.test.tsx
+++ b/src/components/chat-thread-rewind.test.tsx
@@ -1,0 +1,195 @@
+/**
+ * Rewind-to-here affordance on user bubbles (session/rollback UI).
+ *
+ * Covers: two-click confirm (single click must never rewind), correct
+ * `num_turns` for older bubbles (threads.length - index), composer
+ * prefill dispatch on success, and inline error on the server's
+ * turn-in-progress guard.
+ */
+
+import { afterEach, describe, expect, it, vi } from "vitest";
+import * as React from "react";
+import { act } from "react";
+import { createRoot, type Root } from "react-dom/client";
+
+(
+  globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }
+).IS_REACT_ACT_ENVIRONMENT = true;
+
+const rollbackSessionTurns = vi.fn();
+vi.mock("@/runtime/session-rollback", () => ({
+  rollbackSessionTurns: (...args: unknown[]) => rollbackSessionTurns(...args),
+}));
+
+import { ChatThread } from "./chat-thread";
+import { SessionContext } from "@/runtime/session-context";
+import type { SessionContextValue } from "@/runtime/session-context";
+import * as ThreadStore from "@/store/thread-store";
+
+const SESSION = "sess-rewind-ui";
+
+interface MountedHarness {
+  container: HTMLDivElement;
+  root: Root;
+  unmount: () => void;
+}
+
+function makeSessionCtx(): SessionContextValue {
+  return {
+    sessions: [],
+    currentSessionId: SESSION,
+    historyTopic: undefined,
+    currentSessionTitle: "",
+    currentSessionStats: null,
+    initialMessages: [],
+    activeTaskOnServer: false,
+    queueMode: null,
+    adaptiveMode: null,
+    setServerTaskActive: () => {},
+    renameSession: () => {},
+    updateSessionStats: () => {},
+    switchSession: () => {},
+    goBack: async () => false,
+    createSession: () => SESSION,
+    removeSession: async () => {},
+    refreshSessions: async () => {},
+    markSessionActive: () => {},
+  };
+}
+
+function mountThread(): MountedHarness {
+  const container = document.createElement("div");
+  document.body.appendChild(container);
+  const root = createRoot(container);
+  act(() => {
+    root.render(
+      <SessionContext.Provider value={makeSessionCtx()}>
+        <ChatThread />
+      </SessionContext.Provider>,
+    );
+  });
+  return {
+    container,
+    root,
+    unmount: () => {
+      act(() => root.unmount());
+      container.remove();
+    },
+  };
+}
+
+function seedTwoTurns(): { firstThreadId: string; secondThreadId: string } {
+  ThreadStore.addUserMessage(SESSION, {
+    text: "first prompt",
+    clientMessageId: "cmid-first",
+  });
+  ThreadStore.appendAssistantToken("cmid-first", "first reply");
+  ThreadStore.finalizeAssistant("cmid-first", { committedSeq: 2 });
+  ThreadStore.addUserMessage(SESSION, {
+    text: "second prompt",
+    clientMessageId: "cmid-second",
+  });
+  ThreadStore.appendAssistantToken("cmid-second", "second reply");
+  ThreadStore.finalizeAssistant("cmid-second", { committedSeq: 4 });
+  const threads = ThreadStore.getThreads(SESSION);
+  expect(threads).toHaveLength(2);
+  return { firstThreadId: threads[0].id, secondThreadId: threads[1].id };
+}
+
+function rewindButton(
+  harness: MountedHarness,
+  threadId: string,
+): HTMLButtonElement {
+  const el = harness.container.querySelector(
+    `[data-testid="rewind-to-${threadId}"]`,
+  ) as HTMLButtonElement | null;
+  expect(el).toBeTruthy();
+  return el as HTMLButtonElement;
+}
+
+afterEach(() => {
+  for (const node of [...document.body.children]) node.remove();
+  ThreadStore.__resetForTests();
+  rollbackSessionTurns.mockReset();
+});
+
+describe("user-bubble rewind affordance", () => {
+  it("requires a second confirming click before calling session/rollback", async () => {
+    rollbackSessionTurns.mockResolvedValue({ ok: true, droppedTurns: 1 });
+    const { secondThreadId } = seedTwoTurns();
+    const harness = mountThread();
+    const btn = rewindButton(harness, secondThreadId);
+
+    act(() => btn.click());
+    // Armed, not fired.
+    expect(rollbackSessionTurns).not.toHaveBeenCalled();
+    expect(rewindButton(harness, secondThreadId).textContent).toContain(
+      "Confirm",
+    );
+
+    await act(async () => {
+      rewindButton(harness, secondThreadId).click();
+    });
+    // Newest turn → num_turns = 1.
+    expect(rollbackSessionTurns).toHaveBeenCalledWith(SESSION, undefined, 1);
+    harness.unmount();
+  });
+
+  it("computes num_turns from the bubble's distance from the end", async () => {
+    rollbackSessionTurns.mockResolvedValue({ ok: true, droppedTurns: 2 });
+    const { firstThreadId } = seedTwoTurns();
+    const harness = mountThread();
+
+    act(() => rewindButton(harness, firstThreadId).click());
+    await act(async () => {
+      rewindButton(harness, firstThreadId).click();
+    });
+    // Oldest of two turns → rewinding here drops BOTH.
+    expect(rollbackSessionTurns).toHaveBeenCalledWith(SESSION, undefined, 2);
+    harness.unmount();
+  });
+
+  it("prefills the composer with the dropped prompt on success", async () => {
+    rollbackSessionTurns.mockResolvedValue({ ok: true, droppedTurns: 1 });
+    const { secondThreadId } = seedTwoTurns();
+    const harness = mountThread();
+    const prefills: Array<{ sessionId?: string; text?: string }> = [];
+    const onPrefill = (e: Event) =>
+      prefills.push((e as CustomEvent).detail as { text?: string });
+    window.addEventListener("crew:composer_prefill", onPrefill);
+
+    act(() => rewindButton(harness, secondThreadId).click());
+    await act(async () => {
+      rewindButton(harness, secondThreadId).click();
+    });
+    window.removeEventListener("crew:composer_prefill", onPrefill);
+    expect(prefills).toHaveLength(1);
+    expect(prefills[0].text).toBe("second prompt");
+    expect(prefills[0].sessionId).toBe(SESSION);
+    harness.unmount();
+  });
+
+  it("surfaces the turn-in-progress guard inline and does not prefill", async () => {
+    rollbackSessionTurns.mockResolvedValue({
+      ok: false,
+      reason: "turn_in_progress",
+    });
+    const { secondThreadId } = seedTwoTurns();
+    const harness = mountThread();
+    const prefills: Event[] = [];
+    const onPrefill = (e: Event) => prefills.push(e);
+    window.addEventListener("crew:composer_prefill", onPrefill);
+
+    act(() => rewindButton(harness, secondThreadId).click());
+    await act(async () => {
+      rewindButton(harness, secondThreadId).click();
+    });
+    window.removeEventListener("crew:composer_prefill", onPrefill);
+    const error = harness.container.querySelector(
+      '[data-testid="rewind-error"]',
+    );
+    expect(error?.textContent).toContain("turn is running");
+    expect(prefills).toHaveLength(0);
+    harness.unmount();
+  });
+});

--- a/src/components/chat-thread.tsx
+++ b/src/components/chat-thread.tsx
@@ -1287,17 +1287,20 @@ function ThreadList({
   // inflates `num_turns` (rewinding B in [A, B, orphan] would send 2
   // and delete A too) and puts a Rewind button on a non-turn.
   // Placeholders map to 0 → no affordance.
+  //
+  // Round 2: while ANY orphan placeholder exists in the scope, the
+  // local turn list is KNOWN-incomplete — the orphan may be a real
+  // persisted turn whose user message simply hasn't hydrated, so every
+  // relative index computed from the list may be off by one or more.
+  // Withhold ALL rewind affordances (everything maps to 0) until
+  // hydration resolves the orphan.
   const turnsFromEndByThreadId = useMemo(() => {
     const byId = new Map<string, number>();
+    if (threads.some((t) => isPlaceholderThread(t))) return byId;
     let fromEnd = 0;
     for (let i = threads.length - 1; i >= 0; i -= 1) {
-      const thread = threads[i];
-      if (isPlaceholderThread(thread)) {
-        byId.set(thread.id, 0);
-      } else {
-        fromEnd += 1;
-        byId.set(thread.id, fromEnd);
-      }
+      fromEnd += 1;
+      byId.set(threads[i].id, fromEnd);
     }
     return byId;
   }, [threads]);

--- a/src/components/chat-thread.tsx
+++ b/src/components/chat-thread.tsx
@@ -35,8 +35,12 @@ import {
   Check,
 } from "lucide-react";
 import { useSession } from "@/runtime/session-context";
-import { rollbackSessionTurns } from "@/runtime/session-rollback";
 import {
+  rollbackSessionTurns,
+  useRollbackBusy,
+} from "@/runtime/session-rollback";
+import {
+  isPlaceholderThread,
   useThreads,
   type MessageFile,
   type MessageMeta,
@@ -579,6 +583,11 @@ const ThreadUserBubble = memo(function ThreadUserBubble({
   turnsFromEnd?: number;
 }) {
   const visibleText = threadMessageVisibleText(message);
+  // A rollback applying anywhere in this scope disables every Rewind
+  // button: rollback counts are RELATIVE ("last N"), so a second click
+  // confirmed against pre-trim indices would delete unintended turns
+  // (codex #262 P1). The applier itself also refuses concurrent runs.
+  const rollbackBusy = useRollbackBusy(sessionId ?? "", historyTopic);
   // Rewind affordance state: idle → confirm (second click required) →
   // busy. Errors render inline under the bubble and reset to idle.
   const [rewindState, setRewindState] = useState<
@@ -669,7 +678,7 @@ const ThreadUserBubble = memo(function ThreadUserBubble({
             ? `Drops the last ${turnsFromEnd} turn${turnsFromEnd === 1 ? "" : "s"} — click again to confirm`
             : "Rewind to before this message"
         }
-        disabled={rewindState === "busy"}
+        disabled={rewindState === "busy" || rollbackBusy}
         onClick={() => {
           if (rewindState === "idle" || rewindState === "error") {
             setRewindState("confirm");
@@ -1272,6 +1281,27 @@ function ThreadList({
   onSettleGhost: (clientMessageId: string) => void;
   hideFileOnlyAssistantMessages: boolean;
 }) {
+  // Rewind math (codex #262 P1): `session/rollback` counts persisted
+  // USER turns only, but `threads` can contain placeholder orphans
+  // (late-event buckets with no user message). Counting those both
+  // inflates `num_turns` (rewinding B in [A, B, orphan] would send 2
+  // and delete A too) and puts a Rewind button on a non-turn.
+  // Placeholders map to 0 → no affordance.
+  const turnsFromEndByThreadId = useMemo(() => {
+    const byId = new Map<string, number>();
+    let fromEnd = 0;
+    for (let i = threads.length - 1; i >= 0; i -= 1) {
+      const thread = threads[i];
+      if (isPlaceholderThread(thread)) {
+        byId.set(thread.id, 0);
+      } else {
+        fromEnd += 1;
+        byId.set(thread.id, fromEnd);
+      }
+    }
+    return byId;
+  }, [threads]);
+
   const viewportRef = useRef<HTMLDivElement>(null);
   const stickToBottomRef = useRef(true);
 
@@ -1303,12 +1333,12 @@ function ThreadList({
       className="chat-thread-viewport flex-1 min-h-0 overflow-y-auto overscroll-contain"
     >
       <div className="chat-thread-inner mx-auto max-w-4xl py-6">
-        {threads.map((thread, index) => (
+        {threads.map((thread) => (
           <ThreadView
             key={thread.id}
             thread={thread}
             hideFileOnlyAssistantMessages={hideFileOnlyAssistantMessages}
-            turnsFromEnd={threads.length - index}
+            turnsFromEnd={turnsFromEndByThreadId.get(thread.id) ?? 0}
           />
         ))}
         {ghosts.map((g) => (

--- a/src/components/chat-thread.tsx
+++ b/src/components/chat-thread.tsx
@@ -22,6 +22,7 @@ import {
   Paperclip,
   X,
   FileIcon,
+  RotateCcw,
   Mic,
   Video,
   Camera,
@@ -34,6 +35,7 @@ import {
   Check,
 } from "lucide-react";
 import { useSession } from "@/runtime/session-context";
+import { rollbackSessionTurns } from "@/runtime/session-rollback";
 import {
   useThreads,
   type MessageFile,
@@ -565,12 +567,69 @@ const ThreadUserBubble = memo(function ThreadUserBubble({
   message,
   threadId,
   sessionId,
+  historyTopic,
+  turnsFromEnd,
 }: {
   message: ThreadMessage;
   threadId: string;
   sessionId?: string;
+  historyTopic?: string;
+  /** 1 = newest user turn. Rewinding AT this bubble drops this turn and
+   *  everything after it (`session/rollback num_turns`). */
+  turnsFromEnd?: number;
 }) {
   const visibleText = threadMessageVisibleText(message);
+  // Rewind affordance state: idle → confirm (second click required) →
+  // busy. Errors render inline under the bubble and reset to idle.
+  const [rewindState, setRewindState] = useState<
+    "idle" | "confirm" | "busy" | "error"
+  >("idle");
+  const [rewindError, setRewindError] = useState<string | null>(null);
+  // Leaving confirm-state on blur/timeout keeps a stray first click from
+  // arming a destructive second click minutes later.
+  useEffect(() => {
+    if (rewindState !== "confirm") return;
+    const timer = setTimeout(() => setRewindState("idle"), 4000);
+    return () => clearTimeout(timer);
+  }, [rewindState]);
+
+  async function runRewind() {
+    if (!sessionId || !turnsFromEnd || turnsFromEnd < 1) return;
+    setRewindState("busy");
+    setRewindError(null);
+    const textForPrefill = visibleText;
+    const outcome = await rollbackSessionTurns(
+      sessionId,
+      historyTopic,
+      turnsFromEnd,
+    );
+    if (!outcome.ok) {
+      setRewindState("error");
+      setRewindError(
+        outcome.reason === "turn_in_progress"
+          ? "A turn is running — stop it first."
+          : outcome.reason === "no_bridge"
+            ? "Not connected."
+            : "Rewind failed.",
+      );
+      setTimeout(() => {
+        setRewindState("idle");
+        setRewindError(null);
+      }, 4000);
+      return;
+    }
+    // The bubble (this component) is unmounted by the store rebuild the
+    // moment the rollback applies — no local state reset needed. Hand the
+    // dropped prompt to the composer so rewind = edit-and-resend.
+    if (textForPrefill) {
+      window.dispatchEvent(
+        new CustomEvent("crew:composer_prefill", {
+          detail: { sessionId, topic: historyTopic, text: textForPrefill },
+        }),
+      );
+    }
+  }
+
   // Visual layout is shared with `<GhostBubble>` via `<UserBubbleShell>`
   // so the optimistic overlay and the canonical user bubble cannot drift
   // (codex BLOCK 4 fix). Only the file-row content differs: the real
@@ -584,11 +643,62 @@ const ThreadUserBubble = memo(function ThreadUserBubble({
         ))}
       </>
     ) : null;
+  // Rewind control lives in the shell's `trailing` slot (right-aligned
+  // under the footer). Subtle at rest; explicit two-click confirm.
+  const canRewind = Boolean(sessionId && turnsFromEnd && turnsFromEnd >= 1);
+  const rewindControl = canRewind ? (
+    <span className="flex items-center gap-1">
+      {rewindState === "error" && rewindError && (
+        <span
+          data-testid="rewind-error"
+          className="text-[10px] text-rose-400"
+        >
+          {rewindError}
+        </span>
+      )}
+      <button
+        type="button"
+        data-testid={`rewind-to-${threadId}`}
+        aria-label={
+          rewindState === "confirm"
+            ? "Confirm rewind — drops this turn and everything after it"
+            : "Rewind to before this message"
+        }
+        title={
+          rewindState === "confirm"
+            ? `Drops the last ${turnsFromEnd} turn${turnsFromEnd === 1 ? "" : "s"} — click again to confirm`
+            : "Rewind to before this message"
+        }
+        disabled={rewindState === "busy"}
+        onClick={() => {
+          if (rewindState === "idle" || rewindState === "error") {
+            setRewindState("confirm");
+          } else if (rewindState === "confirm") {
+            void runRewind();
+          }
+        }}
+        className={`flex items-center gap-1 rounded-[6px] px-1.5 py-0.5 text-[10px] font-medium transition-opacity ${
+          rewindState === "confirm"
+            ? "border border-rose-400 text-rose-300"
+            : "text-muted opacity-40 hover:opacity-100"
+        } disabled:opacity-60`}
+      >
+        <RotateCcw size={10} />
+        {rewindState === "busy"
+          ? "Rewinding…"
+          : rewindState === "confirm"
+            ? "Confirm rewind?"
+            : "Rewind"}
+      </button>
+    </span>
+  ) : null;
+
   return (
     <UserBubbleShell
       text={visibleText || null}
       files={fileRows}
       footer={formatTimestamp(message.timestamp)}
+      trailing={rewindControl}
       textTestId="user-message"
       textDataAttributes={{ "data-thread-id": threadId }}
     />
@@ -1084,9 +1194,13 @@ function isVisibleResponse(
 function ThreadView({
   thread,
   hideFileOnlyAssistantMessages,
+  turnsFromEnd,
 }: {
   thread: Thread;
   hideFileOnlyAssistantMessages: boolean;
+  /** 1 for the newest user turn, N for the oldest — the `num_turns`
+   *  a rewind AT this bubble sends to `session/rollback`. */
+  turnsFromEnd: number;
 }) {
   const visibleResponses = thread.responses.filter((r) =>
     isVisibleResponse(r, hideFileOnlyAssistantMessages),
@@ -1113,6 +1227,8 @@ function ThreadView({
         message={thread.userMsg}
         threadId={thread.id}
         sessionId={currentSessionId}
+        historyTopic={historyTopic}
+        turnsFromEnd={turnsFromEnd}
       />
       {visibleResponses.map((response) => (
         <ThreadAssistantBubble
@@ -1187,11 +1303,12 @@ function ThreadList({
       className="chat-thread-viewport flex-1 min-h-0 overflow-y-auto overscroll-contain"
     >
       <div className="chat-thread-inner mx-auto max-w-4xl py-6">
-        {threads.map((thread) => (
+        {threads.map((thread, index) => (
           <ThreadView
             key={thread.id}
             thread={thread}
             hideFileOnlyAssistantMessages={hideFileOnlyAssistantMessages}
+            turnsFromEnd={threads.length - index}
           />
         ))}
         {ghosts.map((g) => (
@@ -1370,6 +1487,29 @@ function Composer({ mountGhost, unmountGhost }: ComposerProps) {
   const [text, setText] = useState("");
   const [cmdFeedback, setCmdFeedback] = useState<string | null>(null);
   const [pendingFiles, setPendingFiles] = useState<PendingFile[]>([]);
+
+  // Rewind → edit-and-resend: `ThreadUserBubble` dispatches
+  // `crew:composer_prefill` with the dropped user prompt after a
+  // successful `session/rollback`, so the user lands with the old text
+  // ready to edit. Scope-checked — a prefill for another session/topic
+  // (stale event across a fast switch) must not clobber this composer.
+  useEffect(() => {
+    function onPrefill(e: Event) {
+      const detail = (e as CustomEvent).detail as
+        | { sessionId?: string; topic?: string; text?: string }
+        | undefined;
+      if (!detail || typeof detail.text !== "string") return;
+      if (detail.sessionId !== currentSessionId) return;
+      const evTopic = detail.topic?.trim() || undefined;
+      const myTopic = historyTopic?.trim() || undefined;
+      if (evTopic !== myTopic) return;
+      setText(detail.text);
+      textareaRef.current?.focus();
+    }
+    window.addEventListener("crew:composer_prefill", onPrefill);
+    return () =>
+      window.removeEventListener("crew:composer_prefill", onPrefill);
+  }, [currentSessionId, historyTopic]);
   const [uploading, setUploading] = useState(false);
   const fileInputRef = useRef<HTMLInputElement>(null);
   const textareaRef = useRef<HTMLTextAreaElement>(null);

--- a/src/runtime/session-rollback.test.ts
+++ b/src/runtime/session-rollback.test.ts
@@ -883,6 +883,83 @@ describe("rollbackSessionTurns", () => {
     expect(ThreadStore.hasPlaceholderThreads(SESSION, "slides")).toBe(false);
   });
 
+  it("queues an echo that lands during an in-flight nudge and fetches again (codex round 9 P1)", async () => {
+    // Scope seeded via replay (roots carry no seq → echoes can't open
+    // the gate → nudges fire).
+    ThreadStore.replayHistory(SESSION, [
+      {
+        role: "user",
+        content: "anchor",
+        client_message_id: "cmid-anchor-q",
+        thread_id: "cmid-anchor-q",
+        timestamp: "2026-07-10T00:00:00Z",
+      },
+    ] as never);
+    ThreadStore.appendToolProgress("cmid-qa", "tc-qa", "late progress");
+    ThreadStore.appendToolProgress("cmid-qb", "tc-qb", "late progress");
+    const anchorRow = {
+      role: "user",
+      content: "anchor",
+      client_message_id: "cmid-anchor-q",
+      thread_id: "cmid-anchor-q",
+      timestamp: "2026-07-10T00:00:00Z",
+    };
+    const rowA = {
+      role: "user",
+      content: "prompt A",
+      client_message_id: "cmid-qa",
+      thread_id: "cmid-qa",
+      timestamp: "2026-07-10T00:00:01Z",
+    };
+    const rowB = {
+      role: "user",
+      content: "prompt B",
+      client_message_id: "cmid-qb",
+      thread_id: "cmid-qb",
+      timestamp: "2026-07-10T00:00:02Z",
+    };
+    // Nudge #1's fetch: response predates echo B (no rowB) and is held
+    // open until after echo B lands.
+    let resolveFirst!: (v: unknown) => void;
+    getMessagesPage.mockReturnValueOnce(
+      new Promise((resolve) => {
+        resolveFirst = resolve;
+      }),
+    );
+    ThreadStore.appendPersistedMessage(SESSION, undefined, {
+      seq: 2,
+      role: "user",
+      content: "prompt A",
+      client_message_id: "cmid-qa",
+      thread_id: "cmid-qa",
+      timestamp: "2026-07-10T00:00:01Z",
+    } as never);
+    await new Promise((r) => setTimeout(r, 0));
+    // Echo B arrives while nudge #1 is fetching → queued, not dropped.
+    ThreadStore.appendPersistedMessage(SESSION, undefined, {
+      seq: 4,
+      role: "user",
+      content: "prompt B",
+      client_message_id: "cmid-qb",
+      thread_id: "cmid-qb",
+      timestamp: "2026-07-10T00:00:02Z",
+    } as never);
+    // Follow-up fetch sees the full post-B history.
+    getMessagesPage.mockResolvedValue({
+      messages: [anchorRow, rowA, rowB],
+      has_more: false,
+    });
+    resolveFirst({ messages: [anchorRow, rowA], has_more: false });
+    await new Promise((r) => setTimeout(r, 0));
+    await new Promise((r) => setTimeout(r, 0));
+    // Two forced loads: the in-flight one + the queued follow-up.
+    expect(getMessagesPage.mock.calls.length).toBe(2);
+    expect(ThreadStore.hasPlaceholderThreads(SESSION)).toBe(false);
+    expect(
+      ThreadStore.getThreads(SESSION).map((t) => t.userMsg.text),
+    ).toEqual(["anchor", "prompt A", "prompt B"]);
+  });
+
   it("orders equal-timestamp roots by seq once every root carries one (codex rounds 5-6)", () => {
     ThreadStore.replayHistory(SESSION, [
       {

--- a/src/runtime/session-rollback.test.ts
+++ b/src/runtime/session-rollback.test.ts
@@ -16,6 +16,13 @@ const rollbackSession = vi.fn();
 vi.mock("./ui-protocol-runtime", () => ({
   getActiveBridge: () => mockBridge,
 }));
+// The round-7 placeholder-refetch nudge drives ThreadStore.loadHistory →
+// getMessagesPage. Default: reject (loadHistory swallows), so gate-closed
+// tests stay inert; the nudge liveness test resolves it with history.
+const getMessagesPage = vi.fn();
+vi.mock("@/api/sessions", () => ({
+  getMessagesPage: (...args: unknown[]) => getMessagesPage(...args),
+}));
 // Reassigned per-test; `null` simulates a disconnected scope.
 let mockBridge: { rollbackSession: typeof rollbackSession } | null = {
   rollbackSession,
@@ -55,6 +62,8 @@ function trimmedResult(): SessionRollbackResult {
 beforeEach(() => {
   mockBridge = { rollbackSession };
   rollbackSession.mockReset();
+  getMessagesPage.mockReset();
+  getMessagesPage.mockRejectedValue(new Error("no fetch in test"));
 });
 
 afterEach(() => {
@@ -582,6 +591,76 @@ describe("rollbackSessionTurns", () => {
       timestamp: "2026-07-10T00:00:05Z",
     } as never);
     expect(ThreadStore.hasPlaceholderThreads(SESSION)).toBe(true);
+  });
+
+  it("nudges ONE forced REST replay when an echo cannot resolve the scope (codex round 7)", async () => {
+    // Topic-scope shape: the sibling came from messages_page (no seq)
+    // and no hydrate will ever supply one. The orphan's echo cannot
+    // open the gate — but the echoed turn IS persisted now, so the
+    // store falls back to one forced REST replay, which re-roots both
+    // user rows in server order and resolves the placeholder.
+    ThreadStore.replayHistory(
+      SESSION,
+      [
+        {
+          role: "user",
+          content: "sibling",
+          client_message_id: "cmid-sib3",
+          thread_id: "cmid-sib3",
+          timestamp: "2026-07-10T00:00:01Z",
+        },
+      ] as never,
+      "slides",
+    );
+    ThreadStore.appendToolProgress("cmid-late3", "tc-1", "late progress");
+    // The orphan landed in the slides scope alongside the sibling.
+    expect(ThreadStore.hasPlaceholderThreads(SESSION, "slides")).toBe(true);
+    getMessagesPage.mockResolvedValue({
+      messages: [
+        {
+          role: "user",
+          content: "sibling",
+          client_message_id: "cmid-sib3",
+          thread_id: "cmid-sib3",
+          timestamp: "2026-07-10T00:00:01Z",
+        },
+        {
+          role: "user",
+          content: "late prompt",
+          client_message_id: "cmid-late3",
+          thread_id: "cmid-late3",
+          timestamp: "2026-07-10T00:00:02Z",
+        },
+        {
+          role: "assistant",
+          content: "late reply",
+          thread_id: "cmid-late3",
+          timestamp: "2026-07-10T00:00:03Z",
+        },
+      ],
+      has_more: false,
+    });
+    ThreadStore.appendPersistedMessage(SESSION, "slides", {
+      seq: 4,
+      role: "user",
+      content: "late prompt",
+      client_message_id: "cmid-late3",
+      thread_id: "cmid-late3",
+      timestamp: "2026-07-10T00:00:02Z",
+    } as never);
+    // Echo alone: gate still closed (sibling has no seq)…
+    expect(ThreadStore.hasPlaceholderThreads(SESSION, "slides")).toBe(true);
+    // …but the nudge fired one forced replay; let it land.
+    await Promise.resolve();
+    await Promise.resolve();
+    await Promise.resolve();
+    expect(getMessagesPage).toHaveBeenCalledTimes(1);
+    expect(ThreadStore.hasPlaceholderThreads(SESSION, "slides")).toBe(false);
+    const threads = ThreadStore.getThreads(SESSION, "slides");
+    expect(threads.map((t) => t.userMsg.text)).toEqual([
+      "sibling",
+      "late prompt",
+    ]);
   });
 
   it("orders equal-timestamp roots by seq once every root carries one (codex rounds 5-6)", () => {

--- a/src/runtime/session-rollback.test.ts
+++ b/src/runtime/session-rollback.test.ts
@@ -1,0 +1,123 @@
+/**
+ * session-rollback applier tests.
+ *
+ * The server's `session/rollback` returns the TRIMMED thread in the
+ * hydrate shape. The applier must clear the local scope BEFORE seeding —
+ * `setHydrateSnapshot` only adds/coalesces rows, so without the clear
+ * the rolled-back bubbles would survive locally until a full reload.
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import * as ThreadStore from "@/store/thread-store";
+import type { SessionRollbackResult } from "./ui-protocol-types";
+
+const rollbackSession = vi.fn();
+vi.mock("./ui-protocol-runtime", () => ({
+  getActiveBridge: () => mockBridge,
+}));
+// Reassigned per-test; `null` simulates a disconnected scope.
+let mockBridge: { rollbackSession: typeof rollbackSession } | null = {
+  rollbackSession,
+};
+
+import { rollbackSessionTurns } from "./session-rollback";
+
+const SESSION = "sess-rollback-applier";
+
+function trimmedResult(): SessionRollbackResult {
+  return {
+    dropped_turns: 1,
+    thread: {
+      session_id: SESSION,
+      cursor: { stream: SESSION, seq: 2 },
+      messages: [
+        {
+          seq: 1,
+          role: "user",
+          content: "keep me",
+          client_message_id: "cmid-keep",
+          message_id: "m1",
+          persisted_at: "2026-07-10T00:00:00Z",
+        },
+        {
+          seq: 2,
+          role: "assistant",
+          content: "kept reply",
+          message_id: "m2",
+          persisted_at: "2026-07-10T00:00:01Z",
+        },
+      ],
+    },
+  };
+}
+
+beforeEach(() => {
+  mockBridge = { rollbackSession };
+  rollbackSession.mockReset();
+});
+
+afterEach(() => {
+  ThreadStore.__resetForTests();
+});
+
+describe("rollbackSessionTurns", () => {
+  it("clears the scope and rebuilds it from the trimmed projection", async () => {
+    // Local store holds TWO turns; the server trims to one.
+    ThreadStore.addUserMessage(SESSION, {
+      text: "keep me",
+      clientMessageId: "cmid-keep",
+    });
+    ThreadStore.appendAssistantToken("cmid-keep", "kept reply");
+    ThreadStore.finalizeAssistant("cmid-keep", { committedSeq: 2 });
+    ThreadStore.addUserMessage(SESSION, {
+      text: "drop me",
+      clientMessageId: "cmid-drop",
+    });
+    ThreadStore.appendAssistantToken("cmid-drop", "dropped reply");
+    ThreadStore.finalizeAssistant("cmid-drop", { committedSeq: 4 });
+    expect(ThreadStore.getThreads(SESSION)).toHaveLength(2);
+
+    rollbackSession.mockResolvedValue(trimmedResult());
+    const outcome = await rollbackSessionTurns(SESSION, undefined, 1);
+    expect(outcome).toEqual({ ok: true, droppedTurns: 1 });
+    expect(rollbackSession).toHaveBeenCalledWith(1);
+
+    const threads = ThreadStore.getThreads(SESSION);
+    expect(threads).toHaveLength(1);
+    expect(threads[0].userMsg.text).toBe("keep me");
+    // The rolled-back turn is gone locally, not just deprioritised.
+    expect(JSON.stringify(threads)).not.toContain("drop me");
+  });
+
+  it("maps the server busy-guard to turn_in_progress and leaves the store intact", async () => {
+    ThreadStore.addUserMessage(SESSION, {
+      text: "still here",
+      clientMessageId: "cmid-still",
+    });
+    rollbackSession.mockRejectedValue(
+      new Error(
+        'session/rollback: a turn is in progress; interrupt it before rolling back {"kind":"turn_in_progress"}',
+      ),
+    );
+    const outcome = await rollbackSessionTurns(SESSION, undefined, 1);
+    expect(outcome).toEqual({ ok: false, reason: "turn_in_progress" });
+    expect(ThreadStore.getThreads(SESSION)).toHaveLength(1);
+  });
+
+  it("reports rpc_failed on other errors without touching the store", async () => {
+    ThreadStore.addUserMessage(SESSION, {
+      text: "still here",
+      clientMessageId: "cmid-still-2",
+    });
+    rollbackSession.mockRejectedValue(new Error("boom"));
+    const outcome = await rollbackSessionTurns(SESSION, undefined, 1);
+    expect(outcome).toEqual({ ok: false, reason: "rpc_failed" });
+    expect(ThreadStore.getThreads(SESSION)).toHaveLength(1);
+  });
+
+  it("reports no_bridge when the scope has no connected bridge", async () => {
+    mockBridge = null;
+    const outcome = await rollbackSessionTurns(SESSION, undefined, 1);
+    expect(outcome).toEqual({ ok: false, reason: "no_bridge" });
+  });
+});

--- a/src/runtime/session-rollback.test.ts
+++ b/src/runtime/session-rollback.test.ts
@@ -384,7 +384,15 @@ describe("rollbackSessionTurns", () => {
     );
     expect(applied).toBe(true);
     expect(ThreadStore.hasPlaceholderThreads(SESSION)).toBe(true);
-    // The persisted echo (timestamp + seq) is what adopts it.
+    // The persisted echoes (timestamp + seq for EVERY root) adopt it.
+    ThreadStore.appendPersistedMessage(SESSION, undefined, {
+      seq: 5,
+      role: "user",
+      content: "anchor",
+      client_message_id: "cmid-anchor",
+      thread_id: "cmid-anchor",
+      timestamp: "2026-07-10T00:00:04Z",
+    } as never);
     ThreadStore.appendPersistedMessage(SESSION, undefined, {
       seq: 7,
       role: "user",
@@ -443,12 +451,13 @@ describe("rollbackSessionTurns", () => {
     expect(ThreadStore.getThreads(SESSION)[0].responses).toHaveLength(before);
   });
 
-  it("hydrate media adoption re-anchors the orphan's order before opening the rewind gate", () => {
-    // codex #262 round 4 P1: a late background assistant mints the
+  it("hydrate rows (media or not) normalize order and adopt the orphan by seq", () => {
+    // codex #262 rounds 4-6: a late background assistant mints the
     // orphan at ASSISTANT-arrival time, placing an OLDER media turn
-    // AFTER a newer prompt. Adoption must restore the server order
-    // (row.persisted_at) — otherwise rewinding the newer prompt sends
-    // num_turns=2 and deletes both turns.
+    // AFTER a newer prompt. The gate opens only once EVERY user root
+    // carries server order; the sibling's order arrives via its
+    // NO-media hydrate row (round 6 P2), the orphan's via its media
+    // row. Sorting by per-session seq restores the server order.
     ThreadStore.addUserMessage(SESSION, {
       text: "newer prompt",
       clientMessageId: "cmid-new",
@@ -467,7 +476,14 @@ describe("rollbackSessionTurns", () => {
           content: "older prompt",
           client_message_id: "cmid-old",
           media: ["uploads/x.wav"],
-          persisted_at: "2020-01-01T00:00:00Z",
+          persisted_at: "2026-07-09T00:00:00Z",
+        },
+        {
+          seq: 3,
+          role: "user",
+          content: "newer prompt",
+          client_message_id: "cmid-new",
+          persisted_at: "2026-07-09T00:00:01Z",
         },
       ],
     });
@@ -479,7 +495,10 @@ describe("rollbackSessionTurns", () => {
     expect(ThreadStore.hasPlaceholderThreads(SESSION)).toBe(false);
   });
 
-  it("hydrate media adoption keeps the gate closed without a usable persisted_at", () => {
+  it("keeps the gate closed while ANY user root lacks server order", () => {
+    // The orphan's own row carries seq, but the optimistic sibling's
+    // echo hasn't landed — its root is still in the client clock
+    // domain, so placement would mix domains (round 6 P1).
     ThreadStore.addUserMessage(SESSION, {
       text: "newer prompt",
       clientMessageId: "cmid-new2",
@@ -493,14 +512,14 @@ describe("rollbackSessionTurns", () => {
           content: "older prompt",
           client_message_id: "cmid-old2",
           media: ["uploads/y.wav"],
-          // no persisted_at → order unknowable → stay withheld
+          persisted_at: "2026-07-09T00:00:00Z",
         },
       ],
     });
     expect(ThreadStore.hasPlaceholderThreads(SESSION)).toBe(true);
   });
 
-  it("persisted-echo adoption re-anchors the orphan's order (codex round 5 P1)", () => {
+  it("persisted echoes normalize every root; the second echo adopts and reorders (codex rounds 5-6)", () => {
     // Newer real prompt first; late stream mints the orphan AFTER it.
     ThreadStore.addUserMessage(SESSION, {
       text: "newer prompt",
@@ -511,14 +530,26 @@ describe("rollbackSessionTurns", () => {
       "cmid-new5",
       "cmid-old5",
     ]);
-    // The persisted user echo carries the true (older) order.
+    // The orphan's echo alone must NOT open the gate: the optimistic
+    // sibling is still client-clocked (round 6 P1 — mixed domains).
     ThreadStore.appendPersistedMessage(SESSION, undefined, {
       seq: 1,
       role: "user",
       content: "older prompt",
       client_message_id: "cmid-old5",
       thread_id: "cmid-old5",
-      timestamp: "2020-01-01T00:00:00Z",
+      timestamp: "2026-07-09T00:00:00Z",
+    } as never);
+    expect(ThreadStore.hasPlaceholderThreads(SESSION)).toBe(true);
+    // The sibling's own echo lands moments later (normal send flow) —
+    // every root is now server-ordered, so adoption sorts by seq.
+    ThreadStore.appendPersistedMessage(SESSION, undefined, {
+      seq: 3,
+      role: "user",
+      content: "newer prompt",
+      client_message_id: "cmid-new5",
+      thread_id: "cmid-new5",
+      timestamp: "2026-07-09T00:00:01Z",
     } as never);
     expect(ThreadStore.getThreads(SESSION).map((t) => t.id)).toEqual([
       "cmid-old5",
@@ -527,9 +558,11 @@ describe("rollbackSessionTurns", () => {
     expect(ThreadStore.hasPlaceholderThreads(SESSION)).toBe(false);
   });
 
-  it("keeps the gate closed on an equal-timestamp tie without a seq tiebreak (codex round 5 P2)", () => {
-    // Sibling built by replay with a known timestamp but NO seq
-    // (messages_page strips it) …
+  it("keeps the gate closed while a seq-stripped sibling remains (codex rounds 5-6)", () => {
+    // Sibling built by replay WITHOUT seq (messages_page strips it) —
+    // even an identical timestamp cannot order the pair (sub-ms server
+    // times collapse under Date.parse), so seq is the only axis and
+    // the sibling doesn't have one yet.
     ThreadStore.replayHistory(SESSION, [
       {
         role: "user",
@@ -540,8 +573,6 @@ describe("rollbackSessionTurns", () => {
       },
     ] as never);
     ThreadStore.appendAssistantToken("cmid-tie", "late stream");
-    // …and the echo lands in the SAME millisecond: placement between
-    // the two is a guess — the gate must stay closed.
     ThreadStore.appendPersistedMessage(SESSION, undefined, {
       seq: 4,
       role: "user",
@@ -553,7 +584,7 @@ describe("rollbackSessionTurns", () => {
     expect(ThreadStore.hasPlaceholderThreads(SESSION)).toBe(true);
   });
 
-  it("breaks an equal-timestamp tie by seq when both sides carry one (codex round 5 P2)", () => {
+  it("orders equal-timestamp roots by seq once every root carries one (codex rounds 5-6)", () => {
     ThreadStore.replayHistory(SESSION, [
       {
         seq: 3,

--- a/src/runtime/session-rollback.test.ts
+++ b/src/runtime/session-rollback.test.ts
@@ -428,6 +428,63 @@ describe("rollbackSessionTurns", () => {
     expect(ThreadStore.getThreads(SESSION)[0].responses).toHaveLength(before);
   });
 
+  it("hydrate media adoption re-anchors the orphan's order before opening the rewind gate", () => {
+    // codex #262 round 4 P1: a late background assistant mints the
+    // orphan at ASSISTANT-arrival time, placing an OLDER media turn
+    // AFTER a newer prompt. Adoption must restore the server order
+    // (row.persisted_at) — otherwise rewinding the newer prompt sends
+    // num_turns=2 and deletes both turns.
+    ThreadStore.addUserMessage(SESSION, {
+      text: "newer prompt",
+      clientMessageId: "cmid-new",
+    });
+    ThreadStore.appendAssistantToken("cmid-old", "late narration");
+    expect(ThreadStore.hasPlaceholderThreads(SESSION)).toBe(true);
+    expect(ThreadStore.getThreads(SESSION).map((t) => t.id)).toEqual([
+      "cmid-new",
+      "cmid-old",
+    ]);
+    ThreadStore.setHydrateSnapshot(SESSION, undefined, {
+      messages: [
+        {
+          seq: 1,
+          role: "user",
+          content: "older prompt",
+          client_message_id: "cmid-old",
+          media: ["uploads/x.wav"],
+          persisted_at: "2020-01-01T00:00:00Z",
+        },
+      ],
+    });
+    // Adopted AND reordered: the older turn now precedes the newer one.
+    expect(ThreadStore.getThreads(SESSION).map((t) => t.id)).toEqual([
+      "cmid-old",
+      "cmid-new",
+    ]);
+    expect(ThreadStore.hasPlaceholderThreads(SESSION)).toBe(false);
+  });
+
+  it("hydrate media adoption keeps the gate closed without a usable persisted_at", () => {
+    ThreadStore.addUserMessage(SESSION, {
+      text: "newer prompt",
+      clientMessageId: "cmid-new2",
+    });
+    ThreadStore.appendAssistantToken("cmid-old2", "late narration");
+    ThreadStore.setHydrateSnapshot(SESSION, undefined, {
+      messages: [
+        {
+          seq: 1,
+          role: "user",
+          content: "older prompt",
+          client_message_id: "cmid-old2",
+          media: ["uploads/y.wav"],
+          // no persisted_at → order unknowable → stay withheld
+        },
+      ],
+    });
+    expect(ThreadStore.hasPlaceholderThreads(SESSION)).toBe(true);
+  });
+
   it("treats provenance placeholders — not empty-shaped rows — as non-turns", () => {
     // A bucket synthesized for a late persisted assistant row (no user
     // message yet) IS a placeholder…

--- a/src/runtime/session-rollback.test.ts
+++ b/src/runtime/session-rollback.test.ts
@@ -303,6 +303,131 @@ describe("rollbackSessionTurns", () => {
     expect(ThreadStore.getThreads(SESSION)[0].responses).toHaveLength(before);
   });
 
+  // ── codex #262 round 3 folds ─────────────────────────────────────────────
+
+  it("replayHistory carries an unresolved orphan's provenance forward", () => {
+    // A real turn + a late stream for an unknown thread (orphan with
+    // in-flight pending). A forced replay whose rows STILL lack the
+    // orphan's user row must carry the bucket forward AS an orphan —
+    // round 3 P1: dropping the flag let it bypass the rewind gate and
+    // count as a real turn, inflating num_turns for earlier bubbles.
+    ThreadStore.addUserMessage(SESSION, {
+      text: "real prompt",
+      clientMessageId: "cmid-real",
+    });
+    ThreadStore.appendAssistantToken("orphan-carry", "late stream");
+    expect(ThreadStore.hasPlaceholderThreads(SESSION)).toBe(true);
+    ThreadStore.replayHistory(SESSION, [
+      {
+        role: "user",
+        content: "real prompt",
+        client_message_id: "cmid-real",
+        thread_id: "cmid-real",
+        timestamp: "2026-07-10T00:00:00Z",
+      },
+    ] as never);
+    const carried = ThreadStore.getThreads(SESSION).find(
+      (t) => t.id === "orphan-carry",
+    );
+    expect(carried).toBeTruthy();
+    expect(ThreadStore.isPlaceholderThread(carried!)).toBe(true);
+    expect(ThreadStore.hasPlaceholderThreads(SESSION)).toBe(true);
+  });
+
+  it("replayHistory adopts a synthesized bucket when its user row follows", () => {
+    // Assistant row precedes its user row in the same replay batch —
+    // the synthesized bucket must become a KNOWN turn when the user
+    // row lands (round 3 P2: it stayed a placeholder and suppressed
+    // Rewind for every turn indefinitely).
+    ThreadStore.replayHistory(SESSION, [
+      {
+        seq: 2,
+        role: "assistant",
+        content: "answer",
+        thread_id: "t1",
+        message_id: "m2",
+        timestamp: "2026-07-10T00:00:01Z",
+      },
+      {
+        seq: 1,
+        role: "user",
+        content: "prompt",
+        client_message_id: "t1",
+        thread_id: "t1",
+        timestamp: "2026-07-10T00:00:00Z",
+      },
+    ] as never);
+    const threads = ThreadStore.getThreads(SESSION);
+    expect(threads).toHaveLength(1);
+    expect(threads[0].userMsg.text).toBe("prompt");
+    expect(ThreadStore.isPlaceholderThread(threads[0])).toBe(false);
+    expect(ThreadStore.hasPlaceholderThreads(SESSION)).toBe(false);
+  });
+
+  it("applyVoiceTranscript adopts an orphan bucket", () => {
+    ThreadStore.addUserMessage(SESSION, {
+      text: "anchor",
+      clientMessageId: "cmid-anchor",
+    });
+    ThreadStore.appendAssistantToken("orphan-voice", "streamed");
+    expect(ThreadStore.hasPlaceholderThreads(SESSION)).toBe(true);
+    const applied = ThreadStore.applyVoiceTranscript(
+      SESSION,
+      undefined,
+      "orphan-voice",
+      "what I said",
+    );
+    expect(applied).toBe(true);
+    expect(ThreadStore.hasPlaceholderThreads(SESSION)).toBe(false);
+  });
+
+  it("unions the projection's seqs so re-emissions for seq-stripped survivors dedup", async () => {
+    // messages_page replay strips seq → surviving rows carry NO
+    // historySeq, so the post-trim ledger rebuild alone would forget
+    // them and a live re-emission would append a duplicate (round 3
+    // P2). The rollback projection carries the authoritative seqs.
+    ThreadStore.replayHistory(SESSION, [
+      {
+        role: "user",
+        content: "keep me",
+        client_message_id: "cmid-keep",
+        thread_id: "cmid-keep",
+        timestamp: "2026-07-10T00:00:00Z",
+      },
+      {
+        role: "assistant",
+        content: "kept reply",
+        thread_id: "cmid-keep",
+        message_id: "m2",
+        timestamp: "2026-07-10T00:00:01Z",
+      },
+      {
+        role: "user",
+        content: "drop me",
+        client_message_id: "cmid-drop",
+        thread_id: "cmid-drop",
+        timestamp: "2026-07-10T00:00:02Z",
+      },
+    ] as never);
+    expect(ThreadStore.getThreads(SESSION)).toHaveLength(2);
+    rollbackSession.mockResolvedValue(trimmedResult());
+    const outcome = await rollbackSessionTurns(SESSION, undefined, 1);
+    expect(outcome.ok).toBe(true);
+    const [thread] = ThreadStore.getThreads(SESSION);
+    const before = thread.responses.length;
+    // Live re-emission of the SURVIVING assistant row (projection seq
+    // 2) under a fresh message_id: only the unioned ledger dedups it.
+    ThreadStore.appendPersistedMessage(SESSION, undefined, {
+      seq: 2,
+      role: "assistant",
+      content: "kept reply",
+      thread_id: "cmid-keep",
+      message_id: "m2-reemit",
+      timestamp: "2026-07-10T00:00:03Z",
+    } as never);
+    expect(ThreadStore.getThreads(SESSION)[0].responses).toHaveLength(before);
+  });
+
   it("treats provenance placeholders — not empty-shaped rows — as non-turns", () => {
     // A bucket synthesized for a late persisted assistant row (no user
     // message yet) IS a placeholder…

--- a/src/runtime/session-rollback.test.ts
+++ b/src/runtime/session-rollback.test.ts
@@ -1,10 +1,11 @@
 /**
  * session-rollback applier tests.
  *
- * The server's `session/rollback` returns the TRIMMED thread in the
- * hydrate shape. The applier must clear the local scope BEFORE seeding —
- * `setHydrateSnapshot` only adds/coalesces rows, so without the clear
- * the rolled-back bubbles would survive locally until a full reload.
+ * Normal path: a SURGICAL suffix trim (`dropLastUserTurnThreads`) that
+ * keeps surviving thread objects — and their tool cards / progress /
+ * meta — intact. Only a local-vs-server count mismatch falls back to an
+ * exact-scope clear + reseed from the returned trimmed projection.
+ * Rollbacks are relative, so a per-scope lock refuses concurrent runs.
  */
 
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
@@ -61,7 +62,7 @@ afterEach(() => {
 });
 
 describe("rollbackSessionTurns", () => {
-  it("clears the scope and rebuilds it from the trimmed projection", async () => {
+  it("surgically trims the dropped suffix and keeps surviving threads", async () => {
     // Local store holds TWO turns; the server trims to one.
     ThreadStore.addUserMessage(SESSION, {
       text: "keep me",
@@ -87,6 +88,64 @@ describe("rollbackSessionTurns", () => {
     expect(threads[0].userMsg.text).toBe("keep me");
     // The rolled-back turn is gone locally, not just deprioritised.
     expect(JSON.stringify(threads)).not.toContain("drop me");
+    // Surgical trim, NOT clear+reseed: the surviving thread keeps its
+    // finalized assistant response verbatim (hydrate rows carry no
+    // rich state, so a reseed would visibly degrade it).
+    expect(threads[0].responses[0]?.text).toBe("kept reply");
+  });
+
+  it("falls back to exact-scope clear+reseed when local rows disagree with dropped_turns", async () => {
+    // Local store has ONE user turn but the server reports dropping 2 —
+    // the local view was inconsistent; reconcile from the projection.
+    ThreadStore.addUserMessage(SESSION, {
+      text: "only local turn",
+      clientMessageId: "cmid-only",
+    });
+    // Sibling topic cache must SURVIVE the reconciliation (exact-key
+    // clear — the RPC did not touch the topic bucket).
+    ThreadStore.addUserMessage(SESSION, {
+      text: "topic turn",
+      clientMessageId: "cmid-topic",
+      topic: "slides",
+    });
+    rollbackSession.mockResolvedValue({
+      ...trimmedResult(),
+      dropped_turns: 2,
+    });
+    const outcome = await rollbackSessionTurns(SESSION, undefined, 2);
+    expect(outcome).toEqual({ ok: true, droppedTurns: 2 });
+    // Root scope reseeded from the projection…
+    const rootThreads = ThreadStore.getThreads(SESSION);
+    expect(JSON.stringify(rootThreads)).toContain("keep me");
+    expect(JSON.stringify(rootThreads)).not.toContain("only local turn");
+    // …while the topic bucket is untouched.
+    const topicThreads = ThreadStore.getThreads(SESSION, "slides");
+    expect(topicThreads).toHaveLength(1);
+    expect(topicThreads[0].userMsg.text).toBe("topic turn");
+  });
+
+  it("refuses a concurrent rollback for the same scope (relative counts)", async () => {
+    ThreadStore.addUserMessage(SESSION, {
+      text: "turn",
+      clientMessageId: "cmid-lock",
+    });
+    let resolveRpc!: (v: unknown) => void;
+    rollbackSession.mockReturnValue(
+      new Promise((resolve) => {
+        resolveRpc = resolve;
+      }),
+    );
+    const first = rollbackSessionTurns(SESSION, undefined, 1);
+    // Second rollback while the first RPC is in flight → busy.
+    const second = await rollbackSessionTurns(SESSION, undefined, 1);
+    expect(second).toEqual({ ok: false, reason: "busy" });
+    resolveRpc(trimmedResult());
+    const firstOutcome = await first;
+    expect(firstOutcome.ok).toBe(true);
+    // Lock released → a later rollback may start again.
+    rollbackSession.mockResolvedValue(trimmedResult());
+    const third = await rollbackSessionTurns(SESSION, undefined, 1);
+    expect(third.ok).toBe(true);
   });
 
   it("maps the server busy-guard to turn_in_progress and leaves the store intact", async () => {

--- a/src/runtime/session-rollback.test.ts
+++ b/src/runtime/session-rollback.test.ts
@@ -650,10 +650,10 @@ describe("rollbackSessionTurns", () => {
     } as never);
     // Echo alone: gate still closed (sibling has no seq)…
     expect(ThreadStore.hasPlaceholderThreads(SESSION, "slides")).toBe(true);
-    // …but the nudge fired one forced replay; let it land.
-    await Promise.resolve();
-    await Promise.resolve();
-    await Promise.resolve();
+    // …but the nudge fired one forced replay; let it land (macrotask
+    // flush drains the nudge's chained awaits deterministically).
+    await new Promise((r) => setTimeout(r, 0));
+    await new Promise((r) => setTimeout(r, 0));
     expect(getMessagesPage).toHaveBeenCalledTimes(1);
     expect(ThreadStore.hasPlaceholderThreads(SESSION, "slides")).toBe(false);
     const threads = ThreadStore.getThreads(SESSION, "slides");
@@ -661,6 +661,226 @@ describe("rollbackSessionTurns", () => {
       "sibling",
       "late prompt",
     ]);
+  });
+
+  it("drains a stale in-flight load, then issues a FRESH forced replay (codex round 8 P1)", async () => {
+    // A mount/reconnect load is in flight and its response PREDATES
+    // the echoed row. The nudge must not coalesce onto it — it waits
+    // it out and fires a fresh request that includes the row.
+    ThreadStore.replayHistory(
+      SESSION,
+      [
+        {
+          role: "user",
+          content: "slides anchor",
+          client_message_id: "cmid-anchor8",
+          thread_id: "cmid-anchor8",
+          timestamp: "2026-07-10T00:00:01Z",
+        },
+      ] as never,
+      "slides",
+    );
+    let resolveStale!: (v: unknown) => void;
+    getMessagesPage.mockReturnValueOnce(
+      new Promise((resolve) => {
+        resolveStale = resolve;
+      }),
+    );
+    const staleLoad = ThreadStore.loadHistory(SESSION, "slides", {
+      force: true,
+    });
+    ThreadStore.appendToolProgress("cmid-late8", "tc-8", "late progress");
+    expect(ThreadStore.hasPlaceholderThreads(SESSION, "slides")).toBe(true);
+    // Fresh (post-echo) response for the SECOND request only.
+    getMessagesPage.mockResolvedValue({
+      messages: [
+        {
+          role: "user",
+          content: "slides anchor",
+          client_message_id: "cmid-anchor8",
+          thread_id: "cmid-anchor8",
+          timestamp: "2026-07-10T00:00:01Z",
+        },
+        {
+          role: "user",
+          content: "late prompt",
+          client_message_id: "cmid-late8",
+          thread_id: "cmid-late8",
+          timestamp: "2026-07-10T00:00:02Z",
+        },
+      ],
+      has_more: false,
+    });
+    ThreadStore.appendPersistedMessage(SESSION, "slides", {
+      seq: 4,
+      role: "user",
+      content: "late prompt",
+      client_message_id: "cmid-late8",
+      thread_id: "cmid-late8",
+      timestamp: "2026-07-10T00:00:02Z",
+    } as never);
+    // The stale response lands WITHOUT the late row.
+    resolveStale({
+      messages: [
+        {
+          role: "user",
+          content: "slides anchor",
+          client_message_id: "cmid-anchor8",
+          thread_id: "cmid-anchor8",
+          timestamp: "2026-07-10T00:00:01Z",
+        },
+      ],
+      has_more: false,
+    });
+    await staleLoad;
+    await new Promise((r) => setTimeout(r, 0));
+    await new Promise((r) => setTimeout(r, 0));
+    // stale + fresh = 2 requests; the fresh one resolved the scope.
+    expect(getMessagesPage).toHaveBeenCalledTimes(2);
+    expect(ThreadStore.hasPlaceholderThreads(SESSION, "slides")).toBe(false);
+  });
+
+  it("re-arms the nudge for a later episode in the same scope (codex round 8 P2)", async () => {
+    // Root scope seeded via replay (roots carry no seq — the shape
+    // that makes echoes unresolvable and forces the nudge).
+    ThreadStore.replayHistory(SESSION, [
+      {
+        role: "user",
+        content: "root anchor",
+        client_message_id: "cmid-anchor-r",
+        thread_id: "cmid-anchor-r",
+        timestamp: "2026-07-10T00:00:00Z",
+      },
+    ] as never);
+    // Episode 1: orphan + echo → nudge resolves it.
+    ThreadStore.appendToolProgress("cmid-ep1", "tc-e1", "late progress");
+    getMessagesPage.mockResolvedValue({
+      messages: [
+        {
+          role: "user",
+          content: "root anchor",
+          client_message_id: "cmid-anchor-r",
+          thread_id: "cmid-anchor-r",
+          timestamp: "2026-07-10T00:00:00Z",
+        },
+        {
+          role: "user",
+          content: "ep1 prompt",
+          client_message_id: "cmid-ep1",
+          thread_id: "cmid-ep1",
+          timestamp: "2026-07-10T00:00:01Z",
+        },
+      ],
+      has_more: false,
+    });
+    ThreadStore.appendPersistedMessage(SESSION, undefined, {
+      seq: 2,
+      role: "user",
+      content: "ep1 prompt",
+      client_message_id: "cmid-ep1",
+      thread_id: "cmid-ep1",
+      timestamp: "2026-07-10T00:00:01Z",
+    } as never);
+    await new Promise((r) => setTimeout(r, 0));
+    await new Promise((r) => setTimeout(r, 0));
+    expect(ThreadStore.hasPlaceholderThreads(SESSION)).toBe(false);
+    const callsAfterEp1 = getMessagesPage.mock.calls.length;
+    expect(callsAfterEp1).toBeGreaterThan(0);
+    // Episode 2 in the SAME scope: a new orphan must nudge again.
+    ThreadStore.appendToolProgress("cmid-ep2", "tc-e2", "late progress");
+    getMessagesPage.mockResolvedValue({
+      messages: [
+        {
+          role: "user",
+          content: "root anchor",
+          client_message_id: "cmid-anchor-r",
+          thread_id: "cmid-anchor-r",
+          timestamp: "2026-07-10T00:00:00Z",
+        },
+        {
+          role: "user",
+          content: "ep1 prompt",
+          client_message_id: "cmid-ep1",
+          thread_id: "cmid-ep1",
+          timestamp: "2026-07-10T00:00:01Z",
+        },
+        {
+          role: "user",
+          content: "ep2 prompt",
+          client_message_id: "cmid-ep2",
+          thread_id: "cmid-ep2",
+          timestamp: "2026-07-10T00:00:03Z",
+        },
+      ],
+      has_more: false,
+    });
+    ThreadStore.appendPersistedMessage(SESSION, undefined, {
+      seq: 4,
+      role: "user",
+      content: "ep2 prompt",
+      client_message_id: "cmid-ep2",
+      thread_id: "cmid-ep2",
+      timestamp: "2026-07-10T00:00:03Z",
+    } as never);
+    await new Promise((r) => setTimeout(r, 0));
+    await new Promise((r) => setTimeout(r, 0));
+    expect(getMessagesPage.mock.calls.length).toBeGreaterThan(callsAfterEp1);
+    expect(ThreadStore.hasPlaceholderThreads(SESSION)).toBe(false);
+  });
+
+  it("nudges the scope that OWNS the orphan, not the event's scope (codex round 8 P2)", async () => {
+    // Orphan lives in the slides scope; the echo arrives addressed to
+    // the ROOT scope but findThreadById locates the bucket in slides.
+    // The forced replay must target slides.
+    ThreadStore.replayHistory(
+      SESSION,
+      [
+        {
+          role: "user",
+          content: "slides anchor",
+          client_message_id: "cmid-anchor9",
+          thread_id: "cmid-anchor9",
+          timestamp: "2026-07-10T00:00:01Z",
+        },
+      ] as never,
+      "slides",
+    );
+    ThreadStore.appendToolProgress("cmid-cross9", "tc-9", "late progress");
+    expect(ThreadStore.hasPlaceholderThreads(SESSION, "slides")).toBe(true);
+    getMessagesPage.mockResolvedValue({
+      messages: [
+        {
+          role: "user",
+          content: "slides anchor",
+          client_message_id: "cmid-anchor9",
+          thread_id: "cmid-anchor9",
+          timestamp: "2026-07-10T00:00:01Z",
+        },
+        {
+          role: "user",
+          content: "cross prompt",
+          client_message_id: "cmid-cross9",
+          thread_id: "cmid-cross9",
+          timestamp: "2026-07-10T00:00:02Z",
+        },
+      ],
+      has_more: false,
+    });
+    // Echo addressed to the ROOT scope (no topic).
+    ThreadStore.appendPersistedMessage(SESSION, undefined, {
+      seq: 5,
+      role: "user",
+      content: "cross prompt",
+      client_message_id: "cmid-cross9",
+      thread_id: "cmid-cross9",
+      timestamp: "2026-07-10T00:00:02Z",
+    } as never);
+    await new Promise((r) => setTimeout(r, 0));
+    await new Promise((r) => setTimeout(r, 0));
+    // The refetch went to the slides topic (5th arg of getMessagesPage).
+    const topics = getMessagesPage.mock.calls.map((c) => c[4]);
+    expect(topics).toContain("slides");
+    expect(ThreadStore.hasPlaceholderThreads(SESSION, "slides")).toBe(false);
   });
 
   it("orders equal-timestamp roots by seq once every root carries one (codex rounds 5-6)", () => {

--- a/src/runtime/session-rollback.test.ts
+++ b/src/runtime/session-rollback.test.ts
@@ -364,7 +364,12 @@ describe("rollbackSessionTurns", () => {
     expect(ThreadStore.hasPlaceholderThreads(SESSION)).toBe(false);
   });
 
-  it("applyVoiceTranscript adopts an orphan bucket", () => {
+  it("applyVoiceTranscript fills an orphan but leaves the rewind gate closed", () => {
+    // Rounds 3→5: a transcript proves the turn exists but carries no
+    // ORDER (no persisted timestamp/seq), so it must not open the
+    // rewind gate — the persisted user echo that follows carries both
+    // and adopts via the order-restoring path. Real voice turns are
+    // minted by addUserMessage and were never placeholders.
     ThreadStore.addUserMessage(SESSION, {
       text: "anchor",
       clientMessageId: "cmid-anchor",
@@ -378,6 +383,16 @@ describe("rollbackSessionTurns", () => {
       "what I said",
     );
     expect(applied).toBe(true);
+    expect(ThreadStore.hasPlaceholderThreads(SESSION)).toBe(true);
+    // The persisted echo (timestamp + seq) is what adopts it.
+    ThreadStore.appendPersistedMessage(SESSION, undefined, {
+      seq: 7,
+      role: "user",
+      content: "what I said",
+      client_message_id: "orphan-voice",
+      thread_id: "orphan-voice",
+      timestamp: "2026-07-10T00:00:06Z",
+    } as never);
     expect(ThreadStore.hasPlaceholderThreads(SESSION)).toBe(false);
   });
 
@@ -483,6 +498,88 @@ describe("rollbackSessionTurns", () => {
       ],
     });
     expect(ThreadStore.hasPlaceholderThreads(SESSION)).toBe(true);
+  });
+
+  it("persisted-echo adoption re-anchors the orphan's order (codex round 5 P1)", () => {
+    // Newer real prompt first; late stream mints the orphan AFTER it.
+    ThreadStore.addUserMessage(SESSION, {
+      text: "newer prompt",
+      clientMessageId: "cmid-new5",
+    });
+    ThreadStore.appendAssistantToken("cmid-old5", "late stream");
+    expect(ThreadStore.getThreads(SESSION).map((t) => t.id)).toEqual([
+      "cmid-new5",
+      "cmid-old5",
+    ]);
+    // The persisted user echo carries the true (older) order.
+    ThreadStore.appendPersistedMessage(SESSION, undefined, {
+      seq: 1,
+      role: "user",
+      content: "older prompt",
+      client_message_id: "cmid-old5",
+      thread_id: "cmid-old5",
+      timestamp: "2020-01-01T00:00:00Z",
+    } as never);
+    expect(ThreadStore.getThreads(SESSION).map((t) => t.id)).toEqual([
+      "cmid-old5",
+      "cmid-new5",
+    ]);
+    expect(ThreadStore.hasPlaceholderThreads(SESSION)).toBe(false);
+  });
+
+  it("keeps the gate closed on an equal-timestamp tie without a seq tiebreak (codex round 5 P2)", () => {
+    // Sibling built by replay with a known timestamp but NO seq
+    // (messages_page strips it) …
+    ThreadStore.replayHistory(SESSION, [
+      {
+        role: "user",
+        content: "sibling",
+        client_message_id: "cmid-sib",
+        thread_id: "cmid-sib",
+        timestamp: "2026-07-10T00:00:05Z",
+      },
+    ] as never);
+    ThreadStore.appendAssistantToken("cmid-tie", "late stream");
+    // …and the echo lands in the SAME millisecond: placement between
+    // the two is a guess — the gate must stay closed.
+    ThreadStore.appendPersistedMessage(SESSION, undefined, {
+      seq: 4,
+      role: "user",
+      content: "tied prompt",
+      client_message_id: "cmid-tie",
+      thread_id: "cmid-tie",
+      timestamp: "2026-07-10T00:00:05Z",
+    } as never);
+    expect(ThreadStore.hasPlaceholderThreads(SESSION)).toBe(true);
+  });
+
+  it("breaks an equal-timestamp tie by seq when both sides carry one (codex round 5 P2)", () => {
+    ThreadStore.replayHistory(SESSION, [
+      {
+        seq: 3,
+        role: "user",
+        content: "sibling",
+        client_message_id: "cmid-sib2",
+        thread_id: "cmid-sib2",
+        timestamp: "2026-07-10T00:00:05Z",
+      },
+    ] as never);
+    ThreadStore.appendAssistantToken("cmid-tie2", "late stream");
+    // Echo ties on timestamp but carries seq 1 < 3 → placed BEFORE the
+    // sibling, gate opens.
+    ThreadStore.appendPersistedMessage(SESSION, undefined, {
+      seq: 1,
+      role: "user",
+      content: "tied prompt",
+      client_message_id: "cmid-tie2",
+      thread_id: "cmid-tie2",
+      timestamp: "2026-07-10T00:00:05Z",
+    } as never);
+    expect(ThreadStore.hasPlaceholderThreads(SESSION)).toBe(false);
+    expect(ThreadStore.getThreads(SESSION).map((t) => t.id)).toEqual([
+      "cmid-tie2",
+      "cmid-sib2",
+    ]);
   });
 
   it("treats provenance placeholders — not empty-shaped rows — as non-turns", () => {

--- a/src/runtime/session-rollback.test.ts
+++ b/src/runtime/session-rollback.test.ts
@@ -179,4 +179,156 @@ describe("rollbackSessionTurns", () => {
     const outcome = await rollbackSessionTurns(SESSION, undefined, 1);
     expect(outcome).toEqual({ ok: false, reason: "no_bridge" });
   });
+
+  // ── codex #262 round 2 folds ─────────────────────────────────────────────
+
+  it("reconciles from the projection when the server CLAMPS the count", async () => {
+    // Local has 2 turns; the user asked for 2 but the server only had
+    // 1 persisted turn and clamped. Local trim of 1 would "succeed"
+    // (droppedLocally === dropped_turns) yet local and server now
+    // disagree about the surviving prefix — the request was computed
+    // against indices the server never shared. Must clear + reseed.
+    ThreadStore.addUserMessage(SESSION, {
+      text: "local-only stale turn",
+      clientMessageId: "cmid-stale",
+    });
+    ThreadStore.addUserMessage(SESSION, {
+      text: "drop me",
+      clientMessageId: "cmid-drop-clamp",
+    });
+    rollbackSession.mockResolvedValue({
+      ...trimmedResult(),
+      dropped_turns: 1,
+    });
+    const outcome = await rollbackSessionTurns(SESSION, undefined, 2);
+    expect(outcome).toEqual({ ok: true, droppedTurns: 1 });
+    const threads = ThreadStore.getThreads(SESSION);
+    // Reseeded from the server projection — the stale local turn the
+    // server never had is gone.
+    expect(JSON.stringify(threads)).toContain("keep me");
+    expect(JSON.stringify(threads)).not.toContain("local-only stale turn");
+  });
+
+  it("replaces the hydrate-snapshot cache on the SURGICAL path too", async () => {
+    // Pre-rollback the scope's cached hydrate snapshot contains the
+    // dropped turn; a later replay/dedup pass reading the stale cache
+    // would resurrect it. After a successful surgical rollback the
+    // cache must hold exactly the trimmed projection.
+    ThreadStore.setHydrateSnapshot(SESSION, undefined, {
+      messages: [
+        {
+          seq: 1,
+          role: "user",
+          content: "keep me",
+          client_message_id: "cmid-keep",
+          message_id: "m1",
+          persisted_at: "2026-07-10T00:00:00Z",
+        },
+        {
+          seq: 2,
+          role: "assistant",
+          content: "kept reply",
+          message_id: "m2",
+          persisted_at: "2026-07-10T00:00:01Z",
+        },
+        {
+          seq: 3,
+          role: "user",
+          content: "drop me",
+          client_message_id: "cmid-drop",
+          message_id: "m3",
+          persisted_at: "2026-07-10T00:00:02Z",
+        },
+      ],
+    });
+    ThreadStore.addUserMessage(SESSION, {
+      text: "drop me",
+      clientMessageId: "cmid-drop",
+    });
+    expect(ThreadStore.getThreads(SESSION).length).toBeGreaterThanOrEqual(2);
+    rollbackSession.mockResolvedValue(trimmedResult());
+    const outcome = await rollbackSessionTurns(SESSION, undefined, 1);
+    expect(outcome.ok).toBe(true);
+    const cached = ThreadStore.__getHydrateSnapshotForTest(SESSION);
+    expect(cached).toBeDefined();
+    expect(JSON.stringify(cached)).not.toContain("drop me");
+    expect(cached?.messages).toHaveLength(2);
+  });
+
+  it("rebuilds the seq-dedup ledger so renumbered seqs are accepted after the trim", async () => {
+    // The server renumbers persisted seqs from the trimmed length, so
+    // the first post-rollback commits REUSE seqs the dropped suffix
+    // burned. A stale ledger makes appendPersistedMessage discard them.
+    ThreadStore.addUserMessage(SESSION, {
+      text: "keep me",
+      clientMessageId: "cmid-keep",
+    });
+    ThreadStore.appendAssistantToken("cmid-keep", "kept reply");
+    ThreadStore.finalizeAssistant("cmid-keep", { committedSeq: 2 });
+    ThreadStore.addUserMessage(SESSION, {
+      text: "drop me",
+      clientMessageId: "cmid-drop-seq",
+    });
+    ThreadStore.appendAssistantToken("cmid-drop-seq", "dropped reply");
+    // Burns seq 4 into the ledger for the suffix we're about to drop.
+    ThreadStore.finalizeAssistant("cmid-drop-seq", { committedSeq: 4 });
+    rollbackSession.mockResolvedValue(trimmedResult());
+    const outcome = await rollbackSessionTurns(SESSION, undefined, 1);
+    expect(outcome.ok).toBe(true);
+    expect(ThreadStore.getThreads(SESSION)).toHaveLength(1);
+    // A fresh persisted row REUSING the dropped suffix's seq 4 must
+    // land (post-rollback renumbering)…
+    ThreadStore.appendPersistedMessage(SESSION, undefined, {
+      seq: 4,
+      role: "assistant",
+      content: "fresh post-rollback reply",
+      thread_id: "cmid-keep",
+      message_id: "m-fresh",
+      timestamp: "2026-07-10T00:00:03Z",
+    } as never);
+    const [thread] = ThreadStore.getThreads(SESSION);
+    expect(
+      thread.responses.some((r) => r.text === "fresh post-rollback reply"),
+    ).toBe(true);
+    // …while a replay of a SURVIVING seq (2) still dedups.
+    const before = thread.responses.length;
+    ThreadStore.appendPersistedMessage(SESSION, undefined, {
+      seq: 2,
+      role: "assistant",
+      content: "kept reply (replayed)",
+      thread_id: "cmid-keep",
+      message_id: "m-replay",
+      timestamp: "2026-07-10T00:00:04Z",
+    } as never);
+    expect(ThreadStore.getThreads(SESSION)[0].responses).toHaveLength(before);
+  });
+
+  it("treats provenance placeholders — not empty-shaped rows — as non-turns", () => {
+    // A bucket synthesized for a late persisted assistant row (no user
+    // message yet) IS a placeholder…
+    ThreadStore.appendPersistedMessage(SESSION, undefined, {
+      seq: 9,
+      role: "assistant",
+      content: "late reply",
+      thread_id: "thread-late",
+      message_id: "m-late",
+      timestamp: "2026-07-10T00:00:05Z",
+    } as never);
+    const [synth] = ThreadStore.getThreads(SESSION);
+    expect(ThreadStore.isPlaceholderThread(synth)).toBe(true);
+    expect(ThreadStore.hasPlaceholderThreads(SESSION)).toBe(true);
+    // …until its persisted user record arrives (adoption clears it).
+    ThreadStore.appendPersistedMessage(SESSION, undefined, {
+      seq: 8,
+      role: "user",
+      content: "the real prompt",
+      client_message_id: "thread-late",
+      thread_id: "thread-late",
+      timestamp: "2026-07-10T00:00:04Z",
+    } as never);
+    const [adopted] = ThreadStore.getThreads(SESSION);
+    expect(adopted.userMsg.text).toBe("the real prompt");
+    expect(ThreadStore.isPlaceholderThread(adopted)).toBe(false);
+    expect(ThreadStore.hasPlaceholderThreads(SESSION)).toBe(false);
+  });
 });

--- a/src/runtime/session-rollback.ts
+++ b/src/runtime/session-rollback.ts
@@ -181,6 +181,20 @@ export async function rollbackSessionTurns(
     const serverClamped = result.dropped_turns !== numTurns;
     if (serverClamped || droppedLocally !== result.dropped_turns) {
       ThreadStore.clearSessionScope(sessionId, topic);
+    } else {
+      // Surgical path: the local trim rebuilt the seq ledger from
+      // surviving rows' historySeq, which a prior messages_page replay
+      // may have stripped (and companion merges collapse). Union the
+      // AUTHORITATIVE surviving seqs from the rollback projection so
+      // live re-emissions for surviving rows keep deduping
+      // (codex #262 round 3).
+      ThreadStore.unionSeenSeqs(
+        sessionId,
+        topic,
+        (result.thread.messages ?? [])
+          .map((m) => m.seq)
+          .filter((n): n is number => typeof n === "number"),
+      );
     }
     // ALWAYS replace the hydrate cache with the trimmed projection —
     // surgical path included (codex #262 round 2). The pre-rollback

--- a/src/runtime/session-rollback.ts
+++ b/src/runtime/session-rollback.ts
@@ -1,0 +1,65 @@
+/**
+ * Session rewind (web parity for the TUI rollback flow; server
+ * `session/rollback`, octos #1516/#1517).
+ *
+ * The RPC is conversation-only and server-authoritative: it drops the
+ * last N USER turns (persisted marker + in-memory trim) and returns the
+ * trimmed thread projected in the `session/hydrate` shape. Applying it
+ * client-side CANNOT go through `setHydrateSnapshot` alone — the hydrate
+ * dedup/seed pass only ever ADDS or coalesces rows, it never removes the
+ * rolled-back turns from an already-populated ThreadStore. So the applier
+ * clears the session scope first, then seeds from the trimmed snapshot
+ * (the same `seedFromHydrateMessages` path a reload-mid-stream uses).
+ */
+
+import * as ThreadStore from "@/store/thread-store";
+import { setHydrateSnapshot } from "@/store/thread-store";
+import { getActiveBridge } from "./ui-protocol-runtime";
+
+export type RollbackOutcome =
+  | { ok: true; droppedTurns: number }
+  | { ok: false; reason: "no_bridge" | "turn_in_progress" | "rpc_failed" };
+
+/** True when the RPC error is the server's while-a-turn-is-live guard
+ *  (`invalid_params` with `data.kind === "turn_in_progress"`). The
+ *  bridge surfaces RPC errors as `Error` instances whose message embeds
+ *  the server text, so match on the stable kind marker. */
+function isTurnInProgress(err: unknown): boolean {
+  const text =
+    err instanceof Error ? err.message : typeof err === "string" ? err : "";
+  return text.includes("turn_in_progress") || text.includes("turn is in progress");
+}
+
+/**
+ * Roll the session back by `numTurns` user turns and rebuild the local
+ * thread state from the server's trimmed projection.
+ */
+export async function rollbackSessionTurns(
+  sessionId: string,
+  topic: string | undefined,
+  numTurns: number,
+): Promise<RollbackOutcome> {
+  const bridge = getActiveBridge(sessionId, topic);
+  if (!bridge || typeof bridge.rollbackSession !== "function") {
+    return { ok: false, reason: "no_bridge" };
+  }
+  let result;
+  try {
+    result = await bridge.rollbackSession(numTurns);
+  } catch (err) {
+    return {
+      ok: false,
+      reason: isTurnInProgress(err) ? "turn_in_progress" : "rpc_failed",
+    };
+  }
+  // Server state is already trimmed — rebuild the local store to match.
+  // Clear FIRST: the hydrate seed pass only adds rows; without the clear
+  // the rolled-back bubbles would survive locally until a full reload.
+  ThreadStore.clearSession(sessionId, topic);
+  setHydrateSnapshot(sessionId, topic, {
+    messages: result.thread.messages ?? [],
+    replayed_envelopes: result.thread.replayed_envelopes,
+    replayed_tool_envelopes: result.thread.replayed_tool_envelopes,
+  });
+  return { ok: true, droppedTurns: result.dropped_turns };
+}

--- a/src/runtime/session-rollback.ts
+++ b/src/runtime/session-rollback.ts
@@ -13,9 +13,13 @@
  * with them their tool cards, progress timelines, and message meta,
  * which the hydrate rows cannot rebuild. Only when the local view
  * disagrees with the server's `dropped_turns` (local rows were already
- * inconsistent) does it fall back to an exact-key clear + reseed from
- * the returned projection; `clearSessionScope` never touches sibling
- * topic caches the RPC did not mutate.
+ * inconsistent) — or the server CLAMPED the requested count — does it
+ * fall back to an exact-key clear + reseed from the returned
+ * projection; `clearSessionScope` never touches sibling topic caches
+ * the RPC did not mutate. Either way the scope's hydrate-snapshot
+ * cache is replaced with the trimmed projection and the seq-dedup
+ * ledger is rebuilt from surviving rows (the server renumbers
+ * persisted seqs from the trimmed length).
  *
  * Concurrency: rollbacks are RELATIVE ("last N"), so two in-flight
  * rollbacks — or a send racing the trim — can delete unintended turns.
@@ -163,20 +167,33 @@ export async function rollbackSessionTurns(
       topic,
       result.dropped_turns,
     );
-    if (droppedLocally !== result.dropped_turns) {
-      // Local rows disagreed with the server's count — the local view
-      // was already inconsistent. Reconcile from the authoritative
-      // trimmed projection (exact-key clear: sibling topic caches were
-      // not mutated by the RPC and must survive). This degraded path
-      // loses rich per-turn UI state; the surgical trim above is the
-      // normal path precisely to avoid that.
+    // Reconcile from the authoritative projection when EITHER side
+    // disagrees (codex #262 round 2):
+    //   • server clamped (`dropped_turns !== numTurns`): the request
+    //     was computed against local indices the server didn't share,
+    //     so the surviving local rows are not trustworthy either;
+    //   • local trim count mismatched: local rows were already
+    //     inconsistent.
+    // Exact-key clear — sibling topic caches were not mutated by the
+    // RPC and must survive. This degraded path loses rich per-turn UI
+    // state; the surgical trim above is the normal path precisely to
+    // avoid that.
+    const serverClamped = result.dropped_turns !== numTurns;
+    if (serverClamped || droppedLocally !== result.dropped_turns) {
       ThreadStore.clearSessionScope(sessionId, topic);
-      setHydrateSnapshot(sessionId, topic, {
-        messages: result.thread.messages ?? [],
-        replayed_envelopes: result.thread.replayed_envelopes,
-        replayed_tool_envelopes: result.thread.replayed_tool_envelopes,
-      });
     }
+    // ALWAYS replace the hydrate cache with the trimmed projection —
+    // surgical path included (codex #262 round 2). The pre-rollback
+    // snapshot still contains the dropped turns; a later
+    // `replayHistory`/dedup pass reading it would resurrect them. On
+    // the surgical path the store keeps its surviving threads and the
+    // dedup pass only coalesces; on the reconcile path it reseeds the
+    // just-cleared scope.
+    setHydrateSnapshot(sessionId, topic, {
+      messages: result.thread.messages ?? [],
+      replayed_envelopes: result.thread.replayed_envelopes,
+      replayed_tool_envelopes: result.thread.replayed_tool_envelopes,
+    });
     return { ok: true, droppedTurns: result.dropped_turns };
   } finally {
     setBusy(key, false);

--- a/src/runtime/session-rollback.ts
+++ b/src/runtime/session-rollback.ts
@@ -4,21 +4,117 @@
  *
  * The RPC is conversation-only and server-authoritative: it drops the
  * last N USER turns (persisted marker + in-memory trim) and returns the
- * trimmed thread projected in the `session/hydrate` shape. Applying it
- * client-side CANNOT go through `setHydrateSnapshot` alone — the hydrate
- * dedup/seed pass only ever ADDS or coalesces rows, it never removes the
- * rolled-back turns from an already-populated ThreadStore. So the applier
- * clears the session scope first, then seeds from the trimmed snapshot
- * (the same `seedFromHydrateMessages` path a reload-mid-stream uses).
+ * trimmed thread projected in the `session/hydrate` shape.
+ *
+ * Local application is a SURGICAL SUFFIX TRIM, not a clear+reseed
+ * (codex #262 round 1): `dropLastUserTurnThreads` removes the dropped
+ * user-turn threads (placeholder orphans excluded from the count) and
+ * everything after the cut, keeping surviving thread objects — and
+ * with them their tool cards, progress timelines, and message meta,
+ * which the hydrate rows cannot rebuild. Only when the local view
+ * disagrees with the server's `dropped_turns` (local rows were already
+ * inconsistent) does it fall back to an exact-key clear + reseed from
+ * the returned projection; `clearSessionScope` never touches sibling
+ * topic caches the RPC did not mutate.
+ *
+ * Concurrency: rollbacks are RELATIVE ("last N"), so two in-flight
+ * rollbacks — or a send racing the trim — can delete unintended turns.
+ * A per-scope lock serializes them: `rollbackSessionTurns` refuses to
+ * start while one is running (`busy`), every Rewind button disables via
+ * `useRollbackBusy`, and the send path parks new turns behind
+ * `whenRollbackIdle` until the snapshot is applied.
  */
 
+import { useSyncExternalStore } from "react";
 import * as ThreadStore from "@/store/thread-store";
 import { setHydrateSnapshot } from "@/store/thread-store";
 import { getActiveBridge } from "./ui-protocol-runtime";
 
 export type RollbackOutcome =
   | { ok: true; droppedTurns: number }
-  | { ok: false; reason: "no_bridge" | "turn_in_progress" | "rpc_failed" };
+  | {
+      ok: false;
+      reason: "no_bridge" | "turn_in_progress" | "rpc_failed" | "busy";
+    };
+
+// ── per-scope mutation lock ────────────────────────────────────────────────
+
+const busyKeys = new Set<string>();
+const busyListeners = new Set<() => void>();
+const idleWaiters = new Map<string, Array<() => void>>();
+
+function scopeKey(sessionId: string, topic?: string): string {
+  const trimmedTopic = topic?.trim();
+  return trimmedTopic ? `${sessionId}#${trimmedTopic}` : sessionId;
+}
+
+function setBusy(key: string, value: boolean): void {
+  if (value) {
+    busyKeys.add(key);
+  } else {
+    busyKeys.delete(key);
+    const waiters = idleWaiters.get(key);
+    if (waiters) {
+      idleWaiters.delete(key);
+      for (const resolve of waiters) resolve();
+    }
+  }
+  for (const listener of busyListeners) listener();
+}
+
+export function isRollbackBusy(sessionId: string, topic?: string): boolean {
+  return busyKeys.has(scopeKey(sessionId, topic));
+}
+
+/** React hook: true while a rollback is applying for the scope. Every
+ *  Rewind affordance disables on it so a second RELATIVE rollback
+ *  cannot be confirmed against pre-trim indices. */
+export function useRollbackBusy(sessionId: string, topic?: string): boolean {
+  const subscribe = (listener: () => void) => {
+    busyListeners.add(listener);
+    return () => {
+      busyListeners.delete(listener);
+    };
+  };
+  return useSyncExternalStore(
+    subscribe,
+    () => isRollbackBusy(sessionId, topic),
+    () => isRollbackBusy(sessionId, topic),
+  );
+}
+
+/** Resolves when no rollback is applying for the scope (immediately if
+ *  idle). The send path parks new turns on this so a just-sent bubble
+ *  cannot be wiped by the trim that lands moments later. Bounded
+ *  fail-open so a stuck lock can never wedge sends. */
+export function whenRollbackIdle(
+  sessionId: string,
+  topic: string | undefined,
+  timeoutMs = 5000,
+): Promise<void> {
+  const key = scopeKey(sessionId, topic);
+  if (!busyKeys.has(key)) return Promise.resolve();
+  return new Promise((resolve) => {
+    const timer = setTimeout(() => {
+      const waiters = idleWaiters.get(key);
+      if (waiters) {
+        const next = waiters.filter((w) => w !== wrapped);
+        if (next.length === 0) idleWaiters.delete(key);
+        else idleWaiters.set(key, next);
+      }
+      resolve();
+    }, timeoutMs);
+    const wrapped = () => {
+      clearTimeout(timer);
+      resolve();
+    };
+    const waiters = idleWaiters.get(key) ?? [];
+    waiters.push(wrapped);
+    idleWaiters.set(key, waiters);
+  });
+}
+
+// ── rollback ───────────────────────────────────────────────────────────────
 
 /** True when the RPC error is the server's while-a-turn-is-live guard
  *  (`invalid_params` with `data.kind === "turn_in_progress"`). The
@@ -27,12 +123,14 @@ export type RollbackOutcome =
 function isTurnInProgress(err: unknown): boolean {
   const text =
     err instanceof Error ? err.message : typeof err === "string" ? err : "";
-  return text.includes("turn_in_progress") || text.includes("turn is in progress");
+  return (
+    text.includes("turn_in_progress") || text.includes("turn is in progress")
+  );
 }
 
 /**
- * Roll the session back by `numTurns` user turns and rebuild the local
- * thread state from the server's trimmed projection.
+ * Roll the session back by `numTurns` user turns and trim the local
+ * thread state to match.
  */
 export async function rollbackSessionTurns(
   sessionId: string,
@@ -43,23 +141,44 @@ export async function rollbackSessionTurns(
   if (!bridge || typeof bridge.rollbackSession !== "function") {
     return { ok: false, reason: "no_bridge" };
   }
-  let result;
-  try {
-    result = await bridge.rollbackSession(numTurns);
-  } catch (err) {
-    return {
-      ok: false,
-      reason: isTurnInProgress(err) ? "turn_in_progress" : "rpc_failed",
-    };
+  const key = scopeKey(sessionId, topic);
+  if (busyKeys.has(key)) {
+    // A rollback is already applying; a second RELATIVE count computed
+    // against pre-trim indices would delete unintended turns.
+    return { ok: false, reason: "busy" };
   }
-  // Server state is already trimmed — rebuild the local store to match.
-  // Clear FIRST: the hydrate seed pass only adds rows; without the clear
-  // the rolled-back bubbles would survive locally until a full reload.
-  ThreadStore.clearSession(sessionId, topic);
-  setHydrateSnapshot(sessionId, topic, {
-    messages: result.thread.messages ?? [],
-    replayed_envelopes: result.thread.replayed_envelopes,
-    replayed_tool_envelopes: result.thread.replayed_tool_envelopes,
-  });
-  return { ok: true, droppedTurns: result.dropped_turns };
+  setBusy(key, true);
+  try {
+    let result;
+    try {
+      result = await bridge.rollbackSession(numTurns);
+    } catch (err) {
+      return {
+        ok: false,
+        reason: isTurnInProgress(err) ? "turn_in_progress" : "rpc_failed",
+      };
+    }
+    const droppedLocally = ThreadStore.dropLastUserTurnThreads(
+      sessionId,
+      topic,
+      result.dropped_turns,
+    );
+    if (droppedLocally !== result.dropped_turns) {
+      // Local rows disagreed with the server's count — the local view
+      // was already inconsistent. Reconcile from the authoritative
+      // trimmed projection (exact-key clear: sibling topic caches were
+      // not mutated by the RPC and must survive). This degraded path
+      // loses rich per-turn UI state; the surgical trim above is the
+      // normal path precisely to avoid that.
+      ThreadStore.clearSessionScope(sessionId, topic);
+      setHydrateSnapshot(sessionId, topic, {
+        messages: result.thread.messages ?? [],
+        replayed_envelopes: result.thread.replayed_envelopes,
+        replayed_tool_envelopes: result.thread.replayed_tool_envelopes,
+      });
+    }
+    return { ok: true, droppedTurns: result.dropped_turns };
+  } finally {
+    setBusy(key, false);
+  }
 }

--- a/src/runtime/ui-protocol-bridge.ts
+++ b/src/runtime/ui-protocol-bridge.ts
@@ -44,6 +44,7 @@ import type {
   RouterFailoverEvent,
   RouterStatusEvent,
   RpcErrorPayload,
+  SessionRollbackResult,
   SessionHydrateResult,
   SessionOpenResult,
   TaskOutputDeltaEvent,
@@ -92,6 +93,7 @@ export type {
   SessionHydrateResult,
   SessionOpenResult,
   SessionOpenedResult,
+  SessionRollbackResult,
   TaskOutputDeltaEvent,
   TaskUpdatedEvent,
   ToolCompletedEvent,
@@ -131,6 +133,7 @@ export const METHODS = {
   // client → server
   SESSION_OPEN: "session/open",
   SESSION_HYDRATE: "session/hydrate",
+  SESSION_ROLLBACK: "session/rollback",
   TURN_START: "turn/start",
   TURN_INTERRUPT: "turn/interrupt",
   APPROVAL_RESPOND: "approval/respond",
@@ -404,6 +407,15 @@ export interface UiProtocolBridge {
   hydrateSession(
     include?: ReadonlyArray<"messages" | "threads" | "turns" | "pending_approvals">,
   ): Promise<SessionHydrateResult | null>;
+
+  /**
+   * `session/rollback` — drop the last `numTurns` USER turns from the
+   * session (server-persisted, conversation-only rewind) and return the
+   * trimmed thread in the `session/hydrate` shape. MUTATING. Rejects
+   * with `invalid_params { kind: "turn_in_progress" }` while a turn is
+   * in flight — callers surface that instead of retrying.
+   */
+  rollbackSession(numTurns: number): Promise<SessionRollbackResult>;
 
   /**
    * Generic JSON-RPC request escape hatch.
@@ -2191,6 +2203,29 @@ class UiProtocolBridgeImpl implements UiProtocolBridge {
       });
       return null;
     }
+  }
+
+  async rollbackSession(numTurns: number): Promise<SessionRollbackResult> {
+    if (!Number.isInteger(numTurns) || numTurns < 1) {
+      throw new Error(
+        "ui-protocol-bridge: rollbackSession requires numTurns >= 1",
+      );
+    }
+    // Scoped id: a topic-suffixed bucket (`session#topic`) is its own
+    // SessionKey server-side; rolling back a slides/site topic must trim
+    // THAT bucket, not the root session (same scoping task/cancel uses).
+    const raw = await this.request<unknown>(METHODS.SESSION_ROLLBACK, {
+      session_id: this.requireScopedSessionId(),
+      num_turns: numTurns,
+    });
+    const record = raw as { dropped_turns?: unknown; thread?: unknown };
+    const thread = guardSessionHydrate(record?.thread);
+    if (!thread || typeof record.dropped_turns !== "number") {
+      throw new Error(
+        "ui-protocol-bridge: session/rollback returned a malformed result",
+      );
+    }
+    return { dropped_turns: record.dropped_turns, thread };
   }
 
   callMethod<T = unknown>(method: string, params?: unknown): Promise<T> {

--- a/src/runtime/ui-protocol-send.ts
+++ b/src/runtime/ui-protocol-send.ts
@@ -20,6 +20,7 @@
 import * as ThreadStore from "@/store/thread-store";
 import { displayFilenameFromPath } from "@/lib/utils";
 import { getActiveBridge, startBridgeForSession } from "./ui-protocol-runtime";
+import { isRollbackBusy, whenRollbackIdle } from "./session-rollback";
 import { BridgeStoppedError, BridgeTimeoutError } from "./ui-protocol-bridge";
 import type { TurnStartExtras, TurnStartMediaRef } from "./ui-protocol-types";
 import { request } from "@/api/client";
@@ -286,6 +287,17 @@ export async function interruptActiveTurn(opts: {
 }
 
 async function enqueueSendV1(opts: SendOptions): Promise<void> {
+  // codex #262 P1: a rollback's suffix trim is RELATIVE to the thread
+  // list — a turn mirrored/sent while the trim applies would be wiped
+  // locally (and re-appended server-side against the trimmed state the
+  // user hasn't seen yet). Park the whole send behind the applying
+  // rollback. Conditional so the idle path stays FULLY synchronous —
+  // the Wave4-A queue-state dispatch below must fire before any await;
+  // the wait itself fails open after 5s so a stuck lock cannot wedge
+  // sends.
+  if (isRollbackBusy(opts.sessionId, opts.historyTopic)) {
+    await whenRollbackIdle(opts.sessionId, opts.historyTopic);
+  }
   const key = queueKey(opts.sessionId);
   const prev = turnQueues.get(key) ?? Promise.resolve();
 

--- a/src/runtime/ui-protocol-types.ts
+++ b/src/runtime/ui-protocol-types.ts
@@ -896,6 +896,17 @@ export interface SessionHydrateResult {
   replayed_tool_envelopes?: Envelope[];
 }
 
+/** Result of `session/rollback` — conversation-only rewind. The server
+ *  drops the last `num_turns` USER turns (persisted + in-memory,
+ *  idempotent append-only marker) and returns the trimmed thread
+ *  projected in the same shape as `session/hydrate`. `dropped_turns` is
+ *  clamped to the session's actual turn count. Rejected with
+ *  `invalid_params { kind: "turn_in_progress" }` while a turn is live. */
+export interface SessionRollbackResult {
+  dropped_turns: number;
+  thread: SessionHydrateResult;
+}
+
 // ─── M9-γ canonical projection envelope (UPCR-2026-014) ────────────────────
 //
 // Mirrors `crates/octos-core/src/ui_protocol.rs` (Rust enum uses

--- a/src/store/thread-store.ts
+++ b/src/store/thread-store.ts
@@ -125,6 +125,15 @@ export interface Thread {
   /** In-flight assistant message for the current turn (becomes part of
    *  `responses` when `finalizeAssistant` is called). */
   pendingAssistant: ThreadMessage | null;
+  /** Set when this bucket was MINTED as an orphan placeholder (a late
+   *  event arrived before its user message). Cleared when the real
+   *  user message adopts the bucket. While set, the thread's turn-ness
+   *  is UNKNOWN — the underlying turn may exist server-side and simply
+   *  not be hydrated yet — so rollback math must not run against a
+   *  list containing one (codex #262 round 2: shape-inference
+   *  misclassified a persisted-but-unhydrated turn as a non-turn and
+   *  sent a destructive num_turns for the wrong bubble). */
+  placeholderOrigin?: boolean;
   /** #245 P2: set on a reconnect reopen while this thread had in-flight
    *  streamed text. While set, `appendAssistantToken` drops tokens for this
    *  thread — the server's `after` replay re-emits deltas with no client
@@ -369,6 +378,7 @@ function ensureOrphanThread(threadId: string): {
     userMsg: placeholderUser,
     responses: [],
     pendingAssistant: null,
+    placeholderOrigin: true,
   };
   insertThreadInTimestampOrder(host, thread);
   recordRuntimeCounter("octos_thread_orphan_created_total", {
@@ -686,6 +696,8 @@ export function addUserMessage(
   const existing = state.byId.get(opts.clientMessageId);
   if (existing) {
     existing.userMsg = userMsg;
+    // The real user message arrived — the bucket is a known turn now.
+    existing.placeholderOrigin = false;
     if (!existing.pendingAssistant) {
       const alreadyAnswered = existing.responses.some(
         (r) => r.role === "assistant",
@@ -724,6 +736,8 @@ export function addUserMessage(
       pendingAssistant: orphanAlreadyAnswered
         ? null
         : (orphan.pendingAssistant ?? pendingAssistant),
+      // The real user message arrived — the bucket is a known turn now.
+      placeholderOrigin: false,
     };
     // Detach from the wrong session.
     otherState.byId.delete(opts.clientMessageId);
@@ -1504,6 +1518,7 @@ export function appendCompletionBubble(
           userMsg: placeholderUser,
           responses: [],
           pendingAssistant: null,
+          placeholderOrigin: true,
         };
         insertThreadInTimestampOrder(state, orphan);
         recordRuntimeCounter("octos_thread_orphan_created_total", {
@@ -2518,6 +2533,9 @@ export function replayHistory(
         userMsg: placeholderUser,
         responses: [],
         pendingAssistant: carryPending.get(threadId) ?? null,
+        // Bucket synthesized WITHOUT its user row — turn-ness unknown
+        // (see `isPlaceholderThread`).
+        placeholderOrigin: true,
       };
       state.byId.set(threadId, thread);
       state.threads.push(thread);
@@ -3501,6 +3519,10 @@ export function appendPersistedMessage(
       userMsg: placeholderUser,
       responses: [],
       pendingAssistant: null,
+      // Same provenance rule as `ensureOrphanThread`: a bucket minted
+      // without its user message is turn-ness-UNKNOWN until the real
+      // user record (below) or `addUserMessage` adopts it.
+      placeholderOrigin: true,
     };
     insertThreadInTimestampOrder(state, thread);
   }
@@ -3528,6 +3550,8 @@ export function appendPersistedMessage(
         intra_thread_seq: built.intra_thread_seq,
         clientMessageId: message.client_message_id ?? threadId,
       };
+      // The persisted user record arrived — a known turn now.
+      thread.placeholderOrigin = false;
       notify();
     } else if (thread.userMsg.text === "" && thread.userMsg.files.length === 0) {
       thread.userMsg = {
@@ -3538,6 +3562,7 @@ export function appendPersistedMessage(
         intra_thread_seq: built.intra_thread_seq,
         clientMessageId: message.client_message_id ?? threadId,
       };
+      thread.placeholderOrigin = false;
       notify();
     }
     return;
@@ -3852,11 +3877,30 @@ export function getKnownFilePaths(
  *  file-only user message is a real turn (text empty, files non-empty).
  *  Rollback math (`session/rollback` counts persisted USER turns only)
  *  must skip placeholders — counting them both inflates `num_turns`
- *  and grows a Rewind affordance on a bubble that is not a turn. */
+ *  and grows a Rewind affordance on a bubble that is not a turn.
+ *
+ *  PROVENANCE, not shape (codex #262 round 2): the flag is set when
+ *  the bucket is MINTED as an orphan and cleared when the real user
+ *  message adopts it. Shape-inference ("empty text + no files") also
+ *  matched real-but-unhydrated turns and empty-text turns replayed by
+ *  hydrate, silently shifting relative rollback counts. */
 export function isPlaceholderThread(thread: Thread): boolean {
-  return (
-    thread.userMsg.text.trim() === "" && thread.userMsg.files.length === 0
-  );
+  return thread.placeholderOrigin === true;
+}
+
+/** True when ANY bucket in the scope is still an orphan placeholder.
+ *  While one exists the local turn list is KNOWN-incomplete (a late
+ *  event arrived for a turn we have not seen the user message for), so
+ *  relative rollback indices computed from it may target the wrong
+ *  turn — the UI must withhold every Rewind affordance until hydration
+ *  resolves the orphan (codex #262 round 2). */
+export function hasPlaceholderThreads(
+  sessionId: string,
+  topic?: string,
+): boolean {
+  const state = sessionsByKey.get(storeKey(sessionId, topic));
+  if (!state) return false;
+  return state.threads.some((t) => isPlaceholderThread(t));
 }
 
 /** Conversation-suffix trim for `session/rollback`: drop the last
@@ -3888,6 +3932,25 @@ export function dropLastUserTurnThreads(
   for (const thread of removed) {
     state.byId.delete(thread.id);
   }
+  // Rebuild the seq-dedup ledger from the SURVIVING rows (codex #262
+  // round 2): `seq` is a per-session committed-row index and the
+  // server renumbers from the trimmed length, so the first messages
+  // persisted AFTER a rollback REUSE the seqs the dropped suffix
+  // burned. A stale ledger would make `hasSeenSeq` silently discard
+  // those fresh rows. Surviving rows keep their entries so hydrate /
+  // replay dedup still works for them.
+  const survivingSeqs = new Set<number>();
+  for (const thread of state.threads) {
+    const msgs = [thread.userMsg, ...thread.responses];
+    if (thread.pendingAssistant) msgs.push(thread.pendingAssistant);
+    for (const msg of msgs) {
+      if (typeof msg.historySeq === "number") {
+        survivingSeqs.add(msg.historySeq);
+      }
+    }
+  }
+  if (survivingSeqs.size > 0) seenSeqsByKey.set(key, survivingSeqs);
+  else seenSeqsByKey.delete(key);
   notify();
   return dropped;
 }
@@ -4050,6 +4113,17 @@ export function resolveEventThreadId(
 }
 
 /** Test-only helper: reset all in-memory state. Not exported in production. */
+/** Test-only: read the cached hydrate snapshot for a scope. Rollback
+ *  must REPLACE it with the trimmed projection (codex #262 round 2) —
+ *  a stale cache resurrects dropped turns on the next replay/dedup
+ *  pass, and that staleness is otherwise unobservable from outside. */
+export function __getHydrateSnapshotForTest(
+  sessionId: string,
+  topic?: string,
+): HydrateSnapshot | undefined {
+  return hydrateSnapshotByKey.get(storeKey(sessionId, topic));
+}
+
 export function __resetForTests(): void {
   sessionsByKey.clear();
   listeners.clear();

--- a/src/store/thread-store.ts
+++ b/src/store/thread-store.ts
@@ -2820,6 +2820,43 @@ function hydrateRowMatchesResponse(
   return timestamp === null || response.timestamp === timestamp;
 }
 
+/** Consume the server order carried by EVERY hydrate user row — media
+ *  or not (codex #262 round 6 P2: normal user rows have no media and
+ *  were skipped, so REST-seeded roots never learned their seq and the
+ *  rewind gate could stay closed after a complete hydrate). Stamps
+ *  `(persisted_at, seq)` onto matching user roots, then retries orphan
+ *  adoption against the now-normalized scope. */
+function normalizeHydrateUserOrder(
+  sessionId: string,
+  topic: string | undefined,
+  rows: HydrateMessageRow[],
+): boolean {
+  if (rows.length === 0) return false;
+  const state = sessionsByKey.get(storeKey(sessionId, topic));
+  if (!state) return false;
+  let changed = false;
+  for (const row of rows) {
+    if (row.role !== "user") continue;
+    const anchor = row.client_message_id ?? row.thread_id;
+    const thread = anchor ? state.byId.get(anchor) : undefined;
+    if (!thread) continue;
+    const timestampMs = row.persisted_at
+      ? Date.parse(row.persisted_at)
+      : Number.NaN;
+    if (
+      normalizeUserRootOrder(
+        thread,
+        timestampMs,
+        typeof row.seq === "number" ? row.seq : undefined,
+      )
+    ) {
+      changed = true;
+    }
+  }
+  if (tryAdoptPlaceholders(state)) changed = true;
+  return changed;
+}
+
 function mergeHydrateMediaIntoExisting(
   sessionId: string,
   topic: string | undefined,
@@ -2841,26 +2878,9 @@ function mergeHydrateMediaIntoExisting(
         thread.userMsg = mergedUser;
         changed = true;
       }
-      // The hydrate row IS a persisted user record for this bucket —
-      // authoritative turn proof even when the media merge no-ops.
-      // BUT (codex #262 round 4 P1): an orphan bucket was inserted at
-      // ASSISTANT-arrival time, which can place an older turn AFTER a
-      // newer prompt. Adopting without restoring the server order
-      // would let rewind's distance-from-end math delete an extra
-      // turn. Re-anchor `userMsg.timestamp` to the row's
-      // `persisted_at` and REINSERT before clearing provenance; with
-      // no usable timestamp the gate stays closed (a later replay or
-      // persisted echo carries order and adopts then).
-      if (
-        adoptPlaceholderWithOrder(state, thread, {
-          timestampMs: row.persisted_at
-            ? Date.parse(row.persisted_at)
-            : Number.NaN,
-          seq: typeof row.seq === "number" ? row.seq : undefined,
-        })
-      ) {
-        changed = true;
-      }
+      // Order/adoption is handled by `normalizeHydrateUserOrder` (which
+      // also consumes NO-media user rows — codex #262 round 6 P2);
+      // this pass merges media only.
       continue;
     }
 
@@ -3209,6 +3229,9 @@ export function applyHydrateDedup(
   if (mergeHydrateMediaIntoExisting(sessionId, topic, messages)) {
     notify();
   }
+  if (normalizeHydrateUserOrder(sessionId, topic, messages)) {
+    notify();
+  }
   if (envelopes.length === 0) {
     replayHydrateToolEnvelopes(sessionId, topic, hydrate.replayed_tool_envelopes);
     return;
@@ -3428,12 +3451,13 @@ export function applyVoiceTranscript(
     ...thread.userMsg,
     text,
   };
-  // NOTE (codex #262 rounds 3→5): a transcript proves the user turn
+  // NOTE (codex #262 rounds 3→6): a transcript proves the user turn
   // exists but carries NO order information (no persisted timestamp or
   // seq), so it must not open the rewind gate on a true orphan — the
-  // persisted user echo that follows carries both and adopts through
-  // `adoptPlaceholderWithOrder`. Real voice turns are minted by
-  // `addUserMessage` and were never placeholders.
+  // persisted user echo that follows carries both, and adoption runs
+  // through `tryAdoptPlaceholders` once every root is server-ordered.
+  // Real voice turns are minted by `addUserMessage` and were never
+  // placeholders.
   notify();
   return true;
 }
@@ -3574,21 +3598,22 @@ export function appendPersistedMessage(
     // are optimistically inserted with an audio file and empty text; the
     // persisted echo carries the ASR transcript, so keep local media while
     // filling the transcript in.
-    // A persisted USER record is authoritative proof of turn-ness —
-    // adopt even when the local bubble already has text (an
-    // ASR/hydrate-filled orphan; codex #262 round 3). Adoption goes
-    // through the ORDER-restoring helper (round 5 P1): the orphan sits
-    // at event-arrival time, and clearing the gate without reinserting
-    // it at message.timestamp leaves [newer, older] so a rewind on the
-    // newer bubble deletes an extra turn.
-    const adopted = state
-      ? adoptPlaceholderWithOrder(state, thread, {
-          timestampMs: message.timestamp
-            ? Date.parse(message.timestamp)
-            : Number.NaN,
-          seq: typeof message.seq === "number" ? message.seq : undefined,
-        })
-      : false;
+    // A persisted USER record carries this root's server order — stamp
+    // it even when the bubble text is already filled (rounds 3+6: the
+    // echo used to update only empty bubbles, so optimistic siblings
+    // never entered the server clock domain and orphan adoption had to
+    // compare against client `Date.now()`). Adoption itself only
+    // happens through `tryAdoptPlaceholders`, i.e. once EVERY root in
+    // the scope is server-ordered.
+    let adopted = false;
+    if (state) {
+      normalizeUserRootOrder(
+        thread,
+        message.timestamp ? Date.parse(message.timestamp) : Number.NaN,
+        typeof message.seq === "number" ? message.seq : undefined,
+      );
+      adopted = tryAdoptPlaceholders(state);
+    }
     const built = buildResponseFromApi(message);
     if (thread.userMsg.text === "" && built.text.trim().length > 0) {
       thread.userMsg = {
@@ -3948,66 +3973,65 @@ function markThreadAdopted(thread: Thread): boolean {
   return true;
 }
 
-/** Adopt an orphan bucket into a KNOWN turn once its server ORDER is
- *  establishable (codex #262 rounds 4-5). An orphan is inserted at
- *  event-arrival time, which can place an older turn AFTER a newer
- *  prompt; opening the rewind gate without restoring order lets the
- *  distance-from-end math send an inflated num_turns. Re-anchors the
- *  user root to the persisted timestamp, stamps the row seq, reinserts
- *  by (timestamp, seq) and clears provenance. Returns false — gate
- *  stays closed — when the row carries no usable timestamp, or when
- *  the timestamp TIES with a sibling turn and the seq tiebreak is
- *  unavailable on either side (sub-millisecond server timestamps
- *  collapse under Date.parse; placement would be a guess). */
-function adoptPlaceholderWithOrder(
-  state: SessionState,
+/** Stamp server order (persisted timestamp + per-session seq) onto a
+ *  user root. Returns whether anything changed. Content is untouched —
+ *  this only normalizes the ORDER axes so `tryAdoptPlaceholders` can
+ *  compare turns within a single server-authoritative domain
+ *  (codex #262 round 6 P1: comparing an orphan's server timestamp
+ *  against a sibling's optimistic `Date.now()` mixes clock domains,
+ *  and skew re-orders real turns before opening the rewind gate). */
+function normalizeUserRootOrder(
   thread: Thread,
-  order: { timestampMs: number; seq?: number },
+  timestampMs: number,
+  seq: number | undefined,
 ): boolean {
-  if (thread.placeholderOrigin !== true) return false;
-  if (!Number.isFinite(order.timestampMs) || order.timestampMs <= 0) {
-    return false;
+  let changed = false;
+  if (
+    Number.isFinite(timestampMs) &&
+    timestampMs > 0 &&
+    thread.userMsg.timestamp !== timestampMs
+  ) {
+    thread.userMsg = { ...thread.userMsg, timestamp: timestampMs };
+    changed = true;
   }
-  for (const other of state.threads) {
-    if (other === thread) continue;
-    if (other.userMsg.timestamp !== order.timestampMs) continue;
-    const otherSeq = other.userMsg.historySeq;
-    if (typeof order.seq !== "number" || typeof otherSeq !== "number") {
-      return false; // ambiguous tie — keep the gate closed
+  if (typeof seq === "number" && thread.userMsg.historySeq !== seq) {
+    thread.userMsg = { ...thread.userMsg, historySeq: seq };
+    changed = true;
+  }
+  return changed;
+}
+
+/** Open the rewind gate for orphan buckets ONLY from a single
+ *  server-authoritative total order (codex #262 rounds 4-6): when
+ *  EVERY user root in the scope carries a per-session `historySeq`,
+ *  sort the scope by seq and clear provenance. Seq is the one axis the
+ *  server guarantees monotonic — timestamps are display-only and may
+ *  tie at millisecond precision or come from the client clock for
+ *  optimistic turns. Any root without seq (optimistic send whose echo
+ *  hasn't landed, REST rows stripped by messages_page) keeps the gate
+ *  closed; its own echo / the next hydrate normalizes it and retries
+ *  here. Returns whether anything was adopted. */
+function tryAdoptPlaceholders(state: SessionState): boolean {
+  let sawPlaceholder = false;
+  for (const t of state.threads) {
+    if (t.placeholderOrigin === true) {
+      sawPlaceholder = true;
+      break;
     }
   }
-  thread.userMsg = {
-    ...thread.userMsg,
-    timestamp: order.timestampMs,
-    historySeq:
-      typeof order.seq === "number" ? order.seq : thread.userMsg.historySeq,
-  };
-  const idx = state.threads.indexOf(thread);
-  if (idx !== -1) state.threads.splice(idx, 1);
-  let i = state.threads.length - 1;
-  while (i >= 0) {
-    const other = state.threads[i];
-    const otherTs = other.userMsg.timestamp;
-    if (otherTs > order.timestampMs) {
-      i -= 1;
-      continue;
-    }
-    if (otherTs === order.timestampMs) {
-      const otherSeq = other.userMsg.historySeq;
-      if (
-        typeof order.seq === "number" &&
-        typeof otherSeq === "number" &&
-        otherSeq > order.seq
-      ) {
-        i -= 1;
-        continue;
-      }
-    }
-    break;
+  if (!sawPlaceholder) return false;
+  const allOrdered = state.threads.every(
+    (t) => typeof t.userMsg.historySeq === "number",
+  );
+  if (!allOrdered) return false;
+  state.threads.sort(
+    (a, b) =>
+      (a.userMsg.historySeq as number) - (b.userMsg.historySeq as number),
+  );
+  for (const t of state.threads) {
+    if (t.placeholderOrigin === true) t.placeholderOrigin = false;
   }
-  state.threads.splice(i + 1, 0, thread);
-  state.byId.set(thread.id, thread);
-  return markThreadAdopted(thread);
+  return true;
 }
 
 /** True when ANY bucket in the scope is still an orphan placeholder.

--- a/src/store/thread-store.ts
+++ b/src/store/thread-store.ts
@@ -3613,9 +3613,21 @@ export function appendPersistedMessage(
         typeof message.seq === "number" ? message.seq : undefined,
       );
       adopted = tryAdoptPlaceholders(state);
-      // Unresolvable from live traffic (round 7): fall back to ONE
-      // forced REST replay for the scope.
-      if (!adopted) nudgePlaceholderRefetch(key, state);
+      if (!adopted) {
+        // Unresolvable from live traffic (round 7): fall back to a
+        // forced REST replay. Round 8 P2: `state` may be a DIFFERENT
+        // scope than the incoming (sessionId, topic) when the global
+        // findThreadById fallback located the orphan elsewhere —
+        // nudge the scope that owns the thread we just inspected.
+        let ownerKey = key;
+        for (const [k, s] of sessionsByKey.entries()) {
+          if (s === state) {
+            ownerKey = k;
+            break;
+          }
+        }
+        nudgePlaceholderRefetch(ownerKey, state);
+      }
     }
     const built = buildResponseFromApi(message);
     if (thread.userMsg.text === "" && built.text.trim().length > 0) {
@@ -4037,30 +4049,52 @@ function tryAdoptPlaceholders(state: SessionState): boolean {
   return true;
 }
 
-/** One-shot per scope: a persisted user echo landed while the scope
- *  still had UNRESOLVABLE placeholders — some sibling root carries no
- *  server seq and never will from live traffic (topic scopes skip
- *  `session/hydrate` and REST `messages_page` strips `seq`; codex
- *  #262 round 7). The echoed turn IS persisted now, so ONE forced
- *  REST replay re-roots it in server order and resolves the orphan
- *  without any cross-domain heuristics (`replayHistory` roots user
- *  rows found in the batch; only rows still missing stay gated).
- *  Re-armed when the scope's placeholders fully resolve so a later
- *  episode can nudge again; `loadHistory` itself dedups in-flight
- *  fetches and swallows fetch errors. */
-const placeholderRefetchByKey = new Set<string>();
+/** Fallback replay for a scope whose placeholders CANNOT resolve from
+ *  live traffic — some sibling root carries no server seq and never
+ *  will (topic scopes skip `session/hydrate` and REST `messages_page`
+ *  strips `seq`; codex #262 rounds 7-8). The echoed turn IS persisted
+ *  by the time this runs, so a REST replay begun AFTER the echo
+ *  re-roots it (and every sibling) in server order and resolves the
+ *  orphan without cross-domain heuristics.
+ *
+ *  Latch semantics (round 8): the latch marks an IN-FLIGHT nudge only
+ *  and is always released on completion — each later persisted echo is
+ *  a fresh server-side signal and may nudge again (loadHistory dedups
+ *  concurrent fetches), and a resolved episode re-arms automatically.
+ *  An in-flight mount/reconnect load may PREDATE the echoed row, so
+ *  the nudge waits it out and then issues a genuinely fresh forced
+ *  load if the scope is still gated. */
+const placeholderRefetchInFlight = new Set<string>();
 
 function nudgePlaceholderRefetch(key: string, state: SessionState): void {
-  if (!state.threads.some((t) => t.placeholderOrigin === true)) {
-    placeholderRefetchByKey.delete(key);
-    return;
-  }
-  if (placeholderRefetchByKey.has(key)) return;
-  placeholderRefetchByKey.add(key);
+  if (!state.threads.some((t) => t.placeholderOrigin === true)) return;
+  if (placeholderRefetchInFlight.has(key)) return;
+  placeholderRefetchInFlight.add(key);
   const hashIdx = key.indexOf("#");
   const sessionId = hashIdx === -1 ? key : key.slice(0, hashIdx);
   const topic = hashIdx === -1 ? undefined : key.slice(hashIdx + 1);
-  void loadHistory(sessionId, topic, { force: true });
+  void (async () => {
+    try {
+      // Round 8 P1: `loadHistory` coalesces onto an in-flight load,
+      // which may have started BEFORE the echoed row was persisted.
+      // Drain it first; the forced load below then issues a fresh
+      // request (the finished load's `loadingPromises` entry is gone).
+      const existing = loadingPromises.get(key);
+      if (existing) await existing.catch(() => {});
+      const current = sessionsByKey.get(key);
+      if (
+        !current ||
+        !current.threads.some((t) => t.placeholderOrigin === true)
+      ) {
+        return;
+      }
+      await loadHistory(sessionId, topic, { force: true });
+    } catch {
+      // loadHistory swallows fetch errors itself; defensive only.
+    } finally {
+      placeholderRefetchInFlight.delete(key);
+    }
+  })();
 }
 
 /** True when ANY bucket in the scope is still an orphan placeholder.
@@ -4168,7 +4202,7 @@ export function clearSessionScope(
   pendingClientMessageIds.delete(key);
   seenSeqsByKey.delete(key);
   appliedHydrateToolEnvelopesByKey.delete(key);
-  placeholderRefetchByKey.delete(key);
+  placeholderRefetchInFlight.delete(key);
   notify();
 }
 
@@ -4182,7 +4216,7 @@ export function clearSession(sessionId: string, topic?: string): void {
     pendingClientMessageIds.delete(key);
     seenSeqsByKey.delete(key);
     appliedHydrateToolEnvelopesByKey.delete(key);
-    placeholderRefetchByKey.delete(key);
+    placeholderRefetchInFlight.delete(key);
   } else {
     for (const k of [...sessionsByKey.keys()]) {
       if (k === sessionId || k.startsWith(`${sessionId}#`)) {
@@ -4193,7 +4227,7 @@ export function clearSession(sessionId: string, topic?: string): void {
         pendingClientMessageIds.delete(k);
         seenSeqsByKey.delete(k);
         appliedHydrateToolEnvelopesByKey.delete(k);
-        placeholderRefetchByKey.delete(k);
+        placeholderRefetchInFlight.delete(k);
       }
     }
     // Codex round-5 P3: a hydrate snapshot may exist without a
@@ -4330,7 +4364,7 @@ export function __resetForTests(): void {
   loadingPromises.clear();
   snapshotCache.clear();
   hydrateSnapshotByKey.clear();
-  placeholderRefetchByKey.clear();
+  placeholderRefetchInFlight.clear();
   pendingClientMessageIds.clear();
   seenSeqsByKey.clear();
   appliedHydrateToolEnvelopesByKey.clear();

--- a/src/store/thread-store.ts
+++ b/src/store/thread-store.ts
@@ -3613,6 +3613,9 @@ export function appendPersistedMessage(
         typeof message.seq === "number" ? message.seq : undefined,
       );
       adopted = tryAdoptPlaceholders(state);
+      // Unresolvable from live traffic (round 7): fall back to ONE
+      // forced REST replay for the scope.
+      if (!adopted) nudgePlaceholderRefetch(key, state);
     }
     const built = buildResponseFromApi(message);
     if (thread.userMsg.text === "" && built.text.trim().length > 0) {
@@ -4034,6 +4037,32 @@ function tryAdoptPlaceholders(state: SessionState): boolean {
   return true;
 }
 
+/** One-shot per scope: a persisted user echo landed while the scope
+ *  still had UNRESOLVABLE placeholders — some sibling root carries no
+ *  server seq and never will from live traffic (topic scopes skip
+ *  `session/hydrate` and REST `messages_page` strips `seq`; codex
+ *  #262 round 7). The echoed turn IS persisted now, so ONE forced
+ *  REST replay re-roots it in server order and resolves the orphan
+ *  without any cross-domain heuristics (`replayHistory` roots user
+ *  rows found in the batch; only rows still missing stay gated).
+ *  Re-armed when the scope's placeholders fully resolve so a later
+ *  episode can nudge again; `loadHistory` itself dedups in-flight
+ *  fetches and swallows fetch errors. */
+const placeholderRefetchByKey = new Set<string>();
+
+function nudgePlaceholderRefetch(key: string, state: SessionState): void {
+  if (!state.threads.some((t) => t.placeholderOrigin === true)) {
+    placeholderRefetchByKey.delete(key);
+    return;
+  }
+  if (placeholderRefetchByKey.has(key)) return;
+  placeholderRefetchByKey.add(key);
+  const hashIdx = key.indexOf("#");
+  const sessionId = hashIdx === -1 ? key : key.slice(0, hashIdx);
+  const topic = hashIdx === -1 ? undefined : key.slice(hashIdx + 1);
+  void loadHistory(sessionId, topic, { force: true });
+}
+
 /** True when ANY bucket in the scope is still an orphan placeholder.
  *  While one exists the local turn list is KNOWN-incomplete (a late
  *  event arrived for a turn we have not seen the user message for), so
@@ -4139,6 +4168,7 @@ export function clearSessionScope(
   pendingClientMessageIds.delete(key);
   seenSeqsByKey.delete(key);
   appliedHydrateToolEnvelopesByKey.delete(key);
+  placeholderRefetchByKey.delete(key);
   notify();
 }
 
@@ -4152,6 +4182,7 @@ export function clearSession(sessionId: string, topic?: string): void {
     pendingClientMessageIds.delete(key);
     seenSeqsByKey.delete(key);
     appliedHydrateToolEnvelopesByKey.delete(key);
+    placeholderRefetchByKey.delete(key);
   } else {
     for (const k of [...sessionsByKey.keys()]) {
       if (k === sessionId || k.startsWith(`${sessionId}#`)) {
@@ -4162,6 +4193,7 @@ export function clearSession(sessionId: string, topic?: string): void {
         pendingClientMessageIds.delete(k);
         seenSeqsByKey.delete(k);
         appliedHydrateToolEnvelopesByKey.delete(k);
+        placeholderRefetchByKey.delete(k);
       }
     }
     // Codex round-5 P3: a hydrate snapshot may exist without a
@@ -4298,6 +4330,7 @@ export function __resetForTests(): void {
   loadingPromises.clear();
   snapshotCache.clear();
   hydrateSnapshotByKey.clear();
+  placeholderRefetchByKey.clear();
   pendingClientMessageIds.clear();
   seenSeqsByKey.clear();
   appliedHydrateToolEnvelopesByKey.clear();

--- a/src/store/thread-store.ts
+++ b/src/store/thread-store.ts
@@ -4065,34 +4065,47 @@ function tryAdoptPlaceholders(state: SessionState): boolean {
  *  the nudge waits it out and then issues a genuinely fresh forced
  *  load if the scope is still gated. */
 const placeholderRefetchInFlight = new Set<string>();
+// Round 9 P1a: echoes that land while a nudge is in flight are QUEUED
+// here — the running task loops and issues another fresh load, so a
+// request that predates the newer echo can never be the last word.
+const placeholderRefetchDirty = new Set<string>();
 
 function nudgePlaceholderRefetch(key: string, state: SessionState): void {
   if (!state.threads.some((t) => t.placeholderOrigin === true)) return;
-  if (placeholderRefetchInFlight.has(key)) return;
+  if (placeholderRefetchInFlight.has(key)) {
+    placeholderRefetchDirty.add(key);
+    return;
+  }
   placeholderRefetchInFlight.add(key);
   const hashIdx = key.indexOf("#");
   const sessionId = hashIdx === -1 ? key : key.slice(0, hashIdx);
   const topic = hashIdx === -1 ? undefined : key.slice(hashIdx + 1);
   void (async () => {
     try {
-      // Round 8 P1: `loadHistory` coalesces onto an in-flight load,
-      // which may have started BEFORE the echoed row was persisted.
-      // Drain it first; the forced load below then issues a fresh
-      // request (the finished load's `loadingPromises` entry is gone).
-      const existing = loadingPromises.get(key);
-      if (existing) await existing.catch(() => {});
-      const current = sessionsByKey.get(key);
-      if (
-        !current ||
-        !current.threads.some((t) => t.placeholderOrigin === true)
-      ) {
-        return;
-      }
-      await loadHistory(sessionId, topic, { force: true });
+      do {
+        placeholderRefetchDirty.delete(key);
+        // Round 8 P1: `loadHistory` coalesces onto an in-flight load,
+        // which may have started BEFORE the echoed row was persisted.
+        // Drain it first; the forced load below then issues a fresh
+        // request (the finished load's `loadingPromises` entry is
+        // gone).
+        const existing = loadingPromises.get(key);
+        if (existing) await existing.catch(() => {});
+        if (!sessionsByKey.has(key)) return; // scope cleared — moot
+        // Round 9 P1b: fetch UNCONDITIONALLY once per armed signal.
+        // The previous post-drain placeholder scan skipped the fetch
+        // when a stale replay had SWEPT the orphan bucket (replay
+        // carries only pending assistants), leaving the echoed turn
+        // absent until an unrelated event. The armed echo itself is
+        // the trigger; the worst case of not scanning is one
+        // redundant history request in a rare overlap.
+        await loadHistory(sessionId, topic, { force: true });
+      } while (placeholderRefetchDirty.has(key));
     } catch {
       // loadHistory swallows fetch errors itself; defensive only.
     } finally {
       placeholderRefetchInFlight.delete(key);
+      placeholderRefetchDirty.delete(key);
     }
   })();
 }
@@ -4203,6 +4216,7 @@ export function clearSessionScope(
   seenSeqsByKey.delete(key);
   appliedHydrateToolEnvelopesByKey.delete(key);
   placeholderRefetchInFlight.delete(key);
+  placeholderRefetchDirty.delete(key);
   notify();
 }
 
@@ -4217,6 +4231,7 @@ export function clearSession(sessionId: string, topic?: string): void {
     seenSeqsByKey.delete(key);
     appliedHydrateToolEnvelopesByKey.delete(key);
     placeholderRefetchInFlight.delete(key);
+    placeholderRefetchDirty.delete(key);
   } else {
     for (const k of [...sessionsByKey.keys()]) {
       if (k === sessionId || k.startsWith(`${sessionId}#`)) {
@@ -4228,6 +4243,7 @@ export function clearSession(sessionId: string, topic?: string): void {
         seenSeqsByKey.delete(k);
         appliedHydrateToolEnvelopesByKey.delete(k);
         placeholderRefetchInFlight.delete(k);
+        placeholderRefetchDirty.delete(k);
       }
     }
     // Codex round-5 P3: a hydrate snapshot may exist without a
@@ -4365,6 +4381,7 @@ export function __resetForTests(): void {
   snapshotCache.clear();
   hydrateSnapshotByKey.clear();
   placeholderRefetchInFlight.clear();
+  placeholderRefetchDirty.clear();
   pendingClientMessageIds.clear();
   seenSeqsByKey.clear();
   appliedHydrateToolEnvelopesByKey.clear();

--- a/src/store/thread-store.ts
+++ b/src/store/thread-store.ts
@@ -2843,7 +2843,31 @@ function mergeHydrateMediaIntoExisting(
       }
       // The hydrate row IS a persisted user record for this bucket —
       // authoritative turn proof even when the media merge no-ops.
-      if (markThreadAdopted(thread)) changed = true;
+      // BUT (codex #262 round 4 P1): an orphan bucket was inserted at
+      // ASSISTANT-arrival time, which can place an older turn AFTER a
+      // newer prompt. Adopting without restoring the server order
+      // would let rewind's distance-from-end math delete an extra
+      // turn. Re-anchor `userMsg.timestamp` to the row's
+      // `persisted_at` and REINSERT before clearing provenance; with
+      // no usable timestamp the gate stays closed (a later replay or
+      // persisted echo carries order and adopts then).
+      if (thread.placeholderOrigin === true) {
+        const persistedAtMs = row.persisted_at
+          ? Date.parse(row.persisted_at)
+          : Number.NaN;
+        if (Number.isFinite(persistedAtMs) && persistedAtMs > 0) {
+          if (thread.userMsg.timestamp !== persistedAtMs) {
+            thread.userMsg = { ...thread.userMsg, timestamp: persistedAtMs };
+            const idx = state.threads.indexOf(thread);
+            if (idx !== -1) {
+              state.threads.splice(idx, 1);
+              insertThreadInTimestampOrder(state, thread);
+            }
+          }
+          markThreadAdopted(thread);
+          changed = true;
+        }
+      }
       continue;
     }
 

--- a/src/store/thread-store.ts
+++ b/src/store/thread-store.ts
@@ -2500,7 +2500,11 @@ export function replayHistory(
       userMsg.role = "user";
       userMsg.clientMessageId = apiMessage.client_message_id ?? threadId;
       if (thread) {
+        // The bucket was synthesized earlier in this replay (assistant
+        // row preceded its user row) — the user row makes it a known
+        // turn.
         thread.userMsg = userMsg;
+        markThreadAdopted(thread);
       } else {
         thread = {
           id: threadId,
@@ -2608,6 +2612,10 @@ export function replayHistory(
           userMsg: prevThread.userMsg,
           responses: prevThread.responses,
           pendingAssistant: pending,
+          // Carried forward VERBATIM — an unresolved orphan stays an
+          // orphan (codex #262 round 3 P1: dropping the flag here let
+          // the bucket bypass the rewind gate and inflate num_turns).
+          placeholderOrigin: prevThread.placeholderOrigin,
         };
         state.byId.set(tid, carried);
         state.threads.push(carried);
@@ -2833,6 +2841,9 @@ function mergeHydrateMediaIntoExisting(
         thread.userMsg = mergedUser;
         changed = true;
       }
+      // The hydrate row IS a persisted user record for this bucket —
+      // authoritative turn proof even when the media merge no-ops.
+      if (markThreadAdopted(thread)) changed = true;
       continue;
     }
 
@@ -3400,6 +3411,8 @@ export function applyVoiceTranscript(
     ...thread.userMsg,
     text,
   };
+  // A transcript proves the user turn exists.
+  markThreadAdopted(thread);
   notify();
   return true;
 }
@@ -3540,6 +3553,11 @@ export function appendPersistedMessage(
     // are optimistically inserted with an audio file and empty text; the
     // persisted echo carries the ASR transcript, so keep local media while
     // filling the transcript in.
+    // A persisted USER record is authoritative proof of turn-ness —
+    // clear provenance even when the local bubble already has text
+    // (e.g. an ASR/hydrate-filled orphan), or the scope's rewind gate
+    // sticks closed forever (codex #262 round 3).
+    const adopted = markThreadAdopted(thread);
     const built = buildResponseFromApi(message);
     if (thread.userMsg.text === "" && built.text.trim().length > 0) {
       thread.userMsg = {
@@ -3550,8 +3568,6 @@ export function appendPersistedMessage(
         intra_thread_seq: built.intra_thread_seq,
         clientMessageId: message.client_message_id ?? threadId,
       };
-      // The persisted user record arrived — a known turn now.
-      thread.placeholderOrigin = false;
       notify();
     } else if (thread.userMsg.text === "" && thread.userMsg.files.length === 0) {
       thread.userMsg = {
@@ -3562,7 +3578,8 @@ export function appendPersistedMessage(
         intra_thread_seq: built.intra_thread_seq,
         clientMessageId: message.client_message_id ?? threadId,
       };
-      thread.placeholderOrigin = false;
+      notify();
+    } else if (adopted) {
       notify();
     }
     return;
@@ -3888,6 +3905,18 @@ export function isPlaceholderThread(thread: Thread): boolean {
   return thread.placeholderOrigin === true;
 }
 
+/** Centralized adoption (codex #262 round 3): EVERY path that applies
+ *  an authoritative user row — live add, orphan adoption, replay
+ *  rebuild, persisted user echo, hydrate user-media merge, ASR
+ *  transcript — must clear provenance, or the scope's rewind gate
+ *  (`hasPlaceholderThreads`) sticks closed forever. Returns whether
+ *  the flag actually flipped so callers can decide to notify. */
+function markThreadAdopted(thread: Thread): boolean {
+  if (thread.placeholderOrigin !== true) return false;
+  thread.placeholderOrigin = false;
+  return true;
+}
+
 /** True when ANY bucket in the scope is still an orphan placeholder.
  *  While one exists the local turn list is KNOWN-incomplete (a late
  *  event arrived for a turn we have not seen the user message for), so
@@ -3953,6 +3982,27 @@ export function dropLastUserTurnThreads(
   else seenSeqsByKey.delete(key);
   notify();
   return dropped;
+}
+
+/** Union authoritative seqs into a scope's seen-seq ledger. Used by
+ *  the rollback applier after a surgical trim: the post-trim rebuild in
+ *  `dropLastUserTurnThreads` derives entries from surviving rows'
+ *  `historySeq` alone, but a prior forced `messages_page` replay can
+ *  have stripped those fields and companion merges collapse multiple
+ *  seqs into one row (codex #262 round 3). The rollback RESULT carries
+ *  the authoritative surviving rows WITH seqs — union them in so live
+ *  re-emissions for surviving rows keep deduping. */
+export function unionSeenSeqs(
+  sessionId: string,
+  topic: string | undefined,
+  seqs: number[],
+): void {
+  const key = storeKey(sessionId, topic);
+  for (const seq of seqs) {
+    if (typeof seq === "number" && Number.isFinite(seq)) {
+      rememberSeq(key, seq);
+    }
+  }
 }
 
 /** Exact-key variant of `clearSession`: clears ONLY the addressed

--- a/src/store/thread-store.ts
+++ b/src/store/thread-store.ts
@@ -2851,22 +2851,15 @@ function mergeHydrateMediaIntoExisting(
       // `persisted_at` and REINSERT before clearing provenance; with
       // no usable timestamp the gate stays closed (a later replay or
       // persisted echo carries order and adopts then).
-      if (thread.placeholderOrigin === true) {
-        const persistedAtMs = row.persisted_at
-          ? Date.parse(row.persisted_at)
-          : Number.NaN;
-        if (Number.isFinite(persistedAtMs) && persistedAtMs > 0) {
-          if (thread.userMsg.timestamp !== persistedAtMs) {
-            thread.userMsg = { ...thread.userMsg, timestamp: persistedAtMs };
-            const idx = state.threads.indexOf(thread);
-            if (idx !== -1) {
-              state.threads.splice(idx, 1);
-              insertThreadInTimestampOrder(state, thread);
-            }
-          }
-          markThreadAdopted(thread);
-          changed = true;
-        }
+      if (
+        adoptPlaceholderWithOrder(state, thread, {
+          timestampMs: row.persisted_at
+            ? Date.parse(row.persisted_at)
+            : Number.NaN,
+          seq: typeof row.seq === "number" ? row.seq : undefined,
+        })
+      ) {
+        changed = true;
       }
       continue;
     }
@@ -3435,8 +3428,12 @@ export function applyVoiceTranscript(
     ...thread.userMsg,
     text,
   };
-  // A transcript proves the user turn exists.
-  markThreadAdopted(thread);
+  // NOTE (codex #262 rounds 3→5): a transcript proves the user turn
+  // exists but carries NO order information (no persisted timestamp or
+  // seq), so it must not open the rewind gate on a true orphan — the
+  // persisted user echo that follows carries both and adopts through
+  // `adoptPlaceholderWithOrder`. Real voice turns are minted by
+  // `addUserMessage` and were never placeholders.
   notify();
   return true;
 }
@@ -3578,10 +3575,20 @@ export function appendPersistedMessage(
     // persisted echo carries the ASR transcript, so keep local media while
     // filling the transcript in.
     // A persisted USER record is authoritative proof of turn-ness —
-    // clear provenance even when the local bubble already has text
-    // (e.g. an ASR/hydrate-filled orphan), or the scope's rewind gate
-    // sticks closed forever (codex #262 round 3).
-    const adopted = markThreadAdopted(thread);
+    // adopt even when the local bubble already has text (an
+    // ASR/hydrate-filled orphan; codex #262 round 3). Adoption goes
+    // through the ORDER-restoring helper (round 5 P1): the orphan sits
+    // at event-arrival time, and clearing the gate without reinserting
+    // it at message.timestamp leaves [newer, older] so a rewind on the
+    // newer bubble deletes an extra turn.
+    const adopted = state
+      ? adoptPlaceholderWithOrder(state, thread, {
+          timestampMs: message.timestamp
+            ? Date.parse(message.timestamp)
+            : Number.NaN,
+          seq: typeof message.seq === "number" ? message.seq : undefined,
+        })
+      : false;
     const built = buildResponseFromApi(message);
     if (thread.userMsg.text === "" && built.text.trim().length > 0) {
       thread.userMsg = {
@@ -3939,6 +3946,68 @@ function markThreadAdopted(thread: Thread): boolean {
   if (thread.placeholderOrigin !== true) return false;
   thread.placeholderOrigin = false;
   return true;
+}
+
+/** Adopt an orphan bucket into a KNOWN turn once its server ORDER is
+ *  establishable (codex #262 rounds 4-5). An orphan is inserted at
+ *  event-arrival time, which can place an older turn AFTER a newer
+ *  prompt; opening the rewind gate without restoring order lets the
+ *  distance-from-end math send an inflated num_turns. Re-anchors the
+ *  user root to the persisted timestamp, stamps the row seq, reinserts
+ *  by (timestamp, seq) and clears provenance. Returns false — gate
+ *  stays closed — when the row carries no usable timestamp, or when
+ *  the timestamp TIES with a sibling turn and the seq tiebreak is
+ *  unavailable on either side (sub-millisecond server timestamps
+ *  collapse under Date.parse; placement would be a guess). */
+function adoptPlaceholderWithOrder(
+  state: SessionState,
+  thread: Thread,
+  order: { timestampMs: number; seq?: number },
+): boolean {
+  if (thread.placeholderOrigin !== true) return false;
+  if (!Number.isFinite(order.timestampMs) || order.timestampMs <= 0) {
+    return false;
+  }
+  for (const other of state.threads) {
+    if (other === thread) continue;
+    if (other.userMsg.timestamp !== order.timestampMs) continue;
+    const otherSeq = other.userMsg.historySeq;
+    if (typeof order.seq !== "number" || typeof otherSeq !== "number") {
+      return false; // ambiguous tie — keep the gate closed
+    }
+  }
+  thread.userMsg = {
+    ...thread.userMsg,
+    timestamp: order.timestampMs,
+    historySeq:
+      typeof order.seq === "number" ? order.seq : thread.userMsg.historySeq,
+  };
+  const idx = state.threads.indexOf(thread);
+  if (idx !== -1) state.threads.splice(idx, 1);
+  let i = state.threads.length - 1;
+  while (i >= 0) {
+    const other = state.threads[i];
+    const otherTs = other.userMsg.timestamp;
+    if (otherTs > order.timestampMs) {
+      i -= 1;
+      continue;
+    }
+    if (otherTs === order.timestampMs) {
+      const otherSeq = other.userMsg.historySeq;
+      if (
+        typeof order.seq === "number" &&
+        typeof otherSeq === "number" &&
+        otherSeq > order.seq
+      ) {
+        i -= 1;
+        continue;
+      }
+    }
+    break;
+  }
+  state.threads.splice(i + 1, 0, thread);
+  state.byId.set(thread.id, thread);
+  return markThreadAdopted(thread);
 }
 
 /** True when ANY bucket in the scope is still an orphan placeholder.

--- a/src/store/thread-store.ts
+++ b/src/store/thread-store.ts
@@ -3846,6 +3846,72 @@ export function getKnownFilePaths(
   return out;
 }
 
+/** True when the thread was minted as an orphan placeholder (a late
+ *  assistant/tool event whose user message never landed in the store)
+ *  rather than a real persisted user turn: empty text AND no files. A
+ *  file-only user message is a real turn (text empty, files non-empty).
+ *  Rollback math (`session/rollback` counts persisted USER turns only)
+ *  must skip placeholders — counting them both inflates `num_turns`
+ *  and grows a Rewind affordance on a bubble that is not a turn. */
+export function isPlaceholderThread(thread: Thread): boolean {
+  return (
+    thread.userMsg.text.trim() === "" && thread.userMsg.files.length === 0
+  );
+}
+
+/** Conversation-suffix trim for `session/rollback`: drop the last
+ *  `dropTurns` REAL user-turn threads and EVERY thread after the cut
+ *  (trailing orphan placeholders carry late events for the dropped
+ *  suffix). Exact-key scope — topic caches are untouched by a root
+ *  rollback. Keeps surviving thread objects intact, so their tool
+ *  cards / progress timelines / meta survive (unlike a clear+reseed,
+ *  whose HydratedMessage rows carry none of that state).
+ *  Returns how many user turns were actually dropped. */
+export function dropLastUserTurnThreads(
+  sessionId: string,
+  topic: string | undefined,
+  dropTurns: number,
+): number {
+  if (!Number.isInteger(dropTurns) || dropTurns < 1) return 0;
+  const key = storeKey(sessionId, topic);
+  const state = sessionsByKey.get(key);
+  if (!state) return 0;
+  const userTurnIndices: number[] = [];
+  state.threads.forEach((thread, index) => {
+    if (!isPlaceholderThread(thread)) userTurnIndices.push(index);
+  });
+  if (userTurnIndices.length === 0) return 0;
+  const dropped = Math.min(dropTurns, userTurnIndices.length);
+  const cutIndex = userTurnIndices[userTurnIndices.length - dropped];
+  const removed = state.threads.slice(cutIndex);
+  state.threads = state.threads.slice(0, cutIndex);
+  for (const thread of removed) {
+    state.byId.delete(thread.id);
+  }
+  notify();
+  return dropped;
+}
+
+/** Exact-key variant of `clearSession`: clears ONLY the addressed
+ *  scope. `clearSession(sessionId)` intentionally sweeps every
+ *  topic-suffixed key too (session delete), which is wrong for a root
+ *  `session/rollback` — the RPC mutates only the root SessionKey, so
+ *  cached slides/site topic histories must survive locally. */
+export function clearSessionScope(
+  sessionId: string,
+  topic?: string,
+): void {
+  const key = storeKey(sessionId, topic);
+  sessionsByKey.delete(key);
+  loadedSessions.delete(key);
+  loadingPromises.delete(key);
+  hydrateSnapshotByKey.delete(key);
+  pendingClientMessageIds.delete(key);
+  seenSeqsByKey.delete(key);
+  appliedHydrateToolEnvelopesByKey.delete(key);
+  notify();
+}
+
 export function clearSession(sessionId: string, topic?: string): void {
   const key = storeKey(sessionId, topic);
   if (topic?.trim()) {


### PR DESCRIPTION
Second of the three P2 web-parity gaps (WEB-PARITY-2026-07-10): the server's `session/rollback` (octos #1516/#1517, TUI #229/#230 precedent) surfaced as a per-bubble rewind control.

## What
- Every user bubble grows a subtle **Rewind** control (two-click confirm, auto-disarm): rewinding at a bubble drops that user turn and everything after it (`num_turns` = distance from the end).
- `bridge.rollbackSession(numTurns)` → `session/rollback {session_id (scoped), num_turns}`; result guarded through `guardSessionHydrate`.
- The applier **clears the local scope before seeding** from the returned trimmed projection — the hydrate dedup/seed pass only ever adds rows, so clearing is what actually removes the rolled-back turns client-side.
- Server's `turn_in_progress` busy-guard surfaces inline; local store untouched on any failure.
- Rewind = edit-and-resend: the dropped prompt prefills the composer (`crew:composer_prefill`, scope-checked).

## Tests
901 passing (+8: applier clear+rebuild/busy-guard/failure/no-bridge; bubble confirm flow, num_turns math, prefill, inline error). `npm run build` (tsc -b) clean — that's the gate that catches import-block vs export-block drift; zero new lint errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Codex fold rounds
- **Round 1** (folded): surgical suffix trim instead of clear+reseed (`dropLastUserTurnThreads` keeps surviving tool cards/progress/meta); exact-key `clearSessionScope` so sibling topic caches survive; per-scope rollback lock (`useRollbackBusy` disables every Rewind affordance; the send path parks behind `whenRollbackIdle`); orphan placeholders excluded from turn math.
- **Round 2** (folded): `Thread.placeholderOrigin` **provenance** flag replaces shape-inference (`empty text + no files` misclassified real-but-unhydrated turns); ALL rewind affordances withheld while any placeholder exists in scope; seq-dedup ledger rebuilt from surviving rows after the trim (server renumbers persisted seqs from the trimmed length); hydrate-snapshot cache replaced with the trimmed projection on the **surgical** path too (stale cache resurrected dropped turns); reconcile via clear+reseed when the server **clamps** the requested count, not only on local trim mismatch.