### PR TITLE
fix(settings): add API Keys tab for provider, channel, and infra keys

### DIFF
--- a/src/settings/api-keys-tab.test.tsx
+++ b/src/settings/api-keys-tab.test.tsx
@@ -1,0 +1,132 @@
+import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { ApiKeysTab } from "./api-keys-tab";
+import {
+  normalizeProfileConfig,
+  type Profile,
+  type ProfileConfig,
+} from "./settings-api";
+
+const apiMocks = vi.hoisted(() => ({
+  updateMyProfileConfig: vi.fn(),
+  formatSettingsError: vi.fn((e: unknown, fb = "failed") =>
+    e instanceof Error ? e.message : fb,
+  ),
+}));
+// Keep the real module (normalizeProfileConfig etc.) and only spy the two
+// functions ApiKeysTab calls at runtime.
+vi.mock("./settings-api", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("./settings-api")>();
+  return { ...actual, ...apiMocks };
+});
+
+/** Build a fully-typed Profile from a partial config (no `as any`). */
+function makeProfile(config: Partial<ProfileConfig>): Profile {
+  return {
+    id: "p1",
+    name: "p1",
+    enabled: true,
+    data_dir: null,
+    config: normalizeProfileConfig(config),
+    created_at: "",
+    updated_at: "",
+    status: { running: false, pid: null, started_at: null, uptime_secs: null },
+  };
+}
+
+const baseProfile = makeProfile({
+  env_vars: {
+    OPENAI_API_KEY: "sk-p***xyz", // masked => already set
+    SERPER_API_KEY: "se***er", // unrelated key must survive the save
+  },
+});
+
+describe("ApiKeysTab", () => {
+  beforeEach(() => {
+    cleanup();
+    apiMocks.updateMyProfileConfig.mockReset();
+    apiMocks.updateMyProfileConfig.mockResolvedValue(baseProfile);
+  });
+
+  it("renders the three groups with fields for every documented key", () => {
+    render(<ApiKeysTab profile={baseProfile} onProfileUpdated={() => {}} />);
+
+    expect(screen.getByText("LLM Providers")).toBeTruthy();
+    expect(screen.getByText("Channels")).toBeTruthy();
+    expect(screen.getByText("Infrastructure")).toBeTruthy();
+
+    for (const key of [
+      "OPENAI_API_KEY",
+      "DASHSCOPE_API_KEY",
+      "DEEPSEEK_API_KEY",
+      "MOONSHOT_API_KEY",
+      "MINIMAX_API_KEY",
+      "GEMINI_API_KEY",
+      "NVIDIA_API_KEY",
+      "ZAI_API_KEY",
+      "PERPLEXITY_API_KEY",
+      "TELEGRAM_BOT_TOKEN",
+      "LARK_APP_ID",
+      "LARK_APP_SECRET",
+      "SMTP_PASSWORD",
+      "NGROK_AUTHTOKEN",
+    ]) {
+      expect(
+        screen.getByLabelText(key),
+        `missing input for ${key}`,
+      ).toBeTruthy();
+    }
+  });
+
+  it("shows stored keys as masked values and disables save until dirty", () => {
+    render(<ApiKeysTab profile={baseProfile} onProfileUpdated={() => {}} />);
+    const openaiInput = screen.getByLabelText(
+      "OPENAI_API_KEY",
+    ) as HTMLInputElement;
+    expect(openaiInput.value).toBe("sk-p***xyz");
+
+    const saveBtn = screen.getByRole("button", {
+      name: /save changes/i,
+    }) as HTMLButtonElement;
+    expect(saveBtn.disabled).toBe(true);
+  });
+
+  it("writes newly typed keys, echoes masked ones, and keeps unrelated vars", async () => {
+    render(<ApiKeysTab profile={baseProfile} onProfileUpdated={() => {}} />);
+
+    fireEvent.change(screen.getByLabelText("DASHSCOPE_API_KEY"), {
+      target: { value: "sk-dash-123" },
+    });
+    fireEvent.change(screen.getByLabelText("NGROK_AUTHTOKEN"), {
+      target: { value: "ngrok-token-1" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: /save changes/i }));
+
+    await waitFor(() =>
+      expect(apiMocks.updateMyProfileConfig).toHaveBeenCalled(),
+    );
+    const [, patch] = apiMocks.updateMyProfileConfig.mock.calls[0];
+    expect(patch.env_vars.DASHSCOPE_API_KEY).toBe("sk-dash-123");
+    expect(patch.env_vars.NGROK_AUTHTOKEN).toBe("ngrok-token-1");
+    // untouched: masked value echoed so the backend restores the real secret
+    expect(patch.env_vars.OPENAI_API_KEY).toBe("sk-p***xyz");
+    // unrelated key managed elsewhere is preserved
+    expect(patch.env_vars.SERPER_API_KEY).toBe("se***er");
+  });
+
+  it("removes a key when its field is cleared before saving", async () => {
+    render(<ApiKeysTab profile={baseProfile} onProfileUpdated={() => {}} />);
+
+    fireEvent.change(screen.getByLabelText("OPENAI_API_KEY"), {
+      target: { value: "" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: /save changes/i }));
+
+    await waitFor(() =>
+      expect(apiMocks.updateMyProfileConfig).toHaveBeenCalled(),
+    );
+    const [, patch] = apiMocks.updateMyProfileConfig.mock.calls[0];
+    expect("OPENAI_API_KEY" in patch.env_vars).toBe(false);
+    expect(patch.env_vars.SERPER_API_KEY).toBe("se***er");
+  });
+});

