### PR TITLE
feat(chat): manual /compact command (session/compact parity)

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ Multi-tenant accounts, per-user isolation, and the admin surfaces for them are w
 | `/` | Project launcher — every chat, deck, and site as a project card |
 | `/home` | Home-assistant standby — clock, weather/news/calendar/photo/smart-home widgets, night mode, wake-word |
 | `/voice` | Voice assistant — on-device VAD, streamed TTS with barge-in, spoken transcripts, user-selectable voices, live video chat |
-| `/chat` | The chat workbench — streaming turns, tool activity, approvals and clarifying-question cards, a context-compaction indicator, file uploads, rich media |
+| `/chat` | The chat workbench — streaming turns, tool activity, approvals and clarifying-question cards, a context-compaction indicator with a manual `/compact` command, file uploads, rich media |
 | `/studio/:projectId` | Studio — three-pane grounded workspace (sources · chat · skills) pinned to a project session |
 | `/slides`, `/slides/:id/present` | Slide-deck gallery, editor, and full-screen present mode |
 | `/sites`, `/sites/:id` | Generated-site gallery and editor with signed previews |

--- a/src/api/sessions.ts
+++ b/src/api/sessions.ts
@@ -209,6 +209,33 @@ export async function deleteSession(sessionId: string): Promise<void> {
   });
 }
 
