### PR TITLE
feat(settings): Memory tab — MEMORY.md, daily notes, entity bank viewer

### DIFF
--- a/src/settings/memory-tab.test.tsx
+++ b/src/settings/memory-tab.test.tsx
@@ -112,6 +112,24 @@ describe("MemoryTab", () => {
     expect(apiMocks.getMyMemoryEntity).toHaveBeenCalledTimes(1);
   });
 
+  it("keeps the snapshot but flags a failed reload", async () => {
+    apiMocks.getMyMemory.mockResolvedValueOnce(OVERVIEW);
+    apiMocks.getMyMemory.mockRejectedValueOnce(new Error("reload boom"));
+    render(<MemoryTab />);
+    await waitFor(() =>
+      expect(screen.getByText(/remembers things/)).toBeTruthy(),
+    );
+
+    fireEvent.click(screen.getByText("Reload"));
+    await waitFor(() =>
+      expect(screen.getByTestId("memory-reload-error").textContent).toContain(
+        "reload boom",
+      ),
+    );
+    // The stale snapshot stays on screen, flagged — not silently kept.
+    expect(screen.getByText(/remembers things/)).toBeTruthy();
+  });
+
   it("surfaces a load error with a retry", async () => {
     apiMocks.getMyMemory.mockRejectedValueOnce(new Error("boom"));
     apiMocks.getMyMemory.mockResolvedValueOnce(OVERVIEW);

--- a/src/settings/memory-tab.test.tsx
+++ b/src/settings/memory-tab.test.tsx
@@ -1,0 +1,126 @@
+import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { MemoryTab } from "./memory-tab";
+
+const apiMocks = vi.hoisted(() => ({
+  getMyMemory: vi.fn(),
+  getMyMemoryEntity: vi.fn(),
+  formatSettingsError: vi.fn((err: unknown, fallback = "Request failed.") =>
+    err instanceof Error ? err.message : fallback,
+  ),
+}));
+
+vi.mock("./settings-api", () => apiMocks);
+
+// MarkdownContent pulls in mermaid/katex — irrelevant to tab behavior.
+vi.mock("@/components/markdown-renderer", () => ({
+  MarkdownContent: ({ text }: { text: string }) => <div>{text}</div>,
+}));
+
+const OVERVIEW = {
+  ok: true,
+  long_term: "# MEMORY\n\n- remembers things\n",
+  long_term_updated_at: "2026-07-10T08:00:00Z",
+  today: "did a thing today",
+  recent: [{ date: "2026-07-09", content: "yesterday note" }],
+  entities: [{ name: "fleet", summary: "five minis" }],
+  staging_notes: 2,
+  refresh_enabled: true,
+};
+
+describe("MemoryTab", () => {
+  beforeEach(() => {
+    cleanup();
+    apiMocks.getMyMemory.mockReset();
+    apiMocks.getMyMemoryEntity.mockReset();
+  });
+
+  it("renders overview sections from /api/my/memory", async () => {
+    apiMocks.getMyMemory.mockResolvedValue(OVERVIEW);
+    render(<MemoryTab />);
+
+    await waitFor(() =>
+      expect(screen.getByText(/remembers things/)).toBeTruthy(),
+    );
+    expect(screen.getByText("Long-term memory")).toBeTruthy();
+    expect(screen.getByText("did a thing today")).toBeTruthy();
+    expect(screen.getByText("2026-07-09")).toBeTruthy();
+    expect(screen.getByText("fleet")).toBeTruthy();
+    expect(screen.getByText("five minis")).toBeTruthy();
+    expect(screen.getByTestId("memory-refresh-state").textContent).toContain(
+      "on",
+    );
+    expect(screen.getByTestId("memory-staging-count").textContent).toContain(
+      "2 staged notes",
+    );
+  });
+
+  it("renders the zero state for a fresh profile", async () => {
+    apiMocks.getMyMemory.mockResolvedValue({
+      ok: true,
+      long_term: "",
+      today: "",
+      recent: [],
+      entities: [],
+      staging_notes: 0,
+      refresh_enabled: true,
+    });
+    render(<MemoryTab />);
+
+    await waitFor(() =>
+      expect(screen.getByText(/Nothing here yet/)).toBeTruthy(),
+    );
+    expect(screen.queryByText("Long-term memory")).toBeNull();
+    expect(screen.queryByTestId("memory-staging-count")).toBeNull();
+  });
+
+  it("shows refresh off when the pipeline is disabled", async () => {
+    apiMocks.getMyMemory.mockResolvedValue({
+      ...OVERVIEW,
+      refresh_enabled: false,
+    });
+    render(<MemoryTab />);
+
+    await waitFor(() =>
+      expect(screen.getByTestId("memory-refresh-state").textContent).toContain(
+        "off",
+      ),
+    );
+  });
+
+  it("lazily fetches an entity page on expand", async () => {
+    apiMocks.getMyMemory.mockResolvedValue(OVERVIEW);
+    apiMocks.getMyMemoryEntity.mockResolvedValue({
+      ok: true,
+      name: "fleet",
+      content: "# fleet\n\nfive minis and a WireGuard hub\n",
+    });
+    render(<MemoryTab />);
+    await waitFor(() => expect(screen.getByText("fleet")).toBeTruthy());
+
+    expect(apiMocks.getMyMemoryEntity).not.toHaveBeenCalled();
+    fireEvent.click(screen.getByText("fleet"));
+    await waitFor(() =>
+      expect(screen.getByText(/WireGuard hub/)).toBeTruthy(),
+    );
+    expect(apiMocks.getMyMemoryEntity).toHaveBeenCalledWith("fleet");
+
+    // Collapse + re-expand must NOT refetch (page cached).
+    fireEvent.click(screen.getByText("fleet"));
+    fireEvent.click(screen.getByText("fleet"));
+    expect(apiMocks.getMyMemoryEntity).toHaveBeenCalledTimes(1);
+  });
+
+  it("surfaces a load error with a retry", async () => {
+    apiMocks.getMyMemory.mockRejectedValueOnce(new Error("boom"));
+    apiMocks.getMyMemory.mockResolvedValueOnce(OVERVIEW);
+    render(<MemoryTab />);
+
+    await waitFor(() => expect(screen.getByText("boom")).toBeTruthy());
+    fireEvent.click(screen.getByText("Retry"));
+    await waitFor(() =>
+      expect(screen.getByText(/remembers things/)).toBeTruthy(),
+    );
+  });
+});

--- a/src/settings/memory-tab.tsx
+++ b/src/settings/memory-tab.tsx
@@ -1,0 +1,282 @@
+// Memory tab — read-only viewer over `/api/my/memory*` (web parity
+// audit P3 item 6: the book gives the memory system top-3 prominence,
+// but the dashboard had zero memory UX). Writes stay with the agent
+// tools and the refresh pipeline; this surface only renders what the
+// profile's own data dir holds: MEMORY.md, today's + recent daily
+// notes, the entity bank, and the refresh pipeline status.
+import { useCallback, useEffect, useState } from "react";
+import {
+  Brain,
+  CalendarDays,
+  ChevronDown,
+  ChevronRight,
+  Loader2,
+  NotebookPen,
+  RefreshCw,
+  Users,
+} from "lucide-react";
+
+import { MarkdownContent } from "@/components/markdown-renderer";
+import {
+  formatSettingsError,
+  getMyMemory,
+  getMyMemoryEntity,
+  type MemoryOverview,
+} from "./settings-api";
+
+function formatUpdatedAt(iso: string | undefined): string | null {
+  if (!iso) return null;
+  const parsed = new Date(iso);
+  if (Number.isNaN(parsed.getTime())) return null;
+  return parsed.toLocaleString();
+}
+
+/** One collapsible daily-note row (recent notes default collapsed). */
+function DailyNoteRow({ date, content }: { date: string; content: string }) {
+  const [open, setOpen] = useState(false);
+  return (
+    <div className="rounded-lg border border-border/60">
+      <button
+        type="button"
+        className="flex w-full items-center gap-2 px-3 py-2 text-left text-sm hover:bg-surface-container/60 transition"
+        onClick={() => setOpen((prev) => !prev)}
+        aria-expanded={open}
+      >
+        {open ? <ChevronDown size={14} /> : <ChevronRight size={14} />}
+        <span className="font-medium">{date}</span>
+      </button>
+      {open ? (
+        <div className="border-t border-border/60 px-3 py-2">
+          <MarkdownContent text={content} className="text-sm" />
+        </div>
+      ) : null}
+    </div>
+  );
+}
+
+/** One entity row; the full page is fetched lazily on expand. */
+function EntityRow({ name, summary }: { name: string; summary: string }) {
+  const [open, setOpen] = useState(false);
+  const [page, setPage] = useState<string | null>(null);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const toggle = async () => {
+    const next = !open;
+    setOpen(next);
+    if (!next || page !== null || loading) return;
+    setLoading(true);
+    setError(null);
+    try {
+      const resp = await getMyMemoryEntity(name);
+      setPage(resp.content);
+    } catch (err) {
+      setError(formatSettingsError(err, "Failed to load entity page."));
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <div className="rounded-lg border border-border/60">
+      <button
+        type="button"
+        className="flex w-full items-center gap-2 px-3 py-2 text-left hover:bg-surface-container/60 transition"
+        onClick={() => void toggle()}
+        aria-expanded={open}
+      >
+        {open ? <ChevronDown size={14} /> : <ChevronRight size={14} />}
+        <span className="min-w-0">
+          <span className="block text-sm font-medium">{name}</span>
+          {summary ? (
+            <span className="block truncate text-xs text-muted">
+              {summary}
+            </span>
+          ) : null}
+        </span>
+      </button>
+      {open ? (
+        <div className="border-t border-border/60 px-3 py-2">
+          {loading ? (
+            <div className="flex items-center gap-2 py-2 text-sm text-muted">
+              <Loader2 size={14} className="animate-spin" /> Loading…
+            </div>
+          ) : error ? (
+            <p className="py-2 text-sm text-red-400">{error}</p>
+          ) : (
+            <MarkdownContent text={page ?? ""} className="text-sm" />
+          )}
+        </div>
+      ) : null}
+    </div>
+  );
+}
+
+export function MemoryTab() {
+  const [overview, setOverview] = useState<MemoryOverview | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  const load = useCallback(async () => {
+    setLoading(true);
+    setError(null);
+    try {
+      setOverview(await getMyMemory());
+    } catch (err) {
+      setError(formatSettingsError(err, "Failed to load memory."));
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    void load();
+  }, [load]);
+
+  if (loading && !overview) {
+    return (
+      <div className="flex items-center gap-2 py-10 text-sm text-muted">
+        <Loader2 size={16} className="animate-spin" /> Loading memory…
+      </div>
+    );
+  }
+
+  if (error && !overview) {
+    return (
+      <div className="glass-section space-y-3 p-5">
+        <p className="text-sm text-red-400">{error}</p>
+        <button
+          type="button"
+          className="flex items-center gap-1.5 rounded-xl border border-border px-3 py-2 text-xs text-muted hover:text-text-strong hover:border-accent/30 transition"
+          onClick={() => void load()}
+        >
+          Retry
+        </button>
+      </div>
+    );
+  }
+
+  if (!overview) return null;
+
+  const updatedAt = formatUpdatedAt(overview.long_term_updated_at);
+  const hasAnything =
+    overview.long_term.trim() !== "" ||
+    overview.today.trim() !== "" ||
+    overview.recent.length > 0 ||
+    overview.entities.length > 0;
+
+  return (
+    <div className="space-y-5">
+      {/* Status header: refresh pipeline + staging */}
+      <section className="glass-section p-5">
+        <div className="flex flex-wrap items-center gap-3">
+          <div className="workbench-icon-tile flex h-10 w-10 shrink-0 items-center justify-center">
+            <Brain size={18} />
+          </div>
+          <div className="min-w-0 flex-1">
+            <h3 className="text-sm font-semibold">Memory</h3>
+            <p className="text-xs text-muted">
+              What the agent remembers about you and your projects — long-term
+              notes, daily notes, and the entity bank.
+            </p>
+          </div>
+          <span
+            className={`rounded-full px-2.5 py-1 text-xs font-medium ${
+              overview.refresh_enabled
+                ? "bg-emerald-500/15 text-emerald-500"
+                : "bg-surface-dark/60 text-muted"
+            }`}
+            data-testid="memory-refresh-state"
+          >
+            refresh {overview.refresh_enabled ? "on" : "off"}
+          </span>
+          {overview.staging_notes > 0 ? (
+            <span
+              className="rounded-full bg-amber-500/15 px-2.5 py-1 text-xs font-medium text-amber-500"
+              data-testid="memory-staging-count"
+            >
+              {overview.staging_notes} staged note
+              {overview.staging_notes === 1 ? "" : "s"}
+            </span>
+          ) : null}
+          <button
+            type="button"
+            className="flex items-center gap-1.5 rounded-xl border border-border px-3 py-2 text-xs text-muted hover:text-text-strong hover:border-accent/30 disabled:opacity-40 transition"
+            onClick={() => void load()}
+            disabled={loading}
+          >
+            <RefreshCw size={12} className={loading ? "animate-spin" : ""} />
+            Reload
+          </button>
+        </div>
+      </section>
+
+      {!hasAnything ? (
+        <section className="glass-section p-5">
+          <p className="text-sm text-muted">
+            Nothing here yet. Memory builds up as you chat — ask the agent to
+            remember something, or just keep working and the refresh pipeline
+            will consolidate what matters.
+          </p>
+        </section>
+      ) : null}
+
+      {/* Long-term MEMORY.md */}
+      {overview.long_term.trim() !== "" ? (
+        <section className="glass-section p-5">
+          <div className="mb-3 flex items-center gap-2">
+            <NotebookPen size={15} />
+            <h4 className="text-sm font-semibold">Long-term memory</h4>
+            {updatedAt ? (
+              <span className="ml-auto text-xs text-muted">
+                updated {updatedAt}
+              </span>
+            ) : null}
+          </div>
+          <MarkdownContent text={overview.long_term} className="text-sm" />
+        </section>
+      ) : null}
+
+      {/* Daily notes */}
+      {overview.today.trim() !== "" || overview.recent.length > 0 ? (
+        <section className="glass-section p-5">
+          <div className="mb-3 flex items-center gap-2">
+            <CalendarDays size={15} />
+            <h4 className="text-sm font-semibold">Daily notes</h4>
+          </div>
+          {overview.today.trim() !== "" ? (
+            <div className="mb-3">
+              <p className="mb-1 text-xs font-medium text-muted">Today</p>
+              <MarkdownContent text={overview.today} className="text-sm" />
+            </div>
+          ) : null}
+          {overview.recent.length > 0 ? (
+            <div className="space-y-2">
+              {overview.recent.map((note) => (
+                <DailyNoteRow key={note.date} date={note.date} content={note.content} />
+              ))}
+            </div>
+          ) : null}
+        </section>
+      ) : null}
+
+      {/* Entity bank */}
+      {overview.entities.length > 0 ? (
+        <section className="glass-section p-5">
+          <div className="mb-3 flex items-center gap-2">
+            <Users size={15} />
+            <h4 className="text-sm font-semibold">Entity bank</h4>
+            <span className="text-xs text-muted">
+              {overview.entities.length}
+            </span>
+          </div>
+          <div className="space-y-2">
+            {overview.entities.map((entity) => (
+              <EntityRow key={entity.name} name={entity.name} summary={entity.summary} />
+            ))}
+          </div>
+        </section>
+      ) : null}
+    </div>
+  );
+}

--- a/src/settings/memory-tab.tsx
+++ b/src/settings/memory-tab.tsx
@@ -159,6 +159,10 @@ export function MemoryTab() {
   if (!overview) return null;
 
   const updatedAt = formatUpdatedAt(overview.long_term_updated_at);
+  // Reload failure with a snapshot on screen: keep the snapshot but
+  // say it's stale (codex web#265 r1 P2) — the blocking error screen
+  // above only covers the nothing-loaded-yet case.
+  const reloadError = error;
   const hasAnything =
     overview.long_term.trim() !== "" ||
     overview.today.trim() !== "" ||
@@ -209,6 +213,14 @@ export function MemoryTab() {
             Reload
           </button>
         </div>
+        {reloadError ? (
+          <p
+            className="mt-3 text-xs text-red-400"
+            data-testid="memory-reload-error"
+          >
+            {reloadError} Showing the last loaded snapshot.
+          </p>
+        ) : null}
       </section>
 
       {!hasAnything ? (

--- a/src/settings/settings-api.ts
+++ b/src/settings/settings-api.ts
@@ -1040,3 +1040,42 @@ export async function disableOminixModel(modelId: string): Promise<AdminActionRe
     body: JSON.stringify({ model_id: modelId }),
   });
 }
+
+// ── Memory panel (read-only viewer: /api/my/memory*) ──
+
+export interface MemoryDailyNote {
+  date: string;
+  content: string;
+}
+
+export interface MemoryEntitySummary {
+  name: string;
+  summary: string;
+}
+
+export interface MemoryOverview {
+  ok: boolean;
+  long_term: string;
+  long_term_updated_at?: string;
+  today: string;
+  recent: MemoryDailyNote[];
+  entities: MemoryEntitySummary[];
+  staging_notes: number;
+  refresh_enabled: boolean;
+}
+
+export interface MemoryEntityPage {
+  ok: boolean;
+  name: string;
+  content: string;
+}
+
+export async function getMyMemory(): Promise<MemoryOverview> {
+  return await request<MemoryOverview>("/api/my/memory");
+}
+
+export async function getMyMemoryEntity(name: string): Promise<MemoryEntityPage> {
+  return await request<MemoryEntityPage>(
+    `/api/my/memory/entities/${encodeURIComponent(name)}`,
+  );
+}

--- a/src/settings/settings-page.tsx
+++ b/src/settings/settings-page.tsx
@@ -208,7 +208,7 @@ export function AdminSettingsPage() {
                       onProfileUpdated={setProfile}
                     />
                   )}
-                  {activeTab === "memory" && <MemoryTab />}
+                  {activeTab === "memory" && <MemoryTab key={profile.id} />}
                   {activeTab === "skills" && <SkillsTab />}
                   {activeTab === "channels" && <ChannelsTab profile={profile} onProfileUpdated={setProfile} />}
                   {activeTab === "sandbox" && (

--- a/src/settings/settings-page.tsx
+++ b/src/settings/settings-page.tsx
@@ -16,6 +16,7 @@ import {
   Settings as SettingsIcon,
   Palette,
   Volume2,
+  Brain,
 } from "lucide-react";
 import {
   WorkbenchStatusPill,
@@ -36,8 +37,9 @@ import { ServerTab } from "./server-tab";
 import { OminixTab } from "./ominix-tab";
 import { AppearanceTab } from "./appearance-tab";
 import { VoiceTab } from "./voice-tab";
+import { MemoryTab } from "./memory-tab";
 
-type TabId = "profile" | "appearance" | "llm" | "voice" | "skills" | "channels" | "sandbox" | "tools" | "users" | "system" | "server" | "ominix";
+type TabId = "profile" | "appearance" | "llm" | "voice" | "memory" | "skills" | "channels" | "sandbox" | "tools" | "users" | "system" | "server" | "ominix";
 
 interface TabDef {
   id: TabId;
@@ -51,6 +53,7 @@ const TABS: TabDef[] = [
   { id: "appearance", label: "Appearance", icon: Palette },
   { id: "llm", label: "LLM", icon: Cpu },
   { id: "voice", label: "Voice", icon: Volume2 },
+  { id: "memory", label: "Memory", icon: Brain },
   { id: "skills", label: "Skills", icon: Puzzle },
   { id: "channels", label: "Channels", icon: Radio },
   { id: "sandbox", label: "Sandbox", icon: Shield },
@@ -205,6 +208,7 @@ export function AdminSettingsPage() {
                       onProfileUpdated={setProfile}
                     />
                   )}
+                  {activeTab === "memory" && <MemoryTab />}
                   {activeTab === "skills" && <SkillsTab />}
                   {activeTab === "channels" && <ChannelsTab profile={profile} onProfileUpdated={setProfile} />}
                   {activeTab === "sandbox" && (

--- a/src/settings/settings-page.tsx
+++ b/src/settings/settings-page.tsx
@@ -208,7 +208,7 @@ export function AdminSettingsPage() {
                       onProfileUpdated={setProfile}
                     />
                   )}
-                  {activeTab === "memory" && <MemoryTab key={profile.id} />}
+                  {activeTab === "memory" && <MemoryTab key={selectedProfileId} />}
                   {activeTab === "skills" && <SkillsTab />}
                   {activeTab === "channels" && <ChannelsTab profile={profile} onProfileUpdated={setProfile} />}
                   {activeTab === "sandbox" && (


### PR DESCRIPTION
## Summary

Web parity P3 item 6 (~/home/octos-audit/WEB-PARITY-2026-07-10.md): the book gives the memory system top-3 prominence but the dashboard had **zero** memory UX. This adds a read-only **Memory** settings tab over the new `/api/my/memory` + `/api/my/memory/entities/{name}` endpoints (octos-org/octos#1611).

- Long-term `MEMORY.md` rendered as markdown with its updated-at stamp
- Today's daily note + last-7-days collapsible rows
- Entity bank list showing the store-parity summary line; full pages fetched lazily on expand, cached per mount
- Refresh-pipeline status chip (`refresh on/off`) + staged-note count
- Zero state for fresh profiles, load-error + retry, reload button

Viewer-only by design — writes stay with the agent tools and the refresh pipeline, so the panel can never race a consolidation sweep.

## Tests
5 new tests (overview render, zero state, refresh-off chip, lazy entity fetch + no-refetch cache, error retry). Full suite: 967 passed / 94 files. `npm run build` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)