--- a/src/settings/api-keys-tab.tsx
+++ b/src/settings/api-keys-tab.tsx
@@ -1,0 +1,297 @@
+import { useState } from "react";
+import {
+  Save,
+  Loader2,
+  Check,
+  RotateCcw,
+  Cpu,
+  Radio,
+  Server,
+  KeyRound,
+} from "lucide-react";
+import {
+  formatSettingsError,
+  updateMyProfileConfig,
+  type Profile,
+} from "./settings-api";
+import { LLM_PROVIDERS } from "./llm-providers";
+
+interface ApiKeysTabProps {
+  profile: Profile;
+  onProfileUpdated: (p: Profile) => void;
+}
+
+interface KeyField {
+  key: string; // env var name stored in config.env_vars
+  name: string; // human label
+  description: string;
+}
+
+interface KeyGroup {
+  id: string;
+  title: string;
+  description: string;
+  icon: typeof Cpu;
+  fields: KeyField[];
+}
+
+// One field per provider that takes a single-line API key. JSON-credential
+// providers (e.g. Vertex) stay inline in the LLM tab; keyless providers
+// (Ollama, custom) have no env key at all.
+const LLM_KEY_FIELDS: KeyField[] = LLM_PROVIDERS.filter(
+  (p) => p.envKey && p.credentialKind !== "json",
+).map((p) => ({
+  key: p.envKey,
+  name: p.name,
+  description: `API key for ${p.name} models`,
+}));
+
+const GROUPS: KeyGroup[] = [
+  {
+    id: "llm_providers",
+    title: "LLM Providers",
+    description:
+      "API keys for model providers. The LLM tab binds the selected model to one of these keys.",
+    icon: Cpu,
+    fields: LLM_KEY_FIELDS,
+  },
+  {
+    id: "channels",
+    title: "Channels",
+    description: "Credentials for messaging channels and the email tool.",
+    icon: Radio,
+    fields: [
+      {
+        key: "TELEGRAM_BOT_TOKEN",
+        name: "Telegram Bot Token",
+        description: "Bot token from @BotFather",
+      },
+      {
+        key: "LARK_APP_ID",
+        name: "Lark App ID",
+        description: "Lark suite app ID",
+      },
+      {
+        key: "LARK_APP_SECRET",
+        name: "Lark App Secret",
+        description: "Lark suite app secret",
+      },
+      {
+        key: "FEISHU_APP_ID",
+        name: "Feishu App ID",
+        description: "Feishu channel app ID",
+      },
+      {
+        key: "FEISHU_APP_SECRET",
+        name: "Feishu App Secret",
+        description: "Feishu channel app secret",
+      },
+      {
+        key: "SMTP_PASSWORD",
+        name: "SMTP Password",
+        description: "Password for the email tool's SMTP account",
+      },
+    ],
+  },
+  {
+    id: "infrastructure",
+    title: "Infrastructure",
+    description: "Tokens for local infrastructure and tunnels.",
+    icon: Server,
+    fields: [
+      {
+        key: "NGROK_AUTHTOKEN",
+        name: "ngrok Authtoken",
+        description: "Authtoken for ngrok tunnels",
+      },
+    ],
+  },
+];
+
+const ALL_FIELDS = GROUPS.flatMap((g) => g.fields);
+
+// Stored values arrive masked from the server (e.g. "sk-a***xyz"); echoing
+// them back on save makes the backend keep the real secret.
+function profileToValues(profile: Profile): Record<string, string> {
+  const env = profile.config.env_vars ?? {};
+  const values: Record<string, string> = {};
+  for (const field of ALL_FIELDS) values[field.key] = env[field.key] ?? "";
+  return values;
+}
+
+function KeyFieldRow({
+  field,
+  value,
+  onChange,
+}: {
+  field: KeyField;
+  value: string;
+  onChange: (val: string) => void;
+}) {
+  const configured = Boolean(value.trim());
+
+  return (
+    <div className="rounded-xl bg-surface-container/60 p-4 border border-transparent hover:border-border transition">
+      <div className="flex items-start justify-between gap-3 mb-3">
+        <div className="min-w-0">
+          <h4 className="text-sm font-medium text-text-strong">{field.name}</h4>
+          <p className="text-xs text-muted">{field.description}</p>
+          <p className="mt-0.5 font-mono text-[11px] text-muted/70">
+            {field.key}
+          </p>
+        </div>
+        <div className="shrink-0 flex items-center gap-1.5">
+          <span
+            className={`inline-block h-2 w-2 rounded-full ${
+              configured ? "bg-green-400" : "bg-muted/30"
+            }`}
+          />
+          <span className="text-[10px] font-medium text-muted">
+            {configured ? "Configured" : "Not set"}
+          </span>
+        </div>
+      </div>
+
+      <input
+        type="password"
+        aria-label={field.key}
+        value={value}
+        onChange={(e) => onChange(e.target.value)}
+        placeholder={`Enter ${field.name}`}
+        spellCheck={false}
+        autoComplete="off"
+        className="w-full rounded-xl bg-surface-dark/50 px-4 py-2.5 text-sm text-text placeholder-muted/50 outline-none border border-transparent focus:border-accent/30 transition font-mono"
+      />
+    </div>
+  );
+}
+
+export function ApiKeysTab({ profile, onProfileUpdated }: ApiKeysTabProps) {
+  const [values, setValues] = useState<Record<string, string>>(() =>
+    profileToValues(profile),
+  );
+  const [original, setOriginal] = useState<Record<string, string>>(() =>
+    profileToValues(profile),
+  );
+  const [saving, setSaving] = useState(false);
+  const [saved, setSaved] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const isDirty = ALL_FIELDS.some(
+    (f) => (values[f.key] ?? "") !== (original[f.key] ?? ""),
+  );
+
+  const handleSave = async () => {
+    setSaving(true);
+    setError(null);
+
+    // Merge over the existing env vars so unrelated keys (search engines,
+    // TTS tokens, free-form vars) survive. Untouched fields still hold their
+    // masked value — the backend restores the real secret for those. A
+    // cleared field removes the key.
+    const mergedEnv: Record<string, string> = { ...profile.config.env_vars };
+    for (const field of ALL_FIELDS) {
+      const val = (values[field.key] ?? "").trim();
+      if (val) {
+        mergedEnv[field.key] = val;
+      } else {
+        delete mergedEnv[field.key];
+      }
+    }
+
+    try {
+      const result = await updateMyProfileConfig(profile, {
+        env_vars: mergedEnv,
+      });
+      onProfileUpdated(result);
+      const next = profileToValues(result);
+      setValues(next);
+      setOriginal(next);
+      setSaved(true);
+      setTimeout(() => setSaved(false), 2000);
+    } catch (err) {
+      setError(formatSettingsError(err, "Failed to save API keys."));
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  const handleReset = () => {
+    const next = profileToValues(profile);
+    setValues(next);
+    setOriginal(next);
+  };
+
+  return (
+    <div className="space-y-6">
+      {GROUPS.map((group) => {
+        const Icon = group.icon;
+        return (
+          <div key={group.id} className="glass-section rounded-lg p-6">
+            <div className="flex items-center gap-3 mb-6">
+              <div className="flex h-10 w-10 items-center justify-center rounded-xl bg-accent/10 text-accent">
+                <Icon size={20} />
+              </div>
+              <div>
+                <h3 className="text-sm font-semibold text-text-strong">
+                  {group.title}
+                </h3>
+                <p className="text-xs text-muted">{group.description}</p>
+              </div>
+            </div>
+
+            <div className="space-y-3">
+              {group.fields.map((field) => (
+                <KeyFieldRow
+                  key={field.key}
+                  field={field}
+                  value={values[field.key] ?? ""}
+                  onChange={(val) =>
+                    setValues((v) => ({ ...v, [field.key]: val }))
+                  }
+                />
+              ))}
+            </div>
+          </div>
+        );
+      })}
+
+      <div className="flex items-start gap-2 rounded-xl bg-surface-dark/50 px-4 py-3">
+        <KeyRound size={14} className="mt-0.5 shrink-0 text-muted" />
+        <p className="text-xs text-muted">
+          Keys are stored per profile on the server and never shown in plain
+          text. Saving keeps unchanged keys as-is; clearing a field and saving
+          removes that key.
+        </p>
+      </div>
+
+      {/* Save actions */}
+      <div className="flex items-center gap-3">
+        <button
+          onClick={handleSave}
+          disabled={saving || !isDirty}
+          className="flex items-center gap-2 rounded-xl bg-accent px-5 py-2.5 text-sm font-medium text-white hover:bg-accent-dim disabled:opacity-30 transition"
+        >
+          {saving ? (
+            <Loader2 size={14} className="animate-spin" />
+          ) : saved ? (
+            <Check size={14} />
+          ) : (
+            <Save size={14} />
+          )}
+          {saved ? "Saved" : "Save Changes"}
+        </button>
+        {isDirty && (
+          <button
+            onClick={handleReset}
+            className="flex items-center gap-2 rounded-xl border border-border px-4 py-2.5 text-sm text-muted hover:text-text-strong hover:border-accent/30 transition"
+          >
+            <RotateCcw size={14} />
+            Reset
+          </button>
+        )}
+        {error && <span className="text-xs text-red-400">{error}</span>}
+      </div>
+    </div>
+  );
+}

--- a/src/settings/llm-providers.ts
+++ b/src/settings/llm-providers.ts
@@ -89,6 +89,7 @@ export const LLM_PROVIDERS: LlmProvider[] = [
     ],
   },
   { id: "zhipu", name: "Zhipu (GLM)", envKey: "ZHIPU_API_KEY", models: [] },
+  { id: "zai", name: "Z.ai (GLM)", envKey: "ZAI_API_KEY", models: [] },
   { id: "moonshot", name: "Moonshot", envKey: "MOONSHOT_API_KEY", models: [] },
   { id: "perplexity", name: "Perplexity", envKey: "PERPLEXITY_API_KEY", models: [] },
   {

--- a/src/settings/llm-tab.tsx
+++ b/src/settings/llm-tab.tsx
@@ -542,7 +542,7 @@ export function LlmTab({ profile, onProfileUpdated }: LlmTabProps) {
                 <code className="rounded bg-surface-container px-1.5 py-0.5 font-mono text-[11px] text-text">
                   {selectedProvider.envKey}
                 </code>{" "}
-                in Environment Variables
+                in Environment Variables (see the API Keys tab)
               </span>
             </div>
           )}

--- a/src/settings/settings-page.tsx
+++ b/src/settings/settings-page.tsx
@@ -19,6 +19,7 @@ import {
   Brain,
   AlarmClock,
   ShieldCheck,
+  KeyRound,
 } from "lucide-react";
 import {
   WorkbenchStatusPill,
@@ -29,6 +30,7 @@ import { getMyProfile, type Profile } from "./settings-api";
 import { setSelectedProfileId as persistSelectedProfile } from "@/api/client";
 import { ProfileTab } from "./profile-tab";
 import { LlmTab } from "./llm-tab";
+import { ApiKeysTab } from "./api-keys-tab";
 import { SkillsTab } from "./skills-tab";
 import { ChannelsTab } from "./channels-tab";
 import { UsersTab } from "./users-tab";
@@ -43,7 +45,7 @@ import { MemoryTab } from "./memory-tab";
 import { CronTab } from "./cron-tab";
 import { AuthenticationTab } from "./authentication-tab";
 
-type TabId = "profile" | "appearance" | "llm" | "voice" | "memory" | "schedule" | "skills" | "channels" | "sandbox" | "tools" | "authentication" | "users" | "system" | "server" | "ominix";
+type TabId = "profile" | "appearance" | "llm" | "api-keys" | "voice" | "memory" | "schedule" | "skills" | "channels" | "sandbox" | "tools" | "authentication" | "users" | "system" | "server" | "ominix";
 
 interface TabDef {
   id: TabId;
@@ -56,6 +58,7 @@ const TABS: TabDef[] = [
   { id: "profile", label: "Profile", icon: User },
   { id: "appearance", label: "Appearance", icon: Palette },
   { id: "llm", label: "LLM", icon: Cpu },
+  { id: "api-keys", label: "API Keys", icon: KeyRound },
   { id: "voice", label: "Voice", icon: Volume2 },
   { id: "memory", label: "Memory", icon: Brain },
   { id: "schedule", label: "Schedule", icon: AlarmClock },
@@ -216,6 +219,13 @@ export function AdminSettingsPage() {
                   {activeTab === "appearance" && <AppearanceTab />}
                   {activeTab === "llm" && (
                     <LlmTab profile={profile} onProfileUpdated={setProfile} />
+                  )}
+                  {activeTab === "api-keys" && (
+                    <ApiKeysTab
+                      key={profile.id}
+                      profile={profile}
+                      onProfileUpdated={setProfile}
+                    />
                   )}
                   {activeTab === "voice" && (
                     <VoiceTab


### PR DESCRIPTION
## 问题
设置页没有地方结构化配置 octos 的 key：只有 Profile tab 的自由格式环境变量编辑器，LLM tab 只有一句提示，`ZAI_API_KEY` / `LARK_*` / `NGROK_AUTHTOKEN` 完全没有 UI 入口。

## 修复
- 新增 **API Keys** tab（`api-keys-tab.tsx`）：按 LLM Providers / Channels / Infrastructure 分组的命名掩码输入框，保存时合并进 `config.env_vars`（`PUT /api/my/profile`），不影响其他 env 变量；清空字段即删除该 key
- LLM provider 列表补上 `zai`（后端已支持 `ZAI_API_KEY`）
- LLM tab 的 key 提示指向 API Keys tab

## 测试
- 单测：106 文件 1043 用例全过（含新增 api-keys-tab 4 用例）
- Playwright settings-tabs.spec.ts：25/25 通过
- 真实后端（octos serve）+ 真实浏览器端到端：token 登录 → 填入全部 14 个 key → 保存 → REST 掩码读回 / 磁盘真实值 / 刷新回显 / DeepSeek test-provider 实调，36/36 通过