### PR TITLE
fix(runtime): stop crew:message_meta clobbering session token totals

### DIFF
--- a/src/runtime/session-context.test.ts
+++ b/src/runtime/session-context.test.ts
@@ -844,3 +844,74 @@ describe("SessionProvider branchSession fork scoping", () => {
     }
   });
 });
+
+describe("SessionProvider session stats events", () => {
+  /**
+   * `crew:cost` carries SESSION-cumulative token counts (octos#1632 made
+   * them truthful across turns and model switches); `crew:message_meta`
+   * carries PER-TURN deltas for the bubble footer. Both feed the same
+   * stats store — meta must not clobber the session totals with its
+   * turn-sized numbers, or the cost bar snaps back to the latest turn's
+   * counts after every turn.
+   */
+  it("keeps crew:cost session totals when crew:message_meta reports turn deltas", async () => {
+    const sessionId = idAt(900, "stats");
+    apiMocks.listSessions.mockResolvedValue([
+      { id: sessionId, message_count: 2 },
+    ] satisfies SessionInfo[]);
+
+    let latest: SessionContextValue | null = null;
+    const harness = mountSessionProvider((ctx) => {
+      latest = ctx;
+    });
+    try {
+      await flushReactWork();
+      act(() => {
+        latest?.switchSession(sessionId);
+      });
+      await flushReactWork();
+
+      // Session-cumulative figures from token_cost_update.
+      act(() => {
+        window.dispatchEvent(
+          new CustomEvent("crew:cost", {
+            detail: {
+              sessionId,
+              input_tokens: 120_000,
+              output_tokens: 30_000,
+              session_cost: 1.25,
+            },
+          }),
+        );
+      });
+      await flushReactWork();
+      expect(latest?.currentSessionStats?.inputTokens).toBe(120_000);
+      expect(latest?.currentSessionStats?.outputTokens).toBe(30_000);
+      expect(latest?.currentSessionStats?.cost).toBe(1.25);
+
+      // A bubble-footer meta event for ONE turn (small numbers) must not
+      // shrink the session totals; the model label and (session-scoped)
+      // cost still merge.
+      act(() => {
+        window.dispatchEvent(
+          new CustomEvent("crew:message_meta", {
+            detail: {
+              sessionId,
+              model: "glm-5",
+              tokens_in: 900,
+              tokens_out: 150,
+              session_cost: 1.31,
+            },
+          }),
+        );
+      });
+      await flushReactWork();
+      expect(latest?.currentSessionStats?.inputTokens).toBe(120_000);
+      expect(latest?.currentSessionStats?.outputTokens).toBe(30_000);
+      expect(latest?.currentSessionStats?.model).toBe("glm-5");
+      expect(latest?.currentSessionStats?.cost).toBe(1.31);
+    } finally {
+      harness.unmount();
+    }
+  });
+});

--- a/src/runtime/session-context.tsx
+++ b/src/runtime/session-context.tsx
@@ -851,11 +851,16 @@ export function SessionProvider({ children }: { children: ReactNode }) {
         outputTokens: 0,
         cost: null,
       };
+      // `crew:message_meta` carries PER-TURN token deltas (the event
+      // router baselines the cumulative counters for the bubble footer),
+      // while this store is SESSION-scoped and fed session-cumulative
+      // counts by `crew:cost` (octos#1632 made those truthful across
+      // turns/model switches). Merging tokens_in/tokens_out here snapped
+      // the cost bar back to the latest turn's counts after every turn —
+      // take only the model label and the (session-scoped) cost.
       storeSessionStats(sessionId, {
         ...current,
         model: detail.model || current.model,
-        inputTokens: detail.tokens_in ?? current.inputTokens,
-        outputTokens: detail.tokens_out ?? current.outputTokens,
         cost: mergeNullableCost(detail.session_cost, current.cost),
       });
     }


### PR DESCRIPTION
Companion to octos#1632 (per-model session-cumulative cost).

## Problem

The session stats store (cost bar: `N in / M out · $cost`) is fed by two window events off the same `token_cost_update` frames:

- **`crew:cost`** — session-cumulative input/output tokens + `session_cost`. octos#1632 makes these truthful across turns and model switches (previously turn-scoped).
- **`crew:message_meta`** — **per-turn** token deltas (the event router baselines the cumulative counters for the assistant-bubble footer), plus the model label.

`handleMeta` merged its turn-sized `tokens_in`/`tokens_out` into the session-scoped store — so the cost bar snapped back to the latest turn's counts after every completed turn. With #1632's now-monotonic session counters the flicker becomes obvious: 120k in → 900 in.

## Fix

`handleMeta` merges only the **model label** and the (session-scoped) **cost**; `crew:cost` owns the token totals. The bubble footer is unaffected — it reads per-turn meta off `message.meta`, not this store.

## Tests

- New: `keeps crew:cost session totals when crew:message_meta reports turn deltas` (RED reproduced the clobber: expected 120000, got 900).
- `npm run build` (tsc -b) green; full vitest suite 1009/1009.

🤖 Generated with [Claude Code](https://claude.com/claude-code)