### PR TITLE
feat(autonomy): header loop/goal chip with stop controls (coding.loop_runtime.v1 parity)

### DIFF
--- a/src/components/session-autonomy-chip.test.tsx
+++ b/src/components/session-autonomy-chip.test.tsx
@@ -1,0 +1,240 @@
+/**
+ * SessionAutonomyChip tests — visibility, pause/resume, two-click
+ * delete/clear, scope discipline.
+ */
+
+import { afterEach, describe, expect, it, vi } from "vitest";
+import * as React from "react";
+import { act } from "react";
+import { createRoot, type Root } from "react-dom/client";
+
+(
+  globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }
+).IS_REACT_ACT_ENVIRONMENT = true;
+
+const controlLoop = vi.fn();
+const clearGoal = vi.fn();
+vi.mock("@/runtime/ui-protocol-runtime", () => ({
+  getActiveBridge: () => ({ controlLoop, clearGoal }),
+}));
+
+import { SessionAutonomyChip } from "./session-autonomy-chip";
+import { SessionContext } from "@/runtime/session-context";
+import type { SessionContextValue } from "@/runtime/session-context";
+import type { UiLoopRecord } from "@/runtime/ui-protocol-types";
+import {
+  __resetAutonomyStoreForTest,
+  getAutonomyState,
+  replaceLoops,
+  setGoal,
+} from "@/store/autonomy-store";
+
+const SESSION = "sess-autonomy-chip";
+
+interface MountedHarness {
+  container: HTMLDivElement;
+  root: Root;
+  unmount: () => void;
+}
+
+function makeSessionCtx(): SessionContextValue {
+  return {
+    sessions: [],
+    currentSessionId: SESSION,
+    historyTopic: undefined,
+    currentSessionTitle: "",
+    currentSessionStats: null,
+    initialMessages: [],
+    activeTaskOnServer: false,
+    queueMode: null,
+    adaptiveMode: null,
+    setServerTaskActive: () => {},
+    renameSession: () => {},
+    updateSessionStats: () => {},
+    switchSession: () => {},
+    goBack: async () => false,
+    createSession: () => SESSION,
+    removeSession: async () => {},
+    refreshSessions: async () => {},
+    markSessionActive: () => {},
+  };
+}
+
+function mountChip(): MountedHarness {
+  const container = document.createElement("div");
+  document.body.appendChild(container);
+  const root = createRoot(container);
+  act(() => {
+    root.render(
+      <SessionContext.Provider value={makeSessionCtx()}>
+        <SessionAutonomyChip />
+      </SessionContext.Provider>,
+    );
+  });
+  return {
+    container,
+    root,
+    unmount: () => {
+      act(() => root.unmount());
+      container.remove();
+    },
+  };
+}
+
+function makeLoop(
+  partial: Partial<UiLoopRecord> & { loop_id: string },
+): UiLoopRecord {
+  return {
+    session_id: SESSION,
+    prompt: "poll the deploy queue",
+    mode: "interval",
+    interval_seconds: 300,
+    status: "active",
+    expires_at_ms: 0,
+    created_at_ms: 1,
+    updated_at_ms: 1,
+    ...partial,
+  };
+}
+
+function q<T extends Element>(h: MountedHarness, sel: string): T | null {
+  return h.container.querySelector(sel) as T | null;
+}
+
+afterEach(() => {
+  for (const node of [...document.body.children]) node.remove();
+  __resetAutonomyStoreForTest();
+  controlLoop.mockReset();
+  clearGoal.mockReset();
+});
+
+describe("SessionAutonomyChip", () => {
+  it("renders nothing without live loops or goal", () => {
+    const harness = mountChip();
+    expect(q(harness, '[data-testid="session-autonomy-chip"]')).toBeNull();
+    // Terminal loops don't count as live.
+    replaceLoops(SESSION, [makeLoop({ loop_id: "l1", status: "completed" })]);
+    act(() => {});
+    expect(q(harness, '[data-testid="session-autonomy-chip"]')).toBeNull();
+    harness.unmount();
+  });
+
+  it("pauses an active loop and merges the returned record", async () => {
+    controlLoop.mockResolvedValue({
+      ok: true,
+      status: "paused",
+      loop: makeLoop({ loop_id: "l1", status: "paused" }),
+    });
+    replaceLoops(SESSION, [makeLoop({ loop_id: "l1" })]);
+    const harness = mountChip();
+    const chip = q<HTMLButtonElement>(
+      harness,
+      '[data-testid="session-autonomy-chip"]',
+    );
+    expect(chip).toBeTruthy();
+    expect(chip?.getAttribute("data-loop-count")).toBe("1");
+    act(() => chip?.click());
+    const toggle = q<HTMLButtonElement>(
+      harness,
+      '[data-testid="loop-toggle-l1"]',
+    );
+    expect(toggle?.textContent).toBe("Pause");
+    await act(async () => {
+      toggle?.click();
+    });
+    expect(controlLoop).toHaveBeenCalledWith("l1", "pause");
+    expect(getAutonomyState(SESSION).loops[0]?.status).toBe("paused");
+    harness.unmount();
+  });
+
+  it("resumes a paused loop", async () => {
+    controlLoop.mockResolvedValue({
+      ok: true,
+      status: "active",
+      loop: makeLoop({ loop_id: "l1", status: "active" }),
+    });
+    replaceLoops(SESSION, [makeLoop({ loop_id: "l1", status: "paused" })]);
+    const harness = mountChip();
+    act(() =>
+      q<HTMLButtonElement>(
+        harness,
+        '[data-testid="session-autonomy-chip"]',
+      )?.click(),
+    );
+    const toggle = q<HTMLButtonElement>(
+      harness,
+      '[data-testid="loop-toggle-l1"]',
+    );
+    expect(toggle?.textContent).toBe("Resume");
+    await act(async () => {
+      toggle?.click();
+    });
+    expect(controlLoop).toHaveBeenCalledWith("l1", "resume");
+    harness.unmount();
+  });
+
+  it("requires a confirming second click to delete a loop", async () => {
+    controlLoop.mockResolvedValue({ ok: true, status: "deleted" });
+    replaceLoops(SESSION, [makeLoop({ loop_id: "l1" })]);
+    const harness = mountChip();
+    act(() =>
+      q<HTMLButtonElement>(
+        harness,
+        '[data-testid="session-autonomy-chip"]',
+      )?.click(),
+    );
+    const del = q<HTMLButtonElement>(
+      harness,
+      '[data-testid="loop-delete-l1"]',
+    );
+    act(() => del?.click());
+    expect(controlLoop).not.toHaveBeenCalled();
+    expect(
+      q<HTMLButtonElement>(harness, '[data-testid="loop-delete-l1"]')
+        ?.textContent,
+    ).toContain("Confirm");
+    await act(async () => {
+      q<HTMLButtonElement>(
+        harness,
+        '[data-testid="loop-delete-l1"]',
+      )?.click();
+    });
+    expect(controlLoop).toHaveBeenCalledWith("l1", "delete");
+    // Optimistic removal → chip disappears (no other live state).
+    expect(q(harness, '[data-testid="session-autonomy-chip"]')).toBeNull();
+    harness.unmount();
+  });
+
+  it("shows and clears the goal with a confirm", async () => {
+    clearGoal.mockResolvedValue(null);
+    setGoal(SESSION, {
+      goal_id: "g1",
+      objective: "keep the fleet green",
+      status: "active",
+      token_budget: 100000,
+      tokens_used: 42,
+      time_used_seconds: 60,
+      created_at_ms: 1,
+      updated_at_ms: 1,
+    });
+    const harness = mountChip();
+    const chip = q<HTMLButtonElement>(
+      harness,
+      '[data-testid="session-autonomy-chip"]',
+    );
+    expect(chip?.getAttribute("data-has-goal")).toBe("true");
+    act(() => chip?.click());
+    expect(q(harness, '[data-testid="goal-row"]')?.textContent).toContain(
+      "keep the fleet green",
+    );
+    const clear = q<HTMLButtonElement>(harness, '[data-testid="goal-clear"]');
+    act(() => clear?.click());
+    expect(clearGoal).not.toHaveBeenCalled();
+    await act(async () => {
+      q<HTMLButtonElement>(harness, '[data-testid="goal-clear"]')?.click();
+    });
+    expect(clearGoal).toHaveBeenCalledTimes(1);
+    expect(getAutonomyState(SESSION).goal).toBe(null);
+    harness.unmount();
+  });
+});

--- a/src/components/session-autonomy-chip.test.tsx
+++ b/src/components/session-autonomy-chip.test.tsx
@@ -119,6 +119,31 @@ describe("SessionAutonomyChip", () => {
     harness.unmount();
   });
 
