### PR TITLE
feat(chat): fork a session from the sidebar (session/fork parity)

### DIFF
--- a/src/api/sessions.ts
+++ b/src/api/sessions.ts
@@ -180,6 +180,29 @@ export async function getMessagesPage(
   );
 }
 
+export interface SessionForkResult {
+  new_session_id: string;
+  parent_session_id: string;
+  copied_messages: number;
+}
+
+/**
+ * `session/fork` — branch a NEW session off `sessionId`, copying its
+ * full history (server default) and recording parent lineage. The
+ * server derives the child key from the parent's key shape; for the
+ * SPA's raw `web-*` handles the child id comes back verbatim.
+ * MUTATING; refuses unknown parents and existing child ids.
+ */
+export async function forkSession(
+  sessionId: string,
+  newChatId: string,
+): Promise<SessionForkResult> {
+  return await callAuxWs<SessionForkResult>(METHODS.SESSION_FORK, {
+    session_id: sessionId,
+    new_chat_id: newChatId,
+  });
+}
+
 export async function deleteSession(sessionId: string): Promise<void> {
   await callAuxWs<Record<string, never>>(METHODS.SESSION_DELETE, {
     session_id: sessionId,

--- a/src/components/session-list-fork.test.tsx
+++ b/src/components/session-list-fork.test.tsx
@@ -1,0 +1,153 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import * as React from "react";
+import { act } from "react";
+import { createRoot, type Root } from "react-dom/client";
+
+(globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT =
+  true;
+
+vi.mock("@/runtime/ui-protocol-send", () => ({
+  sendMessage: vi.fn(),
+}));
+
+import { SessionContext, type SessionContextValue } from "@/runtime/session-context";
+import { SessionList } from "./session-list";
+
+interface MountedHarness {
+  container: HTMLDivElement;
+  root: Root;
+  unmount: () => void;
+}
+
+function makeSessionCtx(
+  overrides: Partial<SessionContextValue> = {},
+): SessionContextValue {
+  return {
+    sessions: [],
+    currentSessionId: "web-current",
+    historyTopic: undefined,
+    currentSessionTitle: "Current",
+    currentSessionStats: null,
+    initialMessages: [],
+    activeTaskOnServer: false,
+    queueMode: null,
+    adaptiveMode: null,
+    setServerTaskActive: () => {},
+    renameSession: () => {},
+    updateSessionStats: () => {},
+    switchSession: () => {},
+    goBack: async () => false,
+    createSession: () => "web-new",
+    branchSession: async () => "web-new",
+    removeSession: async () => {},
+    refreshSessions: async () => {},
+    markSessionActive: () => {},
+    ...overrides,
+  };
+}
+
+function mount(ctx: SessionContextValue): MountedHarness {
+  const container = document.createElement("div");
+  document.body.appendChild(container);
+  const root = createRoot(container);
+  act(() => {
+    root.render(
+      <SessionContext.Provider value={ctx}>
+        <SessionList />
+      </SessionContext.Provider>,
+    );
+  });
+  return {
+    container,
+    root,
+    unmount: () => {
+      act(() => root.unmount());
+      container.remove();
+    },
+  };
+}
+
+const mounted: MountedHarness[] = [];
+afterEach(() => {
+  while (mounted.length) mounted.pop()?.unmount();
+});
+
+const SESSIONS = [
+  { id: "web-111", message_count: 4, title: "research thread" },
+  { id: "web-222", message_count: 2, title: "second thread" },
+];
+
+describe("SessionList fork action", () => {
+  it("forks the addressed row via branchSession", async () => {
+    let resolveFork: (id: string) => void = () => {};
+    const branchSession = vi.fn(
+      () =>
+        new Promise<string>((resolve) => {
+          resolveFork = resolve;
+        }),
+    );
+    const harness = mount(
+      makeSessionCtx({ sessions: SESSIONS, branchSession }),
+    );
+    mounted.push(harness);
+
+    const forkButtons = harness.container.querySelectorAll(
+      '[data-testid="session-fork-button"]',
+    );
+    expect(forkButtons.length).toBe(2);
+
+    await act(async () => {
+      (forkButtons[1] as HTMLButtonElement).click();
+    });
+    expect(branchSession).toHaveBeenCalledWith("web-222");
+
+    // While the fork is in flight EVERY fork button is disabled (one
+    // fork at a time) and the addressed row shows a spinner.
+    const busyButtons = harness.container.querySelectorAll(
+      '[data-testid="session-fork-button"]',
+    );
+    expect(
+      Array.from(busyButtons).every(
+        (b) => (b as HTMLButtonElement).disabled,
+      ),
+    ).toBe(true);
+
+    await act(async () => {
+      resolveFork("web-child");
+    });
+    const settled = harness.container.querySelectorAll(
+      '[data-testid="session-fork-button"]',
+    );
+    expect(
+      Array.from(settled).some((b) => (b as HTMLButtonElement).disabled),
+    ).toBe(false);
+  });
+
+  it("survives a fork failure without wedging the buttons", async () => {
+    const branchSession = vi.fn(async () => {
+      throw new Error("fork refused");
+    });
+    const errorSpy = vi
+      .spyOn(console, "error")
+      .mockImplementation(() => {});
+    const harness = mount(
+      makeSessionCtx({ sessions: SESSIONS, branchSession }),
+    );
+    mounted.push(harness);
+
+    const forkButton = harness.container.querySelector(
+      '[data-testid="session-fork-button"]',
+    ) as HTMLButtonElement;
+    await act(async () => {
+      forkButton.click();
+    });
+
+    expect(branchSession).toHaveBeenCalledTimes(1);
+    const after = harness.container.querySelector(
+      '[data-testid="session-fork-button"]',
+    ) as HTMLButtonElement;
+    expect(after.disabled).toBe(false);
+    expect(errorSpy).toHaveBeenCalled();
+    errorSpy.mockRestore();
+  });
+});

--- a/src/components/session-list-template-selector.test.tsx
+++ b/src/components/session-list-template-selector.test.tsx
@@ -47,6 +47,7 @@ function makeSessionCtx(
     switchSession: () => {},
     goBack: async () => false,
     createSession: () => SESSION_ID,
+    branchSession: async () => SESSION_ID,
     removeSession: async () => {},
     refreshSessions: async () => {},
     markSessionActive: () => {},

--- a/src/components/session-list.tsx
+++ b/src/components/session-list.tsx
@@ -17,6 +17,7 @@ import {
   Plus,
   MessageSquare,
   Trash2,
+  GitBranch,
   Check,
   X,
   Loader2,
@@ -44,6 +45,7 @@ export function SessionList() {
     currentSessionId,
     switchSession,
     createSession,
+    branchSession,
     removeSession,
     markSessionActive,
     refreshSessions,
@@ -51,6 +53,7 @@ export function SessionList() {
   const taskEntries = useAllTasksBySession();
   const [confirmingDelete, setConfirmingDelete] = useState<string | null>(null);
   const [deletingId, setDeletingId] = useState<string | null>(null);
+  const [forkingId, setForkingId] = useState<string | null>(null);
   const [selectorOpen, setSelectorOpen] = useState(false);
   const [pendingTemplate, setPendingTemplate] =
     useState<Exclude<SessionTemplateKind, "chat"> | null>(null);
@@ -106,6 +109,21 @@ export function SessionList() {
       return next;
     });
   }, []);
+
+  const handleFork = useCallback(
+    async (id: string) => {
+      if (forkingId) return; // one fork at a time
+      setForkingId(id);
+      try {
+        await branchSession(id);
+      } catch (error) {
+        console.error("Failed to fork session", error);
+      } finally {
+        setForkingId(null);
+      }
+    },
+    [branchSession, forkingId],
+  );
 
   const handleDelete = useCallback(async (id: string) => {
     setDeletingId(id);
@@ -380,6 +398,22 @@ export function SessionList() {
                             {isBusy ? "Live session" : sessionLabel}
                           </div>
                         </div>
+                      </button>
+                      <button
+                        data-testid="session-fork-button"
+                        onClick={(e) => {
+                          e.stopPropagation();
+                          void handleFork(s.id);
+                        }}
+                        disabled={forkingId !== null}
+                        className="glass-icon-button shrink-0 rounded-[10px] p-1.5 opacity-60 hover:text-accent group-hover:opacity-100 disabled:opacity-30"
+                        title="Branch this conversation into a new session"
+                      >
+                        {forkingId === s.id ? (
+                          <Loader2 size={12} className="animate-spin" />
+                        ) : (
+                          <GitBranch size={12} />
+                        )}
                       </button>
                       <button
                         data-testid="session-delete-button"

--- a/src/home/home-assistant-page.tsx
+++ b/src/home/home-assistant-page.tsx
@@ -267,6 +267,9 @@ export function HomeAssistantPage() {
       goBack: async () => false,
       createSession: () => homeSessionId,
       removeSession: async () => {},
+      branchSession: async () => {
+        throw new Error("session fork is not available on this surface");
+      },
       refreshSessions: async () => {},
       markSessionActive: () => {},
     }),

--- a/src/home/voice/voice-page.tsx
+++ b/src/home/voice/voice-page.tsx
@@ -86,6 +86,9 @@ export function VoicePage() {
       goBack: async () => false,
       createSession: () => voiceSessionId,
       removeSession: async () => {},
+      branchSession: async () => {
+        throw new Error("session fork is not available on this surface");
+      },
       refreshSessions: async () => {},
       markSessionActive: () => {},
     }),

--- a/src/runtime/session-context.test.ts
+++ b/src/runtime/session-context.test.ts
@@ -745,6 +745,38 @@ describe("resolveSessionScope", () => {
   });
 });
 
+describe("SessionProvider initial topic restore", () => {
+  it("resolves the FIRST render's topic through the resolver for a scoped saved id", async () => {
+    // codex web#267 r3 P2: with a scoped id saved as the current
+    // session and a STALE map entry under that scoped key (e.g. after
+    // `/s other` on that row), the state initializer used the raw map
+    // and exposed `other` to children's mount effects for the first
+    // render — the restore effect only corrected it afterwards. The
+    // initializer must apply the same resolution: scoped id ⇒ its own
+    // scope is authoritative ⇒ topic undefined.
+    const scopedId = `${idAt(900, "scoped")}#slides`;
+    localStorage.setItem("octos_current_session", scopedId);
+    localStorage.setItem(
+      SESSION_TOPIC_STORAGE_KEY,
+      JSON.stringify({ [scopedId]: "other" }),
+    );
+
+    const seenTopics: Array<string | undefined> = [];
+    const harness = mountSessionProvider((ctx) => {
+      seenTopics.push(ctx.historyTopic);
+    });
+    try {
+      expect(seenTopics.length).toBeGreaterThan(0);
+      expect(seenTopics[0]).toBeUndefined();
+      await flushReactWork();
+      // …and it stays resolved after the restore effect runs.
+      expect(seenTopics[seenTopics.length - 1]).toBeUndefined();
+    } finally {
+      harness.unmount();
+    }
+  });
+});
+
 describe("SessionProvider branchSession fork scoping", () => {
   it("forks the topic-scoped parent key for a session opened under a topic", async () => {
     const topicSessionId = idAt(700, "slides");

--- a/src/runtime/session-context.test.ts
+++ b/src/runtime/session-context.test.ts
@@ -45,8 +45,8 @@ vi.mock("@/api/sessions", () => ({
 import {
   applyOptimisticRename,
   mergeSessionLists,
+  resolveSessionScope,
   rollbackOptimisticRename,
-  scopedForkParent,
   sessionTimestamp,
   SessionProvider,
   SESSION_LIST_RENDER_CAP,
@@ -694,33 +694,54 @@ describe("renameSession rollback wiring (replicated from SessionProvider)", () =
 });
 
 // ---------------------------------------------------------------------------
-// Session fork scoping (codex web#267 r1 P1)
+// Session bucket resolution (codex web#267 r1 P1 + r2 P1)
 // ---------------------------------------------------------------------------
 //
 // A session opened under a topic (`/new slides …`) lives in its own
-// `id#topic` SessionKey server-side. `branchSession` must fork that
-// scoped key, not the bare id — otherwise `session/fork` branches the
-// default bucket, copying the wrong (or empty) history. We test the pure
-// `scopedForkParent` composition helper, then the wiring end-to-end
-// through the real provider callback with a seeded topic.
+// `id#topic` SessionKey server-side. `resolveSessionScope` is the ONE
+// authority for which bucket a sidebar row denotes — shared by
+// `switchSession` (what clicking shows) and `branchSession` (what
+// forking copies), so fork ≡ click-view by construction: a fork can
+// never copy a conversation the row would not open.
 
-describe("scopedForkParent", () => {
-  it("returns the bare id when the session has no topic", () => {
-    expect(scopedForkParent("web-123", undefined)).toBe("web-123");
-    expect(scopedForkParent("web-123", "")).toBe("web-123");
+describe("resolveSessionScope", () => {
+  it("resolves a bare id with no topic to itself (default bucket)", () => {
+    expect(resolveSessionScope("web-123", {})).toEqual({
+      scopedId: "web-123",
+      topic: undefined,
+    });
   });
 
-  it("appends the stored topic as a `#scope` suffix", () => {
-    expect(scopedForkParent("web-123", "slides")).toBe("web-123#slides");
+  it("resolves a bare id with a stored topic to the topic bucket", () => {
+    // This mirrors switchSession: clicking this row loads the TOPIC
+    // history, so forking it must copy that same conversation.
+    expect(resolveSessionScope("web-123", { "web-123": "slides" })).toEqual({
+      scopedId: "web-123#slides",
+      topic: "slides",
+    });
   });
 
-  it("does not double-scope an id that already carries a topic", () => {
-    // Defensive: an already-scoped id is passed through untouched so the
-    // suffix is never applied twice.
-    expect(scopedForkParent("web-123#slides", "slides")).toBe(
-      "web-123#slides",
-    );
-    expect(scopedForkParent("web-123#slides", "other")).toBe("web-123#slides");
+  it("treats an already-scoped id as authoritative", () => {
+    // A topic-bucket row from the server list forks as-is; the topic
+    // map never overrides an explicit scope (codex web#267 r2 P1:
+    // "preserve the selected row's scope") — and it is never
+    // double-suffixed.
+    expect(
+      resolveSessionScope("web-123#slides", { "web-123#slides": "other" }),
+    ).toEqual({ scopedId: "web-123#slides", topic: undefined });
+    expect(resolveSessionScope("web-123#slides", {})).toEqual({
+      scopedId: "web-123#slides",
+      topic: undefined,
+    });
+  });
+
+  it("ignores topics stored under OTHER ids", () => {
+    // codex web#267 r2 P1 scenario: base id web-123 has both a default
+    // and a topic history. The scoped row `web-123#slides` keeps its
+    // own scope; a DIFFERENT bare row (another session) is untouched
+    // by web-123's map entry.
+    const topics = { "web-123": "slides" };
+    expect(resolveSessionScope("web-456", topics).scopedId).toBe("web-456");
   });
 });
 

--- a/src/runtime/session-context.test.ts
+++ b/src/runtime/session-context.test.ts
@@ -29,6 +29,7 @@ const apiMocks = vi.hoisted(() => ({
   getSessionTasks: vi.fn(),
   deleteSession: vi.fn(),
   setSessionTitle: vi.fn(),
+  forkSession: vi.fn(),
 }));
 
 vi.mock("@/api/sessions", () => ({
@@ -38,12 +39,14 @@ vi.mock("@/api/sessions", () => ({
   getSessionTasks: apiMocks.getSessionTasks,
   deleteSession: apiMocks.deleteSession,
   setSessionTitle: apiMocks.setSessionTitle,
+  forkSession: apiMocks.forkSession,
 }));
 
 import {
   applyOptimisticRename,
   mergeSessionLists,
   rollbackOptimisticRename,
+  scopedForkParent,
   sessionTimestamp,
   SessionProvider,
   SESSION_LIST_RENDER_CAP,
@@ -58,6 +61,8 @@ import type { BackgroundTaskInfo, SessionInfo } from "@/api/types";
 const NO_TITLES: Record<string, string> = {};
 const NO_DELETES = new Set<string>();
 const SESSION_TITLES_KEY = "octos_session_titles";
+// Mirrors the private SESSION_TOPIC_STORAGE_KEY in session-context.tsx.
+const SESSION_TOPIC_STORAGE_KEY = "octos_session_topics";
 
 // `sessionTimestamp` rejects ms timestamps < 1700000000000 (~Nov 2023) so
 // fixtures need a realistic base.
@@ -169,6 +174,7 @@ beforeEach(() => {
   apiMocks.getSessionTasks.mockResolvedValue([]);
   apiMocks.deleteSession.mockResolvedValue(undefined);
   apiMocks.setSessionTitle.mockResolvedValue(undefined);
+  apiMocks.forkSession.mockReset();
 });
 
 afterEach(() => {
@@ -683,6 +689,105 @@ describe("renameSession rollback wiring (replicated from SessionProvider)", () =
       expect(latest.find((s) => s.id === "web-1")?.title).toBeUndefined();
     } finally {
       console.warn = warn;
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Session fork scoping (codex web#267 r1 P1)
+// ---------------------------------------------------------------------------
+//
+// A session opened under a topic (`/new slides …`) lives in its own
+// `id#topic` SessionKey server-side. `branchSession` must fork that
+// scoped key, not the bare id — otherwise `session/fork` branches the
+// default bucket, copying the wrong (or empty) history. We test the pure
+// `scopedForkParent` composition helper, then the wiring end-to-end
+// through the real provider callback with a seeded topic.
+
+describe("scopedForkParent", () => {
+  it("returns the bare id when the session has no topic", () => {
+    expect(scopedForkParent("web-123", undefined)).toBe("web-123");
+    expect(scopedForkParent("web-123", "")).toBe("web-123");
+  });
+
+  it("appends the stored topic as a `#scope` suffix", () => {
+    expect(scopedForkParent("web-123", "slides")).toBe("web-123#slides");
+  });
+
+  it("does not double-scope an id that already carries a topic", () => {
+    // Defensive: an already-scoped id is passed through untouched so the
+    // suffix is never applied twice.
+    expect(scopedForkParent("web-123#slides", "slides")).toBe(
+      "web-123#slides",
+    );
+    expect(scopedForkParent("web-123#slides", "other")).toBe("web-123#slides");
+  });
+});
+
+describe("SessionProvider branchSession fork scoping", () => {
+  it("forks the topic-scoped parent key for a session opened under a topic", async () => {
+    const topicSessionId = idAt(700, "slides");
+    // The session was opened via `/new slides …`, so it lives under the
+    // `slides` topic — persisted in localStorage as the provider hydrates.
+    localStorage.setItem(
+      SESSION_TOPIC_STORAGE_KEY,
+      JSON.stringify({ [topicSessionId]: "slides" }),
+    );
+    apiMocks.listSessions.mockResolvedValue([
+      { id: topicSessionId, message_count: 4, title: "deck" },
+    ] satisfies SessionInfo[]);
+    apiMocks.forkSession.mockResolvedValue({
+      new_session_id: "web-1777700000900-child",
+      parent_session_id: `${topicSessionId}#slides`,
+      copied_messages: 4,
+    });
+
+    let latest: SessionContextValue | null = null;
+    const harness = mountSessionProvider((ctx) => {
+      latest = ctx;
+    });
+    try {
+      await flushReactWork();
+      await act(async () => {
+        await latest?.branchSession(topicSessionId);
+      });
+      // The bare id would have branched the default bucket; the fix
+      // appends the stored topic so the right conversation is copied.
+      expect(apiMocks.forkSession).toHaveBeenCalledTimes(1);
+      const call = apiMocks.forkSession.mock.calls[0];
+      expect(call[0]).toBe(`${topicSessionId}#slides`);
+      // The child id is minted client-side (raw `web-*`), never scoped.
+      expect(String(call[1])).toMatch(/^web-/);
+      expect(String(call[1])).not.toContain("#");
+    } finally {
+      harness.unmount();
+    }
+  });
+
+  it("forks the bare id for a session with no topic", async () => {
+    const plainSessionId = idAt(800, "plain");
+    apiMocks.listSessions.mockResolvedValue([
+      { id: plainSessionId, message_count: 2 },
+    ] satisfies SessionInfo[]);
+    apiMocks.forkSession.mockResolvedValue({
+      new_session_id: "web-1777700000950-child",
+      parent_session_id: plainSessionId,
+      copied_messages: 2,
+    });
+
+    let latest: SessionContextValue | null = null;
+    const harness = mountSessionProvider((ctx) => {
+      latest = ctx;
+    });
+    try {
+      await flushReactWork();
+      await act(async () => {
+        await latest?.branchSession(plainSessionId);
+      });
+      expect(apiMocks.forkSession).toHaveBeenCalledTimes(1);
+      expect(apiMocks.forkSession.mock.calls[0][0]).toBe(plainSessionId);
+    } finally {
+      harness.unmount();
     }
   });
 });

--- a/src/runtime/session-context.tsx
+++ b/src/runtime/session-context.tsx
@@ -503,9 +503,15 @@ export function SessionProvider({ children }: { children: ReactNode }) {
     return saved || generateSessionId();
   });
   const [activeHistoryTopic, setActiveHistoryTopic] = useState<string | undefined>(() => {
+    // Through the resolver, NOT a raw map read (codex web#267 r3 P2):
+    // a restored scoped id (`web-123#slides`) is authoritative as-is,
+    // and a stale map entry under that scoped key must not expose a
+    // different topic to children's mount effects for the first render
+    // — the restore effect would only correct it AFTER mount.
     const saved = localStorage.getItem("octos_current_session");
-    const topics = loadStoredTopics();
-    return saved ? topics[saved] : undefined;
+    return saved
+      ? resolveSessionScope(saved, loadStoredTopics()).topic
+      : undefined;
   });
   const [initialMessages, setInitialMessages] = useState<MessageInfo[]>([]);
   const [serverTaskActiveBySession, setServerTaskActiveBySession] = useState<

--- a/src/runtime/session-context.tsx
+++ b/src/runtime/session-context.tsx
@@ -12,6 +12,7 @@ import {
   getMessages,
   getSessionTasks,
   deleteSession as apiDeleteSession,
+  forkSession,
   setSessionTitle as apiSetSessionTitle,
 } from "@/api/sessions";
 import type { BackgroundTaskInfo, SessionInfo, MessageInfo } from "@/api/types";
@@ -190,6 +191,10 @@ export interface SessionContextValue {
   switchSession: (id: string) => void;
   goBack: () => Promise<boolean>;
   createSession: (title?: string) => string;
+  /** Fork `sourceId` into a fresh session (full history copied,
+   *  parent lineage recorded server-side) and switch to it. Resolves
+   *  to the new session id. */
+  branchSession: (sourceId: string) => Promise<string>;
   removeSession: (id: string) => Promise<void>;
   refreshSessions: () => Promise<void>;
   /** Mark the current session as active (has sent at least one message). */
@@ -982,6 +987,21 @@ export function SessionProvider({ children }: { children: ReactNode }) {
     return nextId;
   }, [currentSessionId]);
 
+  const branchSession = useCallback(
+    async (sourceId: string) => {
+      // Server-side fork: copies the parent's FULL history and records
+      // parent_key lineage; the SPA then treats the child as any other
+      // session. The child id is minted client-side (raw `web-*`
+      // convention) — the server echoes it back for raw parents.
+      const result = await forkSession(sourceId, generateSessionId());
+      const newId = result.new_session_id;
+      await refreshSessions();
+      switchSession(newId);
+      return newId;
+    },
+    [refreshSessions, switchSession],
+  );
+
   const goBack = useCallback(async () => {
     const previous = previousSessionIdRef.current;
     if (!previous || previous === currentSessionId) return false;
@@ -1075,6 +1095,7 @@ export function SessionProvider({ children }: { children: ReactNode }) {
         switchSession,
         goBack,
         createSession,
+        branchSession,
         removeSession,
         refreshSessions,
         markSessionActive,

--- a/src/runtime/session-context.tsx
+++ b/src/runtime/session-context.tsx
@@ -465,22 +465,34 @@ export function rollbackOptimisticRename(
 }
 
 /**
- * Compose the scoped parent key for a session fork. A session opened
- * under a topic (e.g. `/new slides …`) lives in its own `id#topic`
- * SessionKey server-side; forking the bare id would branch the default
- * bucket instead — copying the wrong (or empty) history, or 404ing as
- * `unknown_session` (codex web#267 r1 P1). Mirror the ui-protocol
- * bridge's `requireScopedSessionId`: append the stored topic unless the
- * id already carries a `#` scope. Returns the bare id when the session
- * has no topic. The server derives the child from `base_key` (topic
- * dropped), so the child is always a fresh raw conversation.
+ * Resolve which server-side bucket a sidebar session id denotes — THE
+ * single authority shared by `switchSession` (what clicking a row
+ * shows) and `branchSession` (what forking a row copies), so the two
+ * can never diverge (codex web#267 r1 P1 + r2 P1).
+ *
+ * A session opened under a topic (e.g. `/new slides …`) lives in its
+ * own `id#topic` SessionKey server-side. The SPA keys sidebar rows by
+ * BARE id and tracks the active topic in `sessionTopics`; clicking a
+ * bare row loads `(id, topics[id])` — i.e. the row denotes the TOPIC
+ * bucket whenever the map holds one, and the default bucket under that
+ * base id is not reachable from that row. Forking follows the same
+ * resolution: it copies exactly the conversation the row opens.
+ *
+ * An id that already carries a `#` scope (a server list row for a
+ * topic bucket) is authoritative as-is — the topic map never overrides
+ * it, mirroring the bridge's `requireScopedSessionId` pass-through.
+ * The server derives a fork child from `base_key` (topic dropped), so
+ * the child is always a fresh raw conversation regardless of scope.
  */
-export function scopedForkParent(
-  sourceId: string,
-  topic: string | undefined,
-): string {
-  if (!topic || sourceId.includes("#")) return sourceId;
-  return `${sourceId}#${topic}`;
+export function resolveSessionScope(
+  id: string,
+  topics: Record<string, string>,
+): { scopedId: string; topic: string | undefined } {
+  if (id.includes("#")) {
+    return { scopedId: id, topic: undefined };
+  }
+  const topic = topics[id] || undefined;
+  return { scopedId: topic ? `${id}#${topic}` : id, topic };
 }
 
 export function SessionProvider({ children }: { children: ReactNode }) {
@@ -587,7 +599,7 @@ export function SessionProvider({ children }: { children: ReactNode }) {
     restoredRef.current = true;
     const saved = localStorage.getItem("octos_current_session");
     if (saved && saved.startsWith("web-")) {
-      const restoredTopic = sessionTopics[saved];
+      const { topic: restoredTopic } = resolveSessionScope(saved, sessionTopics);
       void ThreadStore.loadHistory(saved, restoredTopic);
       getSessionTasks(saved, restoredTopic)
         .then((tasks) => {
@@ -962,7 +974,9 @@ export function SessionProvider({ children }: { children: ReactNode }) {
     // pages through `getMessagesPage` so >500-msg sessions render in
     // full instead of silent truncation.
     const requestId = ++switchRequestRef.current;
-    const topic = sessionTopics[id];
+    // Shared bucket resolution with branchSession — see
+    // resolveSessionScope.
+    const { topic } = resolveSessionScope(id, sessionTopics);
     setCurrentSessionId(id);
     setActiveHistoryTopic(topic);
     setInitialMessages([]);
@@ -1008,17 +1022,23 @@ export function SessionProvider({ children }: { children: ReactNode }) {
 
   const branchSession = useCallback(
     async (sourceId: string) => {
-      // Fork the SCOPED parent key (see `scopedForkParent`): a
-      // topic-scoped session must be forked as `id#topic`, not the bare
-      // id, or the server branches the wrong bucket (codex web#267 r1
-      // P1). Server-side fork copies the parent's FULL message history
-      // and records parent_key lineage — matching the CLI `/new` fork.
-      // Workspace artifacts (uploads, generated files) intentionally
-      // stay with the parent, same as the CLI: the child inherits the
+      // Fork the bucket the row DENOTES — the same resolution
+      // switchSession uses (see resolveSessionScope), so a fork always
+      // copies exactly the conversation clicking that row shows: the
+      // topic bucket when the map holds a topic for a bare id, the
+      // scoped id as-is for a topic-bucket row, the default bucket
+      // otherwise (codex web#267 r1 P1 + r2 P1). Server-side fork
+      // copies the parent's FULL message history and records
+      // parent_key lineage — matching the CLI `/new` fork. Workspace
+      // artifacts (uploads, generated files) intentionally stay with
+      // the parent, same as the CLI: the child inherits the
       // conversation, not the parent's on-disk resources. The child id
       // is minted client-side (raw `web-*` convention); the server
       // echoes it back for raw parents.
-      const scopedSource = scopedForkParent(sourceId, sessionTopics[sourceId]);
+      const { scopedId: scopedSource } = resolveSessionScope(
+        sourceId,
+        sessionTopics,
+      );
       const result = await forkSession(scopedSource, generateSessionId());
       const newId = result.new_session_id;
       await refreshSessions();

--- a/src/runtime/session-context.tsx
+++ b/src/runtime/session-context.tsx
@@ -464,6 +464,25 @@ export function rollbackOptimisticRename(
   );
 }
 
+/**
+ * Compose the scoped parent key for a session fork. A session opened
+ * under a topic (e.g. `/new slides …`) lives in its own `id#topic`
+ * SessionKey server-side; forking the bare id would branch the default
+ * bucket instead — copying the wrong (or empty) history, or 404ing as
+ * `unknown_session` (codex web#267 r1 P1). Mirror the ui-protocol
+ * bridge's `requireScopedSessionId`: append the stored topic unless the
+ * id already carries a `#` scope. Returns the bare id when the session
+ * has no topic. The server derives the child from `base_key` (topic
+ * dropped), so the child is always a fresh raw conversation.
+ */
+export function scopedForkParent(
+  sourceId: string,
+  topic: string | undefined,
+): string {
+  if (!topic || sourceId.includes("#")) return sourceId;
+  return `${sourceId}#${topic}`;
+}
+
 export function SessionProvider({ children }: { children: ReactNode }) {
   const [sessions, setSessions] = useState<SessionWithTitle[]>([]);
   const [currentSessionId, setCurrentSessionId] = useState(() => {
@@ -989,17 +1008,24 @@ export function SessionProvider({ children }: { children: ReactNode }) {
 
   const branchSession = useCallback(
     async (sourceId: string) => {
-      // Server-side fork: copies the parent's FULL history and records
-      // parent_key lineage; the SPA then treats the child as any other
-      // session. The child id is minted client-side (raw `web-*`
-      // convention) — the server echoes it back for raw parents.
-      const result = await forkSession(sourceId, generateSessionId());
+      // Fork the SCOPED parent key (see `scopedForkParent`): a
+      // topic-scoped session must be forked as `id#topic`, not the bare
+      // id, or the server branches the wrong bucket (codex web#267 r1
+      // P1). Server-side fork copies the parent's FULL message history
+      // and records parent_key lineage — matching the CLI `/new` fork.
+      // Workspace artifacts (uploads, generated files) intentionally
+      // stay with the parent, same as the CLI: the child inherits the
+      // conversation, not the parent's on-disk resources. The child id
+      // is minted client-side (raw `web-*` convention); the server
+      // echoes it back for raw parents.
+      const scopedSource = scopedForkParent(sourceId, sessionTopics[sourceId]);
+      const result = await forkSession(scopedSource, generateSessionId());
       const newId = result.new_session_id;
       await refreshSessions();
       switchSession(newId);
       return newId;
     },
-    [refreshSessions, switchSession],
+    [sessionTopics, refreshSessions, switchSession],
   );
 
   const goBack = useCallback(async () => {

--- a/src/runtime/ui-protocol-bridge.ts
+++ b/src/runtime/ui-protocol-bridge.ts
@@ -153,6 +153,7 @@ export const METHODS = {
   SESSION_OPEN: "session/open",
   SESSION_HYDRATE: "session/hydrate",
   SESSION_ROLLBACK: "session/rollback",
+  SESSION_FORK: "session/fork",
   LOOP_LIST: "loop/list",
   LOOP_PAUSE: "loop/pause",
   LOOP_RESUME: "loop/resume",

--- a/src/sites/components/sites-chat.tsx
+++ b/src/sites/components/sites-chat.tsx
@@ -321,6 +321,9 @@ export function SitesChat({ sessionId }: Props) {
       goBack: async () => false,
       createSession: () => sessionId,
       removeSession: async () => {},
+      branchSession: async () => {
+        throw new Error("session fork is not available on this surface");
+      },
       refreshSessions: async () => {},
       markSessionActive: () => {},
       beforeSend,

--- a/src/slides/components/slides-chat.tsx
+++ b/src/slides/components/slides-chat.tsx
@@ -222,6 +222,9 @@ export function SlidesChat({ sessionId, retryNonce = 0 }: Props) {
       goBack: async () => false,
       createSession: () => sessionId,
       removeSession: async () => {},
+      branchSession: async () => {
+        throw new Error("session fork is not available on this surface");
+      },
       refreshSessions: async () => {},
       markSessionActive: () => {},
     }),

--- a/src/studio/studio-page.tsx
+++ b/src/studio/studio-page.tsx
@@ -229,6 +229,9 @@ function StudioWorkspace({ projectId }: { projectId: string }) {
       goBack: async () => false,
       createSession: () => projectId,
       removeSession: async () => {},
+      branchSession: async () => {
+        throw new Error("session fork is not available on this surface");
+      },
       refreshSessions: async () => {},
       markSessionActive: () => {},
       beforeSend,


### PR DESCRIPTION
## Summary

Web parity P3 item 8 (~/home/octos-audit/WEB-PARITY-2026-07-10.md): `SessionManager::fork` (parent lineage + history copy) has existed since the `/new` work but had **no wire surface** — the SPA's `/new` is topic scaffolding. octos-org/octos#1613 lifts fork onto the UI Protocol; this consumes it.

- A **branch icon** on every sidebar session row forks that conversation — the server copies the full history and records `parent_key` lineage, then the SPA switches to the child.
- **ui-protocol-bridge**: `SESSION_FORK` method constant.
- **api/sessions**: `forkSession(sessionId, newChatId)` wrapper over the WS `session/fork` method.
- **session-context**: `branchSession` — fork + `refreshSessions` + `switchSession`; the child id is minted client-side (the raw `web-*` convention the server echoes back for raw parents).
- **session-list**: per-row fork button with a one-fork-at-a-time guard, a spinner on the addressed row, and failure that leaves the buttons usable.
- Surfaces without a fork affordance (home-assistant, voice, slides, sites, studio) stub `branchSession` (throws if called).

## Tests
2 new session-list tests (fork routes to the addressed row + disables all buttons while in flight; failure recovers) + the existing session-list suite updated for the new context field. Full suite: 964 passed / 94 files. `npm run build` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)