### PR TITLE
feat: add authentication settings

### DIFF
--- a/src/auth/login-page.test.tsx
+++ b/src/auth/login-page.test.tsx
@@ -1,0 +1,61 @@
+import { cleanup, render, screen } from "@testing-library/react";
+import { MemoryRouter } from "react-router-dom";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import type { AuthStatusResponse } from "@/api/types";
+import { LoginPage } from "./login-page";
+
+const authMocks = vi.hoisted(() => ({
+  authStatus: null as AuthStatusResponse | null,
+  login: vi.fn(),
+  loginWithToken: vi.fn(),
+  soloLogin: vi.fn(),
+}));
+
+vi.mock("./auth-context", () => ({
+  useAuth: () => ({
+    authStatus: authMocks.authStatus,
+    login: authMocks.login,
+    loginWithToken: authMocks.loginWithToken,
+    soloLogin: authMocks.soloLogin,
+  }),
+}));
+
+function renderLogin(allowSelfRegistration: boolean) {
+  authMocks.authStatus = {
+    bootstrap_mode: false,
+    email_login_enabled: true,
+    admin_token_login_enabled: false,
+    allow_self_registration: allowSelfRegistration,
+    local_solo_enabled: false,
+    scoped_profile: null,
+  };
+  render(
+    <MemoryRouter>
+      <LoginPage />
+    </MemoryRouter>,
+  );
+}
+
+describe("LoginPage registration guidance", () => {
+  afterEach(() => cleanup());
+
+  it("invites a new user to create an account when registration is open", () => {
+    renderLogin(true);
+
+    expect(
+      screen.getByText(/verify your email to create an account and sign in/i),
+    ).toBeTruthy();
+    expect(
+      screen.queryByText(/use an allowed or registered email/i),
+    ).toBeNull();
+  });
+
+  it("requires an allowed or registered email when registration is restricted", () => {
+    renderLogin(false);
+
+    expect(
+      screen.getByText(/use an allowed or registered email to sign in/i),
+    ).toBeTruthy();
+  });
+});

--- a/src/auth/login-page.test.tsx
+++ b/src/auth/login-page.test.tsx
@@ -1,6 +1,6 @@
-import { cleanup, render, screen } from "@testing-library/react";
+import { cleanup, render, screen, waitFor } from "@testing-library/react";
 import { MemoryRouter } from "react-router-dom";
