### PR TITLE
feat(settings): Schedule tab — cron job list + enable toggles

### DIFF
--- a/src/settings/cron-tab.test.tsx
+++ b/src/settings/cron-tab.test.tsx
@@ -1,4 +1,5 @@
 import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { StrictMode } from "react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 import { CronTab, describeSchedule } from "./cron-tab";
@@ -165,27 +166,44 @@ describe("CronTab", () => {
   });
 
   it("does not blank the tab when a superseded load resolves first", async () => {
-    // codex web#266 r2 P2: StrictMode mounts two loads. If the FIRST
-    // (superseded) resolves before the second, it must not clear
-    // loading while overview is still null — the tab would go blank.
+    // codex web#266 r2 P2: under real StrictMode the effect runs
+    // TWICE, starting two loads. If the FIRST (superseded) resolves
+    // while the SECOND (winning) is still pending, the superseded load
+    // must NOT clear loading — otherwise `!overview` blanks the tab.
     let resolveFirst: (v: typeof OVERVIEW) => void = () => {};
+    let resolveSecond: (v: typeof OVERVIEW) => void = () => {};
     apiMocks.getMyCron.mockImplementationOnce(
       () =>
         new Promise((resolve) => {
           resolveFirst = resolve as (v: typeof OVERVIEW) => void;
         }),
     );
-    apiMocks.getMyCron.mockResolvedValueOnce(OVERVIEW);
-    render(<CronTab />);
+    apiMocks.getMyCron.mockImplementationOnce(
+      () =>
+        new Promise((resolve) => {
+          resolveSecond = resolve as (v: typeof OVERVIEW) => void;
+        }),
+    );
+    render(
+      <StrictMode>
+        <CronTab />
+      </StrictMode>,
+    );
+    // Both effects have run → two pending GETs. Loader is visible.
+    await waitFor(() =>
+      expect(screen.getByText(/Loading schedule/)).toBeTruthy(),
+    );
 
-    // Simulate the StrictMode second mount: a second load supersedes.
-    // (Both effects run; the component instance is the same.) Resolve
-    // the FIRST after the second is armed.
-    await new Promise((r) => setTimeout(r, 0));
+    // The SUPERSEDED (first) load resolves. With the old unconditional
+    // clear this stopped the spinner while overview was still null →
+    // blank tab. The fix keeps the loader up until the winner resolves.
     resolveFirst({ ...OVERVIEW, count: 99 });
+    await new Promise((r) => setTimeout(r, 0));
+    expect(screen.getByText(/Loading schedule/)).toBeTruthy();
+    expect(screen.queryByText("morning briefing")).toBeNull();
 
-    // The winning (second) load renders the real jobs; the tab is
-    // never stuck blank.
+    // The WINNING (second) load resolves → real content, loader gone.
+    resolveSecond(OVERVIEW);
     await waitFor(() =>
       expect(screen.getByText("morning briefing")).toBeTruthy(),
     );

--- a/src/settings/cron-tab.test.tsx
+++ b/src/settings/cron-tab.test.tsx
@@ -164,6 +164,33 @@ describe("CronTab", () => {
     );
   });
 
+  it("does not blank the tab when a superseded load resolves first", async () => {
+    // codex web#266 r2 P2: StrictMode mounts two loads. If the FIRST
+    // (superseded) resolves before the second, it must not clear
+    // loading while overview is still null — the tab would go blank.
+    let resolveFirst: (v: typeof OVERVIEW) => void = () => {};
+    apiMocks.getMyCron.mockImplementationOnce(
+      () =>
+        new Promise((resolve) => {
+          resolveFirst = resolve as (v: typeof OVERVIEW) => void;
+        }),
+    );
+    apiMocks.getMyCron.mockResolvedValueOnce(OVERVIEW);
+    render(<CronTab />);
+
+    // Simulate the StrictMode second mount: a second load supersedes.
+    // (Both effects run; the component instance is the same.) Resolve
+    // the FIRST after the second is armed.
+    await new Promise((r) => setTimeout(r, 0));
+    resolveFirst({ ...OVERVIEW, count: 99 });
+
+    // The winning (second) load renders the real jobs; the tab is
+    // never stuck blank.
+    await waitFor(() =>
+      expect(screen.getByText("morning briefing")).toBeTruthy(),
+    );
+  });
+
   it("rejects a stale reload snapshot that resolves after a toggle", async () => {
     // codex web#266 r1 P2: GET starts (old rows) → PUT resolves and
     // applies the toggled row → GET resolves late. The stale snapshot

--- a/src/settings/cron-tab.test.tsx
+++ b/src/settings/cron-tab.test.tsx
@@ -53,6 +53,16 @@ describe("describeSchedule", () => {
     expect(describeSchedule({ kind: "Every", every_ms: 45_000 })).toBe(
       "every 45s",
     );
+    // Remainders survive — 90s is NOT "every 2m" (codex web#266 r1 P2).
+    expect(describeSchedule({ kind: "Every", every_ms: 90_000 })).toBe(
+      "every 1m 30s",
+    );
+    expect(describeSchedule({ kind: "Every", every_ms: 3_599_000 })).toBe(
+      "every 59m 59s",
+    );
+    expect(describeSchedule({ kind: "Every", every_ms: 3_690_000 })).toBe(
+      "every 1h 1m 30s",
+    );
     expect(describeSchedule({ kind: "Cron", expr: "0 0 9 * * * *" })).toBe(
       "0 0 9 * * * *",
     );
@@ -151,6 +161,45 @@ describe("CronTab", () => {
     // The refetch adopted the lock state.
     await waitFor(() =>
       expect(screen.getByTestId("cron-gateway-lock")).toBeTruthy(),
+    );
+  });
+
+  it("rejects a stale reload snapshot that resolves after a toggle", async () => {
+    // codex web#266 r1 P2: GET starts (old rows) → PUT resolves and
+    // applies the toggled row → GET resolves late. The stale snapshot
+    // must NOT overwrite the fresh row.
+    let resolveStaleLoad: (v: typeof OVERVIEW) => void = () => {};
+    apiMocks.getMyCron.mockResolvedValueOnce(OVERVIEW);
+    apiMocks.setMyCronEnabled.mockResolvedValue({
+      ok: true,
+      job: { ...JOB, enabled: false, next_in: null },
+    });
+    render(<CronTab />);
+    await waitFor(() => expect(screen.getByRole("switch")).toBeTruthy());
+
+    // Arm the SECOND load (Reload click) as a hanging promise.
+    apiMocks.getMyCron.mockImplementationOnce(
+      () =>
+        new Promise((resolve) => {
+          resolveStaleLoad = resolve as (v: typeof OVERVIEW) => void;
+        }),
+    );
+    fireEvent.click(screen.getByText("Reload"));
+
+    // Toggle lands while the reload is still in flight.
+    fireEvent.click(screen.getByRole("switch"));
+    await waitFor(() =>
+      expect(screen.getByRole("switch").getAttribute("aria-checked")).toBe(
+        "false",
+      ),
+    );
+
+    // The stale reload resolves with the OLD (enabled) row — rejected.
+    resolveStaleLoad(OVERVIEW);
+    await waitFor(() =>
+      expect(screen.getByRole("switch").getAttribute("aria-checked")).toBe(
+        "false",
+      ),
     );
   });
 

--- a/src/settings/cron-tab.test.tsx
+++ b/src/settings/cron-tab.test.tsx
@@ -1,0 +1,173 @@
+import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { CronTab, describeSchedule } from "./cron-tab";
+
+const apiMocks = vi.hoisted(() => ({
+  getMyCron: vi.fn(),
+  setMyCronEnabled: vi.fn(),
+  cronToggleRefusalReason: vi.fn((err: unknown) => {
+    if (!(err instanceof Error)) return null;
+    try {
+      const body = JSON.parse(err.message) as { reason?: unknown };
+      return typeof body.reason === "string" ? body.reason : null;
+    } catch {
+      return null;
+    }
+  }),
+  formatSettingsError: vi.fn((err: unknown, fallback = "Request failed.") =>
+    err instanceof Error ? err.message : fallback,
+  ),
+}));
+
+vi.mock("./settings-api", () => apiMocks);
+
+const JOB = {
+  id: "aa11",
+  name: "morning briefing",
+  enabled: true,
+  schedule: { kind: "Every" as const, every_ms: 1_800_000 },
+  message: "check the queue",
+  channel: "system",
+  last_run: "2026-07-10T08:00:00Z",
+  last_status: "ok",
+  next_in: "12m",
+  timezone: null,
+};
+
+const OVERVIEW = {
+  ok: true,
+  count: 1,
+  jobs: [JOB],
+  gateway_running: false,
+};
+
+describe("describeSchedule", () => {
+  it("renders each schedule kind", () => {
+    expect(describeSchedule({ kind: "Every", every_ms: 1_800_000 })).toBe(
+      "every 30m",
+    );
+    expect(describeSchedule({ kind: "Every", every_ms: 5_400_000 })).toBe(
+      "every 1h 30m",
+    );
+    expect(describeSchedule({ kind: "Every", every_ms: 45_000 })).toBe(
+      "every 45s",
+    );
+    expect(describeSchedule({ kind: "Cron", expr: "0 0 9 * * * *" })).toBe(
+      "0 0 9 * * * *",
+    );
+    expect(
+      describeSchedule({ kind: "At", at_ms: Date.UTC(2026, 6, 10, 9) }),
+    ).toContain("once at");
+  });
+});
+
+describe("CronTab", () => {
+  beforeEach(() => {
+    cleanup();
+    apiMocks.getMyCron.mockReset();
+    apiMocks.setMyCronEnabled.mockReset();
+  });
+
+  it("lists jobs with schedule and history", async () => {
+    apiMocks.getMyCron.mockResolvedValue(OVERVIEW);
+    render(<CronTab />);
+
+    await waitFor(() =>
+      expect(screen.getByText("morning briefing")).toBeTruthy(),
+    );
+    expect(screen.getByText("every 30m")).toBeTruthy();
+    expect(screen.getByText("check the queue")).toBeTruthy();
+    expect(screen.getByRole("switch").getAttribute("aria-checked")).toBe(
+      "true",
+    );
+    expect(screen.queryByTestId("cron-gateway-lock")).toBeNull();
+  });
+
+  it("renders the zero state without jobs", async () => {
+    apiMocks.getMyCron.mockResolvedValue({
+      ok: true,
+      count: 0,
+      jobs: [],
+      gateway_running: false,
+    });
+    render(<CronTab />);
+
+    await waitFor(() =>
+      expect(screen.getByText(/No scheduled jobs yet/)).toBeTruthy(),
+    );
+  });
+
+  it("toggles a job and applies the server row", async () => {
+    apiMocks.getMyCron.mockResolvedValue(OVERVIEW);
+    apiMocks.setMyCronEnabled.mockResolvedValue({
+      ok: true,
+      job: { ...JOB, enabled: false, next_in: null },
+    });
+    render(<CronTab />);
+    await waitFor(() => expect(screen.getByRole("switch")).toBeTruthy());
+
+    fireEvent.click(screen.getByRole("switch"));
+    await waitFor(() =>
+      expect(screen.getByRole("switch").getAttribute("aria-checked")).toBe(
+        "false",
+      ),
+    );
+    expect(apiMocks.setMyCronEnabled).toHaveBeenCalledWith("aa11", false);
+  });
+
+  it("locks toggles while the gateway owns the schedule", async () => {
+    apiMocks.getMyCron.mockResolvedValue({
+      ...OVERVIEW,
+      gateway_running: true,
+    });
+    render(<CronTab />);
+
+    await waitFor(() =>
+      expect(screen.getByTestId("cron-gateway-lock")).toBeTruthy(),
+    );
+    const toggle = screen.getByRole("switch") as HTMLButtonElement;
+    expect(toggle.disabled).toBe(true);
+  });
+
+  it("reflects a 409 gateway_running refusal and refreshes", async () => {
+    apiMocks.getMyCron.mockResolvedValueOnce(OVERVIEW);
+    apiMocks.setMyCronEnabled.mockRejectedValue(
+      new Error(JSON.stringify({ ok: false, reason: "gateway_running" })),
+    );
+    apiMocks.getMyCron.mockResolvedValueOnce({
+      ...OVERVIEW,
+      gateway_running: true,
+    });
+    render(<CronTab />);
+    await waitFor(() => expect(screen.getByRole("switch")).toBeTruthy());
+
+    fireEvent.click(screen.getByRole("switch"));
+    await waitFor(() =>
+      expect(screen.getByTestId("cron-toggle-error").textContent).toContain(
+        "gateway is running",
+      ),
+    );
+    // The refetch adopted the lock state.
+    await waitFor(() =>
+      expect(screen.getByTestId("cron-gateway-lock")).toBeTruthy(),
+    );
+  });
+
+  it("keeps the snapshot but flags a failed reload", async () => {
+    apiMocks.getMyCron.mockResolvedValueOnce(OVERVIEW);
+    apiMocks.getMyCron.mockRejectedValueOnce(new Error("reload boom"));
+    render(<CronTab />);
+    await waitFor(() =>
+      expect(screen.getByText("morning briefing")).toBeTruthy(),
+    );
+
+    fireEvent.click(screen.getByText("Reload"));
+    await waitFor(() =>
+      expect(screen.getByTestId("cron-reload-error").textContent).toContain(
+        "reload boom",
+      ),
+    );
+    expect(screen.getByText("morning briefing")).toBeTruthy();
+  });
+});

--- a/src/settings/cron-tab.tsx
+++ b/src/settings/cron-tab.tsx
@@ -10,7 +10,7 @@
 // `gateway_running`, so the UI disables the switches and points at
 // the Profile tab's stop/start controls instead of offering writes
 // that would be refused.
-import { useCallback, useEffect, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import { AlarmClock, Loader2, RefreshCw } from "lucide-react";
 
 import {
@@ -63,13 +63,19 @@ export function describeSchedule(schedule: CronScheduleWire): string {
         : `once at ${when.toLocaleString()}`;
     }
     case "Every": {
+      // Preserve remainders: 90s is "every 1m 30s", not "every 2m"
+      // (codex web#266 r1 P2 — rounding misstated valid intervals).
       const totalSecs = Math.round(schedule.every_ms / 1000);
       if (totalSecs < 60) return `every ${totalSecs}s`;
-      const totalMins = Math.round(totalSecs / 60);
-      if (totalMins < 60) return `every ${totalMins}m`;
-      const hours = Math.floor(totalMins / 60);
-      const mins = totalMins % 60;
-      return mins === 0 ? `every ${hours}h` : `every ${hours}h ${mins}m`;
+      const mins = Math.floor(totalSecs / 60);
+      const secs = totalSecs % 60;
+      if (mins < 60) {
+        return secs === 0 ? `every ${mins}m` : `every ${mins}m ${secs}s`;
+      }
+      const parts = [`${Math.floor(mins / 60)}h`];
+      if (mins % 60 !== 0) parts.push(`${mins % 60}m`);
+      if (secs !== 0) parts.push(`${secs}s`);
+      return `every ${parts.join(" ")}`;
     }
     case "Cron":
       return schedule.expr;
@@ -128,15 +134,27 @@ export function CronTab() {
   const [error, setError] = useState<string | null>(null);
   const [togglingId, setTogglingId] = useState<string | null>(null);
   const [toggleError, setToggleError] = useState<string | null>(null);
+  // Generation gate: a Reload GET that was in flight when a toggle
+  // PUT resolved would overwrite the fresh server row with the old
+  // snapshot (codex web#266 r1 P2). Every toggle bumps the
+  // generation; a load only applies if no toggle landed after it
+  // started.
+  const loadGenRef = useRef(0);
 
   const load = useCallback(async () => {
+    const gen = ++loadGenRef.current;
     setLoading(true);
     setError(null);
     try {
-      setOverview(await getMyCron());
+      const next = await getMyCron();
+      if (gen === loadGenRef.current) setOverview(next);
     } catch (err) {
-      setError(formatSettingsError(err, "Failed to load schedule."));
+      if (gen === loadGenRef.current) {
+        setError(formatSettingsError(err, "Failed to load schedule."));
+      }
     } finally {
+      // Unconditional: an invalidated load must not leave the spinner
+      // wedged on (its RESULT is gated above, its liveness is not).
       setLoading(false);
     }
   }, []);
@@ -150,6 +168,9 @@ export function CronTab() {
     setToggleError(null);
     try {
       const resp = await setMyCronEnabled(job.id, enabled);
+      // Invalidate any in-flight GET that started before this PUT
+      // resolved — its snapshot predates the toggle.
+      loadGenRef.current++;
       setOverview((prev) =>
         prev
           ? {

--- a/src/settings/cron-tab.tsx
+++ b/src/settings/cron-tab.tsx
@@ -134,28 +134,36 @@ export function CronTab() {
   const [error, setError] = useState<string | null>(null);
   const [togglingId, setTogglingId] = useState<string | null>(null);
   const [toggleError, setToggleError] = useState<string | null>(null);
-  // Generation gate: a Reload GET that was in flight when a toggle
-  // PUT resolved would overwrite the fresh server row with the old
-  // snapshot (codex web#266 r1 P2). Every toggle bumps the
-  // generation; a load only applies if no toggle landed after it
-  // started.
-  const loadGenRef = useRef(0);
+  // Two independent guards (codex web#266 r1+r2 P2):
+  //  - loadSeqRef: newest-load-wins. Bumped ONLY by load(), it gates
+  //    BOTH the result AND the loading flag, so a superseded StrictMode
+  //    double-mount load never clears loading while the winning load is
+  //    still pending (which would blank the tab via `!overview`).
+  //  - toggleStampRef: bumped by each toggle. A Reload GET in flight
+  //    when a toggle PUT resolved carries a pre-toggle snapshot — it is
+  //    rejected so it cannot clobber the fresh server row. Kept
+  //    separate from loadSeqRef so a toggle never strands `loading`.
+  const loadSeqRef = useRef(0);
+  const toggleStampRef = useRef(0);
 
   const load = useCallback(async () => {
-    const gen = ++loadGenRef.current;
+    const seq = ++loadSeqRef.current;
+    const toggleStamp = toggleStampRef.current;
     setLoading(true);
     setError(null);
     try {
       const next = await getMyCron();
-      if (gen === loadGenRef.current) setOverview(next);
+      if (seq === loadSeqRef.current && toggleStamp === toggleStampRef.current) {
+        setOverview(next);
+      }
     } catch (err) {
-      if (gen === loadGenRef.current) {
+      if (seq === loadSeqRef.current) {
         setError(formatSettingsError(err, "Failed to load schedule."));
       }
     } finally {
-      // Unconditional: an invalidated load must not leave the spinner
-      // wedged on (its RESULT is gated above, its liveness is not).
-      setLoading(false);
+      // Only the newest load controls the spinner — a superseded load
+      // must NOT clear it while the winner is still in flight.
+      if (seq === loadSeqRef.current) setLoading(false);
     }
   }, []);
 
@@ -170,7 +178,7 @@ export function CronTab() {
       const resp = await setMyCronEnabled(job.id, enabled);
       // Invalidate any in-flight GET that started before this PUT
       // resolved — its snapshot predates the toggle.
-      loadGenRef.current++;
+      toggleStampRef.current++;
       setOverview((prev) =>
         prev
           ? {

--- a/src/settings/cron-tab.tsx
+++ b/src/settings/cron-tab.tsx
@@ -1,0 +1,273 @@
+// Schedule tab — user-scoped cron job list + enable toggle over
+// `/api/my/cron*` (web parity audit P3 item 7: the book documents
+// scheduled tasks, but the dashboard had no cron surface — only the
+// admin-token list). Creation/editing stays with the agent (`cron`
+// tool) and CLI; this surface reads the schedule and flips jobs on
+// and off.
+//
+// Ownership rule mirrored from the server: while the profile's
+// gateway process runs, IT owns cron.json — toggles 409 with
+// `gateway_running`, so the UI disables the switches and points at
+// the Profile tab's stop/start controls instead of offering writes
+// that would be refused.
+import { useCallback, useEffect, useState } from "react";
+import { AlarmClock, Loader2, RefreshCw } from "lucide-react";
+
+import {
+  cronToggleRefusalReason,
+  formatSettingsError,
+  getMyCron,
+  setMyCronEnabled,
+  type CronJobRow,
+  type CronOverview,
+  type CronScheduleWire,
+} from "./settings-api";
+
+function Toggle({
+  checked,
+  onChange,
+  disabled,
+  label,
+}: {
+  checked: boolean;
+  onChange: (v: boolean) => void;
+  disabled?: boolean;
+  label: string;
+}) {
+  return (
+    <button
+      role="switch"
+      aria-checked={checked}
+      aria-label={label}
+      onClick={() => onChange(!checked)}
+      disabled={disabled}
+      className={`relative inline-flex h-5 w-9 shrink-0 cursor-pointer items-center rounded-full transition-colors disabled:opacity-40 ${
+        checked ? "bg-accent" : "bg-border"
+      }`}
+    >
+      <span
+        className={`inline-block h-3.5 w-3.5 rounded-full bg-white shadow transition-transform ${
+          checked ? "translate-x-4.5" : "translate-x-0.5"
+        }`}
+      />
+    </button>
+  );
+}
+
+export function describeSchedule(schedule: CronScheduleWire): string {
+  switch (schedule.kind) {
+    case "At": {
+      const when = new Date(schedule.at_ms);
+      return Number.isNaN(when.getTime())
+        ? "once"
+        : `once at ${when.toLocaleString()}`;
+    }
+    case "Every": {
+      const totalSecs = Math.round(schedule.every_ms / 1000);
+      if (totalSecs < 60) return `every ${totalSecs}s`;
+      const totalMins = Math.round(totalSecs / 60);
+      if (totalMins < 60) return `every ${totalMins}m`;
+      const hours = Math.floor(totalMins / 60);
+      const mins = totalMins % 60;
+      return mins === 0 ? `every ${hours}h` : `every ${hours}h ${mins}m`;
+    }
+    case "Cron":
+      return schedule.expr;
+  }
+}
+
+function JobRow({
+  job,
+  disabledReason,
+  onToggle,
+  busy,
+}: {
+  job: CronJobRow;
+  disabledReason: string | null;
+  onToggle: (enabled: boolean) => void;
+  busy: boolean;
+}) {
+  return (
+    <div className="flex flex-wrap items-center gap-3 rounded-lg border border-border/60 bg-surface-dark/50 px-3 py-2.5">
+      <div className="min-w-0 flex-1">
+        <div className="flex items-center gap-2">
+          <span className="truncate text-sm font-medium">{job.name}</span>
+          <span className="shrink-0 rounded-md bg-surface-container/60 px-1.5 py-0.5 text-[10px] tabular-nums text-muted">
+            {describeSchedule(job.schedule)}
+          </span>
+          {job.timezone ? (
+            <span className="shrink-0 text-[10px] text-muted">{job.timezone}</span>
+          ) : null}
+        </div>
+        <p className="truncate text-xs text-muted">{job.message}</p>
+        <p className="text-[11px] text-muted/80">
+          {job.enabled && job.next_in ? <>next in {job.next_in}</> : null}
+          {job.enabled && job.next_in && job.last_run ? " · " : null}
+          {job.last_run ? (
+            <>
+              last ran {new Date(job.last_run).toLocaleString()}
+              {job.last_status ? ` (${job.last_status})` : ""}
+            </>
+          ) : null}
+        </p>
+      </div>
+      {busy ? <Loader2 size={14} className="animate-spin text-muted" /> : null}
+      <Toggle
+        checked={job.enabled}
+        onChange={onToggle}
+        disabled={busy || disabledReason !== null}
+        label={`Toggle ${job.name}`}
+      />
+    </div>
+  );
+}
+
+export function CronTab() {
+  const [overview, setOverview] = useState<CronOverview | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [togglingId, setTogglingId] = useState<string | null>(null);
+  const [toggleError, setToggleError] = useState<string | null>(null);
+
+  const load = useCallback(async () => {
+    setLoading(true);
+    setError(null);
+    try {
+      setOverview(await getMyCron());
+    } catch (err) {
+      setError(formatSettingsError(err, "Failed to load schedule."));
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    void load();
+  }, [load]);
+
+  const toggle = async (job: CronJobRow, enabled: boolean) => {
+    setTogglingId(job.id);
+    setToggleError(null);
+    try {
+      const resp = await setMyCronEnabled(job.id, enabled);
+      setOverview((prev) =>
+        prev
+          ? {
+              ...prev,
+              jobs: prev.jobs.map((j) => (j.id === job.id ? resp.job : j)),
+            }
+          : prev,
+      );
+    } catch (err) {
+      if (cronToggleRefusalReason(err) === "gateway_running") {
+        // The gateway grabbed ownership since our last load — reflect
+        // reality rather than showing a raw error.
+        setToggleError(
+          "The gateway is running and owns the schedule — stop it from the Profile tab to edit.",
+        );
+        void load();
+      } else {
+        setToggleError(formatSettingsError(err, "Failed to update the job."));
+      }
+    } finally {
+      setTogglingId(null);
+    }
+  };
+
+  if (loading && !overview) {
+    return (
+      <div className="flex items-center gap-2 py-10 text-sm text-muted">
+        <Loader2 size={16} className="animate-spin" /> Loading schedule…
+      </div>
+    );
+  }
+
+  if (error && !overview) {
+    return (
+      <div className="glass-section space-y-3 p-5">
+        <p className="text-sm text-red-400">{error}</p>
+        <button
+          type="button"
+          className="flex items-center gap-1.5 rounded-xl border border-border px-3 py-2 text-xs text-muted hover:text-text-strong hover:border-accent/30 transition"
+          onClick={() => void load()}
+        >
+          Retry
+        </button>
+      </div>
+    );
+  }
+
+  if (!overview) return null;
+
+  const lockReason = overview.gateway_running
+    ? "The gateway is running and owns the schedule."
+    : null;
+
+  return (
+    <div className="space-y-5">
+      <section className="glass-section p-5">
+        <div className="flex flex-wrap items-center gap-3">
+          <div className="workbench-icon-tile flex h-10 w-10 shrink-0 items-center justify-center">
+            <AlarmClock size={18} />
+          </div>
+          <div className="min-w-0 flex-1">
+            <h3 className="text-sm font-semibold">Schedule</h3>
+            <p className="text-xs text-muted">
+              Recurring jobs the agent runs for you. Ask the agent to schedule
+              something new — here you can pause and resume what exists.
+            </p>
+          </div>
+          <button
+            type="button"
+            className="flex items-center gap-1.5 rounded-xl border border-border px-3 py-2 text-xs text-muted hover:text-text-strong hover:border-accent/30 disabled:opacity-40 transition"
+            onClick={() => void load()}
+            disabled={loading}
+          >
+            <RefreshCw size={12} className={loading ? "animate-spin" : ""} />
+            Reload
+          </button>
+        </div>
+        {error ? (
+          <p className="mt-3 text-xs text-red-400" data-testid="cron-reload-error">
+            {error} Showing the last loaded snapshot.
+          </p>
+        ) : null}
+        {lockReason ? (
+          <p
+            className="mt-3 rounded-lg bg-amber-500/10 px-3 py-2 text-xs text-amber-500"
+            data-testid="cron-gateway-lock"
+          >
+            {lockReason} Toggles apply when it is stopped (Profile tab →
+            stop), and take effect on the next start.
+          </p>
+        ) : null}
+        {toggleError ? (
+          <p className="mt-3 text-xs text-red-400" data-testid="cron-toggle-error">
+            {toggleError}
+          </p>
+        ) : null}
+      </section>
+
+      {overview.jobs.length === 0 ? (
+        <section className="glass-section p-5">
+          <p className="text-sm text-muted">
+            No scheduled jobs yet. Ask the agent to remind you about something
+            or run a task on a schedule and it will appear here.
+          </p>
+        </section>
+      ) : (
+        <section className="glass-section space-y-2 p-5">
+          {overview.jobs.map((job) => (
+            <JobRow
+              key={job.id}
+              job={job}
+              disabledReason={lockReason}
+              busy={togglingId === job.id}
+              onToggle={(enabled) => void toggle(job, enabled)}
+            />
+          ))}
+        </section>
+      )}
+    </div>
+  );
+}

--- a/src/settings/settings-api.ts
+++ b/src/settings/settings-api.ts
@@ -1040,3 +1040,55 @@ export async function disableOminixModel(modelId: string): Promise<AdminActionRe
     body: JSON.stringify({ model_id: modelId }),
   });
 }
+
+// ── Cron panel (/api/my/cron*) ──
+
+export type CronScheduleWire =
+  | { kind: "At"; at_ms: number }
+  | { kind: "Every"; every_ms: number }
+  | { kind: "Cron"; expr: string };
+
+export interface CronJobRow {
+  id: string;
+  name: string;
+  enabled: boolean;
+  schedule: CronScheduleWire;
+  message: string;
+  channel: string | null;
+  last_run: string | null;
+  last_status: string | null;
+  next_in: string | null;
+  timezone: string | null;
+}
+
+export interface CronOverview {
+  ok: boolean;
+  count: number;
+  jobs: CronJobRow[];
+  gateway_running: boolean;
+}
+
+export async function getMyCron(): Promise<CronOverview> {
+  return await request<CronOverview>("/api/my/cron");
+}
+
+/** Thrown reason when the toggle is refused (409 etc.). */
+export function cronToggleRefusalReason(err: unknown): string | null {
+  if (!(err instanceof Error)) return null;
+  try {
+    const body = JSON.parse(err.message) as { reason?: unknown };
+    return typeof body.reason === "string" ? body.reason : null;
+  } catch {
+    return null;
+  }
+}
+
+export async function setMyCronEnabled(
+  jobId: string,
+  enabled: boolean,
+): Promise<{ ok: boolean; job: CronJobRow }> {
+  return await request<{ ok: boolean; job: CronJobRow }>(
+    `/api/my/cron/${encodeURIComponent(jobId)}/enabled`,
+    { method: "PUT", body: JSON.stringify({ enabled }) },
+  );
+}

--- a/src/settings/settings-page.tsx
+++ b/src/settings/settings-page.tsx
@@ -16,6 +16,7 @@ import {
   Settings as SettingsIcon,
   Palette,
   Volume2,
+  AlarmClock,
 } from "lucide-react";
 import {
   WorkbenchStatusPill,
@@ -36,8 +37,9 @@ import { ServerTab } from "./server-tab";
 import { OminixTab } from "./ominix-tab";
 import { AppearanceTab } from "./appearance-tab";
 import { VoiceTab } from "./voice-tab";
+import { CronTab } from "./cron-tab";
 
-type TabId = "profile" | "appearance" | "llm" | "voice" | "skills" | "channels" | "sandbox" | "tools" | "users" | "system" | "server" | "ominix";
+type TabId = "profile" | "appearance" | "llm" | "voice" | "schedule" | "skills" | "channels" | "sandbox" | "tools" | "users" | "system" | "server" | "ominix";
 
 interface TabDef {
   id: TabId;
@@ -51,6 +53,7 @@ const TABS: TabDef[] = [
   { id: "appearance", label: "Appearance", icon: Palette },
   { id: "llm", label: "LLM", icon: Cpu },
   { id: "voice", label: "Voice", icon: Volume2 },
+  { id: "schedule", label: "Schedule", icon: AlarmClock },
   { id: "skills", label: "Skills", icon: Puzzle },
   { id: "channels", label: "Channels", icon: Radio },
   { id: "sandbox", label: "Sandbox", icon: Shield },
@@ -205,6 +208,7 @@ export function AdminSettingsPage() {
                       onProfileUpdated={setProfile}
                     />
                   )}
+                  {activeTab === "schedule" && <CronTab key={selectedProfileId} />}
                   {activeTab === "skills" && <SkillsTab />}
                   {activeTab === "channels" && <ChannelsTab profile={profile} onProfileUpdated={setProfile} />}
                   {activeTab === "sandbox" && (


### PR DESCRIPTION
## Summary

Web parity P3 item 7 (~/home/octos-audit/WEB-PARITY-2026-07-10.md): the book documents scheduled tasks but the dashboard had **no cron surface** — only the admin-token `GET /api/admin/profiles/{id}/cron` list. This adds a user-scoped **Schedule** settings tab over the new `/api/my/cron` + `PUT /api/my/cron/{id}/enabled` endpoints (octos-org/octos#1612).

- Job rows: name, human-readable schedule (`every 30m` / cron expr / `once at …`), payload message, next-in countdown, last run + status, timezone
- Per-row enable switch; the server-returned row replaces the local one (next-run semantics come from the server)
- **Gateway-ownership lock**: while the profile's gateway process runs, the server refuses toggles (409 `gateway_running`) — switches disable with a banner pointing at the Profile tab's stop/start controls; a mid-flight 409 surfaces the reason and refreshes the lock state
- Keyed by `selectedProfileId` (profile-switch remounts) and a reload-failure banner that keeps + flags the stale snapshot — both classes pre-applied from web#265's review rounds
- Zero state, load-error retry

Creation/editing stays with the agent's `cron` tool and the CLI — this surface is list + pause/resume.

## Tests
7 new tests (schedule renderer for all three kinds, list render, zero state, toggle applies server row, gateway lock, 409 refusal + refresh, reload-failure banner). Full suite: 969 passed / 94 files. `npm run build` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)