### PR TITLE
feat(settings): ride memory + cron tabs on the ui-protocol bridge

### DIFF
--- a/src/api/client.ts
+++ b/src/api/client.ts
@@ -52,6 +52,20 @@ export function clearToken() {
   // session) does not surface the prior profile id into the next
   // session's headers.
   localStorage.removeItem("selected_profile");
+  // codex web#268 r2 P1: an ORDINARY logout clears the token without
+  // firing `crew:auth_expired`, so identity-bound singletons (the
+  // sessionless auxiliary bridge) would survive into the next login
+  // and keep serving RPCs under the PREVIOUS account's upgrade
+  // identity. Broadcast every token clear so they tear down with the
+  // token. Event-based on purpose — importing the runtime here would
+  // cycle (runtime → bridge → client).
+  if (typeof window !== "undefined") {
+    try {
+      window.dispatchEvent(new CustomEvent("crew:token_cleared"));
+    } catch {
+      // best-effort
+    }
+  }
 }
 
 export function getSelectedProfileId(includeStoredFallback = true): string | null {

--- a/src/runtime/ui-protocol-bridge.test.ts
+++ b/src/runtime/ui-protocol-bridge.test.ts
@@ -2964,3 +2964,108 @@ describe("keepalive", () => {
     expect(pingsAfter).toBeGreaterThan(pingsBefore);
   });
 });
+
+// ---------------------------------------------------------------------------
+// Sessionless (auxiliary) mode — settings memory/cron panels (web#268 r1 P1)
+// ---------------------------------------------------------------------------
+
+describe("sessionless (auxiliary) mode", () => {
+  it("goes connected on socket open WITHOUT sending session/open", async () => {
+    const bridge = createUiProtocolBridge(makeBridgeOpts());
+    const states: ConnectionState[] = [];
+    bridge.onConnectionStateChange((s) => states.push(s));
+
+    const startPromise = bridge.start({});
+    await Promise.resolve();
+    const ws = lastInstance();
+    ws.triggerOpen();
+    await startPromise;
+    await Promise.resolve();
+
+    expect(states).toEqual(["connecting", "connected"]);
+    const sessionOpens = ws.sent.filter((text) => {
+      const parsed = JSON.parse(text) as { method?: string };
+      return parsed.method === METHODS.SESSION_OPEN;
+    });
+    expect(sessionOpens).toHaveLength(0);
+  });
+
+  it("still authenticates and negotiates ui_feature on the URL", async () => {
+    const bridge = createUiProtocolBridge(makeBridgeOpts());
+    void bridge.start({});
+    await Promise.resolve();
+    const ws = lastInstance();
+    expect(ws.url).toContain("token=test-token");
+    expect(ws.url).toContain("ui_feature=");
+  });
+
+  it("serves auxiliary RPCs queued while connecting once the socket opens", async () => {
+    const bridge = createUiProtocolBridge(makeBridgeOpts());
+    void bridge.start({});
+    await Promise.resolve();
+    const ws = lastInstance();
+
+    // Issued pre-open: parks on the send queue (nothing on the wire yet).
+    const pending = bridge.callMethod<{ jobs: unknown[] }>(
+      METHODS.CRON_LIST,
+      {},
+    );
+    expect(ws.sent).toHaveLength(0);
+
+    ws.triggerOpen();
+    await Promise.resolve();
+
+    const req = findRequest(ws, METHODS.CRON_LIST);
+    ws.triggerMessage({
+      jsonrpc: "2.0",
+      id: req.id,
+      result: { jobs: [], count: 0, gateway_running: false },
+    });
+    await expect(pending).resolves.toEqual({
+      jobs: [],
+      count: 0,
+      gateway_running: false,
+    });
+  });
+
+  it("round-trips memory/overview after connect", async () => {
+    const bridge = createUiProtocolBridge(makeBridgeOpts());
+    const startPromise = bridge.start({});
+    await Promise.resolve();
+    const ws = lastInstance();
+    ws.triggerOpen();
+    await startPromise;
+
+    const pending = bridge.callMethod<{ overview: { ok: boolean } }>(
+      METHODS.MEMORY_OVERVIEW,
+      {},
+    );
+    await Promise.resolve();
+    const req = findRequest(ws, METHODS.MEMORY_OVERVIEW);
+    ws.triggerMessage({
+      jsonrpc: "2.0",
+      id: req.id,
+      result: { overview: { ok: true } },
+    });
+    await expect(pending).resolves.toEqual({ overview: { ok: true } });
+  });
+
+  it("rejects session-bound sends (sendTurn) in sessionless mode", async () => {
+    const bridge = createUiProtocolBridge(makeBridgeOpts());
+    const startPromise = bridge.start({});
+    await Promise.resolve();
+    lastInstance().triggerOpen();
+    await startPromise;
+
+    expect(() =>
+      bridge.sendTurn("turn-1", [{ kind: "text", text: "hi" }]),
+    ).toThrow();
+  });
+
+  it("still throws on a non-string sessionId", async () => {
+    const bridge = createUiProtocolBridge(makeBridgeOpts());
+    await expect(
+      bridge.start({ sessionId: 42 as unknown as string }),
+    ).rejects.toThrow("sessionId must be a string");
+  });
+});

--- a/src/runtime/ui-protocol-bridge.test.ts
+++ b/src/runtime/ui-protocol-bridge.test.ts
@@ -3062,6 +3062,35 @@ describe("sessionless (auxiliary) mode", () => {
     ).toThrow();
   });
 