+  it("treats an elapsed expires_at_ms as terminal even when status is active (codex #263 P2)", () => {
+    // The backend enforces expiry by SKIPPING due loops — it does not
+    // necessarily rewrite status or emit loop/completed, so an
+    // elapsed-but-"active" row must not pin the chip with dead
+    // controls.
+    replaceLoops(SESSION, [
+      makeLoop({ loop_id: "l-exp", expires_at_ms: Date.now() - 1_000 }),
+    ]);
+    const harness = mountChip();
+    expect(q(harness, '[data-testid="session-autonomy-chip"]')).toBeNull();
+    // A live loop alongside it counts alone.
+    act(() => {
+      replaceLoops(SESSION, [
+        makeLoop({ loop_id: "l-exp", expires_at_ms: Date.now() - 1_000 }),
+        makeLoop({ loop_id: "l-live", expires_at_ms: Date.now() + 60_000 }),
+      ]);
+    });
+    const chip = q<HTMLButtonElement>(
+      harness,
+      '[data-testid="session-autonomy-chip"]',
+    );
+    expect(chip?.getAttribute("data-loop-count")).toBe("1");
+    harness.unmount();
+  });
+
   it("pauses an active loop and merges the returned record", async () => {
     controlLoop.mockResolvedValue({
       ok: true,

--- a/src/components/session-autonomy-chip.test.tsx
+++ b/src/components/session-autonomy-chip.test.tsx
@@ -109,38 +109,91 @@ afterEach(() => {
 });
 
 describe("SessionAutonomyChip", () => {
-  it("renders nothing without live loops or goal", () => {
+  it("renders nothing without loops or goal; terminal rows become delete-only", () => {
     const harness = mountChip();
     expect(q(harness, '[data-testid="session-autonomy-chip"]')).toBeNull();
-    // Terminal loops don't count as live.
-    replaceLoops(SESSION, [makeLoop({ loop_id: "l1", status: "completed" })]);
-    act(() => {});
-    expect(q(harness, '[data-testid="session-autonomy-chip"]')).toBeNull();
+    // Terminal rows aren't LIVE — but they still count toward the
+    // backend loop quota (codex #263 round 2), so the chip renders
+    // them as delete-only cleanup entries instead of hiding them.
+    act(() => {
+      replaceLoops(SESSION, [makeLoop({ loop_id: "l1", status: "completed" })]);
+    });
+    const chip = q<HTMLButtonElement>(
+      harness,
+      '[data-testid="session-autonomy-chip"]',
+    );
+    expect(chip).toBeTruthy();
+    expect(chip?.getAttribute("data-loop-count")).toBe("0");
+    expect(chip?.getAttribute("data-dead-loop-count")).toBe("1");
+    act(() => chip?.click());
+    // Delete-only: no pause/resume toggle for a dead row.
+    expect(q(harness, '[data-testid="loop-toggle-l1"]')).toBeNull();
+    expect(q(harness, '[data-testid="loop-delete-l1"]')).toBeTruthy();
     harness.unmount();
   });
 
-  it("treats an elapsed expires_at_ms as terminal even when status is active (codex #263 P2)", () => {
+  it("treats an elapsed expires_at_ms as dead: not live, but delete-only (codex #263 P2 rounds 1-2)", () => {
     // The backend enforces expiry by SKIPPING due loops — it does not
-    // necessarily rewrite status or emit loop/completed, so an
-    // elapsed-but-"active" row must not pin the chip with dead
-    // controls.
+    // necessarily rewrite status or emit loop/completed. An
+    // elapsed-but-"active" row must not count as live (round 1) yet
+    // must stay DELETABLE because every non-deleted record still
+    // consumes the backend loop quota (round 2).
     replaceLoops(SESSION, [
       makeLoop({ loop_id: "l-exp", expires_at_ms: Date.now() - 1_000 }),
     ]);
     const harness = mountChip();
-    expect(q(harness, '[data-testid="session-autonomy-chip"]')).toBeNull();
-    // A live loop alongside it counts alone.
+    const chip = q<HTMLButtonElement>(
+      harness,
+      '[data-testid="session-autonomy-chip"]',
+    );
+    expect(chip).toBeTruthy();
+    expect(chip?.getAttribute("data-loop-count")).toBe("0");
+    expect(chip?.getAttribute("data-dead-loop-count")).toBe("1");
+    expect(chip?.textContent).toContain("expired");
+    act(() => chip?.click());
+    expect(q(harness, '[data-testid="loop-toggle-l-exp"]')).toBeNull();
+    expect(q(harness, '[data-testid="loop-delete-l-exp"]')).toBeTruthy();
+    // A live loop alongside it counts alone; both rows reachable.
     act(() => {
       replaceLoops(SESSION, [
         makeLoop({ loop_id: "l-exp", expires_at_ms: Date.now() - 1_000 }),
         makeLoop({ loop_id: "l-live", expires_at_ms: Date.now() + 60_000 }),
       ]);
     });
-    const chip = q<HTMLButtonElement>(
+    const chip2 = q<HTMLButtonElement>(
       harness,
       '[data-testid="session-autonomy-chip"]',
     );
-    expect(chip?.getAttribute("data-loop-count")).toBe("1");
+    expect(chip2?.getAttribute("data-loop-count")).toBe("1");
+    expect(chip2?.getAttribute("data-dead-loop-count")).toBe("1");
+    harness.unmount();
+  });
+
+  it("deletes a dead loop through the delete-only row", async () => {
+    controlLoop.mockResolvedValue({ ok: true, status: "deleted" });
+    replaceLoops(SESSION, [
+      makeLoop({ loop_id: "l-dead", expires_at_ms: Date.now() - 1_000 }),
+    ]);
+    const harness = mountChip();
+    act(() =>
+      q<HTMLButtonElement>(
+        harness,
+        '[data-testid="session-autonomy-chip"]',
+      )?.click(),
+    );
+    act(() =>
+      q<HTMLButtonElement>(harness, '[data-testid="loop-delete-l-dead"]')?.click(),
+    );
+    expect(controlLoop).not.toHaveBeenCalled();
+    await act(async () => {
+      q<HTMLButtonElement>(
+        harness,
+        '[data-testid="loop-delete-l-dead"]',
+      )?.click();
+    });
+    expect(controlLoop).toHaveBeenCalledWith("l-dead", "delete");
+    // Optimistic removal frees the row; nothing else live → chip gone.
+    expect(q(harness, '[data-testid="session-autonomy-chip"]')).toBeNull();
     harness.unmount();
   });
 

--- a/src/components/session-autonomy-chip.tsx
+++ b/src/components/session-autonomy-chip.tsx
@@ -98,8 +98,17 @@ export function SessionAutonomyChip() {
 
   const nowMs = Date.now();
   const liveLoops = loops.filter((l) => isLiveLoop(l, nowMs));
+  // Dead-but-deletable (codex #263 round 2): every non-deleted record —
+  // elapsed-active, completed, expired — still counts toward the
+  // backend's 16-loops-per-session quota (`create_loop` counts
+  // `status != "deleted"`), and `loop/list` returns them all. Hiding
+  // them left no web path to free the quota; render them as
+  // delete-only rows instead.
+  const deadLoops = loops.filter((l) => !isLiveLoop(l, nowMs));
   const liveGoal = goal !== null && isLiveGoal(goal.status) ? goal : null;
-  if (liveLoops.length === 0 && liveGoal === null) return null;
+  if (liveLoops.length === 0 && liveGoal === null && deadLoops.length === 0) {
+    return null;
+  }
 
   const label =
     liveLoops.length > 0 && liveGoal !== null
@@ -110,7 +119,9 @@ export function SessionAutonomyChip() {
             ? "Loop paused"
             : "Loop"
           : `${liveLoops.length} loops`
-        : "Goal";
+        : liveGoal !== null
+          ? "Goal"
+          : `${deadLoops.length} expired`;
 
   function markBusy(id: string, value: boolean) {
     setBusy((prev) => {
@@ -165,6 +176,7 @@ export function SessionAutonomyChip() {
         type="button"
         data-testid="session-autonomy-chip"
         data-loop-count={liveLoops.length}
+        data-dead-loop-count={deadLoops.length}
         data-has-goal={liveGoal !== null ? "true" : "false"}
         aria-haspopup="menu"
         aria-expanded={open}
@@ -217,6 +229,52 @@ export function SessionAutonomyChip() {
                 >
                   {loop.status === "paused" ? "Resume" : "Pause"}
                 </button>
+                <button
+                  type="button"
+                  data-testid={`loop-delete-${loop.loop_id}`}
+                  disabled={rowBusy}
+                  onClick={() => {
+                    if (deleteArmed) void runLoopControl(loop, "delete");
+                    else setArmed(loop.loop_id);
+                  }}
+                  className={`shrink-0 rounded-[6px] border px-2 py-0.5 text-[11px] font-medium disabled:opacity-60 ${
+                    deleteArmed
+                      ? "border-rose-400 text-rose-300"
+                      : "border-border text-muted hover:border-rose-400 hover:text-rose-300"
+                  }`}
+                >
+                  {rowBusy
+                    ? "Working…"
+                    : deleteArmed
+                      ? "Confirm delete?"
+                      : "Delete"}
+                </button>
+              </div>
+            );
+          })}
+          {deadLoops.map((loop) => {
+            const rowBusy = busy[loop.loop_id] === true;
+            const deleteArmed = armed === loop.loop_id;
+            const expiredLabel = TERMINAL_LOOP_STATUSES.has(loop.status)
+              ? loop.status
+              : "expired";
+            return (
+              <div
+                key={loop.loop_id}
+                data-testid={`loop-dead-${loop.loop_id}`}
+                className="flex items-center justify-between gap-2 rounded-[8px] px-2 py-1.5 opacity-70 hover:bg-surface"
+              >
+                <span className="min-w-0 flex-1">
+                  <span
+                    className="block truncate text-[12px] text-muted"
+                    title={loop.prompt}
+                  >
+                    {clip(loop.prompt) || loop.mode || "loop"}
+                  </span>
+                  <span className="block text-[10px] text-muted">
+                    {expiredLabel} · still counts toward the loop quota
+                  </span>
+                </span>
                 <button
                   type="button"
                   data-testid={`loop-delete-${loop.loop_id}`}

--- a/src/components/session-autonomy-chip.tsx
+++ b/src/components/session-autonomy-chip.tsx
@@ -1,0 +1,257 @@
+/**
+ * Header autonomy chip: active recurring loops + persisted goal for the
+ * current session, with stop controls (M15 `coding.loop_runtime.v1` /
+ * `coding.goal_runtime.v1`; web parity P2).
+ *
+ * Why: a paused-loop "Re-entering" zombie (octos #1576) was invisible on
+ * the web — the TUI showed a chip, the SPA showed nothing, so a runaway
+ * or stuck loop could only be found and stopped from a terminal. This
+ * chip makes session autonomy visible and stoppable in place.
+ *
+ * Reads `autonomy-store` (snapshot on connect + live loop/goal
+ * notifications). Renders nothing when the scope has no live loop or
+ * goal, so non-autonomous sessions pay zero header pixels.
+ */
+
+import { useEffect, useState } from "react";
+import { Repeat2 , Target } from "lucide-react";
+import type { UiLoopRecord } from "@/runtime/ui-protocol-types";
+import { useSession } from "@/runtime/session-context";
+import { getActiveBridge } from "@/runtime/ui-protocol-runtime";
+import {
+  removeLoop,
+  setGoal,
+  upsertLoop,
+  useAutonomyState,
+} from "@/store/autonomy-store";
+
+/** Terminal loop statuses the chip should not count as live. The server
+ *  filters `deleted` from `loop/list` already; `completed`/`expired`
+ *  arrive via `loop/completed` records. */
+const TERMINAL_LOOP_STATUSES = new Set(["deleted", "completed", "expired"]);
+
+function isLiveLoop(l: UiLoopRecord): boolean {
+  return !TERMINAL_LOOP_STATUSES.has(l.status);
+}
+
+function isLiveGoal(status: string): boolean {
+  return status === "active" || status === "paused";
+}
+
+function clip(text: string, max = 60): string {
+  const trimmed = text.trim();
+  return trimmed.length <= max ? trimmed : `${trimmed.slice(0, max - 1)}…`;
+}
+
+function relativeNextRun(nextRunAtMs: number | null | undefined): string | null {
+  if (typeof nextRunAtMs !== "number") return null;
+  const deltaSec = Math.round((nextRunAtMs - Date.now()) / 1000);
+  if (deltaSec <= 0) return "due now";
+  if (deltaSec < 90) return `next in ${deltaSec}s`;
+  if (deltaSec < 5400) return `next in ${Math.round(deltaSec / 60)}m`;
+  return `next in ${Math.round(deltaSec / 3600)}h`;
+}
+
+export function SessionAutonomyChip() {
+  const { currentSessionId, historyTopic } = useSession();
+  const { loops, goal } = useAutonomyState(currentSessionId, historyTopic);
+  const [open, setOpen] = useState(false);
+  // Loop ids (or "goal") with an in-flight control RPC.
+  const [busy, setBusy] = useState<Record<string, boolean>>({});
+  // Delete/clear are destructive → two-click confirm per row id.
+  const [armed, setArmed] = useState<string | null>(null);
+
+  // Menu state must not survive a session/topic switch (codex #260
+  // review class: destructive UI rendered over a different session).
+  useEffect(() => {
+    setOpen(false);
+    setBusy({});
+    setArmed(null);
+  }, [currentSessionId, historyTopic]);
+
+  const liveLoops = loops.filter(isLiveLoop);
+  const liveGoal = goal !== null && isLiveGoal(goal.status) ? goal : null;
+  if (liveLoops.length === 0 && liveGoal === null) return null;
+
+  const label =
+    liveLoops.length > 0 && liveGoal !== null
+      ? `${liveLoops.length === 1 ? "Loop" : `${liveLoops.length} loops`} + goal`
+      : liveLoops.length > 0
+        ? liveLoops.length === 1
+          ? liveLoops[0].status === "paused"
+            ? "Loop paused"
+            : "Loop"
+          : `${liveLoops.length} loops`
+        : "Goal";
+
+  function markBusy(id: string, value: boolean) {
+    setBusy((prev) => {
+      const next = { ...prev };
+      if (value) next[id] = true;
+      else delete next[id];
+      return next;
+    });
+  }
+
+  async function runLoopControl(
+    loop: UiLoopRecord,
+    kind: "pause" | "resume" | "delete",
+  ) {
+    const bridge = getActiveBridge(currentSessionId, historyTopic);
+    if (!bridge || typeof bridge.controlLoop !== "function") return;
+    markBusy(loop.loop_id, true);
+    try {
+      const result = await bridge.controlLoop(loop.loop_id, kind);
+      // Optimistic merge; the `loop/updated` notification confirms it.
+      if (kind === "delete") {
+        removeLoop(currentSessionId, loop.loop_id, historyTopic);
+      } else if (result.loop) {
+        upsertLoop(currentSessionId, result.loop, historyTopic);
+      }
+    } catch {
+      // Leave the row as-is so the user can retry.
+    } finally {
+      markBusy(loop.loop_id, false);
+      setArmed(null);
+    }
+  }
+
+  async function runGoalClear() {
+    const bridge = getActiveBridge(currentSessionId, historyTopic);
+    if (!bridge || typeof bridge.clearGoal !== "function") return;
+    markBusy("goal", true);
+    try {
+      await bridge.clearGoal();
+      setGoal(currentSessionId, null, historyTopic);
+    } catch {
+      // Retryable.
+    } finally {
+      markBusy("goal", false);
+      setArmed(null);
+    }
+  }
+
+  return (
+    <div className="relative inline-flex">
+      <button
+        type="button"
+        data-testid="session-autonomy-chip"
+        data-loop-count={liveLoops.length}
+        data-has-goal={liveGoal !== null ? "true" : "false"}
+        aria-haspopup="menu"
+        aria-expanded={open}
+        title="Session autonomy: recurring loops and goal"
+        onClick={() => setOpen((v) => !v)}
+        className="inline-flex items-center gap-1.5 rounded-[8px] px-1.5 py-0.5 text-[12px] font-medium text-text-strong hover:bg-surface-container"
+      >
+        {liveLoops.length > 0 ? <Repeat2 size={13} /> : <Target size={13} />}
+        <span className="truncate">{label}</span>
+      </button>
+
+      {open && (
+        <div
+          role="menu"
+          data-testid="session-autonomy-menu"
+          className="absolute right-0 top-full z-50 mt-1 w-80 rounded-[10px] border border-border bg-surface-container p-1 shadow-lg"
+        >
+          {liveLoops.map((loop) => {
+            const rowBusy = busy[loop.loop_id] === true;
+            const deleteArmed = armed === loop.loop_id;
+            const nextRun = relativeNextRun(loop.next_run_at_ms);
+            return (
+              <div
+                key={loop.loop_id}
+                className="flex items-center justify-between gap-2 rounded-[8px] px-2 py-1.5 hover:bg-surface"
+              >
+                <span className="min-w-0 flex-1">
+                  <span
+                    className="block truncate text-[12px] text-text"
+                    title={loop.prompt}
+                  >
+                    {clip(loop.prompt) || loop.mode || "loop"}
+                  </span>
+                  <span className="block text-[10px] text-muted">
+                    {loop.status}
+                    {nextRun ? ` · ${nextRun}` : ""}
+                  </span>
+                </span>
+                <button
+                  type="button"
+                  data-testid={`loop-toggle-${loop.loop_id}`}
+                  disabled={rowBusy}
+                  onClick={() =>
+                    void runLoopControl(
+                      loop,
+                      loop.status === "paused" ? "resume" : "pause",
+                    )
+                  }
+                  className="shrink-0 rounded-[6px] border border-border px-2 py-0.5 text-[11px] font-medium text-muted hover:text-text-strong disabled:opacity-60"
+                >
+                  {loop.status === "paused" ? "Resume" : "Pause"}
+                </button>
+                <button
+                  type="button"
+                  data-testid={`loop-delete-${loop.loop_id}`}
+                  disabled={rowBusy}
+                  onClick={() => {
+                    if (deleteArmed) void runLoopControl(loop, "delete");
+                    else setArmed(loop.loop_id);
+                  }}
+                  className={`shrink-0 rounded-[6px] border px-2 py-0.5 text-[11px] font-medium disabled:opacity-60 ${
+                    deleteArmed
+                      ? "border-rose-400 text-rose-300"
+                      : "border-border text-muted hover:border-rose-400 hover:text-rose-300"
+                  }`}
+                >
+                  {rowBusy
+                    ? "Working…"
+                    : deleteArmed
+                      ? "Confirm delete?"
+                      : "Delete"}
+                </button>
+              </div>
+            );
+          })}
+          {liveGoal !== null && (
+            <div
+              data-testid="goal-row"
+              className="flex items-center justify-between gap-2 rounded-[8px] px-2 py-1.5 hover:bg-surface"
+            >
+              <span className="min-w-0 flex-1">
+                <span
+                  className="block truncate text-[12px] text-text"
+                  title={liveGoal.objective}
+                >
+                  {clip(liveGoal.objective)}
+                </span>
+                <span className="block text-[10px] text-muted">
+                  goal · {liveGoal.status}
+                </span>
+              </span>
+              <button
+                type="button"
+                data-testid="goal-clear"
+                disabled={busy.goal === true}
+                onClick={() => {
+                  if (armed === "goal") void runGoalClear();
+                  else setArmed("goal");
+                }}
+                className={`shrink-0 rounded-[6px] border px-2 py-0.5 text-[11px] font-medium disabled:opacity-60 ${
+                  armed === "goal"
+                    ? "border-rose-400 text-rose-300"
+                    : "border-border text-muted hover:border-rose-400 hover:text-rose-300"
+                }`}
+              >
+                {busy.goal === true
+                  ? "Working…"
+                  : armed === "goal"
+                    ? "Confirm clear?"
+                    : "Clear"}
+              </button>
+            </div>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/components/session-autonomy-chip.tsx
+++ b/src/components/session-autonomy-chip.tsx
@@ -30,8 +30,17 @@ import {
  *  arrive via `loop/completed` records. */
 const TERMINAL_LOOP_STATUSES = new Set(["deleted", "completed", "expired"]);
 
-function isLiveLoop(l: UiLoopRecord): boolean {
-  return !TERMINAL_LOOP_STATUSES.has(l.status);
+/** Live = non-terminal status AND not past its own expiry (codex #263
+ *  round 1 P2): the backend enforces `expires_at_ms` by SKIPPING due
+ *  loops, without necessarily rewriting `status` or emitting
+ *  `loop/completed`, so an elapsed-but-still-"active" row would
+ *  otherwise pin the chip forever with ineffective controls. */
+function isLiveLoop(l: UiLoopRecord, nowMs: number): boolean {
+  if (TERMINAL_LOOP_STATUSES.has(l.status)) return false;
+  if (typeof l.expires_at_ms === "number" && l.expires_at_ms > 0) {
+    return l.expires_at_ms > nowMs;
+  }
+  return true;
 }
 
 function isLiveGoal(status: string): boolean {
@@ -69,7 +78,26 @@ export function SessionAutonomyChip() {
     setArmed(null);
   }, [currentSessionId, historyTopic]);
 
-  const liveLoops = loops.filter(isLiveLoop);
+  // Re-render when the earliest future expiry elapses so the chip
+  // retires expired rows without waiting for a server event. The tick
+  // is in the deps so each firing re-arms for the NEXT expiry.
+  const [expiryTick, setExpiryTick] = useState(0);
+  useEffect(() => {
+    const now = Date.now();
+    const future = loops
+      .map((l) => l.expires_at_ms)
+      .filter((t): t is number => typeof t === "number" && t > now);
+    if (future.length === 0) return;
+    const delay = Math.min(
+      Math.max(Math.min(...future) - now + 50, 250),
+      2_147_000_000,
+    );
+    const timer = setTimeout(() => setExpiryTick((v) => v + 1), delay);
+    return () => clearTimeout(timer);
+  }, [loops, expiryTick]);
+
+  const nowMs = Date.now();
+  const liveLoops = loops.filter((l) => isLiveLoop(l, nowMs));
   const liveGoal = goal !== null && isLiveGoal(goal.status) ? goal : null;
   if (liveLoops.length === 0 && liveGoal === null) return null;
 
@@ -152,7 +180,7 @@ export function SessionAutonomyChip() {
         <div
           role="menu"
           data-testid="session-autonomy-menu"
-          className="absolute right-0 top-full z-50 mt-1 w-80 rounded-[10px] border border-border bg-surface-container p-1 shadow-lg"
+          className="absolute right-0 top-full z-50 mt-1 max-h-[min(60vh,420px)] w-80 overflow-y-auto rounded-[10px] border border-border bg-surface-container p-1 shadow-lg"
         >
           {liveLoops.map((loop) => {
             const rowBusy = busy[loop.loop_id] === true;

--- a/src/layouts/chat-layout.tsx
+++ b/src/layouts/chat-layout.tsx
@@ -9,6 +9,7 @@ import { SessionList } from "@/components/session-list";
 import { ContentBrowser } from "@/components/content-browser";
 import { SessionTitleEditor } from "@/components/session-title-editor";
 import { SessionTaskIndicator } from "@/components/session-task-dock";
+import { SessionAutonomyChip } from "@/components/session-autonomy-chip";
 import { UiProtocolApprovalHost } from "@/components/ui-protocol-approval-host";
 import { UiProtocolQuestionHost } from "@/components/ui-protocol-question-host";
 import { useSession } from "@/runtime/session-context";
@@ -204,6 +205,7 @@ export function ChatLayout({ children }: { children: ReactNode }) {
                     testId="chat-session-title"
                   />
                 </div>
+                <SessionAutonomyChip />
                 <SessionTaskIndicator />
                 <button
                   onClick={() => setMediaPanelOpen((v) => !v)}

--- a/src/runtime/ui-protocol-bridge.test.ts
+++ b/src/runtime/ui-protocol-bridge.test.ts
@@ -1996,9 +1996,51 @@ describe("notification dispatch", () => {
       "medium",
     );
     await bridge.stop();
-  it("negotiates the M15 autonomy capabilities", () => {
+  });
+
+  it("negotiates the M15 autonomy capabilities incl. the umbrella token", () => {
+    // codex #263 round 1 P1: once ANY tokens are sent the server
+    // requires `coding.autonomy.v1` AND the runtime child — children
+    // alone reject every autonomy RPC with method_not_supported.
+    expect(UI_PROTOCOL_FEATURES).toContain("coding.autonomy.v1");
     expect(UI_PROTOCOL_FEATURES).toContain("coding.loop_runtime.v1");
     expect(UI_PROTOCOL_FEATURES).toContain("coding.goal_runtime.v1");
+  });
+
+  it("autonomy RPCs forward the bridge profile_id (admin-unscoped WS)", async () => {
+    // codex #263 round 1 P1: the server resolves these calls
+    // independently from `session/open` — on an unscoped connection an
+    // omitted profile_id defaults to the session key's profile or
+    // `_main`, silently missing / controlling the wrong profile.
+    const bridge = createUiProtocolBridge(makeBridgeOpts());
+    void bridge.start({ sessionId: "sess-1", profileId: "prof-y" });
+    await Promise.resolve();
+    const ws = lastInstance();
+    ws.triggerOpen();
+    await Promise.resolve();
+    const open = findRequest(ws, METHODS.SESSION_OPEN);
+    ws.triggerMessage({
+      jsonrpc: "2.0",
+      id: open.id,
+      result: { opened: { session_id: "sess-1" } },
+    });
+    await Promise.resolve();
+    // Swallow: stop() below rejects the never-answered RPCs.
+    void bridge.listLoops().catch(() => {});
+    void bridge.controlLoop("l1", "pause").catch(() => {});
+    void bridge.getGoal().catch(() => {});
+    void bridge.clearGoal().catch(() => {});
+    for (const method of [
+      METHODS.LOOP_LIST,
+      METHODS.LOOP_PAUSE,
+      METHODS.SESSION_GOAL_GET,
+      METHODS.SESSION_GOAL_CLEAR,
+    ]) {
+      const req = findRequest(ws, method);
+      expect(req.params?.profile_id).toBe("prof-y");
+      expect(req.params?.session_id).toBe("sess-1");
+    }
+    await bridge.stop();
   });
 
   it("listLoops sends the scoped session id and guards the rows", async () => {

--- a/src/runtime/ui-protocol-bridge.test.ts
+++ b/src/runtime/ui-protocol-bridge.test.ts
@@ -23,6 +23,7 @@ import {
   vi,
 } from "vitest";
 import {
+  UI_PROTOCOL_FEATURES,
   BridgeRpcError,
   BridgeStoppedError,
   BridgeTimeoutError,
@@ -1995,6 +1996,117 @@ describe("notification dispatch", () => {
       "medium",
     );
     await bridge.stop();
+  it("negotiates the M15 autonomy capabilities", () => {
+    expect(UI_PROTOCOL_FEATURES).toContain("coding.loop_runtime.v1");
+    expect(UI_PROTOCOL_FEATURES).toContain("coding.goal_runtime.v1");
+  });
+
+  it("listLoops sends the scoped session id and guards the rows", async () => {
+    const { bridge, ws } = await freshConnected();
+    const call = bridge.listLoops();
+    const req = findRequest(ws, METHODS.LOOP_LIST);
+    expect(req.params?.session_id).toBe("sess-1");
+    ws.triggerMessage({
+      jsonrpc: "2.0",
+      id: req.id,
+      result: {
+        loops: [
+          {
+            loop_id: "l1",
+            session_id: "sess-1",
+            prompt: "p",
+            mode: "interval",
+            status: "active",
+            expires_at_ms: 0,
+            created_at_ms: 1,
+            updated_at_ms: 1,
+          },
+          { rubbish: true },
+        ],
+      },
+    });
+    const loops = await call;
+    expect(loops.map((l) => l.loop_id)).toEqual(["l1"]);
+  });
+
+  it("controlLoop maps pause/resume/delete onto their methods", async () => {
+    const { bridge, ws } = await freshConnected();
+    void bridge.controlLoop("l1", "pause");
+    expect(findRequest(ws, METHODS.LOOP_PAUSE).params?.loop_id).toBe("l1");
+    void bridge.controlLoop("l1", "resume");
+    expect(findRequest(ws, METHODS.LOOP_RESUME).params?.loop_id).toBe("l1");
+    void bridge.controlLoop("l1", "delete");
+    expect(findRequest(ws, METHODS.LOOP_DELETE).params?.loop_id).toBe("l1");
+  });
+
+  it("routes loop/updated through the guard to onLoopUpdated", async () => {
+    const { bridge, ws } = await freshConnected();
+    const seen: unknown[] = [];
+    bridge.onLoopUpdated((e) => seen.push(e));
+    // Malformed (no loop record) → dropped by the guard.
+    ws.triggerMessage({
+      jsonrpc: "2.0",
+      method: METHODS.LOOP_UPDATED,
+      params: { session_id: "sess-1" },
+    });
+    expect(seen).toHaveLength(0);
+    ws.triggerMessage({
+      jsonrpc: "2.0",
+      method: METHODS.LOOP_UPDATED,
+      params: {
+        session_id: "sess-1",
+        loop_id: "l1",
+        loop: {
+          loop_id: "l1",
+          session_id: "sess-1",
+          prompt: "p",
+          mode: "interval",
+          status: "paused",
+          expires_at_ms: 0,
+          created_at_ms: 1,
+          updated_at_ms: 2,
+        },
+        ok: true,
+        status: "paused",
+      },
+    });
+    expect(seen).toHaveLength(1);
+    expect((seen[0] as { loop: { status: string } }).loop.status).toBe(
+      "paused",
+    );
+  });
+
+  it("routes session/goal/updated and /cleared to their handlers", async () => {
+    const { bridge, ws } = await freshConnected();
+    const updated: unknown[] = [];
+    const cleared: unknown[] = [];
+    bridge.onGoalUpdated((e) => updated.push(e));
+    bridge.onGoalCleared((e) => cleared.push(e));
+    ws.triggerMessage({
+      jsonrpc: "2.0",
+      method: METHODS.SESSION_GOAL_UPDATED,
+      params: {
+        session_id: "sess-1",
+        goal: {
+          goal_id: "g1",
+          objective: "o",
+          status: "active",
+          token_budget: 1,
+          tokens_used: 0,
+          time_used_seconds: 0,
+          created_at_ms: 1,
+          updated_at_ms: 1,
+        },
+        transition_actor: "user",
+      },
+    });
+    ws.triggerMessage({
+      jsonrpc: "2.0",
+      method: METHODS.SESSION_GOAL_CLEARED,
+      params: { session_id: "sess-1", cleared: true, transition_actor: "user" },
+    });
+    expect(updated).toHaveLength(1);
+    expect(cleared).toHaveLength(1);
   });
 
   it("sendTurn omits live_video when not set (byte-identical legacy shape)", async () => {

--- a/src/runtime/ui-protocol-bridge.ts
+++ b/src/runtime/ui-protocol-bridge.ts
@@ -318,6 +318,13 @@ export const UI_PROTOCOL_FEATURES = [
   // (`autonomy_method_available` → `loop_runtime_available()` /
   // `goal_runtime_available()`), so without the tokens the header
   // autonomy chip's list/control calls all return method_not_supported.
+  //
+  // codex #263 round 1 P1: once a client sends ANY feature tokens the
+  // server requires the UMBRELLA `coding.autonomy.v1` in ADDITION to
+  // each runtime child (`loop_runtime_available()` = autonomy && loop;
+  // `goal_runtime_available()` = autonomy && goal). Children alone →
+  // every autonomy RPC rejects.
+  "coding.autonomy.v1",
   "coding.loop_runtime.v1",
   "coding.goal_runtime.v1",
 ] as const;
@@ -2408,10 +2415,25 @@ class UiProtocolBridgeImpl implements UiProtocolBridge {
   }
 
   /** `loop/list` for this scope. Requires `coding.loop_runtime.v1`. */
-  async listLoops(): Promise<UiLoopRecord[]> {
-    const raw = await this.request<unknown>(METHODS.LOOP_LIST, {
+  /** Params shared by every autonomy RPC. The server resolves these
+   *  calls independently from `session/open`: on an admin/unscoped
+   *  connection an omitted `profile_id` falls back to the session key's
+   *  embedded profile or `_main`, so a bridge viewing a non-main
+   *  profile must forward it explicitly (codex #263 round 1 P1). */
+  private autonomyParams(extra?: Record<string, unknown>): Record<string, unknown> {
+    const params: Record<string, unknown> = {
       session_id: this.requireScopedSessionId(),
-    });
+      ...extra,
+    };
+    if (this.profileId) params.profile_id = this.profileId;
+    return params;
+  }
+
+  async listLoops(): Promise<UiLoopRecord[]> {
+    const raw = await this.request<unknown>(
+      METHODS.LOOP_LIST,
+      this.autonomyParams(),
+    );
     const record = raw as LoopListResult;
     if (!Array.isArray(record?.loops)) return [];
     const loops: UiLoopRecord[] = [];
@@ -2436,10 +2458,10 @@ class UiProtocolBridgeImpl implements UiProtocolBridge {
         : kind === "resume"
           ? METHODS.LOOP_RESUME
           : METHODS.LOOP_DELETE;
-    const raw = await this.request<unknown>(method, {
-      loop_id: loopId,
-      session_id: this.requireScopedSessionId(),
-    });
+    const raw = await this.request<unknown>(
+      method,
+      this.autonomyParams({ loop_id: loopId }),
+    );
     const record = raw as {
       ok?: unknown;
       status?: unknown;
@@ -2456,9 +2478,10 @@ class UiProtocolBridgeImpl implements UiProtocolBridge {
 
   /** `session/goal/get`. Requires `coding.goal_runtime.v1`. */
   async getGoal(): Promise<UiGoalRecord | null> {
-    const raw = await this.request<unknown>(METHODS.SESSION_GOAL_GET, {
-      session_id: this.requireScopedSessionId(),
-    });
+    const raw = await this.request<unknown>(
+      METHODS.SESSION_GOAL_GET,
+      this.autonomyParams(),
+    );
     const record = raw as SessionGoalGetResult;
     return guardGoalRecord(record?.goal);
   }
@@ -2466,9 +2489,10 @@ class UiProtocolBridgeImpl implements UiProtocolBridge {
   /** `session/goal/clear`. Returns the cleared goal when the server
    *  echoes it. */
   async clearGoal(): Promise<UiGoalRecord | null> {
-    const raw = await this.request<unknown>(METHODS.SESSION_GOAL_CLEAR, {
-      session_id: this.requireScopedSessionId(),
-    });
+    const raw = await this.request<unknown>(
+      METHODS.SESSION_GOAL_CLEAR,
+      this.autonomyParams(),
+    );
     const record = raw as { goal?: unknown };
     return guardGoalRecord(record?.goal);
   }

--- a/src/runtime/ui-protocol-bridge.ts
+++ b/src/runtime/ui-protocol-bridge.ts
@@ -48,6 +48,16 @@ import type {
   SessionOpenedResult,
   SessionOpenResult,
   TaskOutputDeltaEvent,
+  UiLoopRecord,
+  UiGoalRecord,
+  LoopUpdatedEvent,
+  LoopFiredEvent,
+  LoopCompletedEvent,
+  SessionGoalUpdatedEvent,
+  SessionGoalClearedEvent,
+  LoopListResult,
+  LoopControlResult,
+  SessionGoalGetResult,
   TaskUpdatedEvent,
   ToolCompletedEvent,
   ToolProgressEvent,
@@ -94,6 +104,14 @@ export type {
   SessionOpenResult,
   SessionOpenedResult,
   TaskOutputDeltaEvent,
+  UiLoopRecord,
+  UiGoalRecord,
+  LoopUpdatedEvent,
+  LoopFiredEvent,
+  LoopCompletedEvent,
+  SessionGoalUpdatedEvent,
+  SessionGoalClearedEvent,
+  LoopControlResult,
   TaskUpdatedEvent,
   ToolCompletedEvent,
   ToolProgressEvent,
@@ -132,6 +150,12 @@ export const METHODS = {
   // client → server
   SESSION_OPEN: "session/open",
   SESSION_HYDRATE: "session/hydrate",
+  LOOP_LIST: "loop/list",
+  LOOP_PAUSE: "loop/pause",
+  LOOP_RESUME: "loop/resume",
+  LOOP_DELETE: "loop/delete",
+  SESSION_GOAL_GET: "session/goal/get",
+  SESSION_GOAL_CLEAR: "session/goal/clear",
   TURN_START: "turn/start",
   TURN_INTERRUPT: "turn/interrupt",
   APPROVAL_RESPOND: "approval/respond",
@@ -161,6 +185,11 @@ export const METHODS = {
   MESSAGE_DELTA: "message/delta",
   MESSAGE_PERSISTED: "message/persisted",
   TASK_UPDATED: "task/updated",
+  LOOP_UPDATED: "loop/updated",
+  LOOP_FIRED: "loop/fired",
+  LOOP_COMPLETED: "loop/completed",
+  SESSION_GOAL_UPDATED: "session/goal/updated",
+  SESSION_GOAL_CLEARED: "session/goal/cleared",
   TASK_OUTPUT_DELTA: "task/output/delta",
   TURN_STARTED: "turn/started",
   TURN_COMPLETED: "turn/completed",
@@ -284,6 +313,13 @@ export const UI_PROTOCOL_FEATURES = [
   // the SPA's compaction indicator is unreachable in production (the
   // same gap octos-tui#253 fixed for the TUI).
   "context.lifecycle.v1",
+  // M15 autonomy visibility (web parity P2): the server gates every
+  // loop/goal RPC on these negotiated capabilities
+  // (`autonomy_method_available` → `loop_runtime_available()` /
+  // `goal_runtime_available()`), so without the tokens the header
+  // autonomy chip's list/control calls all return method_not_supported.
+  "coding.loop_runtime.v1",
+  "coding.goal_runtime.v1",
 ] as const;
 
 /**
@@ -405,6 +441,22 @@ export interface UiProtocolBridge {
   hydrateSession(
     include?: ReadonlyArray<"messages" | "threads" | "turns" | "pending_approvals">,
   ): Promise<SessionHydrateResult | null>;
+
+  /** M15 autonomy visibility (negotiated behind `coding.loop_runtime.v1`
+   *  / `coding.goal_runtime.v1`). List/control this scope's recurring
+   *  loops and read/clear its persisted goal. */
+  listLoops(): Promise<UiLoopRecord[]>;
+  controlLoop(
+    loopId: string,
+    kind: "pause" | "resume" | "delete",
+  ): Promise<LoopControlResult>;
+  getGoal(): Promise<UiGoalRecord | null>;
+  clearGoal(): Promise<UiGoalRecord | null>;
+  onLoopUpdated(handler: (e: LoopUpdatedEvent) => void): () => void;
+  onLoopFired(handler: (e: LoopFiredEvent) => void): () => void;
+  onLoopCompleted(handler: (e: LoopCompletedEvent) => void): () => void;
+  onGoalUpdated(handler: (e: SessionGoalUpdatedEvent) => void): () => void;
+  onGoalCleared(handler: (e: SessionGoalClearedEvent) => void): () => void;
 
   /**
    * Generic JSON-RPC request escape hatch.
@@ -1163,6 +1215,117 @@ function guardTaskUpdated(p: unknown): TaskUpdatedEvent | null {
   };
 }
 
+/** Minimal structural check for a wire `UiLoopRecord`. Field-tolerant —
+ *  only identity + display essentials are required; numeric bookkeeping
+ *  fields default to 0 so a future server adding/omitting one cannot
+ *  drop the whole notification. */
+function guardLoopRecord(p: unknown): UiLoopRecord | null {
+  if (!isPlainObject(p)) return null;
+  if (!isString(p.loop_id) || !isString(p.session_id)) return null;
+  if (!isString(p.status)) return null;
+  return {
+    loop_id: p.loop_id,
+    session_id: p.session_id,
+    profile_id: isString(p.profile_id) ? p.profile_id : null,
+    prompt: isString(p.prompt) ? p.prompt : "",
+    mode: isString(p.mode) ? p.mode : "",
+    interval_seconds:
+      typeof p.interval_seconds === "number" ? p.interval_seconds : null,
+    status: p.status,
+    next_run_at_ms:
+      typeof p.next_run_at_ms === "number" ? p.next_run_at_ms : null,
+    last_run_at_ms:
+      typeof p.last_run_at_ms === "number" ? p.last_run_at_ms : null,
+    expires_at_ms: typeof p.expires_at_ms === "number" ? p.expires_at_ms : 0,
+    created_at_ms: typeof p.created_at_ms === "number" ? p.created_at_ms : 0,
+    updated_at_ms: typeof p.updated_at_ms === "number" ? p.updated_at_ms : 0,
+  };
+}
+
+function guardGoalRecord(p: unknown): UiGoalRecord | null {
+  if (!isPlainObject(p)) return null;
+  if (!isString(p.goal_id) || !isString(p.objective) || !isString(p.status)) {
+    return null;
+  }
+  return {
+    profile_id: isString(p.profile_id) ? p.profile_id : null,
+    goal_id: p.goal_id,
+    objective: p.objective,
+    status: p.status,
+    token_budget: typeof p.token_budget === "number" ? p.token_budget : 0,
+    tokens_used: typeof p.tokens_used === "number" ? p.tokens_used : 0,
+    time_used_seconds:
+      typeof p.time_used_seconds === "number" ? p.time_used_seconds : 0,
+    created_at_ms: typeof p.created_at_ms === "number" ? p.created_at_ms : 0,
+    updated_at_ms: typeof p.updated_at_ms === "number" ? p.updated_at_ms : 0,
+  };
+}
+
+function guardLoopUpdated(p: unknown): LoopUpdatedEvent | null {
+  if (!isPlainObject(p)) return null;
+  if (!isString(p.session_id)) return null;
+  const loop = guardLoopRecord(p.loop);
+  if (!loop) return null;
+  return {
+    session_id: p.session_id,
+    loop_id: isString(p.loop_id) ? p.loop_id : loop.loop_id,
+    loop,
+    ok: typeof p.ok === "boolean" ? p.ok : undefined,
+    status: isString(p.status) ? p.status : undefined,
+    deleted: typeof p.deleted === "boolean" ? p.deleted : undefined,
+  };
+}
+
+function guardLoopFired(p: unknown): LoopFiredEvent | null {
+  if (!isPlainObject(p)) return null;
+  if (!isString(p.session_id) || !isString(p.loop_id)) return null;
+  return {
+    session_id: p.session_id,
+    loop_id: p.loop_id,
+    loop: guardLoopRecord(p.loop) ?? undefined,
+    status: isString(p.status) ? p.status : undefined,
+  };
+}
+
+function guardLoopCompleted(p: unknown): LoopCompletedEvent | null {
+  if (!isPlainObject(p)) return null;
+  if (!isString(p.session_id) || !isString(p.loop_id)) return null;
+  return {
+    session_id: p.session_id,
+    loop_id: p.loop_id,
+    loop: guardLoopRecord(p.loop) ?? undefined,
+    status: isString(p.status) ? p.status : undefined,
+    error: isString(p.error) ? p.error : undefined,
+  };
+}
+
+function guardGoalUpdated(p: unknown): SessionGoalUpdatedEvent | null {
+  if (!isPlainObject(p)) return null;
+  if (!isString(p.session_id)) return null;
+  const goal = guardGoalRecord(p.goal);
+  if (!goal) return null;
+  return {
+    session_id: p.session_id,
+    goal,
+    transition_actor: isString(p.transition_actor)
+      ? p.transition_actor
+      : undefined,
+  };
+}
+
+function guardGoalCleared(p: unknown): SessionGoalClearedEvent | null {
+  if (!isPlainObject(p)) return null;
+  if (!isString(p.session_id)) return null;
+  return {
+    session_id: p.session_id,
+    cleared: typeof p.cleared === "boolean" ? p.cleared : undefined,
+    goal: guardGoalRecord(p.goal),
+    transition_actor: isString(p.transition_actor)
+      ? p.transition_actor
+      : undefined,
+  };
+}
+
 function guardTaskOutputDelta(p: unknown): TaskOutputDeltaEvent | null {
   if (!isPlainObject(p)) return null;
   // Same relaxation as `guardTaskUpdated`: server-side struct has no
@@ -1762,6 +1925,13 @@ class UiProtocolBridgeImpl implements UiProtocolBridge {
   private readonly subVisualFailed = new Subscribers<VisualFailedEvent>();
   private readonly subVoiceExit = new Subscribers<VoiceExitEvent>();
   private readonly subTaskUpdated = new Subscribers<TaskUpdatedEvent>();
+  private readonly subLoopUpdated = new Subscribers<LoopUpdatedEvent>();
+  private readonly subLoopFired = new Subscribers<LoopFiredEvent>();
+  private readonly subLoopCompleted = new Subscribers<LoopCompletedEvent>();
+  private readonly subGoalUpdated =
+    new Subscribers<SessionGoalUpdatedEvent>();
+  private readonly subGoalCleared =
+    new Subscribers<SessionGoalClearedEvent>();
   private readonly subTaskOutputDelta = new Subscribers<TaskOutputDeltaEvent>();
   private readonly subContextCompaction = new Subscribers<
     ContextCompactionStartedEvent | ContextCompactionCompletedEvent
@@ -1840,6 +2010,26 @@ class UiProtocolBridgeImpl implements UiProtocolBridge {
     [METHODS.TASK_UPDATED]: {
       guard: guardTaskUpdated,
       emit: (v) => this.subTaskUpdated.emit(v as TaskUpdatedEvent),
+    },
+    [METHODS.LOOP_UPDATED]: {
+      guard: guardLoopUpdated,
+      emit: (v) => this.subLoopUpdated.emit(v as LoopUpdatedEvent),
+    },
+    [METHODS.LOOP_FIRED]: {
+      guard: guardLoopFired,
+      emit: (v) => this.subLoopFired.emit(v as LoopFiredEvent),
+    },
+    [METHODS.LOOP_COMPLETED]: {
+      guard: guardLoopCompleted,
+      emit: (v) => this.subLoopCompleted.emit(v as LoopCompletedEvent),
+    },
+    [METHODS.SESSION_GOAL_UPDATED]: {
+      guard: guardGoalUpdated,
+      emit: (v) => this.subGoalUpdated.emit(v as SessionGoalUpdatedEvent),
+    },
+    [METHODS.SESSION_GOAL_CLEARED]: {
+      guard: guardGoalCleared,
+      emit: (v) => this.subGoalCleared.emit(v as SessionGoalClearedEvent),
     },
     [METHODS.TASK_OUTPUT_DELTA]: {
       guard: guardTaskOutputDelta,
@@ -2045,6 +2235,11 @@ class UiProtocolBridgeImpl implements UiProtocolBridge {
     this.subRouterStatus.clear();
     this.subRouterFailover.clear();
     this.subQueueState.clear();
+    this.subLoopUpdated.clear();
+    this.subLoopFired.clear();
+    this.subLoopCompleted.clear();
+    this.subGoalUpdated.clear();
+    this.subGoalCleared.clear();
     this.subWarning.clear();
     this.subState.clear();
     this.subSessionOpened.clear();
@@ -2212,6 +2407,72 @@ class UiProtocolBridgeImpl implements UiProtocolBridge {
     }
   }
 
+  /** `loop/list` for this scope. Requires `coding.loop_runtime.v1`. */
+  async listLoops(): Promise<UiLoopRecord[]> {
+    const raw = await this.request<unknown>(METHODS.LOOP_LIST, {
+      session_id: this.requireScopedSessionId(),
+    });
+    const record = raw as LoopListResult;
+    if (!Array.isArray(record?.loops)) return [];
+    const loops: UiLoopRecord[] = [];
+    for (const entry of record.loops) {
+      const guarded = guardLoopRecord(entry);
+      if (guarded) loops.push(guarded);
+    }
+    return loops;
+  }
+
+  /** loop/pause | loop/resume | loop/delete on one loop. */
+  async controlLoop(
+    loopId: string,
+    kind: "pause" | "resume" | "delete",
+  ): Promise<LoopControlResult> {
+    if (!isString(loopId) || loopId.length === 0) {
+      throw new Error("ui-protocol-bridge: controlLoop requires loopId");
+    }
+    const method =
+      kind === "pause"
+        ? METHODS.LOOP_PAUSE
+        : kind === "resume"
+          ? METHODS.LOOP_RESUME
+          : METHODS.LOOP_DELETE;
+    const raw = await this.request<unknown>(method, {
+      loop_id: loopId,
+      session_id: this.requireScopedSessionId(),
+    });
+    const record = raw as {
+      ok?: unknown;
+      status?: unknown;
+      loop_id?: unknown;
+      loop?: unknown;
+    };
+    return {
+      ok: typeof record?.ok === "boolean" ? record.ok : undefined,
+      status: isString(record?.status) ? record.status : undefined,
+      loop_id: isString(record?.loop_id) ? record.loop_id : undefined,
+      loop: guardLoopRecord(record?.loop) ?? undefined,
+    };
+  }
+
+  /** `session/goal/get`. Requires `coding.goal_runtime.v1`. */
+  async getGoal(): Promise<UiGoalRecord | null> {
+    const raw = await this.request<unknown>(METHODS.SESSION_GOAL_GET, {
+      session_id: this.requireScopedSessionId(),
+    });
+    const record = raw as SessionGoalGetResult;
+    return guardGoalRecord(record?.goal);
+  }
+
+  /** `session/goal/clear`. Returns the cleared goal when the server
+   *  echoes it. */
+  async clearGoal(): Promise<UiGoalRecord | null> {
+    const raw = await this.request<unknown>(METHODS.SESSION_GOAL_CLEAR, {
+      session_id: this.requireScopedSessionId(),
+    });
+    const record = raw as { goal?: unknown };
+    return guardGoalRecord(record?.goal);
+  }
+
   callMethod<T = unknown>(method: string, params?: unknown): Promise<T> {
     if (!isString(method)) {
       return Promise.reject(
@@ -2244,6 +2505,21 @@ class UiProtocolBridgeImpl implements UiProtocolBridge {
   }
   onVoiceExit(handler: Listener<VoiceExitEvent>): () => void {
     return this.subVoiceExit.add(handler);
+  }
+  onLoopUpdated(handler: Listener<LoopUpdatedEvent>): () => void {
+    return this.subLoopUpdated.add(handler);
+  }
+  onLoopFired(handler: Listener<LoopFiredEvent>): () => void {
+    return this.subLoopFired.add(handler);
+  }
+  onLoopCompleted(handler: Listener<LoopCompletedEvent>): () => void {
+    return this.subLoopCompleted.add(handler);
+  }
+  onGoalUpdated(handler: Listener<SessionGoalUpdatedEvent>): () => void {
+    return this.subGoalUpdated.add(handler);
+  }
+  onGoalCleared(handler: Listener<SessionGoalClearedEvent>): () => void {
+    return this.subGoalCleared.add(handler);
   }
   onTaskUpdated(handler: Listener<TaskUpdatedEvent>): () => void {
     return this.subTaskUpdated.add(handler);

--- a/src/runtime/ui-protocol-event-router.test.ts
+++ b/src/runtime/ui-protocol-event-router.test.ts
@@ -14,6 +14,7 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
 import * as ThreadStore from "@/store/thread-store";
 import * as TaskStore from "@/store/task-store";
+import * as AutonomyStore from "@/store/autonomy-store";
 import {
   __resetProjectionForTests,
   __setProjectionV1ForTests,
@@ -22,6 +23,10 @@ import {
 } from "@/store/projection-store";
 import { project } from "@/store/projection";
 import {
+  handleLoopUpdated,
+  handleLoopCompleted,
+  handleGoalUpdated,
+  handleGoalCleared,
   __resetRouterStateForTest,
   __resetTurnMetaForTest,
   attachRouter,
@@ -4312,5 +4317,76 @@ describe("Wave4-A: queue/state fans out into crew:queue_state", () => {
     const detail = (dispatched[0] as CustomEvent).detail;
     expect(detail.pendingCount).toBe(3);
     expect(detail.head).toBe("cmid-head");
+  });
+});
+
+describe("autonomy handlers → autonomy-store", () => {
+  const cfg = { sessionId: SESSION, dispatchEvent: () => {} };
+  const baseLoop = {
+    loop_id: "l-router",
+    session_id: SESSION,
+    prompt: "p",
+    mode: "interval" as const,
+    status: "active",
+    expires_at_ms: 0,
+    created_at_ms: 1,
+    updated_at_ms: 1,
+  };
+
+  afterEach(() => {
+    AutonomyStore.__resetAutonomyStoreForTest();
+  });
+
+  it("loop/updated upserts; deleted flag removes", () => {
+    handleLoopUpdated(cfg, {
+      session_id: SESSION,
+      loop_id: "l-router",
+      loop: { ...baseLoop, status: "paused" },
+    });
+    expect(
+      AutonomyStore.getAutonomyState(SESSION).loops[0]?.status,
+    ).toBe("paused");
+    handleLoopUpdated(cfg, {
+      session_id: SESSION,
+      loop_id: "l-router",
+      loop: { ...baseLoop, status: "paused" },
+      deleted: true,
+    });
+    expect(AutonomyStore.getAutonomyState(SESSION).loops).toHaveLength(0);
+  });
+
+  it("loop/completed without a record drops the row so the chip clears", () => {
+    handleLoopUpdated(cfg, {
+      session_id: SESSION,
+      loop_id: "l-router",
+      loop: baseLoop,
+    });
+    handleLoopCompleted(cfg, {
+      session_id: SESSION,
+      loop_id: "l-router",
+      status: "completed",
+    });
+    expect(AutonomyStore.getAutonomyState(SESSION).loops).toHaveLength(0);
+  });
+
+  it("goal updated/cleared round-trip", () => {
+    handleGoalUpdated(cfg, {
+      session_id: SESSION,
+      goal: {
+        goal_id: "g-router",
+        objective: "o",
+        status: "active",
+        token_budget: 1,
+        tokens_used: 0,
+        time_used_seconds: 0,
+        created_at_ms: 1,
+        updated_at_ms: 1,
+      },
+    });
+    expect(AutonomyStore.getAutonomyState(SESSION).goal?.goal_id).toBe(
+      "g-router",
+    );
+    handleGoalCleared(cfg, { session_id: SESSION, cleared: true });
+    expect(AutonomyStore.getAutonomyState(SESSION).goal).toBe(null);
   });
 });

--- a/src/runtime/ui-protocol-event-router.ts
+++ b/src/runtime/ui-protocol-event-router.ts
@@ -23,6 +23,12 @@
  */
 
 import type {
+  LoopUpdatedEvent,
+  LoopFiredEvent,
+  LoopCompletedEvent,
+  SessionGoalUpdatedEvent,
+  SessionGoalClearedEvent,
+
   ApprovalRequestedEvent,
   ApprovalAutoResolvedEvent,
   UserQuestionRequestedEvent,
@@ -55,6 +61,7 @@ import type { MessageInfo } from "@/api/types";
 import { recordRuntimeCounter } from "./observability";
 import { isSpawnOnlyToolName } from "./spawn-only-tools";
 import { aggregateCallStatus } from "./task-rollup";
+import * as AutonomyStore from "@/store/autonomy-store";
 
 // ---------------------------------------------------------------------------
 // Per-turn meta snapshot
@@ -1918,6 +1925,60 @@ function handleVoiceExit(cfg: RouterConfig, event: VoiceExitEvent): void {
  * removes every listener registered here — call it before swapping the
  * bridge out (e.g. session change) to avoid event leaks.
  */
+/** M15 autonomy visibility — merge loop/goal notifications into the
+ *  autonomy store the header chip reads. Scoped by the router cfg (same
+ *  convention as `handleTaskUpdated`): the bridge only delivers this
+ *  scope's envelopes. A `loop/updated` carrying `deleted` (or a
+ *  tombstone `status === "deleted"`) removes the row. */
+export function handleLoopUpdated(
+  cfg: RouterConfig,
+  event: LoopUpdatedEvent,
+): void {
+  if (event.deleted === true || event.loop.status === "deleted") {
+    AutonomyStore.removeLoop(cfg.sessionId, event.loop.loop_id, cfg.topic);
+    return;
+  }
+  AutonomyStore.upsertLoop(cfg.sessionId, event.loop, cfg.topic);
+}
+
+export function handleLoopFired(
+  cfg: RouterConfig,
+  event: LoopFiredEvent,
+): void {
+  if (event.loop) {
+    AutonomyStore.upsertLoop(cfg.sessionId, event.loop, cfg.topic);
+  }
+}
+
+export function handleLoopCompleted(
+  cfg: RouterConfig,
+  event: LoopCompletedEvent,
+): void {
+  if (event.loop) {
+    AutonomyStore.upsertLoop(cfg.sessionId, event.loop, cfg.topic);
+    return;
+  }
+  // Terminal without a record — drop the row so the chip clears.
+  AutonomyStore.removeLoop(cfg.sessionId, event.loop_id, cfg.topic);
+}
+
+export function handleGoalUpdated(
+  cfg: RouterConfig,
+  event: SessionGoalUpdatedEvent,
+): void {
+  AutonomyStore.setGoal(cfg.sessionId, event.goal, cfg.topic);
+}
+
+export function handleGoalCleared(
+  cfg: RouterConfig,
+  // The event payload carries no state the store needs — a clear is a
+  // clear. Keep the param for the uniform (cfg, event) handler shape.
+  event: SessionGoalClearedEvent,
+): void {
+  void event;
+  AutonomyStore.setGoal(cfg.sessionId, null, cfg.topic);
+}
+
 export function attachRouter(
   bridge: UiProtocolBridge,
   cfg: RouterConfig,
@@ -1993,6 +2054,21 @@ export function attachRouter(
           };
     dispatch(cfg, new CustomEvent("crew:compaction", { detail }));
   });
+  // M15 autonomy chip feeds. Optional-called — test mocks predating the
+  // loop/goal surface simply don't wire them.
+  const offLoopUpdated = bridge.onLoopUpdated?.((e) =>
+    handleLoopUpdated(cfg, e),
+  );
+  const offLoopFired = bridge.onLoopFired?.((e) => handleLoopFired(cfg, e));
+  const offLoopCompleted = bridge.onLoopCompleted?.((e) =>
+    handleLoopCompleted(cfg, e),
+  );
+  const offGoalUpdated = bridge.onGoalUpdated?.((e) =>
+    handleGoalUpdated(cfg, e),
+  );
+  const offGoalCleared = bridge.onGoalCleared?.((e) =>
+    handleGoalCleared(cfg, e),
+  );
   const offToolStarted = bridge.onToolStarted((e) => handleToolStarted(cfg, e));
   const offToolProgress = bridge.onToolProgress((e) =>
     handleToolProgress(cfg, e),
@@ -2053,6 +2129,11 @@ export function attachRouter(
       offToolCompleted();
       offProgressUpdated();
       offContextCompaction?.();
+      offLoopUpdated?.();
+      offLoopFired?.();
+      offLoopCompleted?.();
+      offGoalUpdated?.();
+      offGoalCleared?.();
       offRouterStatus();
       offRouterFailover();
       offQueueState();

--- a/src/runtime/ui-protocol-runtime.test.ts
+++ b/src/runtime/ui-protocol-runtime.test.ts
@@ -40,6 +40,7 @@ import {
   stopActiveBridge,
 } from "./ui-protocol-runtime";
 import * as ThreadStore from "@/store/thread-store";
+import * as AutonomyStore from "@/store/autonomy-store";
 import type { UiProtocolBridge } from "./ui-protocol-bridge";
 import type { ConnectionState } from "./ui-protocol-types";
 
@@ -155,6 +156,7 @@ beforeEach(() => {
 afterEach(() => {
   __resetUiProtocolRuntimeForTest();
   ThreadStore.__resetForTests();
+  AutonomyStore.__resetAutonomyStoreForTest();
 });
 
 describe("startBridgeForSession race safety", () => {
@@ -514,5 +516,85 @@ describe("reload-bug fix: re-hydrate session on WS reconnect", () => {
     await Promise.resolve();
     await Promise.resolve();
     expect(a.bridge.hydrateSession).not.toHaveBeenCalled();
+  });
+});
+
+describe("autonomy snapshot resilience (codex #263 round 1 P2)", () => {
+  const GOAL = {
+    goal_id: "g1",
+    objective: "stay green",
+    status: "active",
+    token_budget: 1000,
+    tokens_used: 1,
+    time_used_seconds: 1,
+    created_at_ms: 1,
+    updated_at_ms: 1,
+  };
+  const LOOP = {
+    loop_id: "l1",
+    session_id: "sess-snap",
+    prompt: "poll",
+    mode: "interval",
+    interval_seconds: 60,
+    status: "active",
+    expires_at_ms: 0,
+    created_at_ms: 1,
+    updated_at_ms: 1,
+  };
+
+  async function startWithAutonomy(
+    listLoops: () => Promise<unknown>,
+    getGoal: () => Promise<unknown>,
+  ) {
+    const deferred = makeDeferredBridge();
+    Object.assign(deferred.bridge, { listLoops, getGoal });
+    createBridgeSpy.mockReturnValueOnce(deferred.bridge);
+    const start = startBridgeForSession("sess-snap");
+    deferred.resolveStart();
+    await start;
+    // The snapshot runs as a void async — flush its microtasks.
+    await new Promise((resolve) => setTimeout(resolve, 0));
+  }
+
+  it("preserves a live goal when the snapshot goal read FAILS", async () => {
+    // A goal is already known (prior load or live goal/updated). A
+    // rejected `getGoal` (timeout, reconnect blip, unsupported) must
+    // NOT masquerade as the authoritative "no goal" null and wipe it.
+    AutonomyStore.setGoal("sess-snap", GOAL);
+    await startWithAutonomy(
+      async () => [LOOP],
+      async () => {
+        throw new Error("rpc timeout");
+      },
+    );
+    expect(AutonomyStore.getAutonomyState("sess-snap").goal?.goal_id).toBe(
+      "g1",
+    );
+    // The loop read succeeded independently and still applied.
+    expect(
+      AutonomyStore.getAutonomyState("sess-snap").loops.map((l) => l.loop_id),
+    ).toEqual(["l1"]);
+  });
+
+  it("still clears the goal on an authoritative null result", async () => {
+    AutonomyStore.setGoal("sess-snap", GOAL);
+    await startWithAutonomy(
+      async () => [],
+      async () => null,
+    );
+    expect(AutonomyStore.getAutonomyState("sess-snap").goal).toBe(null);
+  });
+
+  it("preserves known loops when the snapshot loop read FAILS", async () => {
+    AutonomyStore.replaceLoops("sess-snap", [LOOP]);
+    await startWithAutonomy(
+      async () => {
+        throw new Error("rpc timeout");
+      },
+      async () => null,
+    );
+    expect(
+      AutonomyStore.getAutonomyState("sess-snap").loops.map((l) => l.loop_id),
+    ).toEqual(["l1"]);
   });
 });

--- a/src/runtime/ui-protocol-runtime.ts
+++ b/src/runtime/ui-protocol-runtime.ts
@@ -12,7 +12,11 @@ import {
   createUiProtocolBridge,
   type UiProtocolBridge,
 } from "./ui-protocol-bridge";
-import type { ConnectionState } from "./ui-protocol-types";
+import type {
+  ConnectionState,
+  UiGoalRecord,
+  UiLoopRecord,
+} from "./ui-protocol-types";
 import { attachRouter, type RouterAttachment } from "./ui-protocol-event-router";
 import * as AutonomyStore from "@/store/autonomy-store";
 import {
@@ -327,15 +331,23 @@ function runAutonomySnapshotFor(
     ) {
       return;
     }
+    // Distinct FAILURE sentinel (codex #263 round 1 P2): `getGoal()`
+    // legitimately resolves `null` for "no goal" and that null is
+    // authoritative — but a REJECTED read (timeout, reconnect blip,
+    // method_not_supported) must not masquerade as it and wipe a
+    // previously loaded or live-updated goal. Same for loops.
+    const failed = Symbol("autonomy-read-failed");
     const [loops, goal] = await Promise.all([
-      bridge.listLoops().catch(() => null),
-      bridge.getGoal().catch(() => null),
+      bridge.listLoops().catch(() => failed),
+      bridge.getGoal().catch(() => failed),
     ]);
     if (capturedGeneration !== generation) return;
-    if (loops !== null) {
-      AutonomyStore.replaceLoops(sessionId, loops, topic);
+    if (loops !== failed) {
+      AutonomyStore.replaceLoops(sessionId, loops as UiLoopRecord[], topic);
     }
-    AutonomyStore.setGoal(sessionId, goal, topic);
+    if (goal !== failed) {
+      AutonomyStore.setGoal(sessionId, goal as UiGoalRecord | null, topic);
+    }
   })();
 }
 

--- a/src/runtime/ui-protocol-runtime.ts
+++ b/src/runtime/ui-protocol-runtime.ts
@@ -14,6 +14,7 @@ import {
 } from "./ui-protocol-bridge";
 import type { ConnectionState } from "./ui-protocol-types";
 import { attachRouter, type RouterAttachment } from "./ui-protocol-event-router";
+import * as AutonomyStore from "@/store/autonomy-store";
 import {
   setHydrateSnapshot,
   suppressPendingDeltasForReplay,
@@ -196,6 +197,7 @@ export async function startBridgeForSession(
       // included), unlike the topic-gated hydrate below.
       suppressPendingDeltasForReplay(sessionId, topic);
       runHydrateFor(sessionId, topic, bridge, myGeneration);
+      runAutonomySnapshotFor(sessionId, topic, bridge, myGeneration);
     });
   }
   // Thinking-effort parity: seed the per-session selector from the
@@ -254,6 +256,7 @@ export async function startBridgeForSession(
   // pre-fix N+1 limitation. This avoids cross-topic envelope leakage
   // (codex round-2 P2).
   runHydrateFor(sessionId, topic, bridge, myGeneration);
+  runAutonomySnapshotFor(sessionId, topic, bridge, myGeneration);
 
   return bridge;
 }
@@ -299,6 +302,40 @@ function runHydrateFor(
       replayed_envelopes: hydrate.replayed_envelopes,
       replayed_tool_envelopes: hydrate.replayed_tool_envelopes,
     });
+  })();
+}
+
+/** M15 autonomy chip: snapshot this scope's loops + goal after a
+ *  successful (re)open. Live `loop/*` / `session/goal/*` notifications
+ *  keep it fresh afterwards; this seeds the store for state created
+ *  before the page loaded (the invisible-runaway-loop gap). Best-effort:
+ *  an older server rejects the RPCs (feature not negotiated /
+ *  method_not_supported) and the chip simply stays hidden. Unlike the
+ *  hydrate above this ALSO runs for topic scopes — loops are keyed by
+ *  the scoped SessionKey. */
+function runAutonomySnapshotFor(
+  sessionId: string,
+  topic: string | undefined,
+  bridge: UiProtocolBridge,
+  capturedGeneration: number,
+): void {
+  void (async () => {
+    if (capturedGeneration !== generation) return;
+    if (
+      typeof bridge.listLoops !== "function" ||
+      typeof bridge.getGoal !== "function"
+    ) {
+      return;
+    }
+    const [loops, goal] = await Promise.all([
+      bridge.listLoops().catch(() => null),
+      bridge.getGoal().catch(() => null),
+    ]);
+    if (capturedGeneration !== generation) return;
+    if (loops !== null) {
+      AutonomyStore.replaceLoops(sessionId, loops, topic);
+    }
+    AutonomyStore.setGoal(sessionId, goal, topic);
   })();
 }
 

--- a/src/runtime/ui-protocol-types.ts
+++ b/src/runtime/ui-protocol-types.ts
@@ -109,6 +109,95 @@ export interface SessionOpenResult {
   opened: SessionOpenedResult;
 }
 
+// ─── M15 autonomy surfaces: recurring loops + persisted goal ───────────────
+// Wire mirrors of `octos_core::ui_protocol::{UiLoopRecord, UiGoalRecord}`
+// and the loop/goal notification structs. Negotiated behind
+// `coding.loop_runtime.v1` / `coding.goal_runtime.v1`.
+
+export interface UiLoopRecord {
+  loop_id: string;
+  session_id: string;
+  profile_id?: string | null;
+  prompt: string;
+  mode: string;
+  interval_seconds?: number | null;
+  status: string;
+  next_run_at_ms?: number | null;
+  last_run_at_ms?: number | null;
+  expires_at_ms: number;
+  created_at_ms: number;
+  updated_at_ms: number;
+}
+
+export interface UiGoalRecord {
+  profile_id?: string | null;
+  goal_id: string;
+  objective: string;
+  status: string;
+  token_budget: number;
+  tokens_used: number;
+  time_used_seconds: number;
+  created_at_ms: number;
+  updated_at_ms: number;
+}
+
+/** `loop/updated` — control-plane transitions (create/pause/resume/delete).
+ *  The wire field is `loop` (serde rename of `loop_state`). */
+export interface LoopUpdatedEvent {
+  session_id: string;
+  loop_id?: string;
+  loop: UiLoopRecord;
+  ok?: boolean;
+  status?: string;
+  deleted?: boolean;
+}
+
+/** `loop/fired` — the scheduler queued a continuation for the loop. */
+export interface LoopFiredEvent {
+  session_id: string;
+  loop_id: string;
+  loop?: UiLoopRecord;
+  status?: string;
+}
+
+/** `loop/completed` — a loop reached a terminal state. */
+export interface LoopCompletedEvent {
+  session_id: string;
+  loop_id: string;
+  loop?: UiLoopRecord;
+  status?: string;
+  error?: string;
+}
+
+export interface SessionGoalUpdatedEvent {
+  session_id: string;
+  goal: UiGoalRecord;
+  transition_actor?: string;
+}
+
+export interface SessionGoalClearedEvent {
+  session_id: string;
+  cleared?: boolean;
+  goal?: UiGoalRecord | null;
+  transition_actor?: string;
+}
+
+export interface LoopListResult {
+  loops: UiLoopRecord[];
+}
+
+/** Result of loop/pause | loop/resume | loop/delete. */
+export interface LoopControlResult {
+  ok?: boolean;
+  status?: string;
+  loop_id?: string;
+  loop?: UiLoopRecord;
+}
+
+export interface SessionGoalGetResult {
+  goal: UiGoalRecord | null;
+}
+
 export interface TurnStartResult {
   accepted: boolean;
 }

--- a/src/store/autonomy-store.test.ts
+++ b/src/store/autonomy-store.test.ts
@@ -1,0 +1,77 @@
+/**
+ * autonomy-store unit tests — per-session loops + goal backing the
+ * header autonomy chip.
+ */
+
+import { afterEach, describe, expect, it } from "vitest";
+import type { UiLoopRecord } from "@/runtime/ui-protocol-types";
+import {
+  __resetAutonomyStoreForTest,
+  getAutonomyState,
+  removeLoop,
+  replaceLoops,
+  setGoal,
+  upsertLoop,
+} from "./autonomy-store";
+
+const SESSION = "sess-autonomy-store";
+
+function makeLoop(partial: Partial<UiLoopRecord> & { loop_id: string }): UiLoopRecord {
+  return {
+    session_id: SESSION,
+    prompt: "check the queue",
+    mode: "interval",
+    interval_seconds: 300,
+    status: "active",
+    expires_at_ms: 0,
+    created_at_ms: 1,
+    updated_at_ms: 1,
+    ...partial,
+  };
+}
+
+afterEach(() => {
+  __resetAutonomyStoreForTest();
+});
+
+describe("autonomy-store", () => {
+  it("scopes state per (session, topic)", () => {
+    replaceLoops(SESSION, [makeLoop({ loop_id: "l1" })]);
+    replaceLoops(SESSION, [makeLoop({ loop_id: "l2" })], "slides");
+    expect(getAutonomyState(SESSION).loops.map((l) => l.loop_id)).toEqual([
+      "l1",
+    ]);
+    expect(
+      getAutonomyState(SESSION, "slides").loops.map((l) => l.loop_id),
+    ).toEqual(["l2"]);
+    expect(getAutonomyState("other").loops).toEqual([]);
+  });
+
+  it("upsertLoop inserts, replaces by id, and drops deleted tombstones", () => {
+    upsertLoop(SESSION, makeLoop({ loop_id: "l1", status: "active" }));
+    upsertLoop(SESSION, makeLoop({ loop_id: "l1", status: "paused" }));
+    expect(getAutonomyState(SESSION).loops).toHaveLength(1);
+    expect(getAutonomyState(SESSION).loops[0].status).toBe("paused");
+    upsertLoop(SESSION, makeLoop({ loop_id: "l1", status: "deleted" }));
+    expect(getAutonomyState(SESSION).loops).toHaveLength(0);
+  });
+
+  it("removeLoop drops by id; setGoal round-trips incl. null", () => {
+    upsertLoop(SESSION, makeLoop({ loop_id: "l1" }));
+    removeLoop(SESSION, "l1");
+    expect(getAutonomyState(SESSION).loops).toHaveLength(0);
+    setGoal(SESSION, {
+      goal_id: "g1",
+      objective: "ship it",
+      status: "active",
+      token_budget: 1000,
+      tokens_used: 10,
+      time_used_seconds: 5,
+      created_at_ms: 1,
+      updated_at_ms: 1,
+    });
+    expect(getAutonomyState(SESSION).goal?.goal_id).toBe("g1");
+    setGoal(SESSION, null);
+    expect(getAutonomyState(SESSION).goal).toBe(null);
+  });
+});

--- a/src/store/autonomy-store.ts
+++ b/src/store/autonomy-store.ts
@@ -1,0 +1,125 @@
+/**
+ * Per-session autonomy state: recurring loops + persisted goal (M15
+ * `coding.loop_runtime.v1` / `coding.goal_runtime.v1`).
+ *
+ * Fed from two directions, same as the task store:
+ *   1. Snapshot on (re)connect — the runtime layer calls
+ *      `bridge.listLoops()` + `bridge.getGoal()` after `session/open`
+ *      and replaces this store's scope.
+ *   2. Live notifications — `loop/updated`, `loop/fired`,
+ *      `loop/completed`, `session/goal/updated`, `session/goal/cleared`
+ *      merge incrementally via the event router.
+ *
+ * Why this exists: a paused-loop "Re-entering" zombie was invisible on
+ * the web — the TUI showed the chip but the SPA had no surface at all,
+ * so a runaway or stuck loop could only be found (and stopped) from the
+ * terminal. The header chip reading this store is the web's equivalent.
+ */
+
+import { useSyncExternalStore } from "react";
+import type { UiGoalRecord, UiLoopRecord } from "@/runtime/ui-protocol-types";
+
+export interface AutonomyState {
+  loops: UiLoopRecord[];
+  goal: UiGoalRecord | null;
+}
+
+const EMPTY: AutonomyState = { loops: [], goal: null };
+
+const stateByKey = new Map<string, AutonomyState>();
+const listeners = new Set<() => void>();
+
+function notify(): void {
+  for (const listener of listeners) listener();
+}
+
+function subscribe(listener: () => void): () => void {
+  listeners.add(listener);
+  return () => {
+    listeners.delete(listener);
+  };
+}
+
+function storeKey(sessionId: string, topic?: string): string {
+  const trimmedTopic = topic?.trim();
+  return trimmedTopic ? `${sessionId}#${trimmedTopic}` : sessionId;
+}
+
+function scope(key: string): AutonomyState {
+  return stateByKey.get(key) ?? EMPTY;
+}
+
+export function getAutonomyState(
+  sessionId: string,
+  topic?: string,
+): AutonomyState {
+  return scope(storeKey(sessionId, topic));
+}
+
+export function replaceLoops(
+  sessionId: string,
+  loops: UiLoopRecord[],
+  topic?: string,
+): void {
+  const key = storeKey(sessionId, topic);
+  stateByKey.set(key, { ...scope(key), loops: [...loops] });
+  notify();
+}
+
+/** Merge a live loop record by `loop_id` (insert or replace). A record
+ *  whose status is `deleted` is removed instead — the server keeps
+ *  emitting the tombstone shape on delete transitions. */
+export function upsertLoop(
+  sessionId: string,
+  loop: UiLoopRecord,
+  topic?: string,
+): void {
+  const key = storeKey(sessionId, topic);
+  const current = scope(key);
+  const rest = current.loops.filter((l) => l.loop_id !== loop.loop_id);
+  const next =
+    loop.status === "deleted" ? rest : [...rest, loop];
+  stateByKey.set(key, { ...current, loops: next });
+  notify();
+}
+
+export function removeLoop(
+  sessionId: string,
+  loopId: string,
+  topic?: string,
+): void {
+  const key = storeKey(sessionId, topic);
+  const current = scope(key);
+  stateByKey.set(key, {
+    ...current,
+    loops: current.loops.filter((l) => l.loop_id !== loopId),
+  });
+  notify();
+}
+
+export function setGoal(
+  sessionId: string,
+  goal: UiGoalRecord | null,
+  topic?: string,
+): void {
+  const key = storeKey(sessionId, topic);
+  stateByKey.set(key, { ...scope(key), goal });
+  notify();
+}
+
+export function useAutonomyState(
+  sessionId: string,
+  topic?: string,
+): AutonomyState {
+  return useSyncExternalStore(
+    subscribe,
+    () => getAutonomyState(sessionId, topic),
+    () => getAutonomyState(sessionId, topic),
+  );
+}
+
+/** Test helper — clears all scopes. */
+export function __resetAutonomyStoreForTest(): void {
+  stateByKey.clear();
+  notify();
+}


### PR DESCRIPTION
Third of the three P2 web-parity gaps (WEB-PARITY-2026-07-10): session autonomy (recurring loops + persisted goal, M15) becomes visible and stoppable on the web.

## What
- Header chip (next to the task dock) whenever the session has a live loop or goal; hidden otherwise.
- Menu: per-loop status + next-run countdown with **Pause/Resume** (one click) and **Delete** (two-click confirm); goal row with objective/status and **Clear** (two-click confirm).
- Bridge negotiates `coding.loop_runtime.v1` + `coding.goal_runtime.v1` and adds typed `loop/list`, `loop/pause|resume|delete`, `session/goal/get|clear` RPCs plus guarded `loop/*` / `session/goal/*` notification subscriptions.
- `autonomy-store` seeds from a snapshot on every (re)open and merges live notifications via the event router. Older servers reject the RPCs → the chip simply never appears.

## Why
The paused-loop “Re-entering” zombie (octos #1576) was invisible on the web — a runaway loop could only be found and stopped from a terminal. This closes that visibility gap.

## Tests
909 passing (+17). `npm run build` (tsc -b) clean; zero new lint errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Codex fold rounds
- **Round 1** (folded): negotiate the umbrella `coding.autonomy.v1` alongside the runtime children (server requires umbrella AND child once any tokens are sent — children alone made every autonomy RPC `method_not_supported`); forward the bridge `profile_id` on all autonomy RPCs (server resolves them independently of `session/open`; omission mis-scopes admin/unscoped connections to `_main`); distinct failure sentinel in the connect/reopen snapshot so a rejected `getGoal`/`listLoops` can't masquerade as authoritative empty state and wipe a live goal; elapsed `expires_at_ms` treated as terminal even with status still `active` (backend enforces expiry by skipping, not rewriting status) with a re-arm timer retiring rows as they lapse; chip menu bounded (`max-h` + `overflow-y-auto`).