+export interface SessionCompactResult {
+  session_id: string;
+  compacted: boolean;
+  token_estimate_before: number;
+  token_estimate_after: number | null;
+}
+
+/**
+ * `session/compact` — force a context-compaction pass on the session NOW,
+ * bypassing the auto-compaction threshold (web parity for the CLI
+ * `/compact` command; server octos#1671). `sessionId` must be the SCOPED
+ * id (`web-…#topic` for a topic bucket): the RPC takes the key verbatim,
+ * there is no separate topic param. The server emits the usual
+ * `context/compaction_started|completed` lifecycle events around the
+ * pass, so `CompactionIndicator` renders the progress + outcome notice;
+ * the returned stats are a convenience for the caller. MUTATING. Old
+ * servers reject with method-not-found — surface that instead of
+ * retrying.
+ */
+export async function compactSession(
+  sessionId: string,
+): Promise<SessionCompactResult> {
+  return await callAuxWs<SessionCompactResult>(METHODS.SESSION_COMPACT, {
+    session_id: sessionId,
+  });
+}
+
 export async function getSessionStatus(
   sessionId: string,
   topic?: string,

--- a/src/components/chat-thread-compact-command.test.tsx
+++ b/src/components/chat-thread-compact-command.test.tsx
@@ -1,0 +1,186 @@
+/**
+ * Composer `/compact` command (CLI parity; server `session/compact`,
+ * octos#1671).
+ *
+ * The command issues the RPC with the SCOPED session id — the server
+ * takes the key verbatim and there is no topic param, so a topic bucket
+ * compacts only when addressed as `session#topic`. Success feedback is
+ * NOT local: the server emits the usual compaction lifecycle events and
+ * `CompactionIndicator` renders them; the composer pill only surfaces
+ * RPC-level failures (old server, no runtime).
+ */
+
+import { afterEach, describe, expect, it, vi } from "vitest";
+import * as React from "react";
+import { act } from "react";
+import { createRoot, type Root } from "react-dom/client";
+
+(
+  globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }
+).IS_REACT_ACT_ENVIRONMENT = true;
+
+vi.mock("@/api/sessions", async (importOriginal) => {
+  const original = await importOriginal<typeof import("@/api/sessions")>();
+  return {
+    ...original,
+    compactSession: vi.fn(),
+  };
+});
+
+import { compactSession } from "@/api/sessions";
+import { ChatThread } from "./chat-thread";
+import { SessionContext } from "@/runtime/session-context";
+import type { SessionContextValue } from "@/runtime/session-context";
+import * as ThreadStore from "@/store/thread-store";
+
+const SESSION = "sess-compact-command";
+const compactMock = vi.mocked(compactSession);
+
+interface MountedHarness {
+  container: HTMLDivElement;
+  root: Root;
+  unmount: () => void;
+}
+
+function makeSessionCtx(topic?: string): SessionContextValue {
+  return {
+    sessions: [],
+    currentSessionId: SESSION,
+    historyTopic: topic,
+    currentSessionTitle: "",
+    currentSessionStats: null,
+    initialMessages: [],
+    activeTaskOnServer: false,
+    queueMode: null,
+    adaptiveMode: null,
+    setServerTaskActive: () => {},
+    renameSession: () => {},
+    updateSessionStats: () => {},
+    switchSession: () => {},
+    goBack: async () => false,
+    createSession: () => SESSION,
+    removeSession: async () => {},
+    refreshSessions: async () => {},
+    markSessionActive: () => {},
+  };
+}
+
+function mount(node: React.ReactElement): MountedHarness {
+  const container = document.createElement("div");
+  document.body.appendChild(container);
+  const root = createRoot(container);
+  act(() => {
+    root.render(node);
+  });
+  return {
+    container,
+    root,
+    unmount: () => {
+      act(() => root.unmount());
+      container.remove();
+    },
+  };
+}
+
+function mountThread(topic?: string): MountedHarness {
+  return mount(
+    <SessionContext.Provider value={makeSessionCtx(topic)}>
+      <ChatThread />
+    </SessionContext.Provider>,
+  );
+}
+
+function getInput(harness: MountedHarness): HTMLTextAreaElement {
+  const el = harness.container.querySelector(
+    '[data-testid="chat-input"]',
+  ) as HTMLTextAreaElement | null;
+  expect(el).toBeTruthy();
+  return el as HTMLTextAreaElement;
+}
+
+function getSendButton(harness: MountedHarness): HTMLButtonElement {
+  const el = harness.container.querySelector(
+    '[data-testid="send-button"]',
+  ) as HTMLButtonElement | null;
+  expect(el).toBeTruthy();
+  return el as HTMLButtonElement;
+}
+
+/** Controlled-component value injection: React's value tracker ignores a
+ *  plain `el.value =`, so go through the native setter before input. */
+function typeText(harness: MountedHarness, value: string) {
+  const textarea = getInput(harness);
+  const setter = Object.getOwnPropertyDescriptor(
+    window.HTMLTextAreaElement.prototype,
+    "value",
+  )?.set;
+  expect(setter).toBeTruthy();
+  act(() => {
+    setter!.call(textarea, value);
+    textarea.dispatchEvent(new Event("input", { bubbles: true }));
+  });
+}
+
+async function clickSend(harness: MountedHarness) {
+  await act(async () => {
+    getSendButton(harness).click();
+  });
+}
+
+afterEach(() => {
+  for (const node of [...document.body.children]) node.remove();
+  ThreadStore.__resetForTests();
+  compactMock.mockReset();
+});
+
+describe("composer /compact command", () => {
+  it("issues session/compact with the bare session id outside topics", async () => {
+    compactMock.mockResolvedValue({
+      session_id: SESSION,
+      compacted: true,
+      token_estimate_before: 87400,
+      token_estimate_after: 31200,
+    });
+    const harness = mountThread();
+    typeText(harness, "/compact");
+    await clickSend(harness);
+    expect(compactMock).toHaveBeenCalledTimes(1);
+    expect(compactMock).toHaveBeenCalledWith(SESSION);
+    // The composer clears for the next message; success feedback is the
+    // server-emitted lifecycle notice, not a local pill.
+    expect(getInput(harness).value).toBe("");
+    expect(
+      harness.container.querySelector('[data-testid="cmd-feedback"]'),
+    ).toBeNull();
+    harness.unmount();
+  });
+
+  it("addresses a topic bucket with its scoped session#topic id", async () => {
+    compactMock.mockResolvedValue({
+      session_id: `${SESSION}#slides`,
+      compacted: true,
+      token_estimate_before: 1200,
+      token_estimate_after: 300,
+    });
+    const harness = mountThread("slides");
+    typeText(harness, "/compact");
+    await clickSend(harness);
+    expect(compactMock).toHaveBeenCalledTimes(1);
+    expect(compactMock).toHaveBeenCalledWith(`${SESSION}#slides`);
+    harness.unmount();
+  });
+
+  it("surfaces an RPC failure in the feedback pill", async () => {
+    compactMock.mockRejectedValue(new Error("method not found"));
+    const harness = mountThread();
+    typeText(harness, "/compact");
+    await clickSend(harness);
+    expect(compactMock).toHaveBeenCalledTimes(1);
+    const pill = harness.container.querySelector(
+      '[data-testid="cmd-feedback"]',
+    );
+    expect(pill).toBeTruthy();
+    expect(pill!.textContent).toContain("Compact failed: method not found");
+    harness.unmount();
+  });
+});