+  it("reports terminal after a NORMAL remote close (code 1000)", async () => {
+    // codex web#268 r3 P2: the server closing an auxiliary socket with
+    // 1000 parks the bridge at `closed` (no reconnect, callMethod
+    // rejects) — isTerminal() must say so, or the settings singleton
+    // returns the corpse forever.
+    const bridge = createUiProtocolBridge(makeBridgeOpts());
+    const startPromise = bridge.start({});
+    await Promise.resolve();
+    const ws = lastInstance();
+    ws.triggerOpen();
+    await startPromise;
+    expect(bridge.isTerminal()).toBe(false);
+
+    ws.triggerClose(1000, "server going away");
+    expect(bridge.isTerminal()).toBe(true);
+
+    // A RECOVERABLE drop is NOT terminal (r2 P2 contract preserved).
+    const bridge2 = createUiProtocolBridge(makeBridgeOpts());
+    const start2 = bridge2.start({});
+    await Promise.resolve();
+    const ws2 = lastInstance();
+    ws2.triggerOpen();
+    await start2;
+    ws2.triggerClose(1006, "abnormal");
+    expect(bridge2.isTerminal()).toBe(false);
+    await bridge2.stop();
+    await bridge.stop();
+  });
+
   it("still throws on a non-string sessionId", async () => {
     const bridge = createUiProtocolBridge(makeBridgeOpts());
     await expect(

--- a/src/runtime/ui-protocol-bridge.ts
+++ b/src/runtime/ui-protocol-bridge.ts
@@ -432,6 +432,15 @@ export interface UiProtocolBridge {
   }): Promise<void>;
   stop(): Promise<void>;
 
+  /** True when this bridge will never serve another RPC: it was
+   *  `stop()`ed, or it abandoned reconnecting (attempt budget spent, or
+   *  latched on auth rejection). A transient `"error"` state during a
+   *  RECOVERABLE drop is NOT terminal — the bridge queues sends and
+   *  flushes them after the reconnect (codex web#268 r2 P2: the aux
+   *  singleton must not be replaced mid-recovery, which would reject
+   *  the queued RPCs). */
+  isTerminal(): boolean;
+
   sendTurn(
     turn_id: string,
     input: TurnStartInput[],
@@ -2232,6 +2241,10 @@ class UiProtocolBridgeImpl implements UiProtocolBridge {
     this.lastCursor = null;
     this.installVisibilityListener();
     await this.openSocket();
+  }
+
+  isTerminal(): boolean {
+    return this.stopped || this.reconnectAbandoned;
   }
 
   async stop(): Promise<void> {

--- a/src/runtime/ui-protocol-bridge.ts
+++ b/src/runtime/ui-protocol-bridge.ts
@@ -433,12 +433,13 @@ export interface UiProtocolBridge {
   stop(): Promise<void>;
 
   /** True when this bridge will never serve another RPC: it was
-   *  `stop()`ed, or it abandoned reconnecting (attempt budget spent, or
-   *  latched on auth rejection). A transient `"error"` state during a
-   *  RECOVERABLE drop is NOT terminal — the bridge queues sends and
-   *  flushes them after the reconnect (codex web#268 r2 P2: the aux
-   *  singleton must not be replaced mid-recovery, which would reject
-   *  the queued RPCs). */
+   *  `stop()`ed, it abandoned reconnecting (attempt budget spent, or
+   *  latched on auth rejection), or the remote closed it normally
+   *  (code 1000 — parked at `closed` with no reconnect, codex web#268
+   *  r3 P2). A transient `"error"` state during a RECOVERABLE drop is
+   *  NOT terminal — the bridge queues sends and flushes them after the
+   *  reconnect (codex web#268 r2 P2: the aux singleton must not be
+   *  replaced mid-recovery, which would reject the queued RPCs). */
   isTerminal(): boolean;
 
   sendTurn(
@@ -2244,7 +2245,13 @@ class UiProtocolBridgeImpl implements UiProtocolBridge {
   }
 
   isTerminal(): boolean {
-    return this.stopped || this.reconnectAbandoned;
+    // `closed` covers BOTH `stop()` and a NORMAL remote closure (code
+    // 1000): `onWsClose` parks the bridge there without scheduling a
+    // reconnect and every later `callMethod` rejects, so a consumer
+    // holding it must replace it (codex web#268 r3 P2). Recoverable
+    // drops never pass through `closed` — they go `error` →
+    // `reconnecting`.
+    return this.stopped || this.reconnectAbandoned || this.state === "closed";
   }
 
   async stop(): Promise<void> {

--- a/src/runtime/ui-protocol-bridge.ts
+++ b/src/runtime/ui-protocol-bridge.ts
@@ -184,6 +184,12 @@ export const METHODS = {
   CONTENT_LIST: "content/list",
   CONTENT_DELETE: "content/delete",
   CONTENT_BULK_DELETE: "content/bulk_delete",
+  // Memory/cron settings panels (octos PR #1621): WS wrappers over the
+  // `/api/my/memory*` + `/api/my/cron*` REST panel handlers.
+  MEMORY_OVERVIEW: "memory/overview",
+  MEMORY_ENTITY: "memory/entity",
+  CRON_LIST: "cron/list",
+  CRON_TOGGLE: "cron/toggle",
   // server → client
   // Bridge hygiene (parity audit P3): `user_question/requested` is a
   // NOTIFICATION the server pushes; it was mislisted in the

--- a/src/runtime/ui-protocol-bridge.ts
+++ b/src/runtime/ui-protocol-bridge.ts
@@ -419,9 +419,14 @@ export interface UiProtocolBridge {
    *  broadcast to the negotiated topic (separate server PR), this is
    *  best-effort defense — only events whose Rust struct includes the
    *  `topic` field carry it on the wire (e.g. `TurnStartedEvent`); other
-   *  envelopes pass through unfiltered. */
+   *  envelopes pass through unfiltered.
+   *
+   *  Omit `sessionId` for a SESSIONLESS (auxiliary) bridge: no
+   *  `session/open` handshake, no event scope — the connection serves
+   *  auth-bound auxiliary RPCs only (settings memory/cron panels,
+   *  web#268 r1 P1); session-bound methods throw. */
   start(opts: {
-    sessionId: string;
+    sessionId?: string;
     profileId?: string;
     topic?: string;
   }): Promise<void>;
@@ -2195,15 +2200,19 @@ class UiProtocolBridgeImpl implements UiProtocolBridge {
   // ----- public API --------------------------------------------------------
 
   async start(opts: {
-    sessionId: string;
+    /** Omit for a SESSIONLESS (auxiliary) bridge: no `session/open`
+     *  handshake, no event scope — the connection serves auth-bound
+     *  auxiliary RPCs only (settings memory/cron panels, web#268 r1
+     *  P1). Session-bound methods (`sendTurn`, hydrate, …) throw. */
+    sessionId?: string;
     profileId?: string;
     topic?: string;
   }): Promise<void> {
-    if (!opts || !isString(opts.sessionId)) {
-      throw new Error("ui-protocol-bridge: start requires sessionId");
+    if (!opts || (opts.sessionId !== undefined && !isString(opts.sessionId))) {
+      throw new Error("ui-protocol-bridge: sessionId must be a string when provided");
     }
     this.stopped = false;
-    this.sessionId = opts.sessionId;
+    this.sessionId = opts.sessionId ?? null;
     this.profileId = opts.profileId ?? this.cfg.getProfileId();
     // Codex BLOCK E: stash the topic scope for the client-side
     // envelope-mismatch drop. Empty string => no scope (root).
@@ -2793,6 +2802,24 @@ class UiProtocolBridgeImpl implements UiProtocolBridge {
   private async onWsOpen(): Promise<void> {
     if (this.stopped) return;
     this.lastInboundAt = this.cfg.now();
+    if (!this.sessionId) {
+      // Sessionless (auxiliary) mode: there is no session to open — the
+      // socket itself is the lifecycle gate. Auxiliary methods bind to
+      // the connection identity from the upgrade (`?token=`), not to a
+      // session scope, so the bridge goes `connected` on open and skips
+      // the `session/open` handshake, cursor seeding, `opened` payload
+      // emit, and the reopen-hydrate hook (nothing to replay — aux RPCs
+      // are request/response only).
+      this.reconnectAttempts = 0;
+      this.reconnectAbandoned = false;
+      this.latchReason = null;
+      this.visibilityReconnectInFlight = false;
+      this.hasEverOpened = true;
+      this.setState("connected");
+      this.startKeepalive();
+      this.flushSendQueue();
+      return;
+    }
     try {
       const params: Record<string, unknown> = {
         session_id: this.requireSessionId(),

--- a/src/runtime/ui-protocol-runtime.test.ts
+++ b/src/runtime/ui-protocol-runtime.test.ts
@@ -57,8 +57,13 @@ interface DeferredBridge {
    *  for `getActiveBridge` to return the bridge. */
   setConnected: () => void;
   /** Drive the connection-state subscriber to an arbitrary state (the
-   *  aux-singleton tests use `"error"` to exercise replacement). */
+   *  aux-singleton tests use `"error"` to exercise the transient-error
+   *  reuse path). */
   setState: (state: ConnectionState) => void;
+  /** Mark the bridge terminal (stopped / reconnect abandoned) — the
+   *  aux-singleton replacement gate consults `isTerminal()`, not the
+   *  connection state (codex web#268 r2 P2). */
+  setTerminal: () => void;
   startCalls: number;
   stopCalls: number;
 }
@@ -72,6 +77,7 @@ function makeDeferredBridge(): DeferredBridge {
   });
   let startCalls = 0;
   let stopCalls = 0;
+  let terminal = false;
   // Track the current state subscriber so the test can drive the bridge
   // to `"connected"` after `start()` resolves — `getActiveBridge` only
   // surfaces a bridge that has reached `connected` (codex M10.5 round 2
@@ -88,7 +94,9 @@ function makeDeferredBridge(): DeferredBridge {
     }),
     stop: vi.fn(async () => {
       stopCalls++;
+      terminal = true;
     }),
+    isTerminal: vi.fn(() => terminal),
     sendTurn: vi.fn(async () => ({ accepted: true })),
     interruptTurn: vi.fn(async () => ({ interrupted: true })),
     respondToApproval: vi.fn(async () => ({
@@ -141,6 +149,9 @@ function makeDeferredBridge(): DeferredBridge {
     rejectStart: (err) => rejectStart(err),
     setConnected: () => stateHandler?.("connected"),
     setState: (state: ConnectionState) => stateHandler?.(state),
+    setTerminal: () => {
+      terminal = true;
+    },
     /** Simulate the bridge's post-reconnect `session/open` ack
      *  (reload-bug fix Yue 2026-05-15). The runtime layer subscribes via
      *  `onReopened` to re-fire `session/hydrate`. */
@@ -637,13 +648,15 @@ describe("ensureAuxBridge — sessionless auxiliary singleton", () => {
     expect(aux.startCalls).toBe(1);
   });
 
-  it("replaces a singleton that reached a terminal state", async () => {
+  it("replaces a singleton that reached a TERMINAL state", async () => {
     const aux1 = makeDeferredBridge();
     createBridgeSpy.mockReturnValueOnce(aux1.bridge);
     const p1 = ensureAuxBridge();
     aux1.resolveStart();
     await p1;
 
+    // Reconnect abandoned (attempt budget spent / auth latch).
+    aux1.setTerminal();
     aux1.setState("error");
 
     const aux2 = makeDeferredBridge();
@@ -655,6 +668,48 @@ describe("ensureAuxBridge — sessionless auxiliary singleton", () => {
     expect(got).toBe(aux2.bridge);
     expect(aux1.stopCalls).toBe(1);
     expect(aux2.startCalls).toBe(1);
+  });
+
+  it("does NOT replace a bridge in a transient error state (recoverable drop)", async () => {
+    // codex web#268 r2 P2: `onerror` fires state="error" BEFORE
+    // `onclose` moves to "reconnecting"; the bridge queues sends across
+    // that gap. A caller landing in the gap must reuse the recovering
+    // singleton, not stop it (stopping rejects the queued RPCs).
+    const aux = makeDeferredBridge();
+    createBridgeSpy.mockReturnValueOnce(aux.bridge);
+    const p = ensureAuxBridge();
+    aux.resolveStart();
+    await p;
+
+    aux.setState("error"); // transient — isTerminal() stays false
+
+    const got = await ensureAuxBridge();
+    expect(got).toBe(aux.bridge);
+    expect(aux.stopCalls).toBe(0);
+    expect(createBridgeSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it("tears the singleton down on crew:token_cleared (ordinary logout)", async () => {
+    // codex web#268 r2 P1: a normal logout clears the token WITHOUT
+    // firing crew:auth_expired. The aux socket is authenticated as the
+    // logged-out user at the upgrade — reusing it after a different
+    // account logs in would serve the previous user's memory/cron.
+    const aux = makeDeferredBridge();
+    createBridgeSpy.mockReturnValueOnce(aux.bridge);
+    const p = ensureAuxBridge();
+    aux.resolveStart();
+    await p;
+
+    window.dispatchEvent(new CustomEvent("crew:token_cleared"));
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(aux.stopCalls).toBe(1);
+    const aux2 = makeDeferredBridge();
+    createBridgeSpy.mockReturnValueOnce(aux2.bridge);
+    const p2 = ensureAuxBridge();
+    aux2.resolveStart();
+    expect(await p2).toBe(aux2.bridge);
   });
 
   it("tears the singleton down on crew:auth_expired", async () => {

--- a/src/runtime/ui-protocol-runtime.test.ts
+++ b/src/runtime/ui-protocol-runtime.test.ts
@@ -35,6 +35,8 @@ vi.mock("./ui-protocol-bridge", async () => {
 
 import {
   __resetUiProtocolRuntimeForTest,
+  __setActiveBridgeForTest,
+  ensureAuxBridge,
   getActiveBridge,
   startBridgeForSession,
   stopActiveBridge,
@@ -54,6 +56,9 @@ interface DeferredBridge {
    *  fire `setConnected()` after `await startBridgeForSession(...)`
    *  for `getActiveBridge` to return the bridge. */
   setConnected: () => void;
+  /** Drive the connection-state subscriber to an arbitrary state (the
+   *  aux-singleton tests use `"error"` to exercise replacement). */
+  setState: (state: ConnectionState) => void;
   startCalls: number;
   stopCalls: number;
 }
@@ -135,6 +140,7 @@ function makeDeferredBridge(): DeferredBridge {
     resolveStart: () => resolveStart(),
     rejectStart: (err) => rejectStart(err),
     setConnected: () => stateHandler?.("connected"),
+    setState: (state: ConnectionState) => stateHandler?.(state),
     /** Simulate the bridge's post-reconnect `session/open` ack
      *  (reload-bug fix Yue 2026-05-15). The runtime layer subscribes via
      *  `onReopened` to re-fire `session/hydrate`. */
@@ -596,5 +602,95 @@ describe("autonomy snapshot resilience (codex #263 round 1 P2)", () => {
     expect(
       AutonomyStore.getAutonomyState("sess-snap").loops.map((l) => l.loop_id),
     ).toEqual(["l1"]);
+  });
+});
+
+describe("ensureAuxBridge — sessionless auxiliary singleton", () => {
+  it("prefers a connected chat-scoped bridge and starts nothing", async () => {
+    const chat = makeDeferredBridge();
+    __setActiveBridgeForTest("sess-1", chat.bridge);
+
+    const got = await ensureAuxBridge();
+
+    expect(got).toBe(chat.bridge);
+    expect(createBridgeSpy).not.toHaveBeenCalled();
+  });
+
+  it("starts ONE sessionless bridge and shares it across concurrent callers", async () => {
+    const aux = makeDeferredBridge();
+    createBridgeSpy.mockReturnValueOnce(aux.bridge);
+
+    const p1 = ensureAuxBridge();
+    const p2 = ensureAuxBridge();
+    aux.resolveStart();
+    const [b1, b2] = await Promise.all([p1, p2]);
+
+    expect(b1).toBe(aux.bridge);
+    expect(b2).toBe(aux.bridge);
+    expect(createBridgeSpy).toHaveBeenCalledTimes(1);
+    expect(aux.startCalls).toBe(1);
+    // Sessionless: start carries NO sessionId.
+    expect(aux.bridge.start).toHaveBeenCalledWith({});
+    // Subsequent calls reuse the live singleton without a new start.
+    const b3 = await ensureAuxBridge();
+    expect(b3).toBe(aux.bridge);
+    expect(aux.startCalls).toBe(1);
+  });
+
+  it("replaces a singleton that reached a terminal state", async () => {
+    const aux1 = makeDeferredBridge();
+    createBridgeSpy.mockReturnValueOnce(aux1.bridge);
+    const p1 = ensureAuxBridge();
+    aux1.resolveStart();
+    await p1;
+
+    aux1.setState("error");
+
+    const aux2 = makeDeferredBridge();
+    createBridgeSpy.mockReturnValueOnce(aux2.bridge);
+    const p2 = ensureAuxBridge();
+    aux2.resolveStart();
+    const got = await p2;
+
+    expect(got).toBe(aux2.bridge);
+    expect(aux1.stopCalls).toBe(1);
+    expect(aux2.startCalls).toBe(1);
+  });
+
+  it("tears the singleton down on crew:auth_expired", async () => {
+    const aux = makeDeferredBridge();
+    createBridgeSpy.mockReturnValueOnce(aux.bridge);
+    const p = ensureAuxBridge();
+    aux.resolveStart();
+    await p;
+
+    window.dispatchEvent(new CustomEvent("crew:auth_expired"));
+    // stopAuxBridge is async fire-and-forget off the event; drain it.
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(aux.stopCalls).toBe(1);
+    // The next caller after re-login gets a FRESH bridge.
+    const aux2 = makeDeferredBridge();
+    createBridgeSpy.mockReturnValueOnce(aux2.bridge);
+    const p2 = ensureAuxBridge();
+    aux2.resolveStart();
+    expect(await p2).toBe(aux2.bridge);
+  });
+
+  it("surfaces a start failure and does not cache the dead bridge", async () => {
+    const aux1 = makeDeferredBridge();
+    createBridgeSpy.mockReturnValueOnce(aux1.bridge);
+    const p1 = ensureAuxBridge();
+    aux1.rejectStart(new Error("ws refused"));
+    await expect(p1).rejects.toThrow("ws refused");
+    expect(aux1.stopCalls).toBe(1);
+
+    // Retry path: a fresh call creates a fresh bridge.
+    const aux2 = makeDeferredBridge();
+    createBridgeSpy.mockReturnValueOnce(aux2.bridge);
+    const p2 = ensureAuxBridge();
+    aux2.resolveStart();
+    expect(await p2).toBe(aux2.bridge);
   });
 });

--- a/src/runtime/ui-protocol-runtime.test.ts
+++ b/src/runtime/ui-protocol-runtime.test.ts
@@ -733,6 +733,50 @@ describe("ensureAuxBridge — sessionless auxiliary singleton", () => {
     expect(await p2).toBe(aux2.bridge);
   });
 
+  it("invalidates an IN-FLIGHT start when the token clears mid-handshake", async () => {
+    // codex web#268 r3 P1: logout while `bridge.start({})` is pending
+    // finds auxSlot null (nothing to stop). The stale start must NOT
+    // publish its old-token socket after the logout.
+    const aux = makeDeferredBridge();
+    createBridgeSpy.mockReturnValueOnce(aux.bridge);
+    const pending = ensureAuxBridge();
+
+    window.dispatchEvent(new CustomEvent("crew:token_cleared"));
+    await Promise.resolve();
+    await Promise.resolve();
+
+    aux.resolveStart(); // handshake resolves AFTER the token clear
+    await expect(pending).rejects.toThrow("superseded by token clear");
+    expect(aux.stopCalls).toBe(1);
+
+    // Next caller (post-relogin) gets a FRESH bridge.
+    const aux2 = makeDeferredBridge();
+    createBridgeSpy.mockReturnValueOnce(aux2.bridge);
+    const p2 = ensureAuxBridge();
+    aux2.resolveStart();
+    expect(await p2).toBe(aux2.bridge);
+  });
+
+  it("replaces a singleton the REMOTE closed normally (code 1000)", async () => {
+    // codex web#268 r3 P2: a normal remote close parks the bridge at
+    // `closed` with no reconnect — isTerminal() reports it and the
+    // next ensure() must start fresh instead of returning the corpse.
+    const aux1 = makeDeferredBridge();
+    createBridgeSpy.mockReturnValueOnce(aux1.bridge);
+    const p1 = ensureAuxBridge();
+    aux1.resolveStart();
+    await p1;
+
+    aux1.setTerminal(); // mock stand-in for state === "closed"
+
+    const aux2 = makeDeferredBridge();
+    createBridgeSpy.mockReturnValueOnce(aux2.bridge);
+    const p2 = ensureAuxBridge();
+    aux2.resolveStart();
+    expect(await p2).toBe(aux2.bridge);
+    expect(aux1.stopCalls).toBe(1);
+  });
+
   it("surfaces a start failure and does not cache the dead bridge", async () => {
     const aux1 = makeDeferredBridge();
     createBridgeSpy.mockReturnValueOnce(aux1.bridge);

--- a/src/runtime/ui-protocol-runtime.test.ts
+++ b/src/runtime/ui-protocol-runtime.test.ts
@@ -777,6 +777,68 @@ describe("ensureAuxBridge — sessionless auxiliary singleton", () => {
     expect(aux1.stopCalls).toBe(1);
   });
 
+  it("rejects a REPLACEMENT start when the token clears during the internal stop", async () => {
+    // codex web#268 r4 P1: the replacement path stops the old slot
+    // first; a token clear landing while that stop is yielding must
+    // still invalidate the replacement (the r3 guard captured its
+    // generation AFTER the stop and absorbed the clear as baseline).
+    const aux1 = makeDeferredBridge();
+    createBridgeSpy.mockReturnValueOnce(aux1.bridge);
+    const p1 = ensureAuxBridge();
+    aux1.resolveStart();
+    await p1;
+    aux1.setTerminal();
+
+    // Gate the old slot's stop so the clear can land mid-await.
+    let releaseStop: () => void = () => {};
+    (aux1.bridge.stop as ReturnType<typeof vi.fn>).mockImplementationOnce(
+      async () => {
+        await new Promise<void>((resolve) => {
+          releaseStop = resolve;
+        });
+      },
+    );
+    const aux2 = makeDeferredBridge();
+    createBridgeSpy.mockReturnValueOnce(aux2.bridge);
+    const pending = ensureAuxBridge();
+    await Promise.resolve(); // enter the gated internal stop
+
+    window.dispatchEvent(new CustomEvent("crew:token_cleared"));
+    await Promise.resolve();
+    releaseStop();
+    aux2.resolveStart();
+
+    await expect(pending).rejects.toThrow("superseded by token clear");
+    expect(aux2.stopCalls).toBe(1); // stale replacement stopped, never published
+  });
+
+  it("a settling invalidated start does not erase a newer start's shared handle", async () => {
+    // codex web#268 r4 P2: start A is invalidated by a token clear;
+    // start B begins under the fresh generation; A settles LATE. A's
+    // cleanup must not clear B's shared in-flight handle — otherwise a
+    // third caller races bridge C against B.
+    const aux1 = makeDeferredBridge();
+    createBridgeSpy.mockReturnValueOnce(aux1.bridge);
+    const p1 = ensureAuxBridge(); // A pending
+
+    window.dispatchEvent(new CustomEvent("crew:token_cleared"));
+    await Promise.resolve();
+    await Promise.resolve();
+
+    const aux2 = makeDeferredBridge();
+    createBridgeSpy.mockReturnValueOnce(aux2.bridge);
+    const p2 = ensureAuxBridge(); // B pending under the new generation
+
+    aux1.resolveStart(); // A settles AFTER B took the handle
+    await expect(p1).rejects.toThrow("superseded by token clear");
+
+    const p3 = ensureAuxBridge(); // must join B, not start C
+    aux2.resolveStart();
+    expect(await p2).toBe(aux2.bridge);
+    expect(await p3).toBe(aux2.bridge);
+    expect(createBridgeSpy).toHaveBeenCalledTimes(2);
+  });
+
   it("surfaces a start failure and does not cache the dead bridge", async () => {
     const aux1 = makeDeferredBridge();
     createBridgeSpy.mockReturnValueOnce(aux1.bridge);

--- a/src/runtime/ui-protocol-runtime.ts
+++ b/src/runtime/ui-protocol-runtime.ts
@@ -401,6 +401,102 @@ export function getAnyConnectedBridge(): UiProtocolBridge | null {
   return active.bridge;
 }
 
+// ---- Sessionless auxiliary bridge (settings surface) ----
+
+/** The settings page mounts OUTSIDE `OctosRuntimeProvider`, so no
+ *  session-scoped bridge exists there — and navigating chat → settings
+ *  unmounts the provider, which stops the chat bridge (codex web#268 r1
+ *  P1). Auxiliary methods (`memory/overview`, `memory/entity`,
+ *  `cron/list`, `cron/toggle`) bind to connection identity only, so one
+ *  lazy SESSIONLESS bridge (no `session/open`, no event scope) serves
+ *  the whole page. Singleton by design: reused across tabs/visits,
+ *  replaced when it reaches a terminal state, torn down on
+ *  `crew:auth_expired` alongside the token. */
+interface AuxBridgeSlot {
+  bridge: UiProtocolBridge;
+  connectionState: ConnectionState;
+  unsubscribeState: () => void;
+}
+
+let auxSlot: AuxBridgeSlot | null = null;
+let auxStartInFlight: Promise<UiProtocolBridge> | null = null;
+
+/**
+ * Return a bridge suitable for auxiliary (non-session-scoped) RPCs.
+ * Prefers a connected chat-scoped bridge; otherwise starts (or reuses)
+ * the sessionless singleton. Concurrent callers share one start.
+ * A singleton in a terminal state (`closed`/`error`) is stopped and
+ * replaced so a "Reload" after re-login gets a live socket.
+ */
+export async function ensureAuxBridge(): Promise<UiProtocolBridge> {
+  const chat = getAnyConnectedBridge();
+  if (chat) return chat;
+  if (
+    auxSlot &&
+    auxSlot.connectionState !== "closed" &&
+    auxSlot.connectionState !== "error"
+  ) {
+    // `connecting` is fine: `callMethod` parks requests on the bridge's
+    // send queue and `flushSendQueue` drains it on `connected`.
+    return auxSlot.bridge;
+  }
+  if (auxStartInFlight) return auxStartInFlight;
+  auxStartInFlight = (async () => {
+    if (auxSlot) {
+      await stopAuxBridge();
+    }
+    const bridge = createUiProtocolBridge();
+    let connectionState: ConnectionState = "connecting";
+    const unsubscribeState = bridge.onConnectionStateChange((s) => {
+      if (auxSlot?.bridge === bridge) {
+        auxSlot.connectionState = s;
+      } else {
+        connectionState = s;
+      }
+    });
+    try {
+      await bridge.start({});
+    } catch (err) {
+      unsubscribeState();
+      try {
+        await bridge.stop();
+      } catch {
+        // best-effort
+      }
+      throw err;
+    }
+    auxSlot = { bridge, connectionState, unsubscribeState };
+    return bridge;
+  })();
+  try {
+    return await auxStartInFlight;
+  } finally {
+    auxStartInFlight = null;
+  }
+}
+
+/** Stop and clear the sessionless auxiliary bridge (auth expiry, tests). */
+export async function stopAuxBridge(): Promise<void> {
+  const slot = auxSlot;
+  if (!slot) return;
+  auxSlot = null;
+  slot.unsubscribeState();
+  try {
+    await slot.bridge.stop();
+  } catch {
+    // best-effort
+  }
+}
+
+// A dead token latches the aux bridge into a reconnect loop that can
+// never succeed — tear it down with the token. The next `/settings`
+// visit after re-login starts a fresh one.
+if (typeof window !== "undefined") {
+  window.addEventListener("crew:auth_expired", () => {
+    void stopAuxBridge();
+  });
+}
+
 /**
  * Force-restart a bridge for the given scope. Unlike
  * `startBridgeForSession` (which returns the existing same-scope
@@ -475,6 +571,15 @@ export async function stopActiveBridgeIfScope(
 export function __resetUiProtocolRuntimeForTest(): void {
   active = null;
   generation = 0;
+  if (auxSlot) {
+    auxSlot.unsubscribeState();
+    // Best-effort async stop; tests inject mocks whose `stop()` resolves
+    // synchronously, and a leaked real socket would be closed by jsdom
+    // teardown anyway.
+    void auxSlot.bridge.stop().catch(() => {});
+  }
+  auxSlot = null;
+  auxStartInFlight = null;
 }
 
 /** Test-only injection so unit tests can drive a mock bridge into the

--- a/src/runtime/ui-protocol-runtime.ts
+++ b/src/runtime/ui-protocol-runtime.ts
@@ -420,6 +420,13 @@ interface AuxBridgeSlot {
 
 let auxSlot: AuxBridgeSlot | null = null;
 let auxStartInFlight: Promise<UiProtocolBridge> | null = null;
+/** Monotonic teardown counter (codex web#268 r3 P1): `stopAuxBridge`
+ *  bumps it, and an in-flight `ensureAuxBridge` start compares its
+ *  captured value before publishing. Without this, a token clear that
+ *  lands while `bridge.start({})` is still awaiting finds `auxSlot`
+ *  null (nothing to stop) — and the old-token socket would publish
+ *  itself AFTER the logout, surviving into the next account's session. */
+let auxGeneration = 0;
 
 /**
  * Return a bridge suitable for auxiliary (non-session-scoped) RPCs.
@@ -445,6 +452,10 @@ export async function ensureAuxBridge(): Promise<UiProtocolBridge> {
     if (auxSlot) {
       await stopAuxBridge();
     }
+    // Captured AFTER the internal stop above (which bumps it) so only
+    // an EXTERNAL teardown — token clear / auth expiry racing this
+    // start — invalidates us (codex web#268 r3 P1).
+    const myGeneration = auxGeneration;
     const bridge = createUiProtocolBridge();
     let connectionState: ConnectionState = "connecting";
     const unsubscribeState = bridge.onConnectionStateChange((s) => {
@@ -465,6 +476,21 @@ export async function ensureAuxBridge(): Promise<UiProtocolBridge> {
       }
       throw err;
     }
+    if (myGeneration !== auxGeneration) {
+      // A token clear landed while the handshake was in flight: this
+      // socket authenticated with the CLEARED token and must not
+      // publish. Stop it and reject so the caller retries under the
+      // live credentials.
+      unsubscribeState();
+      try {
+        await bridge.stop();
+      } catch {
+        // best-effort
+      }
+      throw new Error(
+        "ui-protocol-runtime: auxiliary bridge start superseded by token clear",
+      );
+    }
     auxSlot = { bridge, connectionState, unsubscribeState };
     return bridge;
   })();
@@ -475,8 +501,14 @@ export async function ensureAuxBridge(): Promise<UiProtocolBridge> {
   }
 }
 
-/** Stop and clear the sessionless auxiliary bridge (auth expiry, tests). */
+/** Stop and clear the sessionless auxiliary bridge (auth expiry,
+ *  logout, tests). Also invalidates any IN-FLIGHT `ensureAuxBridge`
+ *  start (codex web#268 r3 P1) — the pending promise rejects instead
+ *  of publishing a socket authenticated with the cleared token — and
+ *  drops the shared in-flight handle so the next caller starts fresh. */
 export async function stopAuxBridge(): Promise<void> {
+  auxGeneration++;
+  auxStartInFlight = null;
   const slot = auxSlot;
   if (!slot) return;
   auxSlot = null;
@@ -590,6 +622,7 @@ export function __resetUiProtocolRuntimeForTest(): void {
   }
   auxSlot = null;
   auxStartInFlight = null;
+  auxGeneration = 0;
 }
 
 /** Test-only injection so unit tests can drive a mock bridge into the

--- a/src/runtime/ui-protocol-runtime.ts
+++ b/src/runtime/ui-protocol-runtime.ts
@@ -431,13 +431,13 @@ let auxStartInFlight: Promise<UiProtocolBridge> | null = null;
 export async function ensureAuxBridge(): Promise<UiProtocolBridge> {
   const chat = getAnyConnectedBridge();
   if (chat) return chat;
-  if (
-    auxSlot &&
-    auxSlot.connectionState !== "closed" &&
-    auxSlot.connectionState !== "error"
-  ) {
-    // `connecting` is fine: `callMethod` parks requests on the bridge's
-    // send queue and `flushSendQueue` drains it on `connected`.
+  if (auxSlot && !auxSlot.bridge.isTerminal()) {
+    // Reuse across `connecting`, transient `error`, and `reconnecting`:
+    // `callMethod` parks requests on the bridge's send queue and
+    // `flushSendQueue` drains it after (re)connect. Replacing on a
+    // transient `error` would reject those queued RPCs mid-recovery
+    // (codex web#268 r2 P2) — only a TERMINAL bridge (stopped, or
+    // reconnect abandoned / auth-latched) is torn down and replaced.
     return auxSlot.bridge;
   }
   if (auxStartInFlight) return auxStartInFlight;
@@ -488,11 +488,21 @@ export async function stopAuxBridge(): Promise<void> {
   }
 }
 
-// A dead token latches the aux bridge into a reconnect loop that can
-// never succeed — tear it down with the token. The next `/settings`
-// visit after re-login starts a fresh one.
+// The aux bridge is identity-bound (authenticated at the WS upgrade),
+// so it must not outlive the token that authenticated it:
+//  - `crew:auth_expired` — a dead token latches the bridge into a
+//    reconnect loop that can never succeed.
+//  - `crew:token_cleared` — an ORDINARY logout never fires
+//    `auth_expired` (codex web#268 r2 P1); without this, a
+//    logout → login as another account would reuse the socket still
+//    authenticated as the PREVIOUS user for memory/cron reads and
+//    toggles.
+// The next `/settings` visit after re-login starts a fresh one.
 if (typeof window !== "undefined") {
   window.addEventListener("crew:auth_expired", () => {
+    void stopAuxBridge();
+  });
+  window.addEventListener("crew:token_cleared", () => {
     void stopAuxBridge();
   });
 }

--- a/src/runtime/ui-protocol-runtime.ts
+++ b/src/runtime/ui-protocol-runtime.ts
@@ -448,14 +448,17 @@ export async function ensureAuxBridge(): Promise<UiProtocolBridge> {
     return auxSlot.bridge;
   }
   if (auxStartInFlight) return auxStartInFlight;
-  auxStartInFlight = (async () => {
-    if (auxSlot) {
-      await stopAuxBridge();
-    }
-    // Captured AFTER the internal stop above (which bumps it) so only
-    // an EXTERNAL teardown — token clear / auth expiry racing this
-    // start — invalidates us (codex web#268 r3 P1).
+  const myStart = (async () => {
+    // Captured BEFORE any await (codex web#268 r4 P1): the internal
+    // replacement stop below uses `stopAuxSlotOnly` (no generation
+    // bump), so ANY bump observed later is an external teardown —
+    // including one that fires while that stop is yielding. The r3
+    // version captured after the stop and absorbed such a clear as
+    // its baseline, publishing a bridge opened post-logout.
     const myGeneration = auxGeneration;
+    if (auxSlot) {
+      await stopAuxSlotOnly();
+    }
     const bridge = createUiProtocolBridge();
     let connectionState: ConnectionState = "connecting";
     const unsubscribeState = bridge.onConnectionStateChange((s) => {
@@ -494,10 +497,34 @@ export async function ensureAuxBridge(): Promise<UiProtocolBridge> {
     auxSlot = { bridge, connectionState, unsubscribeState };
     return bridge;
   })();
+  auxStartInFlight = myStart;
   try {
-    return await auxStartInFlight;
+    return await myStart;
   } finally {
-    auxStartInFlight = null;
+    // Only the OWNER clears the shared handle (codex web#268 r4 P2):
+    // when a token clear invalidated this start and a newer start B
+    // already took the slot, an unconditional clear here would erase
+    // B's handle and let a third caller race a bridge C against it.
+    if (auxStartInFlight === myStart) {
+      auxStartInFlight = null;
+    }
+  }
+}
+
+/** Stop and detach the CURRENT aux slot without touching the teardown
+ *  generation or the in-flight handle. Internal replacement path only —
+ *  external teardown (logout/auth-expiry) goes through
+ *  [`stopAuxBridge`], whose generation bump is exactly what
+ *  `ensureAuxBridge` uses to detect it. */
+async function stopAuxSlotOnly(): Promise<void> {
+  const slot = auxSlot;
+  if (!slot) return;
+  auxSlot = null;
+  slot.unsubscribeState();
+  try {
+    await slot.bridge.stop();
+  } catch {
+    // best-effort
   }
 }
 
@@ -509,15 +536,7 @@ export async function ensureAuxBridge(): Promise<UiProtocolBridge> {
 export async function stopAuxBridge(): Promise<void> {
   auxGeneration++;
   auxStartInFlight = null;
-  const slot = auxSlot;
-  if (!slot) return;
-  auxSlot = null;
-  slot.unsubscribeState();
-  try {
-    await slot.bridge.stop();
-  } catch {
-    // best-effort
-  }
+  await stopAuxSlotOnly();
 }
 
 // The aux bridge is identity-bound (authenticated at the WS upgrade),

--- a/src/settings/cron-tab.test.tsx
+++ b/src/settings/cron-tab.test.tsx
@@ -3,18 +3,18 @@ import { StrictMode } from "react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 import { CronTab, describeSchedule } from "./cron-tab";
+import { BridgeRpcError } from "@/runtime/ui-protocol-bridge";
 
 const apiMocks = vi.hoisted(() => ({
   getMyCron: vi.fn(),
   setMyCronEnabled: vi.fn(),
+  // Mirrors the real implementation (settings-api.ts): the WS bridge
+  // surfaces `cron/toggle` refusals as `BridgeRpcError` with the REST
+  // `reason` forwarded in `data.detail` (octos PR #1621).
   cronToggleRefusalReason: vi.fn((err: unknown) => {
-    if (!(err instanceof Error)) return null;
-    try {
-      const body = JSON.parse(err.message) as { reason?: unknown };
-      return typeof body.reason === "string" ? body.reason : null;
-    } catch {
-      return null;
-    }
+    if (!(err && typeof err === "object" && "data" in err)) return null;
+    const data = (err as { data?: { detail?: unknown } }).data;
+    return typeof data?.detail === "string" ? data.detail : null;
   }),
   formatSettingsError: vi.fn((err: unknown, fallback = "Request failed.") =>
     err instanceof Error ? err.message : fallback,
@@ -37,7 +37,6 @@ const JOB = {
 };
 
 const OVERVIEW = {
-  ok: true,
   count: 1,
   jobs: [JOB],
   gateway_running: false,
@@ -97,7 +96,6 @@ describe("CronTab", () => {
 
   it("renders the zero state without jobs", async () => {
     apiMocks.getMyCron.mockResolvedValue({
-      ok: true,
       count: 0,
       jobs: [],
       gateway_running: false,
@@ -112,7 +110,6 @@ describe("CronTab", () => {
   it("toggles a job and applies the server row", async () => {
     apiMocks.getMyCron.mockResolvedValue(OVERVIEW);
     apiMocks.setMyCronEnabled.mockResolvedValue({
-      ok: true,
       job: { ...JOB, enabled: false, next_in: null },
     });
     render(<CronTab />);
@@ -144,7 +141,10 @@ describe("CronTab", () => {
   it("reflects a 409 gateway_running refusal and refreshes", async () => {
     apiMocks.getMyCron.mockResolvedValueOnce(OVERVIEW);
     apiMocks.setMyCronEnabled.mockRejectedValue(
-      new Error(JSON.stringify({ ok: false, reason: "gateway_running" })),
+      new BridgeRpcError(-32602, "cron/toggle: REST returned 409 conflict", {
+        detail: "gateway_running",
+        rest_status: 409,
+      }),
     );
     apiMocks.getMyCron.mockResolvedValueOnce({
       ...OVERVIEW,
@@ -216,7 +216,6 @@ describe("CronTab", () => {
     let resolveStaleLoad: (v: typeof OVERVIEW) => void = () => {};
     apiMocks.getMyCron.mockResolvedValueOnce(OVERVIEW);
     apiMocks.setMyCronEnabled.mockResolvedValue({
-      ok: true,
       job: { ...JOB, enabled: false, next_in: null },
     });
     render(<CronTab />);

--- a/src/settings/memory-tab.test.tsx
+++ b/src/settings/memory-tab.test.tsx
@@ -133,6 +133,24 @@ describe("MemoryTab", () => {
     expect(
       screen.getByTestId("memory-truncation-notice").textContent,
     ).toContain("of 200 KB");
+    cleanup();
+
+    // codex web#268 r4 P2: shown bytes are UTF-8, matching the server's
+    // *_total_bytes unit — 32768 CJK chars are 96 KiB on the wire, not
+    // the 32 KiB that string.length (UTF-16 code units) would claim.
+    apiMocks.getMyMemory.mockResolvedValue({
+      ...OVERVIEW,
+      long_term: "\u6c49".repeat(32 * 1024),
+      long_term_truncated: true,
+      long_term_total_bytes: 200 * 1024,
+    });
+    render(<MemoryTab />);
+    await waitFor(() =>
+      expect(screen.getByTestId("memory-truncation-notice")).toBeTruthy(),
+    );
+    expect(
+      screen.getByTestId("memory-truncation-notice").textContent,
+    ).toContain("first 96 KB of 200 KB");
 
     fireEvent.click(screen.getByText("fleet"));
     await waitFor(() =>

--- a/src/settings/memory-tab.test.tsx
+++ b/src/settings/memory-tab.test.tsx
@@ -92,7 +92,6 @@ describe("MemoryTab", () => {
   it("lazily fetches an entity page on expand", async () => {
     apiMocks.getMyMemory.mockResolvedValue(OVERVIEW);
     apiMocks.getMyMemoryEntity.mockResolvedValue({
-      ok: true,
       name: "fleet",
       content: "# fleet\n\nfive minis and a WireGuard hub\n",
     });

--- a/src/settings/memory-tab.test.tsx
+++ b/src/settings/memory-tab.test.tsx
@@ -111,6 +111,35 @@ describe("MemoryTab", () => {
     expect(apiMocks.getMyMemoryEntity).toHaveBeenCalledTimes(1);
   });
 
+  it("surfaces the server's truncation declaration on capped documents", async () => {
+    // octos #1621 codex r1: capped fields arrive as clean prefixes with
+    // <field>_truncated + <field>_total_bytes DECLARED — the tab must
+    // say so rather than render a shorter document as complete.
+    apiMocks.getMyMemory.mockResolvedValue({
+      ...OVERVIEW,
+      long_term_truncated: true,
+      long_term_total_bytes: 200 * 1024,
+    });
+    apiMocks.getMyMemoryEntity.mockResolvedValue({
+      name: "fleet",
+      content: "# fleet prefix",
+      content_truncated: true,
+      content_total_bytes: 512 * 1024,
+    });
+    render(<MemoryTab />);
+    await waitFor(() =>
+      expect(screen.getByText(/remembers things/)).toBeTruthy(),
+    );
+    expect(
+      screen.getByTestId("memory-truncation-notice").textContent,
+    ).toContain("of 200 KB");
+
+    fireEvent.click(screen.getByText("fleet"));
+    await waitFor(() =>
+      expect(screen.getAllByTestId("memory-truncation-notice")).toHaveLength(2),
+    );
+  });
+
   it("keeps the snapshot but flags a failed reload", async () => {
     apiMocks.getMyMemory.mockResolvedValueOnce(OVERVIEW);
     apiMocks.getMyMemory.mockRejectedValueOnce(new Error("reload boom"));

--- a/src/settings/memory-tab.tsx
+++ b/src/settings/memory-tab.tsx
@@ -32,7 +32,17 @@ function formatUpdatedAt(iso: string | undefined): string | null {
 }
 
 /** One collapsible daily-note row (recent notes default collapsed). */
-function DailyNoteRow({ date, content }: { date: string; content: string }) {
+function DailyNoteRow({
+  date,
+  content,
+  truncated,
+  totalBytes,
+}: {
+  date: string;
+  content: string;
+  truncated?: boolean;
+  totalBytes?: number;
+}) {
   const [open, setOpen] = useState(false);
   return (
     <div className="rounded-lg border border-border/60">
@@ -48,16 +58,48 @@ function DailyNoteRow({ date, content }: { date: string; content: string }) {
       {open ? (
         <div className="border-t border-border/60 px-3 py-2">
           <MarkdownContent text={content} className="text-sm" />
+          <TruncationNotice
+            truncated={truncated}
+            totalBytes={totalBytes}
+            shownBytes={content.length}
+          />
         </div>
       ) : null}
     </div>
   );
 }
 
+/** Honest-cap notice (octos #1621 codex r1): the server declares when a
+ *  document field was capped to fit the WS frame; surface it instead of
+ *  letting a silently shorter document masquerade as complete. */
+function TruncationNotice({
+  truncated,
+  totalBytes,
+  shownBytes,
+}: {
+  truncated?: boolean;
+  totalBytes?: number;
+  shownBytes: number;
+}) {
+  if (!truncated) return null;
+  const fmt = (n: number) => `${Math.max(1, Math.round(n / 1024))} KB`;
+  return (
+    <p className="mt-2 text-xs text-muted" data-testid="memory-truncation-notice">
+      Showing the first {fmt(shownBytes)}
+      {typeof totalBytes === "number" ? ` of ${fmt(totalBytes)}` : ""} — large
+      documents are capped in this panel.
+    </p>
+  );
+}
+
 /** One entity row; the full page is fetched lazily on expand. */
 function EntityRow({ name, summary }: { name: string; summary: string }) {
   const [open, setOpen] = useState(false);
-  const [page, setPage] = useState<string | null>(null);
+  const [page, setPage] = useState<{
+    content: string;
+    truncated?: boolean;
+    totalBytes?: number;
+  } | null>(null);
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
@@ -69,7 +111,11 @@ function EntityRow({ name, summary }: { name: string; summary: string }) {
     setError(null);
     try {
       const resp = await getMyMemoryEntity(name);
-      setPage(resp.content);
+      setPage({
+        content: resp.content,
+        truncated: resp.content_truncated,
+        totalBytes: resp.content_total_bytes,
+      });
     } catch (err) {
       setError(formatSettingsError(err, "Failed to load entity page."));
     } finally {
@@ -104,7 +150,14 @@ function EntityRow({ name, summary }: { name: string; summary: string }) {
           ) : error ? (
             <p className="py-2 text-sm text-red-400">{error}</p>
           ) : (
-            <MarkdownContent text={page ?? ""} className="text-sm" />
+            <>
+              <MarkdownContent text={page?.content ?? ""} className="text-sm" />
+              <TruncationNotice
+                truncated={page?.truncated}
+                totalBytes={page?.totalBytes}
+                shownBytes={page?.content.length ?? 0}
+              />
+            </>
           )}
         </div>
       ) : null}
@@ -246,6 +299,11 @@ export function MemoryTab() {
             ) : null}
           </div>
           <MarkdownContent text={overview.long_term} className="text-sm" />
+          <TruncationNotice
+            truncated={overview.long_term_truncated}
+            totalBytes={overview.long_term_total_bytes}
+            shownBytes={overview.long_term.length}
+          />
         </section>
       ) : null}
 
@@ -260,12 +318,23 @@ export function MemoryTab() {
             <div className="mb-3">
               <p className="mb-1 text-xs font-medium text-muted">Today</p>
               <MarkdownContent text={overview.today} className="text-sm" />
+              <TruncationNotice
+                truncated={overview.today_truncated}
+                totalBytes={overview.today_total_bytes}
+                shownBytes={overview.today.length}
+              />
             </div>
           ) : null}
           {overview.recent.length > 0 ? (
             <div className="space-y-2">
               {overview.recent.map((note) => (
-                <DailyNoteRow key={note.date} date={note.date} content={note.content} />
+                <DailyNoteRow
+                  key={note.date}
+                  date={note.date}
+                  content={note.content}
+                  truncated={note.content_truncated}
+                  totalBytes={note.content_total_bytes}
+                />
               ))}
             </div>
           ) : null}

--- a/src/settings/memory-tab.tsx
+++ b/src/settings/memory-tab.tsx
@@ -61,12 +61,20 @@ function DailyNoteRow({
           <TruncationNotice
             truncated={truncated}
             totalBytes={totalBytes}
-            shownBytes={content.length}
+            shownBytes={utf8Len(content)}
           />
         </div>
       ) : null}
     </div>
   );
+}
+
+/** `*_total_bytes` is a UTF-8 byte count from the server; JS
+ *  `string.length` counts UTF-16 code units — for CJK/emoji content the
+ *  two diverge ~3× (codex web#268 r4 P2). Measure shown prefixes the
+ *  same way the server measures totals. */
+function utf8Len(s: string): number {
+  return new TextEncoder().encode(s).length;
 }
 
 /** Honest-cap notice (octos #1621 codex r1): the server declares when a
@@ -155,7 +163,7 @@ function EntityRow({ name, summary }: { name: string; summary: string }) {
               <TruncationNotice
                 truncated={page?.truncated}
                 totalBytes={page?.totalBytes}
-                shownBytes={page?.content.length ?? 0}
+                shownBytes={page ? utf8Len(page.content) : 0}
               />
             </>
           )}
@@ -302,7 +310,7 @@ export function MemoryTab() {
           <TruncationNotice
             truncated={overview.long_term_truncated}
             totalBytes={overview.long_term_total_bytes}
-            shownBytes={overview.long_term.length}
+            shownBytes={utf8Len(overview.long_term)}
           />
         </section>
       ) : null}
@@ -321,7 +329,7 @@ export function MemoryTab() {
               <TruncationNotice
                 truncated={overview.today_truncated}
                 totalBytes={overview.today_total_bytes}
-                shownBytes={overview.today.length}
+                shownBytes={utf8Len(overview.today)}
               />
             </div>
           ) : null}

--- a/src/settings/settings-api.test.ts
+++ b/src/settings/settings-api.test.ts
@@ -1,5 +1,10 @@
 import { describe, expect, it } from "vitest";
-import { mergeProfileConfig, normalizeProfileConfig } from "./settings-api";
+import {
+  cronToggleRefusalReason,
+  mergeProfileConfig,
+  normalizeProfileConfig,
+} from "./settings-api";
+import { BridgeRpcError } from "@/runtime/ui-protocol-bridge";
 
 describe("mergeProfileConfig — voice TTS fields", () => {
   it("should carry tts_provider and tts_cloud through a patch", () => {
@@ -16,5 +21,30 @@ describe("mergeProfileConfig — voice TTS fields", () => {
     const cfg = normalizeProfileConfig({});
     expect(cfg.tts_provider).toBeUndefined();
     expect(cfg.tts_cloud ?? undefined).toBeUndefined();
+  });
+});
+
+describe("cronToggleRefusalReason — WS bridge refusal contract", () => {
+  it("reads the reason from BridgeRpcError data.detail", () => {
+    const err = new BridgeRpcError(
+      -32602,
+      "cron/toggle: REST returned 409 conflict",
+      { detail: "gateway_running", rest_status: 409 },
+    );
+    expect(cronToggleRefusalReason(err)).toBe("gateway_running");
+  });
+
+  it("returns null for a BridgeRpcError without string detail", () => {
+    const err = new BridgeRpcError(-32001, "auth required", {
+      kind: "auth_unavailable",
+    });
+    expect(cronToggleRefusalReason(err)).toBeNull();
+  });
+
+  it("returns null for plain errors (legacy REST body parsing is gone)", () => {
+    const err = new Error(
+      JSON.stringify({ ok: false, reason: "gateway_running" }),
+    );
+    expect(cronToggleRefusalReason(err)).toBeNull();
   });
 });

--- a/src/settings/settings-api.ts
+++ b/src/settings/settings-api.ts
@@ -1,6 +1,6 @@
 import { request } from "@/api/client";
 import { BridgeRpcError, METHODS } from "@/runtime/ui-protocol-bridge";
-import { getAnyConnectedBridge } from "@/runtime/ui-protocol-runtime";
+import { ensureAuxBridge } from "@/runtime/ui-protocol-runtime";
 
 function stringFromUnknown(value: unknown): string | null {
   return typeof value === "string" && value.trim() ? value.trim() : null;
@@ -1046,18 +1046,19 @@ export async function disableOminixModel(modelId: string): Promise<AdminActionRe
 // ── Memory panel (read-only viewer: `memory/overview` + `memory/entity`) ──
 //
 // The memory + cron panels ride the ui-protocol WS bridge (octos PR
-// #1621) rather than the tokened REST surface. Unlike
-// `src/api/content.ts`'s wrapper, this helper deliberately does NOT
-// flatten `BridgeRpcError` into a plain `Error`: the typed `data`
-// payload (`data.detail`, `data.rest_status`) is the contract
-// `cronToggleRefusalReason` branches on for the gateway-owns-the-store
-// refusal, and flattening would reduce it to string matching.
+// #1621) rather than the tokened REST surface. The settings page
+// mounts OUTSIDE `OctosRuntimeProvider`, so there is no chat-scoped
+// bridge here — `ensureAuxBridge` reuses a connected chat bridge when
+// one exists and otherwise lazily starts the SESSIONLESS auxiliary
+// singleton (codex web#268 r1 P1). Unlike `src/api/content.ts`'s
+// wrapper, this helper deliberately does NOT flatten `BridgeRpcError`
+// into a plain `Error`: the typed `data` payload (`data.detail`,
+// `data.rest_status`) is the contract `cronToggleRefusalReason`
+// branches on for the gateway-owns-the-store refusal, and flattening
+// would reduce it to string matching.
 
 async function callAuxWs<T>(method: string, params: unknown): Promise<T> {
-  const bridge = getAnyConnectedBridge();
-  if (!bridge) {
-    throw new Error("ui-protocol-bridge: no connected bridge for " + method);
-  }
+  const bridge = await ensureAuxBridge();
   return await bridge.callMethod<T>(method, params);
 }
 

--- a/src/settings/settings-api.ts
+++ b/src/settings/settings-api.ts
@@ -1065,6 +1065,10 @@ async function callAuxWs<T>(method: string, params: unknown): Promise<T> {
 export interface MemoryDailyNote {
   date: string;
   content: string;
+  /** WS wire only (octos #1621 codex r1): note capped at the RPC-layer
+   *  byte budget — `content` is a clean prefix, never spliced. */
+  content_truncated?: boolean;
+  content_total_bytes?: number;
 }
 
 export interface MemoryEntitySummary {
@@ -1085,11 +1089,21 @@ export interface MemoryOverview {
   /** Staging scan stopped early — `staging_notes` is a lower bound. */
   staging_truncated?: boolean;
   refresh_enabled: boolean;
+  /** WS wire only (octos #1621 codex r1): the RPC layer caps each
+   *  document field so the result fits one WS frame; capped fields are
+   *  clean prefixes DECLARED here, never silently spliced. */
+  long_term_truncated?: boolean;
+  long_term_total_bytes?: number;
+  today_truncated?: boolean;
+  today_total_bytes?: number;
 }
 
 export interface MemoryEntityPage {
   name: string;
   content: string;
+  /** True when `content` is the RPC-layer capped prefix of the page. */
+  content_truncated?: boolean;
+  content_total_bytes?: number;
 }
 
 export async function getMyMemory(): Promise<MemoryOverview> {

--- a/src/settings/settings-api.ts
+++ b/src/settings/settings-api.ts
@@ -1,4 +1,6 @@
 import { request } from "@/api/client";
+import { BridgeRpcError, METHODS } from "@/runtime/ui-protocol-bridge";
+import { getAnyConnectedBridge } from "@/runtime/ui-protocol-runtime";
 
 function stringFromUnknown(value: unknown): string | null {
   return typeof value === "string" && value.trim() ? value.trim() : null;
@@ -1041,7 +1043,23 @@ export async function disableOminixModel(modelId: string): Promise<AdminActionRe
   });
 }
 
-// ── Memory panel (read-only viewer: /api/my/memory*) ──
+// ── Memory panel (read-only viewer: `memory/overview` + `memory/entity`) ──
+//
+// The memory + cron panels ride the ui-protocol WS bridge (octos PR
+// #1621) rather than the tokened REST surface. Unlike
+// `src/api/content.ts`'s wrapper, this helper deliberately does NOT
+// flatten `BridgeRpcError` into a plain `Error`: the typed `data`
+// payload (`data.detail`, `data.rest_status`) is the contract
+// `cronToggleRefusalReason` branches on for the gateway-owns-the-store
+// refusal, and flattening would reduce it to string matching.
+
+async function callAuxWs<T>(method: string, params: unknown): Promise<T> {
+  const bridge = getAnyConnectedBridge();
+  if (!bridge) {
+    throw new Error("ui-protocol-bridge: no connected bridge for " + method);
+  }
+  return await bridge.callMethod<T>(method, params);
+}
 
 export interface MemoryDailyNote {
   date: string;
@@ -1069,22 +1087,25 @@ export interface MemoryOverview {
 }
 
 export interface MemoryEntityPage {
-  ok: boolean;
   name: string;
   content: string;
 }
 
 export async function getMyMemory(): Promise<MemoryOverview> {
-  return await request<MemoryOverview>("/api/my/memory");
+  // `memory/overview` forwards the REST panel body whole under
+  // `overview`, so the interface above stays byte-compatible.
+  const result = await callAuxWs<{ overview: MemoryOverview }>(
+    METHODS.MEMORY_OVERVIEW,
+    {},
+  );
+  return result.overview;
 }
 
 export async function getMyMemoryEntity(name: string): Promise<MemoryEntityPage> {
-  return await request<MemoryEntityPage>(
-    `/api/my/memory/entities/${encodeURIComponent(name)}`,
-  );
+  return await callAuxWs<MemoryEntityPage>(METHODS.MEMORY_ENTITY, { name });
 }
 
-// ── Cron panel (/api/my/cron*) ──
+// ── Cron panel (`cron/list` + `cron/toggle`) ──
 
 export type CronScheduleWire =
   | { kind: "At"; at_ms: number }
@@ -1105,33 +1126,33 @@ export interface CronJobRow {
 }
 
 export interface CronOverview {
-  ok: boolean;
   count: number;
   jobs: CronJobRow[];
   gateway_running: boolean;
 }
 
 export async function getMyCron(): Promise<CronOverview> {
-  return await request<CronOverview>("/api/my/cron");
+  return await callAuxWs<CronOverview>(METHODS.CRON_LIST, {});
 }
 
-/** Thrown reason when the toggle is refused (409 etc.). */
+/**
+ * Refusal reason when `cron/toggle` is rejected. The server forwards
+ * the REST error body's `reason` as the RPC error's `data.detail`
+ * (octos PR #1621): `"gateway_running"` when a spawned gateway owns
+ * `cron.json` (rest_status 409), `"job_not_found"` on a stale row.
+ */
 export function cronToggleRefusalReason(err: unknown): string | null {
-  if (!(err instanceof Error)) return null;
-  try {
-    const body = JSON.parse(err.message) as { reason?: unknown };
-    return typeof body.reason === "string" ? body.reason : null;
-  } catch {
-    return null;
-  }
+  if (!(err instanceof BridgeRpcError)) return null;
+  const data = err.data as { detail?: unknown } | null | undefined;
+  return typeof data?.detail === "string" ? data.detail : null;
 }
 
 export async function setMyCronEnabled(
   jobId: string,
   enabled: boolean,
-): Promise<{ ok: boolean; job: CronJobRow }> {
-  return await request<{ ok: boolean; job: CronJobRow }>(
-    `/api/my/cron/${encodeURIComponent(jobId)}/enabled`,
-    { method: "PUT", body: JSON.stringify({ enabled }) },
-  );
+): Promise<{ job: CronJobRow }> {
+  return await callAuxWs<{ job: CronJobRow }>(METHODS.CRON_TOGGLE, {
+    job_id: jobId,
+    enabled,
+  });
 }


### PR DESCRIPTION
## Summary

Re-points the Memory and Schedule settings tabs from the tokened REST surface to the `auxiliary.rest_to_ws.v1` methods added in octos#1621 (`memory/overview`, `memory/entity`, `cron/list`, `cron/toggle`) — the next step of consolidating interactive clients on ui-protocol before the REST panel routes retire server-side.

## How the settings page gets a bridge

The settings route mounts **outside** `OctosRuntimeProvider` (codex r1 P1 — no chat bridge exists there, ever). The bridge gains a **sessionless mode** (`start({})`: no `session/open`, socket-is-the-lifecycle-gate, auth via `?token=` at upgrade) and the runtime a lazy `ensureAuxBridge()` singleton that prefers a connected chat bridge and otherwise starts one sessionless connection for the page.

Hardening from the review chain (6 codex rounds, 8 findings, all fixed + regression-tested):
- **Identity binding**: torn down on `crew:auth_expired` AND ordinary logout (`clearToken` now broadcasts `crew:token_cleared`); in-flight starts are generation-guarded so a token clear mid-handshake rejects instead of publishing an old-token socket — including during the internal replacement stop; a late-settling invalidated start can't erase a newer start's shared handle.
- **Liveness**: transient `error` (recoverable drop) reuses the recovering bridge (queued RPCs flush after reconnect); a NORMAL remote close (1000) is terminal via `bridge.isTerminal()` and gets replaced.

## Contract changes

- `cronToggleRefusalReason` branches on the RPC error's typed `data.detail` (`gateway_running` / `job_not_found`) instead of JSON-parsing REST error messages.
- Memory types mirror octos#1621's truncation contract (`*_truncated` + `*_total_bytes`); the tab renders an honest "Showing the first X of Y" notice, measured in UTF-8 bytes to match the server's unit (not UTF-16 code units).

## Tests

`tsc -b` + 1008 tests green: sessionless bridge lifecycle (no session/open on the wire, pre-open queueing, aux round-trips, sendTurn rejection, 1000-terminal vs 1006-recoverable), aux singleton semantics (chat-preference, shared concurrent start, terminal replacement, token-clear teardown incl. both races), truncation notice incl. CJK byte-unit regression, refusal-reason contract.

Sequenced after octos#1621 (merged). REST routes retire server-side in the follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)