-import { afterEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import type { AuthStatusResponse } from "@/api/types";
 import { LoginPage } from "./login-page";
@@ -12,6 +12,10 @@ const authMocks = vi.hoisted(() => ({
   soloLogin: vi.fn(),
 }));
 
+const apiMocks = vi.hoisted(() => ({
+  status: vi.fn(),
+}));
+
 vi.mock("./auth-context", () => ({
   useAuth: () => ({
     authStatus: authMocks.authStatus,
@@ -19,6 +23,11 @@ vi.mock("./auth-context", () => ({
     loginWithToken: authMocks.loginWithToken,
     soloLogin: authMocks.soloLogin,
   }),
+}));
+
+vi.mock("@/api/auth", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("@/api/auth")>()),
+  status: apiMocks.status,
 }));
 
 function renderLogin(allowSelfRegistration: boolean) {
@@ -30,6 +39,7 @@ function renderLogin(allowSelfRegistration: boolean) {
     local_solo_enabled: false,
     scoped_profile: null,
   };
+  apiMocks.status.mockResolvedValue(authMocks.authStatus);
   render(
     <MemoryRouter>
       <LoginPage />
@@ -38,6 +48,10 @@ function renderLogin(allowSelfRegistration: boolean) {
 }
 
 describe("LoginPage registration guidance", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
   afterEach(() => cleanup());
 
   it("invites a new user to create an account when registration is open", () => {
@@ -57,5 +71,40 @@ describe("LoginPage registration guidance", () => {
     expect(
       screen.getByText(/use an allowed or registered email to sign in/i),
     ).toBeTruthy();
+  });
+
+  it("refreshes a stale initial auth status when the login page mounts", async () => {
+    authMocks.authStatus = {
+      bootstrap_mode: false,
+      email_login_enabled: false,
+      admin_token_login_enabled: false,
+      allow_self_registration: false,
+      local_solo_enabled: false,
+      scoped_profile: null,
+    };
+    apiMocks.status.mockResolvedValue({
+      bootstrap_mode: false,
+      email_login_enabled: true,
+      admin_token_login_enabled: false,
+      allow_self_registration: true,
+      local_solo_enabled: false,
+      scoped_profile: null,
+    } satisfies AuthStatusResponse);
+
+    render(
+      <MemoryRouter>
+        <LoginPage />
+      </MemoryRouter>,
+    );
+
+    await waitFor(() => expect(apiMocks.status).toHaveBeenCalledOnce());
+    expect(
+      await screen.findByText(
+        /verify your email to create an account and sign in/i,
+      ),
+    ).toBeTruthy();
+    expect(
+      screen.queryByText(/email otp login is not enabled on this host/i),
+    ).toBeNull();
   });
 });

--- a/src/auth/login-page.tsx
+++ b/src/auth/login-page.tsx
@@ -27,14 +27,21 @@ export function LoginPage() {
   const [sending, setSending] = useState(false);
 
   useEffect(() => {
-    if (initialAuthStatus) {
-      setAuthStatus(initialAuthStatus);
-      return;
-    }
-    authApi.status().then(setAuthStatus).catch(() => {
-      // Leave the page usable even if auth status probing fails.
-    });
-  }, [initialAuthStatus]);
+    // The context value provides the initial render. Always refresh it because
+    // authentication settings may have changed since AuthProvider mounted
+    // (for example, when an admin saves SMTP settings and then logs out).
+    let active = true;
+    authApi.status()
+      .then((status) => {
+        if (active) setAuthStatus(status);
+      })
+      .catch(() => {
+        // Leave the page usable even if auth status probing fails.
+      });
+    return () => {
+      active = false;
+    };
+  }, []);
 
   const scopedProfile = authStatus?.scoped_profile ?? null;
   const tokenModeEnabled = useMemo(
@@ -44,11 +51,7 @@ export function LoginPage() {
   const emailLoginEnabled = authStatus?.email_login_enabled ?? true;
   const soloEnabled = authStatus?.local_solo_enabled ?? false;
 
-  useEffect(() => {
-    if (mode === "token" && !tokenModeEnabled) {
-      setMode("otp");
-    }
-  }, [mode, tokenModeEnabled]);
+  const activeMode = mode === "token" && !tokenModeEnabled ? "otp" : mode;
 
   async function handleSendCode() {
     setError("");
@@ -159,7 +162,7 @@ export function LoginPage() {
           <button
             onClick={() => setMode("otp")}
             className={`flex-1 rounded-lg py-2 text-sm font-medium transition ${
-              mode === "otp"
+              activeMode === "otp"
                 ? "bg-accent text-on-accent"
                 : "bg-surface-container text-muted hover:text-text-strong"
             }`}
@@ -170,7 +173,7 @@ export function LoginPage() {
             <button
               onClick={() => setMode("token")}
               className={`flex-1 rounded-lg py-2 text-sm font-medium transition ${
-                mode === "token"
+                activeMode === "token"
                   ? "bg-accent text-on-accent"
                   : "bg-surface-container text-muted hover:text-text-strong"
               }`}
@@ -210,7 +213,7 @@ export function LoginPage() {
               Back
             </button>
           </div>
-        ) : mode === "otp" ? (
+        ) : activeMode === "otp" ? (
           step === "email" ? (
             <div className="space-y-4">
               <input

--- a/src/auth/login-page.tsx
+++ b/src/auth/login-page.tsx
@@ -127,7 +127,9 @@ export function LoginPage() {
             ? "This login is scoped to the addressed account. Use the exact email registered for this sub-account."
             : authStatus?.bootstrap_mode
               ? "Bootstrap admin access is enabled on this host."
-              : "Use an allowed or registered email to sign in."}
+              : authStatus?.allow_self_registration
+                ? "Verify your email to create an account and sign in."
+                : "Use an allowed or registered email to sign in."}
         </p>
 
         {soloEnabled && step !== "solo" && (

--- a/src/components/navigation-settings-access.test.tsx
+++ b/src/components/navigation-settings-access.test.tsx
@@ -1,0 +1,57 @@
+import { cleanup, render, screen } from "@testing-library/react";
+import { MemoryRouter } from "react-router-dom";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("@/auth/auth-context", () => ({
+  useAuth: () => ({
+    user: { email: "member@example.test" },
+    portal: { can_access_admin_portal: false },
+    logout: vi.fn(),
+  }),
+}));
+
+vi.mock("@/hooks/use-theme", () => ({
+  useTheme: () => ({ theme: "light", toggleTheme: vi.fn() }),
+}));
+
+vi.mock("@/home/use-ominix-runtime-summary", () => ({
+  useOminixRuntimeSummary: () => ({
+    label: "Unavailable",
+    tone: "default",
+    ready: false,
+    loading: false,
+    canRepair: false,
+    state: "unavailable",
+    needsAttention: false,
+    refresh: vi.fn(),
+  }),
+}));
+
+vi.mock("@/home/voice/audio-playback", () => ({ unlockAudio: vi.fn() }));
+
+import { StudioNav } from "./studio-nav";
+import { WorkbenchRouteNav } from "./workbench-shell";
+
+afterEach(cleanup);
+
+describe("non-admin Settings navigation", () => {
+  it("keeps Settings in the workbench navigation", () => {
+    render(
+      <MemoryRouter>
+        <WorkbenchRouteNav />
+      </MemoryRouter>,
+    );
+
+    expect(screen.getByRole("link", { name: "Settings" })).toBeTruthy();
+  });
+
+  it("keeps Settings in the studio navigation", () => {
+    render(
+      <MemoryRouter>
+        <StudioNav />
+      </MemoryRouter>,
+    );
+
+    expect(screen.getAllByText("Settings").length).toBeGreaterThan(0);
+  });
+});

--- a/src/components/studio-nav.tsx
+++ b/src/components/studio-nav.tsx
@@ -15,7 +15,7 @@ const NAV_LINKS: Array<{ label: string; to: string; adminOnly?: boolean }> = [
   { label: "Chat", to: "/chat" },
   { label: "Slides", to: "/slides" },
   { label: "Sites", to: "/sites" },
-  { label: "Settings", to: "/settings", adminOnly: true },
+  { label: "Settings", to: "/settings" },
 ];
 
 function isActive(pathname: string, to: string): boolean {

--- a/src/components/workbench-shell.tsx
+++ b/src/components/workbench-shell.tsx
@@ -33,7 +33,7 @@ const routeItems: Array<{
   { to: "/sites", label: "Sites", icon: Globe },
   { to: "/home", label: "Display", icon: MonitorSmartphone },
   { to: "/voice", label: "Voice", icon: Mic },
-  { to: "/settings", label: "Settings", icon: Settings, adminOnly: true },
+  { to: "/settings", label: "Settings", icon: Settings },
 ];
 
 function isRouteActive(pathname: string, to: string) {

--- a/src/layouts/chat-layout.test.tsx
+++ b/src/layouts/chat-layout.test.tsx
@@ -180,6 +180,17 @@ afterEach(() => {
 });
 
 describe("ChatLayout panel layout", () => {
+  it("keeps personal Settings available to a non-admin user", () => {
+    const harness = mount(vi.fn());
+    try {
+      expect(
+        harness.container.querySelector("button[aria-label='Settings']"),
+      ).not.toBeNull();
+    } finally {
+      harness.unmount();
+    }
+  });
+
   it("renders the shared glass shell with left/right resize handles", () => {
     const renameSession = vi.fn();
     const harness = mount(renameSession);

--- a/src/layouts/chat-layout.tsx
+++ b/src/layouts/chat-layout.tsx
@@ -43,7 +43,7 @@ function SettingsNavButton() {
 }
 
 export function ChatLayout({ children }: { children: ReactNode }) {
-  const { user, portal, logout } = useAuth();
+  const { user, logout } = useAuth();
   const { sessions, currentSessionId, currentSessionTitle, historyTopic, renameSession } =
     useSession();
   const status = useOctosStatus();
@@ -161,9 +161,7 @@ export function ChatLayout({ children }: { children: ReactNode }) {
                   </div>
                 </div>
                 <div className="flex items-center gap-2">
-                  {portal?.can_access_admin_portal && (
-                    <SettingsNavButton />
-                  )}
+                  <SettingsNavButton />
                   <button
                     onClick={logout}
                     className="glass-icon-button p-2"

--- a/src/pages/home-page.test.tsx
+++ b/src/pages/home-page.test.tsx
@@ -9,6 +9,9 @@ import { MemoryRouter } from "react-router-dom";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 const unlockAudioMock = vi.hoisted(() => vi.fn());
+const themeMock = vi.hoisted(() => ({
+  uiStyle: "ivory-obsidian" as "ivory-obsidian" | "legacy-blue",
+}));
 
 vi.mock("@/components/studio-nav", () => ({
   StudioNav: ({ actions }: { actions?: React.ReactNode }) => (
@@ -19,7 +22,7 @@ vi.mock("@/components/studio-nav", () => ({
 vi.mock("@/hooks/use-theme", () => ({
   useTheme: () => ({
     theme: "light" as const,
-    uiStyle: "ivory-obsidian" as const,
+    uiStyle: themeMock.uiStyle,
     setTheme: vi.fn(),
     toggleTheme: vi.fn(),
     setUiStyle: vi.fn(),
@@ -93,6 +96,7 @@ function renderHome() {
 beforeEach(() => {
   localStorage.clear();
   seedFixtures();
+  themeMock.uiStyle = "ivory-obsidian";
 });
 
 afterEach(() => {
@@ -102,6 +106,13 @@ afterEach(() => {
 });
 
 describe("HomePage (Ivory Obsidian launcher)", () => {
+  it("keeps Settings available in the legacy shell for a non-admin user", () => {
+    themeMock.uiStyle = "legacy-blue";
+    renderHome();
+
+    expect(screen.getByRole("button", { name: "Settings" })).toBeTruthy();
+  });
+
   it("renders the hero, create card, and the design's three tabs", () => {
     renderHome();
 

--- a/src/pages/home-page.tsx
+++ b/src/pages/home-page.tsx
@@ -489,7 +489,7 @@ function WarmWorkbenchHomePage() {
 }
 
 function LegacyHomeNav() {
-  const { user, portal, logout } = useAuth();
+  const { user, logout } = useAuth();
   const { theme, toggleTheme, setUiStyle } = useTheme();
   const navigate = useNavigate();
 
@@ -528,17 +528,15 @@ function LegacyHomeNav() {
         <MessageSquare size={16} />
         Chat
       </button>
-      {portal?.can_access_admin_portal && (
-        <button
-          type="button"
-          onClick={() => navigate("/settings")}
-          className="rounded-xl p-2.5 text-muted hover:bg-surface-container hover:text-text-strong"
-          title="Settings"
-          aria-label="Settings"
-        >
-          <Settings size={18} />
-        </button>
-      )}
+      <button
+        type="button"
+        onClick={() => navigate("/settings")}
+        className="rounded-xl p-2.5 text-muted hover:bg-surface-container hover:text-text-strong"
+        title="Settings"
+        aria-label="Settings"
+      >
+        <Settings size={18} />
+      </button>
       <button
         type="button"
         onClick={toggleTheme}

--- a/src/settings/authentication-api.test.ts
+++ b/src/settings/authentication-api.test.ts
@@ -1,0 +1,60 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const requestMock = vi.hoisted(() => vi.fn());
+
+vi.mock("@/api/client", () => ({ request: requestMock }));
+
+import {
+  fetchAuthenticationSettings,
+  saveAuthenticationSettings,
+  sendAuthenticationTestEmail,
+} from "./settings-api";
+
+describe("authentication settings API", () => {
+  beforeEach(() => requestMock.mockReset());
+
+  it("reads the admin SMTP settings", async () => {
+    const settings = {
+      host: "smtp.example.com",
+      port: 587,
+      username: "mailer@example.com",
+      from_address: "Octos <mailer@example.com>",
+      password_configured: true,
+      allow_self_registration: true,
+    };
+    requestMock.mockResolvedValue(settings);
+
+    await expect(fetchAuthenticationSettings()).resolves.toEqual(settings);
+    expect(requestMock).toHaveBeenCalledWith("/api/admin/smtp");
+  });
+
+  it("saves the SMTP and registration policy payload", async () => {
+    requestMock.mockResolvedValue(undefined);
+    const body = {
+      host: "smtp.example.com",
+      port: 587,
+      username: "mailer@example.com",
+      from_address: "Octos <mailer@example.com>",
+      allow_self_registration: true,
+    };
+
+    await saveAuthenticationSettings(body);
+
+    expect(requestMock).toHaveBeenCalledWith("/api/admin/smtp", {
+      method: "POST",
+      body: JSON.stringify(body),
+    });
+  });
+
+  it("sends a diagnostic email through the admin SMTP endpoint", async () => {
+    requestMock.mockResolvedValue({ ok: true, message: "sent" });
+
+    await expect(
+      sendAuthenticationTestEmail("new-user@example.com"),
+    ).resolves.toEqual({ ok: true, message: "sent" });
+    expect(requestMock).toHaveBeenCalledWith("/api/admin/smtp/test", {
+      method: "POST",
+      body: JSON.stringify({ to: "new-user@example.com" }),
+    });
+  });
+});

--- a/src/settings/authentication-tab.test.tsx
+++ b/src/settings/authentication-tab.test.tsx
@@ -1,0 +1,96 @@
+import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { AuthenticationTab } from "./authentication-tab";
+
+const apiMocks = vi.hoisted(() => ({
+  fetchAuthenticationSettings: vi.fn(),
+  saveAuthenticationSettings: vi.fn(),
+  sendAuthenticationTestEmail: vi.fn(),
+  formatSettingsError: vi.fn((err: unknown, fallback = "Request failed.") =>
+    err instanceof Error ? err.message : fallback,
+  ),
+}));
+
+vi.mock("./settings-api", () => apiMocks);
+
+describe("AuthenticationTab", () => {
+  beforeEach(() => {
+    cleanup();
+    for (const mock of Object.values(apiMocks)) mock.mockReset();
+    apiMocks.formatSettingsError.mockImplementation(
+      (err: unknown, fallback = "Request failed.") =>
+        err instanceof Error ? err.message : fallback,
+    );
+    apiMocks.fetchAuthenticationSettings.mockResolvedValue({
+      host: "smtp.example.com",
+      port: 587,
+      username: "mailer@example.com",
+      from_address: "Octos <mailer@example.com>",
+      password_configured: true,
+      allow_self_registration: false,
+    });
+    apiMocks.saveAuthenticationSettings.mockResolvedValue(undefined);
+    apiMocks.sendAuthenticationTestEmail.mockResolvedValue({
+      ok: true,
+      message: "Test email sent.",
+    });
+  });
+
+  it("loads SMTP settings and shows restricted registration without revealing the password", async () => {
+    render(<AuthenticationTab />);
+
+    expect(await screen.findByDisplayValue("smtp.example.com")).toBeTruthy();
+    expect(
+      (screen.getByRole("radio", {
+        name: /restricted registration/i,
+      }) as HTMLInputElement).checked,
+    ).toBe(true);
+    expect((screen.getByLabelText(/SMTP password/i) as HTMLInputElement).value).toBe("");
+    expect(screen.getByText(/password is already configured/i)).toBeTruthy();
+  });
+
+  it("enables open registration and preserves the stored password when saving", async () => {
+    render(<AuthenticationTab />);
+    await screen.findByDisplayValue("smtp.example.com");
+
+    fireEvent.click(screen.getByRole("radio", { name: /open registration/i }));
+
+    const warning = screen.getByRole("note", {
+      name: /open registration warning/i,
+    });
+    expect(warning.className).toContain(
+      "[color:var(--workbench-warning-text)]",
+    );
+    expect(screen.getByText(/anyone with an email address can register/i)).toBeTruthy();
+
+    fireEvent.click(screen.getByRole("button", { name: /save authentication settings/i }));
+
+    await waitFor(() => {
+      expect(apiMocks.saveAuthenticationSettings).toHaveBeenCalledWith({
+        host: "smtp.example.com",
+        port: 587,
+        username: "mailer@example.com",
+        from_address: "Octos <mailer@example.com>",
+        allow_self_registration: true,
+      });
+    });
+  });
+
+  it("sends a test login email to the requested recipient", async () => {
+    render(<AuthenticationTab />);
+    await screen.findByDisplayValue("smtp.example.com");
+
+    fireEvent.change(screen.getByLabelText(/test recipient/i), {
+      target: { value: "new-user@example.com" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: /send test email/i }));
+
+    await waitFor(() => {
+      expect(apiMocks.sendAuthenticationTestEmail).toHaveBeenCalledWith(
+        "new-user@example.com",
+      );
+    });
+    expect(await screen.findByText("Test email sent.")).toBeTruthy();
+  });
+});

--- a/src/settings/authentication-tab.test.tsx
+++ b/src/settings/authentication-tab.test.tsx
@@ -75,6 +75,27 @@ describe("AuthenticationTab", () => {
         allow_self_registration: true,
       });
     });
+    expect((await screen.findByRole("status")).className).toContain(
+      "[color:var(--workbench-success-text)]",
+    );
+  });
+
+  it("uses theme-aware danger colors when saving fails", async () => {
+    apiMocks.saveAuthenticationSettings.mockRejectedValue(
+      new Error("SMTP save failed"),
+    );
+    render(<AuthenticationTab />);
+    await screen.findByDisplayValue("smtp.example.com");
+
+    fireEvent.click(
+      screen.getByRole("button", { name: /save authentication settings/i }),
+    );
+
+    const error = await screen.findByRole("alert");
+    expect(error.textContent).toContain("SMTP save failed");
+    expect(error.className).toContain(
+      "[color:var(--workbench-danger-text)]",
+    );
   });
 
   it("sends a test login email to the requested recipient", async () => {

--- a/src/settings/authentication-tab.tsx
+++ b/src/settings/authentication-tab.tsx
@@ -177,7 +177,7 @@ export function AuthenticationTab() {
     return (
       <div
         role="alert"
-        className="glass-section rounded-lg border border-red-400/30 p-6 text-sm text-red-300"
+        className="glass-section rounded-lg border p-6 text-sm [background:var(--workbench-danger-bg)] [border-color:var(--workbench-danger-border)] [color:var(--workbench-danger-text)]"
       >
         <div className="flex items-center gap-2">
           <AlertCircle size={18} />
@@ -348,7 +348,7 @@ export function AuthenticationTab() {
                 className="workbench-input w-full px-3 py-2.5 text-sm text-text-strong"
               />
               {form.passwordConfigured && (
-                <span className="flex items-center gap-1 text-[11px] text-green-400">
+                <span className="flex items-center gap-1 text-[11px] [color:var(--workbench-success-text)]">
                   <CheckCircle2 size={11} />
                   A password is already configured. It is never returned to the browser.
                 </span>
@@ -377,8 +377,8 @@ export function AuthenticationTab() {
               role={saveError ? "alert" : "status"}
               className={`mt-4 flex items-center gap-2 rounded-xl border px-4 py-3 text-xs ${
                 saveError
-                  ? "border-red-400/30 bg-red-400/5 text-red-300"
-                  : "border-green-400/30 bg-green-400/5 text-green-300"
+                  ? "[background:var(--workbench-danger-bg)] [border-color:var(--workbench-danger-border)] [color:var(--workbench-danger-text)]"
+                  : "[background:var(--workbench-success-bg)] [border-color:var(--workbench-success-border)] [color:var(--workbench-success-text)]"
               }`}
             >
               {saveError ? <AlertCircle size={15} /> : <CheckCircle2 size={15} />}
@@ -448,8 +448,8 @@ export function AuthenticationTab() {
             role={testError ? "alert" : "status"}
             className={`mt-4 flex items-center gap-2 rounded-xl border px-4 py-3 text-xs ${
               testError
-                ? "border-red-400/30 bg-red-400/5 text-red-300"
-                : "border-green-400/30 bg-green-400/5 text-green-300"
+                ? "[background:var(--workbench-danger-bg)] [border-color:var(--workbench-danger-border)] [color:var(--workbench-danger-text)]"
+                : "[background:var(--workbench-success-bg)] [border-color:var(--workbench-success-border)] [color:var(--workbench-success-text)]"
             }`}
           >
             {testError ? <AlertCircle size={15} /> : <CheckCircle2 size={15} />}

--- a/src/settings/authentication-tab.tsx
+++ b/src/settings/authentication-tab.tsx
@@ -1,0 +1,462 @@
+import { useEffect, useState, type FormEvent } from "react";
+import {
+  AlertCircle,
+  AlertTriangle,
+  CheckCircle2,
+  KeyRound,
+  Loader2,
+  Mail,
+  Send,
+  ShieldCheck,
+  UserPlus,
+} from "lucide-react";
+
+import {
+  fetchAuthenticationSettings,
+  formatSettingsError,
+  saveAuthenticationSettings,
+  sendAuthenticationTestEmail,
+} from "./settings-api";
+
+type RegistrationMode = "open" | "restricted";
+
+interface FormState {
+  host: string;
+  port: string;
+  username: string;
+  password: string;
+  fromAddress: string;
+  registrationMode: RegistrationMode;
+  passwordConfigured: boolean;
+}
+
+const EMPTY_FORM: FormState = {
+  host: "",
+  port: "587",
+  username: "",
+  password: "",
+  fromAddress: "",
+  registrationMode: "restricted",
+  passwordConfigured: false,
+};
+
+function validateSettings(form: FormState): string | null {
+  if (!form.host.trim()) return "SMTP host is required.";
+  const port = Number(form.port);
+  if (!Number.isInteger(port) || port < 1 || port > 65_535) {
+    return "SMTP port must be an integer between 1 and 65535.";
+  }
+  if (!form.fromAddress.includes("@")) {
+    return "From address must contain an email address.";
+  }
+  return null;
+}
+
+export function AuthenticationTab() {
+  const [form, setForm] = useState<FormState>(EMPTY_FORM);
+  const [loading, setLoading] = useState(true);
+  const [loadError, setLoadError] = useState<string | null>(null);
+  const [saving, setSaving] = useState(false);
+  const [saveMessage, setSaveMessage] = useState<string | null>(null);
+  const [saveError, setSaveError] = useState<string | null>(null);
+  const [testRecipient, setTestRecipient] = useState("");
+  const [testing, setTesting] = useState(false);
+  const [testMessage, setTestMessage] = useState<string | null>(null);
+  const [testError, setTestError] = useState<string | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    void fetchAuthenticationSettings()
+      .then((settings) => {
+        if (cancelled) return;
+        setForm({
+          host: settings.host,
+          port: String(settings.port),
+          username: settings.username,
+          password: "",
+          fromAddress: settings.from_address,
+          registrationMode: settings.allow_self_registration
+            ? "open"
+            : "restricted",
+          passwordConfigured: settings.password_configured,
+        });
+      })
+      .catch((err: unknown) => {
+        if (!cancelled) {
+          setLoadError(
+            formatSettingsError(err, "Failed to load authentication settings."),
+          );
+        }
+      })
+      .finally(() => {
+        if (!cancelled) setLoading(false);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  const updateForm = <K extends keyof FormState>(key: K, value: FormState[K]) => {
+    setForm((current) => ({ ...current, [key]: value }));
+    setSaveMessage(null);
+    setSaveError(null);
+  };
+
+  const handleSave = async (event: FormEvent) => {
+    event.preventDefault();
+    const validationError = validateSettings(form);
+    if (validationError) {
+      setSaveError(validationError);
+      setSaveMessage(null);
+      return;
+    }
+
+    setSaving(true);
+    setSaveError(null);
+    setSaveMessage(null);
+    try {
+      const password = form.password;
+      await saveAuthenticationSettings({
+        host: form.host.trim(),
+        port: Number(form.port),
+        username: form.username.trim(),
+        from_address: form.fromAddress.trim(),
+        allow_self_registration: form.registrationMode === "open",
+        ...(password ? { password } : {}),
+      });
+      setForm((current) => ({
+        ...current,
+        password: "",
+        passwordConfigured: current.passwordConfigured || Boolean(password),
+      }));
+      setSaveMessage("Authentication settings saved and applied.");
+    } catch (err) {
+      setSaveError(
+        formatSettingsError(err, "Failed to save authentication settings."),
+      );
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  const handleTest = async (event: FormEvent) => {
+    event.preventDefault();
+    const recipient = testRecipient.trim();
+    if (!recipient.includes("@")) {
+      setTestError("Enter a valid test recipient email address.");
+      setTestMessage(null);
+      return;
+    }
+
+    setTesting(true);
+    setTestError(null);
+    setTestMessage(null);
+    try {
+      const result = await sendAuthenticationTestEmail(recipient);
+      if (result.ok) {
+        setTestMessage(result.message ?? `Test email sent to ${recipient}.`);
+      } else {
+        setTestError(result.error ?? "The server could not send the test email.");
+      }
+    } catch (err) {
+      setTestError(formatSettingsError(err, "Failed to send the test email."));
+    } finally {
+      setTesting(false);
+    }
+  };
+
+  if (loading) {
+    return (
+      <div className="flex items-center justify-center py-20">
+        <Loader2 size={24} className="animate-spin text-muted" />
+      </div>
+    );
+  }
+
+  if (loadError) {
+    return (
+      <div
+        role="alert"
+        className="glass-section rounded-lg border border-red-400/30 p-6 text-sm text-red-300"
+      >
+        <div className="flex items-center gap-2">
+          <AlertCircle size={18} />
+          {loadError}
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-6">
+      <form onSubmit={(event) => void handleSave(event)} className="space-y-6">
+        <section className="glass-section rounded-lg p-6">
+          <div className="mb-5 flex items-center gap-3">
+            <div className="flex h-10 w-10 items-center justify-center rounded-xl bg-accent/10 text-accent">
+              <ShieldCheck size={20} />
+            </div>
+            <div>
+              <h3 className="text-sm font-semibold text-text-strong">
+                Registration Access
+              </h3>
+              <p className="text-xs text-muted">
+                Choose who can create a user through email verification
+              </p>
+            </div>
+          </div>
+
+          <div className="grid gap-3 sm:grid-cols-2">
+            <label
+              className={`cursor-pointer rounded-xl border p-4 transition ${
+                form.registrationMode === "open"
+                  ? "border-accent/60 bg-accent/10"
+                  : "border-border/40 bg-surface-container/40 hover:border-border"
+              }`}
+            >
+              <div className="flex items-start gap-3">
+                <input
+                  type="radio"
+                  name="registration-mode"
+                  value="open"
+                  checked={form.registrationMode === "open"}
+                  onChange={() => updateForm("registrationMode", "open")}
+                  className="mt-1 accent-[var(--accent)]"
+                />
+                <div>
+                  <div className="flex items-center gap-2 text-sm font-medium text-text-strong">
+                    <UserPlus size={16} />
+                    Open registration
+                  </div>
+                  <p className="mt-1 text-xs leading-relaxed text-muted">
+                    Anyone who verifies an email OTP can create their own user and profile.
+                  </p>
+                </div>
+              </div>
+            </label>
+
+            <label
+              className={`cursor-pointer rounded-xl border p-4 transition ${
+                form.registrationMode === "restricted"
+                  ? "border-accent/60 bg-accent/10"
+                  : "border-border/40 bg-surface-container/40 hover:border-border"
+              }`}
+            >
+              <div className="flex items-start gap-3">
+                <input
+                  type="radio"
+                  name="registration-mode"
+                  value="restricted"
+                  checked={form.registrationMode === "restricted"}
+                  onChange={() => updateForm("registrationMode", "restricted")}
+                  className="mt-1 accent-[var(--accent)]"
+                />
+                <div>
+                  <div className="flex items-center gap-2 text-sm font-medium text-text-strong">
+                    <KeyRound size={16} />
+                    Restricted registration
+                  </div>
+                  <p className="mt-1 text-xs leading-relaxed text-muted">
+                    Only existing users and addresses listed under Users → Allowed Emails can sign in.
+                  </p>
+                </div>
+              </div>
+            </label>
+          </div>
+
+          {form.registrationMode === "open" && (
+            <div
+              role="note"
+              aria-label="Open registration warning"
+              className="mt-4 flex items-start gap-3 rounded-xl border px-4 py-3 text-xs [background:var(--workbench-warning-bg)] [border-color:var(--workbench-warning-border)] [color:var(--workbench-warning-text)]"
+            >
+              <AlertTriangle size={16} className="mt-0.5 shrink-0" />
+              <div>
+                <p className="font-semibold">
+                  Anyone with an email address can register
+                </p>
+                <p className="mt-1 leading-relaxed">
+                  Use open registration for local testing. On an internet-facing server,
+                  each verified email can create a profile and consume resources.
+                </p>
+              </div>
+            </div>
+          )}
+        </section>
+
+        <section className="glass-section rounded-lg p-6">
+          <div className="mb-5 flex items-center gap-3">
+            <div className="flex h-10 w-10 items-center justify-center rounded-xl bg-accent/10 text-accent">
+              <Mail size={20} />
+            </div>
+            <div>
+              <h3 className="text-sm font-semibold text-text-strong">
+                Email OTP Delivery
+              </h3>
+              <p className="text-xs text-muted">
+                SMTP used to send login verification codes
+              </p>
+            </div>
+          </div>
+
+          <div className="grid gap-4 sm:grid-cols-2">
+            <label className="space-y-1.5 text-xs text-muted">
+              SMTP host
+              <input
+                aria-label="SMTP host"
+                value={form.host}
+                onChange={(event) => updateForm("host", event.target.value)}
+                placeholder="smtp.example.com"
+                autoComplete="off"
+                className="workbench-input w-full px-3 py-2.5 text-sm text-text-strong"
+              />
+            </label>
+            <label className="space-y-1.5 text-xs text-muted">
+              SMTP port
+              <input
+                aria-label="SMTP port"
+                type="number"
+                min={1}
+                max={65_535}
+                value={form.port}
+                onChange={(event) => updateForm("port", event.target.value)}
+                className="workbench-input w-full px-3 py-2.5 text-sm text-text-strong"
+              />
+            </label>
+            <label className="space-y-1.5 text-xs text-muted">
+              SMTP username
+              <input
+                aria-label="SMTP username"
+                value={form.username}
+                onChange={(event) => updateForm("username", event.target.value)}
+                autoComplete="username"
+                className="workbench-input w-full px-3 py-2.5 text-sm text-text-strong"
+              />
+            </label>
+            <label className="space-y-1.5 text-xs text-muted">
+              SMTP password
+              <input
+                aria-label="SMTP password"
+                type="password"
+                value={form.password}
+                onChange={(event) => updateForm("password", event.target.value)}
+                placeholder={
+                  form.passwordConfigured
+                    ? "Leave blank to keep the saved password"
+                    : "Enter SMTP password"
+                }
+                autoComplete="new-password"
+                className="workbench-input w-full px-3 py-2.5 text-sm text-text-strong"
+              />
+              {form.passwordConfigured && (
+                <span className="flex items-center gap-1 text-[11px] text-green-400">
+                  <CheckCircle2 size={11} />
+                  A password is already configured. It is never returned to the browser.
+                </span>
+              )}
+              {!form.passwordConfigured && (
+                <span className="text-[11px] text-muted/70">
+                  Leave blank only when the server already provides SMTP credentials,
+                  such as through SMTP_PASSWORD.
+                </span>
+              )}
+            </label>
+            <label className="space-y-1.5 text-xs text-muted sm:col-span-2">
+              From address
+              <input
+                aria-label="From address"
+                value={form.fromAddress}
+                onChange={(event) => updateForm("fromAddress", event.target.value)}
+                placeholder="Octos <login@example.com>"
+                className="workbench-input w-full px-3 py-2.5 text-sm text-text-strong"
+              />
+            </label>
+          </div>
+
+          {(saveError || saveMessage) && (
+            <div
+              role={saveError ? "alert" : "status"}
+              className={`mt-4 flex items-center gap-2 rounded-xl border px-4 py-3 text-xs ${
+                saveError
+                  ? "border-red-400/30 bg-red-400/5 text-red-300"
+                  : "border-green-400/30 bg-green-400/5 text-green-300"
+              }`}
+            >
+              {saveError ? <AlertCircle size={15} /> : <CheckCircle2 size={15} />}
+              {saveError ?? saveMessage}
+            </div>
+          )}
+
+          <div className="mt-5 flex justify-end">
+            <button
+              type="submit"
+              disabled={saving}
+              className="flex items-center gap-2 rounded-lg bg-accent px-4 py-2.5 text-sm font-medium text-white transition hover:bg-accent/90 disabled:cursor-not-allowed disabled:opacity-50"
+            >
+              {saving ? <Loader2 size={15} className="animate-spin" /> : <ShieldCheck size={15} />}
+              Save authentication settings
+            </button>
+          </div>
+        </section>
+      </form>
+
+      <section className="glass-section rounded-lg p-6">
+        <div className="mb-5 flex items-center gap-3">
+          <div className="flex h-10 w-10 items-center justify-center rounded-xl bg-accent/10 text-accent">
+            <Send size={20} />
+          </div>
+          <div>
+            <h3 className="text-sm font-semibold text-text-strong">
+              Test Login Email
+            </h3>
+            <p className="text-xs text-muted">
+              Uses the currently saved SMTP configuration
+            </p>
+          </div>
+        </div>
+
+        <form
+          onSubmit={(event) => void handleTest(event)}
+          className="flex flex-col gap-3 sm:flex-row sm:items-end"
+        >
+          <label className="flex-1 space-y-1.5 text-xs text-muted">
+            Test recipient
+            <input
+              aria-label="Test recipient"
+              type="email"
+              value={testRecipient}
+              onChange={(event) => {
+                setTestRecipient(event.target.value);
+                setTestMessage(null);
+                setTestError(null);
+              }}
+              placeholder="you@example.com"
+              className="workbench-input w-full px-3 py-2.5 text-sm text-text-strong"
+            />
+          </label>
+          <button
+            type="submit"
+            disabled={testing}
+            className="flex shrink-0 items-center justify-center gap-2 rounded-lg border border-accent/40 bg-accent/10 px-4 py-2.5 text-sm font-medium text-accent transition hover:bg-accent/15 disabled:cursor-not-allowed disabled:opacity-50"
+          >
+            {testing ? <Loader2 size={15} className="animate-spin" /> : <Send size={15} />}
+            Send test email
+          </button>
+        </form>
+
+        {(testError || testMessage) && (
+          <div
+            role={testError ? "alert" : "status"}
+            className={`mt-4 flex items-center gap-2 rounded-xl border px-4 py-3 text-xs ${
+              testError
+                ? "border-red-400/30 bg-red-400/5 text-red-300"
+                : "border-green-400/30 bg-green-400/5 text-green-300"
+            }`}
+          >
+            {testError ? <AlertCircle size={15} /> : <CheckCircle2 size={15} />}
+            {testError ?? testMessage}
+          </div>
+        )}
+      </section>
+    </div>
+  );
+}

--- a/src/settings/settings-api.ts
+++ b/src/settings/settings-api.ts
@@ -654,6 +654,54 @@ export async function removeAllowedEmail(email: string): Promise<void> {
   });
 }
 
+// ── Admin: Authentication ──
+
+export interface AuthenticationSettings {
+  host: string;
+  port: number;
+  username: string;
+  from_address: string;
+  password_configured: boolean;
+  allow_self_registration: boolean;
+}
+
+export interface SaveAuthenticationSettingsBody {
+  host: string;
+  port: number;
+  username: string;
+  from_address: string;
+  password?: string;
+  allow_self_registration: boolean;
+}
+
+export interface AuthenticationTestResult {
+  ok: boolean;
+  message?: string;
+  error?: string;
+}
+
+export async function fetchAuthenticationSettings(): Promise<AuthenticationSettings> {
+  return await request<AuthenticationSettings>("/api/admin/smtp");
+}
+
+export async function saveAuthenticationSettings(
+  body: SaveAuthenticationSettingsBody,
+): Promise<void> {
+  await request<void>("/api/admin/smtp", {
+    method: "POST",
+    body: JSON.stringify(body),
+  });
+}
+
+export async function sendAuthenticationTestEmail(
+  to: string,
+): Promise<AuthenticationTestResult> {
+  return await request<AuthenticationTestResult>("/api/admin/smtp/test", {
+    method: "POST",
+    body: JSON.stringify({ to }),
+  });
+}
+
 // ── Admin API types ──
 
 export interface BreakdownEntry {

--- a/src/settings/settings-page.test.tsx
+++ b/src/settings/settings-page.test.tsx
@@ -9,13 +9,17 @@ const apiMocks = vi.hoisted(() => ({
   getMyProfile: vi.fn(),
 }));
 
+const authMocks = vi.hoisted(() => ({
+  portal: {
+    accessible_profiles: [] as never[],
+    can_access_admin_portal: true,
+    home_profile_id: "",
+  },
+}));
+
 vi.mock("@/auth/auth-context", () => ({
   useAuth: () => ({
-    portal: {
-      accessible_profiles: [],
-      can_access_admin_portal: true,
-      home_profile_id: "",
-    },
+    portal: authMocks.portal,
   }),
 }));
 
@@ -36,6 +40,7 @@ describe("AdminSettingsPage", () => {
     cleanup();
     apiMocks.getMyProfile.mockReset();
     apiMocks.getMyProfile.mockResolvedValue(null);
+    authMocks.portal.can_access_admin_portal = true;
   });
 
   it("keeps the Authentication menu icon visible beside the admin badge", async () => {
@@ -52,5 +57,24 @@ describe("AdminSettingsPage", () => {
     const icon = button.querySelector("svg");
 
     expect(icon?.classList.contains("shrink-0")).toBe(true);
+  });
+
+  it("falls back to Profile when a non-admin deep-links to Authentication", async () => {
+    authMocks.portal.can_access_admin_portal = false;
+    render(
+      <MemoryRouter initialEntries={["/settings?tab=authentication"]}>
+        <AdminSettingsPage />
+      </MemoryRouter>,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText(/no profile available/i)).toBeTruthy();
+    });
+    expect(
+      screen.getByRole("button", { name: "Profile" }).getAttribute("data-active"),
+    ).toBe("true");
+    expect(
+      screen.queryByRole("button", { name: /authentication/i }),
+    ).toBeNull();
   });
 });

--- a/src/settings/settings-page.test.tsx
+++ b/src/settings/settings-page.test.tsx
@@ -1,0 +1,56 @@
+import { cleanup, render, screen, waitFor } from "@testing-library/react";
+import type { ReactNode } from "react";
+import { MemoryRouter } from "react-router-dom";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { AdminSettingsPage } from "./settings-page";
+
+const apiMocks = vi.hoisted(() => ({
+  getMyProfile: vi.fn(),
+}));
+
+vi.mock("@/auth/auth-context", () => ({
+  useAuth: () => ({
+    portal: {
+      accessible_profiles: [],
+      can_access_admin_portal: true,
+      home_profile_id: "",
+    },
+  }),
+}));
+
+vi.mock("@/components/workbench-shell", () => ({
+  WorkbenchStatusPill: ({ children }: { children: ReactNode }) => (
+    <span>{children}</span>
+  ),
+  WorkbenchThemeButton: () => null,
+}));
+
+vi.mock("./settings-api", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("./settings-api")>();
+  return { ...actual, ...apiMocks };
+});
+
+describe("AdminSettingsPage", () => {
+  beforeEach(() => {
+    cleanup();
+    apiMocks.getMyProfile.mockReset();
+    apiMocks.getMyProfile.mockResolvedValue(null);
+  });
+
+  it("keeps the Authentication menu icon visible beside the admin badge", async () => {
+    render(
+      <MemoryRouter>
+        <AdminSettingsPage />
+      </MemoryRouter>,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByRole("button", { name: /authentication/i })).toBeTruthy();
+    });
+    const button = screen.getByRole("button", { name: /authentication/i });
+    const icon = button.querySelector("svg");
+
+    expect(icon?.classList.contains("shrink-0")).toBe(true);
+  });
+});

--- a/src/settings/settings-page.tsx
+++ b/src/settings/settings-page.tsx
@@ -74,12 +74,23 @@ function asTabId(value: string | null): TabId | null {
   return TABS.some((tab) => tab.id === value) ? value as TabId : null;
 }
 
+function accessibleTabId(
+  value: string | null,
+  canAccessAdminPortal: boolean,
+): TabId {
+  const id = asTabId(value);
+  if (!id) return "profile";
+  const tab = TABS.find((entry) => entry.id === id);
+  return tab?.adminOnly && !canAccessAdminPortal ? "profile" : id;
+}
+
 export function AdminSettingsPage() {
   const { portal } = useAuth();
   const navigate = useNavigate();
   const [searchParams, setSearchParams] = useSearchParams();
+  const canAccessAdminPortal = Boolean(portal?.can_access_admin_portal);
   const [activeTab, setActiveTab] = useState<TabId>(
-    () => asTabId(searchParams.get("tab")) ?? "profile",
+    () => accessibleTabId(searchParams.get("tab"), canAccessAdminPortal),
   );
   const [profile, setProfile] = useState<Profile | null>(null);
   const [loading, setLoading] = useState(true);
@@ -103,16 +114,14 @@ export function AdminSettingsPage() {
   // Render-phase adjustment (the docs' "adjusting state when props change"
   // pattern): adopt a ?tab= change from the URL exactly once per params
   // change, so back/forward and deep links work without effect cascades.
-  const [lastTabParam, setLastTabParam] = useState<string | null>(null);
+  const [lastTabAccessKey, setLastTabAccessKey] = useState<string | null>(null);
   const tabParam = searchParams.get("tab");
-  if (tabParam !== lastTabParam) {
-    setLastTabParam(tabParam);
-    const nextTab = asTabId(tabParam);
-    if (nextTab && nextTab !== activeTab) {
-      const tab = TABS.find((entry) => entry.id === nextTab);
-      if (!tab?.adminOnly || portal?.can_access_admin_portal) {
-        setActiveTab(nextTab);
-      }
+  const tabAccessKey = `${tabParam ?? ""}:${canAccessAdminPortal}`;
+  if (tabAccessKey !== lastTabAccessKey) {
+    setLastTabAccessKey(tabAccessKey);
+    const nextTab = accessibleTabId(tabParam, canAccessAdminPortal);
+    if (nextTab !== activeTab) {
+      setActiveTab(nextTab);
     }
   }
 

--- a/src/settings/settings-page.tsx
+++ b/src/settings/settings-page.tsx
@@ -18,6 +18,7 @@ import {
   Volume2,
   Brain,
   AlarmClock,
+  ShieldCheck,
 } from "lucide-react";
 import {
   WorkbenchStatusPill,
@@ -40,8 +41,9 @@ import { AppearanceTab } from "./appearance-tab";
 import { VoiceTab } from "./voice-tab";
 import { MemoryTab } from "./memory-tab";
 import { CronTab } from "./cron-tab";
+import { AuthenticationTab } from "./authentication-tab";
 
-type TabId = "profile" | "appearance" | "llm" | "voice" | "memory" | "schedule" | "skills" | "channels" | "sandbox" | "tools" | "users" | "system" | "server" | "ominix";
+type TabId = "profile" | "appearance" | "llm" | "voice" | "memory" | "schedule" | "skills" | "channels" | "sandbox" | "tools" | "authentication" | "users" | "system" | "server" | "ominix";
 
 interface TabDef {
   id: TabId;
@@ -61,6 +63,7 @@ const TABS: TabDef[] = [
   { id: "channels", label: "Channels", icon: Radio },
   { id: "sandbox", label: "Sandbox", icon: Shield },
   { id: "tools", label: "Tools", icon: Wrench },
+  { id: "authentication", label: "Authentication", icon: ShieldCheck, adminOnly: true },
   { id: "users", label: "Users", icon: Users, adminOnly: true },
   { id: "system", label: "System", icon: Activity, adminOnly: true },
   { id: "server", label: "Server", icon: Server, adminOnly: true },
@@ -121,7 +124,7 @@ export function AdminSettingsPage() {
     setSearchParams(next, { replace: true });
   };
 
-  const isAdminOnlyTab = activeTab === "system" || activeTab === "server" || activeTab === "users" || activeTab === "ominix";
+  const isAdminOnlyTab = activeTab === "authentication" || activeTab === "system" || activeTab === "server" || activeTab === "users" || activeTab === "ominix";
 
   return (
     <div className="studio-shell settings-shell flex h-screen flex-col overflow-hidden">
@@ -172,10 +175,10 @@ export function AdminSettingsPage() {
                   data-active={activeTab === id ? "true" : undefined}
                   className="settings-tab-button flex w-full items-center gap-3 rounded-lg border px-4 py-3 text-left text-sm font-medium transition max-md:w-auto max-md:shrink-0 max-md:px-3"
                 >
-                  <Icon size={16} />
+                  <Icon size={16} className="shrink-0" />
                   {label}
                   {adminOnly && (
-                    <span className="ml-auto">
+                    <span className="ml-auto shrink-0">
                       <WorkbenchStatusPill tone="accent">Admin</WorkbenchStatusPill>
                     </span>
                   )}
@@ -188,6 +191,7 @@ export function AdminSettingsPage() {
             <div className={`mx-auto ${isAdminOnlyTab ? "max-w-4xl" : "max-w-3xl"}`}>
               {activeTab === "system" && portal?.can_access_admin_portal && <SystemTab />}
               {activeTab === "server" && portal?.can_access_admin_portal && <ServerTab />}
+              {activeTab === "authentication" && portal?.can_access_admin_portal && <AuthenticationTab />}
               {activeTab === "users" && portal?.can_access_admin_portal && profile && <UsersTab profile={profile} />}
               {activeTab === "ominix" && portal?.can_access_admin_portal && <OminixTab />}
 


### PR DESCRIPTION
## What changed

- Add an admin-only Authentication settings page for registration access and SMTP configuration.
- Support open and restricted registration modes, SMTP persistence, and test-login-email delivery.
- Show personal Settings navigation to regular users while keeping administrative tabs hidden.
- Update login guidance to reflect the active registration policy.
- Refresh public auth status whenever the login page mounts so newly saved SMTP and registration settings take effect without a manual reload.
- Add API, UI, navigation, permission, and stale-status regression tests.

## Why

Local multi-tenant development needs a graphical way to configure email OTP authentication and choose whether verified email addresses may register freely. The login page must also reflect configuration changes immediately after an administrator logs out.

## Impact

Administrators can configure and test authentication from `/settings?tab=authentication`. Regular users retain access to personal settings without gaining access to administrative configuration.

## Validation

- `pnpm exec tsc --noEmit`
- `pnpm exec eslint src/auth/login-page.tsx src/auth/login-page.test.tsx`
- `pnpm test:unit` — 101 files, 1025 tests passed
- Manual E2E registration and permission checks