--- a/src/components/chat-thread.tsx
+++ b/src/components/chat-thread.tsx
@@ -57,6 +57,7 @@ import {
 } from "@/store/thread-store";
 import { isProjectionV1Enabled } from "@/store/projection-store";
 import { uploadFiles } from "@/api/chat";
+import { compactSession } from "@/api/sessions";
 import {
   interruptActiveTurn,
   sendMessage as bridgeSend,
@@ -448,6 +449,7 @@ const COMMANDS = [
   { cmd: "/back", desc: "Switch back to the previous session" },
   { cmd: "/delete", desc: "Delete a session (/delete <name> or /d <name>)" },
   { cmd: "/clear", desc: "Clear current session and start fresh" },
+  { cmd: "/compact", desc: "Compact conversation context now (frees token budget)" },
   // Personality
   { cmd: "/soul", desc: "View or set custom personality (/soul, /soul show, /soul reset, /soul <text>)" },
   // Agent configuration
@@ -1867,6 +1869,33 @@ function Composer({ mountGhost, unmountGhost }: ComposerProps) {
         COMMANDS.map((c) => `${c.cmd} — ${c.desc}`).join("\n"),
       );
       setTimeout(() => setCmdFeedback(null), 10000);
+      releaseSending();
+      return;
+    }
+
+    if (trimmedInput === "/compact") {
+      // Manual context compaction (CLI `/compact` parity; server
+      // `session/compact`, octos#1671). The RPC takes the session key
+      // VERBATIM — there is no topic param — so a topic bucket must send
+      // its scoped `session#topic` id (the same key the pre-turn context
+      // manager is stored under). Progress and the outcome notice render
+      // through the server-emitted `context/compaction_started|completed`
+      // events (`CompactionIndicator`), so only RPC-level failures (old
+      // server, no runtime) surface in the feedback pill here.
+      setText("");
+      const scopedId = currentSessionId.includes("#")
+        ? currentSessionId
+        : historyTopic?.trim()
+          ? `${currentSessionId}#${historyTopic.trim()}`
+          : currentSessionId;
+      try {
+        await compactSession(scopedId);
+      } catch (e) {
+        setCmdFeedback(
+          `Compact failed: ${e instanceof Error ? e.message : "unknown error"}`,
+        );
+        setTimeout(() => setCmdFeedback(null), 4000);
+      }
       releaseSending();
       return;
     }

--- a/src/runtime/ui-protocol-bridge.ts
+++ b/src/runtime/ui-protocol-bridge.ts
@@ -154,6 +154,7 @@ export const METHODS = {
   SESSION_HYDRATE: "session/hydrate",
   SESSION_ROLLBACK: "session/rollback",
   SESSION_FORK: "session/fork",
+  SESSION_COMPACT: "session/compact",
   LOOP_LIST: "loop/list",
   LOOP_PAUSE: "loop/pause",
   LOOP_RESUME: "loop/resume",


### PR DESCRIPTION
## What

Web parity for the server's `session/compact` RPC (octos#1671, the CLI `/compact` command). The SPA rendered the passive compaction indicator (UPCR-2026-026) but offered no way to trigger a pass.

## Changes

- `METHODS.SESSION_COMPACT` + `compactSession()` aux wrapper in `src/api/sessions.ts` — sends the **scoped** `session#topic` id (the RPC takes the key verbatim; no topic param)
- Composer `/compact` command riding the existing `COMMANDS`/`cmdFeedback` slash system — lifecycle events still render through `CompactionIndicator`; only RPC-level failures (old server, no runtime) surface in the feedback pill
- README `/chat` row updated
- New `chat-thread-compact-command.test.tsx`: bare session, topic scope, RPC failure

## Verification

- New tests 3/3; full unit suite 1012/1012 (97 files)
- `tsc -b` clean
- Protocol confirmed against `crates/octos-cli/src/api/ui_protocol.rs` (no capability gate; params `{ session_id }`)