### PR TITLE
feat(chat): opt-in workspace (notebook) chat shell

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -4,6 +4,7 @@ import { AuthGuard } from "./auth/auth-guard";
 import { LoginPage } from "./auth/login-page";
 import { OctosRuntimeProvider } from "./runtime/runtime-provider";
 import { ChatLayout } from "./layouts/chat-layout";
+import { WorkspaceLayout } from "./layouts/workspace-layout";
 import { ChatThread } from "./components/chat-thread";
 import { HomePage } from "./pages/home-page";
 import { HomeAssistantPage } from "./home/home-assistant-page";
@@ -15,17 +16,23 @@ import { SlidesPresentPage } from "./slides/pages/slides-present-page";
 import { SitesGalleryPage } from "./sites/pages/sites-gallery-page";
 import { SitesEditorPage } from "./sites/pages/sites-editor-page";
 import { StudioPage } from "./studio/studio-page";
+import { useLayout } from "./hooks/use-layout";
 
 function ChatPage() {
+  // Opt-in shell switch (Settings → Appearance → Chat Layout): "classic"
+  // is the default; "workspace" renders the notebook three-pane layout.
+  // Both wrap the same ChatThread inside the same runtime provider.
+  const { layout } = useLayout();
+  const Shell = layout === "workspace" ? WorkspaceLayout : ChatLayout;
   return (
     <OctosRuntimeProvider>
-      <ChatLayout>
+      <Shell>
         <div className="flex h-full flex-col min-h-0">
           <div className="flex-1 min-h-0 overflow-hidden">
             <ChatThread />
           </div>
         </div>
-      </ChatLayout>
+      </Shell>
     </OctosRuntimeProvider>
   );
 }

--- a/src/hooks/use-layout.test.ts
+++ b/src/hooks/use-layout.test.ts
@@ -1,0 +1,54 @@
+import { beforeEach, describe, expect, it } from "vitest";
+import { act, renderHook } from "@testing-library/react";
+
+import { resolveInitialLayout, useLayout } from "./use-layout";
+
+const STORAGE_KEY = "octos-layout";
+
+beforeEach(() => {
+  localStorage.clear();
+});
+
+describe("resolveInitialLayout", () => {
+  it("defaults to classic when nothing is stored", () => {
+    expect(resolveInitialLayout()).toBe("classic");
+  });
+
+  it("resolves a stored workspace preference", () => {
+    localStorage.setItem(STORAGE_KEY, "workspace");
+    expect(resolveInitialLayout()).toBe("workspace");
+  });
+
+  it("ignores unknown stored values", () => {
+    localStorage.setItem(STORAGE_KEY, "holographic");
+    expect(resolveInitialLayout()).toBe("classic");
+  });
+});
+
+describe("useLayout", () => {
+  it("persists setLayout and notifies other hook instances", () => {
+    const first = renderHook(() => useLayout());
+    const second = renderHook(() => useLayout());
+
+    act(() => {
+      first.result.current.setLayout("workspace");
+    });
+
+    expect(localStorage.getItem(STORAGE_KEY)).toBe("workspace");
+    expect(first.result.current.layout).toBe("workspace");
+    expect(second.result.current.layout).toBe("workspace");
+  });
+
+  it("switches back to classic", () => {
+    localStorage.setItem(STORAGE_KEY, "workspace");
+    const { result } = renderHook(() => useLayout());
+    expect(result.current.layout).toBe("workspace");
+
+    act(() => {
+      result.current.setLayout("classic");
+    });
+
+    expect(localStorage.getItem(STORAGE_KEY)).toBe("classic");
+    expect(result.current.layout).toBe("classic");
+  });
+});

--- a/src/hooks/use-layout.ts
+++ b/src/hooks/use-layout.ts
@@ -1,0 +1,62 @@
+/**
+ * Chat-surface layout preference ("classic" | "workspace").
+ *
+ * Mirrors the use-theme.ts storage contract: a localStorage key read at
+ * first render, a CustomEvent so same-tab listeners update immediately,
+ * and the native `storage` event for cross-tab sync. "classic" is the
+ * default — the workspace (notebook three-pane) shell is opt-in via
+ * Settings → Appearance → Chat Layout, and App.tsx reads this hook to
+ * pick which layout wraps the /chat ChatThread.
+ */
+
+import { useState, useEffect, useCallback } from "react";
+
+export type AppLayout = "classic" | "workspace";
+
+const STORAGE_KEY = "octos-layout";
+const LAYOUT_CHANGE_EVENT = "octos-layout-change";
+
+function isAppLayout(value: unknown): value is AppLayout {
+  return value === "classic" || value === "workspace";
+}
+
+/** Resolve the active chat layout. Pure: reads storage, mutates nothing. */
+export function resolveInitialLayout(): AppLayout {
+  const stored = localStorage.getItem(STORAGE_KEY);
+  return isAppLayout(stored) ? stored : "classic";
+}
+
+/** Persist the preference. */
+export function applyLayout(layout: AppLayout): void {
+  localStorage.setItem(STORAGE_KEY, layout);
+}
+
+export function useLayout() {
+  const [layout, setLayoutState] = useState<AppLayout>(resolveInitialLayout);
+
+  useEffect(() => {
+    const onLayoutChange = (event: Event) => {
+      const next = event instanceof CustomEvent ? event.detail : null;
+      if (isAppLayout(next)) {
+        setLayoutState(next);
+      }
+    };
+    const onStorage = (event: StorageEvent) => {
+      if (event.key === STORAGE_KEY) setLayoutState(resolveInitialLayout());
+    };
+    window.addEventListener(LAYOUT_CHANGE_EVENT, onLayoutChange);
+    window.addEventListener("storage", onStorage);
+    return () => {
+      window.removeEventListener(LAYOUT_CHANGE_EVENT, onLayoutChange);
+      window.removeEventListener("storage", onStorage);
+    };
+  }, []);
+
+  const setLayout = useCallback((next: AppLayout) => {
+    applyLayout(next);
+    setLayoutState(next);
+    window.dispatchEvent(new CustomEvent(LAYOUT_CHANGE_EVENT, { detail: next }));
+  }, []);
+
+  return { layout, setLayout };
+}

--- a/src/layouts/workspace-layout.test.tsx
+++ b/src/layouts/workspace-layout.test.tsx
@@ -1,0 +1,203 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import * as React from "react";
+import { act } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { MemoryRouter } from "react-router-dom";
+
+(globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT =
+  true;
+
+vi.mock("@/auth/auth-context", () => ({
+  useAuth: () => ({
+    user: { email: "ada@example.test" },
+    portal: { can_access_admin_portal: false },
+    logout: vi.fn(),
+  }),
+}));
+
+vi.mock("@/hooks/use-octos-status", () => ({
+  useOctosStatus: () => ({ provider: "none", model: "none" }),
+}));
+
+vi.mock("@/hooks/use-theme", () => ({
+  useTheme: () => ({ theme: "dark", toggleTheme: vi.fn() }),
+}));
+
+vi.mock("@/store/file-store", () => ({
+  loadSessionFiles: vi.fn(async () => {}),
+  useFileStore: () => [],
+  useAllFiles: () => [],
+}));
+
+vi.mock("@/store/task-store", () => ({
+  useTasks: () => [],
+}));
+
+vi.mock("@/store/autonomy-store", () => ({
+  useAutonomyState: () => ({ loops: [], goal: null }),
+}));
+
+vi.mock("@/runtime/ui-protocol-runtime", () => ({
+  getActiveBridge: vi.fn(),
+}));
+
+vi.mock("@/studio/studio-sources-pane", () => ({
+  StudioSourcesPane: () => null,
+}));
+
+vi.mock("@/studio/studio-rail", () => ({
+  StudioRail: () => null,
+}));
+
+import { WorkspaceLayout } from "./workspace-layout";
+import {
+  SessionContext,
+  type SessionContextValue,
+} from "@/runtime/session-context";
+
+const SESSION_ID = "web-1777700000000-title";
+
+function makeSessionCtx(
+  overrides: Partial<SessionContextValue> = {},
+): SessionContextValue {
+  return {
+    sessions: [{ id: SESSION_ID, message_count: 2, title: "Original title" }],
+    currentSessionId: SESSION_ID,
+    historyTopic: undefined,
+    currentSessionTitle: "Original title",
+    currentSessionStats: null,
+    initialMessages: [],
+    activeTaskOnServer: false,
+    queueMode: null,
+    adaptiveMode: null,
+    setServerTaskActive: () => {},
+    renameSession: () => {},
+    updateSessionStats: () => {},
+    switchSession: () => {},
+    goBack: async () => false,
+    createSession: () => "web-new-session",
+    removeSession: async () => {},
+    refreshSessions: async () => {},
+    markSessionActive: () => {},
+    ...overrides,
+  };
+}
+
+interface Mounted {
+  container: HTMLDivElement;
+  root: Root;
+}
+
+const mounted: Mounted[] = [];
+
+async function mount(ctx: SessionContextValue = makeSessionCtx()): Promise<Mounted> {
+  const container = document.createElement("div");
+  document.body.appendChild(container);
+  const root = createRoot(container);
+  // Async act flushes the loadSessionFiles() promise so the loading-state
+  // update stays inside act.
+  await act(async () => {
+    root.render(
+      <MemoryRouter initialEntries={["/chat"]}>
+        <SessionContext.Provider value={ctx}>
+          <WorkspaceLayout>
+            <div data-testid="workspace-children" />
+          </WorkspaceLayout>
+        </SessionContext.Provider>
+      </MemoryRouter>,
+    );
+  });
+  const entry = { container, root };
+  mounted.push(entry);
+  return entry;
+}
+
+beforeEach(() => {
+  localStorage.clear();
+});
+
+afterEach(() => {
+  while (mounted.length > 0) {
+    const entry = mounted.pop()!;
+    act(() => entry.root.unmount());
+    entry.container.remove();
+  }
+});
+
+function click(element: Element) {
+  act(() => {
+    element.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+  });
+}
+
+describe("WorkspaceLayout", () => {
+  it("renders the topbar, sources pane, and center children", async () => {
+    // jsdom defaults to innerWidth 1024: sources starts open (>= 1024),
+    // rail starts closed (< 1280).
+    const { container } = await mount();
+    expect(container.querySelector("[data-testid='workspace-layout']")).not.toBeNull();
+    expect(container.querySelector("[data-testid='workspace-sources-pane']")).not.toBeNull();
+    expect(container.querySelector("[data-testid='workspace-children']")).not.toBeNull();
+    expect(container.querySelector("[data-testid='workspace-rail']")).toBeNull();
+  });
+
+  it("hides the sources pane via the topbar toggle and persists it", async () => {
+    const { container } = await mount();
+    click(container.querySelector("[data-testid='workspace-toggle-sources']")!);
+    expect(container.querySelector("[data-testid='workspace-sources-pane']")).toBeNull();
+    expect(localStorage.getItem("octos-workspace-panes")).toContain('"sources":false');
+  });
+
+  it("opens the rail and switches between Artifacts and Runs tabs", async () => {
+    const { container } = await mount();
+    click(container.querySelector("[data-testid='workspace-toggle-rail']")!);
+    const rail = container.querySelector("[data-testid='workspace-rail']");
+    expect(rail).not.toBeNull();
+
+    const artifactsTab = rail!.querySelector("[data-testid='workspace-tab-artifacts']")!;
+    const runsTab = rail!.querySelector("[data-testid='workspace-tab-runs']")!;
+    expect(artifactsTab.getAttribute("aria-selected")).toBe("true");
+
+    click(runsTab);
+    expect(runsTab.getAttribute("aria-selected")).toBe("true");
+    expect(rail!.textContent).toContain("No runs yet");
+  });
+
+  it("injects a beforeSend that merges selected sources into turn media", async () => {
+    // The nested provider must preserve the live session value and add
+    // beforeSend. Capture it via a consumer rendered as the child.
+    let seen: SessionContextValue | null = null;
+    function Probe() {
+      const value = React.useContext(SessionContext);
+      React.useEffect(() => {
+        seen = value;
+      }, [value]);
+      return null;
+    }
+    const container2 = document.createElement("div");
+    document.body.appendChild(container2);
+    const root2 = createRoot(container2);
+    const ctx = makeSessionCtx();
+    await act(async () => {
+      root2.render(
+        <MemoryRouter initialEntries={["/chat"]}>
+          <SessionContext.Provider value={ctx}>
+            <WorkspaceLayout>
+              <Probe />
+            </WorkspaceLayout>
+          </SessionContext.Provider>
+        </MemoryRouter>,
+      );
+    });
+    mounted.push({ container: container2, root: root2 });
+
+    expect(seen).not.toBeNull();
+    const value = seen as unknown as SessionContextValue;
+    expect(value.currentSessionId).toBe(SESSION_ID);
+    expect(typeof value.beforeSend).toBe("function");
+    const result = await value.beforeSend!({
+      media: ["/a.png"],
+    } as never);
+    expect(result).toEqual({ media: ["/a.png"] });
+  });
+});

--- a/src/layouts/workspace-layout.tsx
+++ b/src/layouts/workspace-layout.tsx
@@ -1,0 +1,436 @@
+/**
+ * Workspace chat shell ("notebook" layout): sources left, agent center,
+ * artifacts/runs right — the design-mocks/notebook-codex-shell direction
+ * shipped as an opt-in alternative to ChatLayout. Selected in Settings →
+ * Appearance → Chat Layout (`octos-layout` = "workspace"); App.tsx picks
+ * this shell for /chat when the preference is set. Classic stays the
+ * default, and everything here reuses the existing runtime — the same
+ * OctosRuntimeProvider SessionContext, ChatThread, and studio panes — so
+ * the two shells never diverge in protocol behavior.
+ *
+ * beforeSend grounding: checked sources ride along as turn media on the
+ * next send (same contract as the studio workspace). Injected through a
+ * nested SessionContext.Provider that spreads the live session value, so
+ * the shared runtime provider is never touched.
+ */
+
+import { useCallback, useEffect, useMemo, useState, type ReactNode } from "react";
+import { useNavigate } from "react-router-dom";
+import { Mic, PanelLeft, PanelRight, Plus, Target } from "lucide-react";
+
+import type { BackgroundTaskInfo } from "@/api/types";
+import { CostBar } from "@/components/cost-bar";
+import { RouterFailoverBanner } from "@/components/router-failover-banner";
+import { RouterModeSwitcher } from "@/components/router-mode-switcher";
+import { SessionAutonomyChip } from "@/components/session-autonomy-chip";
+import { SessionTaskIndicator } from "@/components/session-task-dock";
+import { SessionTitleEditor } from "@/components/session-title-editor";
+import { UiProtocolApprovalHost } from "@/components/ui-protocol-approval-host";
+import { UiProtocolQuestionHost } from "@/components/ui-protocol-question-host";
+import {
+  WorkbenchBrand,
+  WorkbenchRouteNav,
+  WorkbenchThemeButton,
+  WorkbenchUserActions,
+} from "@/components/workbench-shell";
+import { useOctosStatus } from "@/hooks/use-octos-status";
+import {
+  SessionContext,
+  useSession,
+  type SessionBeforeSendResult,
+  type SessionContextValue,
+  type SessionSendRequest,
+} from "@/runtime/session-context";
+import { displayLabelForRolled } from "@/runtime/task-rollup";
+import { useAutonomyState } from "@/store/autonomy-store";
+import { loadSessionFiles } from "@/store/file-store";
+import { useTasks } from "@/store/task-store";
+import {
+  mergeSourceMedia,
+  relativeTime,
+  type SourceRow,
+} from "@/studio/source-media";
+import { StudioRail } from "@/studio/studio-rail";
+import { StudioSourcesPane } from "@/studio/studio-sources-pane";
+
+const PANES_STORAGE_KEY = "octos-workspace-panes";
+
+interface PaneState {
+  sources: boolean;
+  rail: boolean;
+}
+
+function loadPaneState(): PaneState {
+  // Same breakpoint contract as the studio workspace: below the
+  // side-by-side widths the panes render as overlay drawers and start
+  // closed. Persist only explicit toggles (mirrors studio-page).
+  const defaults: PaneState = {
+    sources: typeof window !== "undefined" && window.innerWidth >= 1024,
+    rail: typeof window !== "undefined" && window.innerWidth >= 1280,
+  };
+  try {
+    const parsed = JSON.parse(
+      localStorage.getItem(PANES_STORAGE_KEY) ?? "null",
+    ) as Partial<PaneState> | null;
+    return {
+      sources:
+        typeof parsed?.sources === "boolean" ? parsed.sources : defaults.sources,
+      rail: typeof parsed?.rail === "boolean" ? parsed.rail : defaults.rail,
+    };
+  } catch {
+    return defaults;
+  }
+}
+
+type RunTone = "default" | "accent" | "success" | "danger";
+
+function runTone(task: BackgroundTaskInfo): RunTone {
+  if (task.status === "spawned" || task.status === "running") return "accent";
+  if (task.status === "failed") return "danger";
+  if (task.status === "completed") return "success";
+  return "default";
+}
+
+/** Runs tab: this session's background tasks, active first (task-store
+ *  already sorts). Reads the same store as the classic header dock. */
+function WorkspaceRuns({
+  sessionId,
+  topic,
+}: {
+  sessionId: string;
+  topic?: string;
+}) {
+  const tasks = useTasks(sessionId, topic);
+  if (tasks.length === 0) {
+    return (
+      <p className="px-4 py-6 text-center text-sm text-muted">
+        No runs yet — background tasks for this workspace show up here.
+      </p>
+    );
+  }
+  return (
+    <div
+      className="flex min-h-0 flex-1 flex-col gap-1.5 overflow-y-auto p-2"
+      data-testid="workspace-runs-list"
+    >
+      {tasks.map((task) => (
+        <div
+          key={task.id}
+          className="glass-section flex items-center gap-2.5 px-3 py-2"
+          data-testid={`workspace-run-${task.id}`}
+        >
+          <span className="min-w-0 flex-1">
+            <span className="block truncate text-[12px] text-text">
+              {displayLabelForRolled(task)}
+            </span>
+            <span className="block truncate text-[10px] text-muted">
+              {task.error ? task.error : task.tool_name}
+              {" · "}
+              {relativeTime(new Date(task.started_at).getTime())}
+            </span>
+          </span>
+          <span className="workbench-status-pill shrink-0" data-tone={runTone(task)}>
+            {task.status}
+          </span>
+        </div>
+      ))}
+    </div>
+  );
+}
+
+export function WorkspaceLayout({ children }: { children: ReactNode }) {
+  const session = useSession();
+  const {
+    sessions,
+    currentSessionId,
+    historyTopic,
+    currentSessionTitle,
+    renameSession,
+    switchSession,
+    createSession,
+  } = session;
+  const status = useOctosStatus();
+  const navigate = useNavigate();
+  const { goal } = useAutonomyState(currentSessionId, historyTopic);
+
+  const [panes, setPanes] = useState<PaneState>(loadPaneState);
+  const updatePanes = useCallback((updater: (prev: PaneState) => PaneState) => {
+    setPanes((prev) => {
+      const next = updater(prev);
+      try {
+        localStorage.setItem(PANES_STORAGE_KEY, JSON.stringify(next));
+      } catch {
+        // Persistence is best-effort.
+      }
+      return next;
+    });
+  }, []);
+
+  const [railTab, setRailTab] = useState<"artifacts" | "runs">("artifacts");
+  const [selectedSources, setSelectedSources] = useState<string[]>([]);
+  const [uploadedSources, setUploadedSources] = useState<SourceRow[]>([]);
+  const [sourcesLoading, setSourcesLoading] = useState(true);
+
+  // Switching sessions resets the source selection (it is scoped to one
+  // workspace's files) and reloads that session's file listing. The reset
+  // is render-phase state adjustment (React's sanctioned alternative to
+  // setState-in-effect); the effect only kicks off the async reload.
+  const [loadedSession, setLoadedSession] = useState(currentSessionId);
+  if (loadedSession !== currentSessionId) {
+    setLoadedSession(currentSessionId);
+    setSelectedSources([]);
+    setSourcesLoading(true);
+  }
+  useEffect(() => {
+    let cancelled = false;
+    void Promise.resolve(loadSessionFiles(currentSessionId)).finally(() => {
+      if (!cancelled) setSourcesLoading(false);
+    });
+    return () => {
+      cancelled = true;
+    };
+  }, [currentSessionId]);
+
+  const toggleSource = useCallback((path: string) => {
+    setSelectedSources((prev) =>
+      prev.includes(path) ? prev.filter((p) => p !== path) : [...prev, path],
+    );
+  }, []);
+
+  const beforeSend = useCallback(
+    async (request: SessionSendRequest): Promise<SessionBeforeSendResult> => ({
+      ...request,
+      media: mergeSourceMedia(request.media, selectedSources),
+    }),
+    [selectedSources],
+  );
+
+  const sessionValue = useMemo<SessionContextValue>(
+    () => ({ ...session, beforeSend }),
+    [session, beforeSend],
+  );
+
+  const liveGoal =
+    goal !== null && (goal.status === "active" || goal.status === "paused")
+      ? goal
+      : null;
+
+  return (
+    <SessionContext.Provider value={sessionValue}>
+      <div
+        className="studio-shell flex h-screen flex-col"
+        data-testid="workspace-layout"
+      >
+        <header className="workbench-topbar shrink-0 px-3">
+          <div className="flex min-h-16 flex-wrap items-center gap-2 py-2">
+            <button
+              type="button"
+              className="glass-icon-button p-2"
+              aria-label="Toggle sources"
+              aria-pressed={panes.sources}
+              data-testid="workspace-toggle-sources"
+              onClick={() =>
+                updatePanes((prev) => ({ ...prev, sources: !prev.sources }))
+              }
+            >
+              <PanelLeft size={16} />
+            </button>
+            <WorkbenchBrand />
+            <WorkbenchRouteNav compact />
+            <div className="flex-1" />
+            <button
+              type="button"
+              className="workbench-status-pill"
+              data-tone="success"
+              onClick={() => navigate("/voice")}
+              title="Open the voice console"
+            >
+              <Mic size={13} />
+              Voice
+            </button>
+            <button
+              type="button"
+              className="workbench-button flex items-center gap-1.5 px-3 py-2 text-sm font-semibold"
+              data-testid="workspace-new-session"
+              onClick={() => createSession()}
+            >
+              <Plus size={14} />
+              New workspace
+            </button>
+            <button
+              type="button"
+              className="glass-icon-button p-2"
+              aria-label="Toggle artifacts and runs"
+              aria-pressed={panes.rail}
+              data-testid="workspace-toggle-rail"
+              onClick={() =>
+                updatePanes((prev) => ({ ...prev, rail: !prev.rail }))
+              }
+            >
+              <PanelRight size={16} />
+            </button>
+            <WorkbenchThemeButton />
+            <WorkbenchUserActions />
+          </div>
+        </header>
+
+        <div className="relative flex min-h-0 flex-1 gap-2 px-2 pb-2">
+          {panes.sources && (
+            <div
+              className="studio-scrim lg:hidden"
+              aria-hidden="true"
+              onClick={() =>
+                updatePanes((prev) => ({ ...prev, sources: false }))
+              }
+            />
+          )}
+          {panes.sources && (
+            <aside
+              className="studio-pane flex w-[280px] shrink-0 flex-col overflow-hidden rounded-lg max-lg:fixed max-lg:bottom-2 max-lg:left-2 max-lg:top-[4.5rem] max-lg:z-[35] max-lg:shadow-2xl"
+              data-testid="workspace-sources-pane"
+            >
+              <div className="px-3 pt-3">
+                <div className="glass-section px-3 py-3">
+                  <div className="shell-kicker">Current workspace</div>
+                  <select
+                    className="mt-2 w-full rounded-lg border border-border bg-surface-container px-2 py-1.5 text-sm text-text"
+                    value={currentSessionId}
+                    onChange={(event) => switchSession(event.target.value)}
+                    aria-label="Switch workspace"
+                    data-testid="workspace-session-select"
+                  >
+                    {sessions.map((entry) => (
+                      <option key={entry.id} value={entry.id}>
+                        {entry.title || entry.id}
+                      </option>
+                    ))}
+                  </select>
+                </div>
+              </div>
+              <div className="min-h-0 flex-1 overflow-hidden">
+                <StudioSourcesPane
+                  sessionId={currentSessionId}
+                  selected={selectedSources}
+                  onToggle={toggleSource}
+                  uploaded={uploadedSources}
+                  onUploaded={(rows) =>
+                    setUploadedSources((prev) => [...rows, ...prev])
+                  }
+                  loading={sourcesLoading}
+                />
+              </div>
+              {liveGoal && (
+                <div className="px-3 pb-3">
+                  <div className="glass-section px-3 py-3">
+                    <div className="shell-kicker">Pinned context</div>
+                    <div
+                      className="mt-2 flex items-start gap-2"
+                      data-testid="workspace-goal-row"
+                    >
+                      <Target size={14} className="mt-0.5 shrink-0 text-muted" />
+                      <div className="min-w-0">
+                        <div className="line-clamp-2 text-xs text-text">
+                          {liveGoal.objective}
+                        </div>
+                        <div className="mt-0.5 text-[10px] text-muted">
+                          goal · {liveGoal.status}
+                        </div>
+                      </div>
+                    </div>
+                  </div>
+                </div>
+              )}
+            </aside>
+          )}
+
+          <main className="glass-panel flex min-h-0 min-w-0 flex-1 flex-col overflow-hidden rounded-lg">
+            <div className="px-3 pt-3">
+              <div className="glass-toolbar px-4 py-4">
+                <div className="flex items-start gap-4">
+                  <div className="min-w-0 flex-1">
+                    <div className="shell-kicker">Agent</div>
+                    <SessionTitleEditor
+                      value={currentSessionTitle}
+                      onSave={(title) => renameSession(currentSessionId, title)}
+                      buttonClassName="mt-1 w-full pr-3 text-left text-[1.24rem] font-semibold tracking-tight text-text-strong transition hover:text-accent"
+                      inputClassName="mt-1 w-full rounded-lg border border-accent/40 bg-surface-container px-3 py-2 text-[1.08rem] font-semibold tracking-tight text-text outline-none"
+                      testId="workspace-session-title"
+                    />
+                  </div>
+                  <SessionAutonomyChip />
+                  <SessionTaskIndicator />
+                </div>
+                <div className="mt-3 flex min-w-0 flex-wrap items-center gap-3">
+                  <CostBar model={status?.model} provider={status?.provider} />
+                  <RouterModeSwitcher />
+                </div>
+              </div>
+            </div>
+            <div className="relative flex-1 min-h-0 overflow-hidden px-2 pb-2">
+              {children}
+              <RouterFailoverBanner />
+            </div>
+          </main>
+
+          {panes.rail && (
+            <div
+              className="studio-scrim xl:hidden"
+              aria-hidden="true"
+              onClick={() =>
+                updatePanes((prev) => ({ ...prev, rail: false }))
+              }
+            />
+          )}
+          {panes.rail && (
+            <aside
+              className="studio-pane flex w-[320px] shrink-0 flex-col overflow-hidden rounded-lg max-xl:fixed max-xl:bottom-2 max-xl:right-2 max-xl:top-[4.5rem] max-xl:z-[35] max-xl:shadow-2xl"
+              data-testid="workspace-rail"
+            >
+              <div className="flex gap-1 px-3 pt-3" role="tablist">
+                <button
+                  type="button"
+                  role="tab"
+                  aria-selected={railTab === "artifacts"}
+                  data-active={railTab === "artifacts" ? "true" : undefined}
+                  data-testid="workspace-tab-artifacts"
+                  className="studio-ghost-button px-3 py-1.5 text-sm"
+                  onClick={() => setRailTab("artifacts")}
+                >
+                  Artifacts
+                </button>
+                <button
+                  type="button"
+                  role="tab"
+                  aria-selected={railTab === "runs"}
+                  data-active={railTab === "runs" ? "true" : undefined}
+                  data-testid="workspace-tab-runs"
+                  className="studio-ghost-button px-3 py-1.5 text-sm"
+                  onClick={() => setRailTab("runs")}
+                >
+                  Runs
+                </button>
+              </div>
+              <div className="flex min-h-0 flex-1 flex-col overflow-hidden">
+                {railTab === "artifacts" ? (
+                  <StudioRail
+                    sessionId={currentSessionId}
+                    historyTopic={historyTopic}
+                    selectedSources={selectedSources}
+                  />
+                ) : (
+                  <WorkspaceRuns
+                    sessionId={currentSessionId}
+                    topic={historyTopic}
+                  />
+                )}
+              </div>
+            </aside>
+          )}
+        </div>
+
+        <UiProtocolApprovalHost />
+        <UiProtocolQuestionHost />
+      </div>
+    </SessionContext.Provider>
+  );
+}

--- a/src/settings/appearance-tab.tsx
+++ b/src/settings/appearance-tab.tsx
@@ -1,6 +1,29 @@
-import { Check, Moon, Palette, Sun } from "lucide-react";
+import { Check, LayoutGrid, MessagesSquare, Moon, Palette, Sun } from "lucide-react";
 
+import { useLayout, type AppLayout } from "@/hooks/use-layout";
 import { useTheme, type UiStyle } from "@/hooks/use-theme";
+
+const LAYOUT_OPTIONS: Array<{
+  id: AppLayout;
+  label: string;
+  description: string;
+  icon: typeof MessagesSquare;
+}> = [
+  {
+    id: "classic",
+    label: "Classic",
+    description:
+      "The current chat shell — session list, conversation, and a collapsible files panel.",
+    icon: MessagesSquare,
+  },
+  {
+    id: "workspace",
+    label: "Workspace (Beta)",
+    description:
+      "Notebook-style three-pane workspace — sources, agent, and artifacts/runs on one screen.",
+    icon: LayoutGrid,
+  },
+];
 
 const STYLE_OPTIONS: Array<{
   id: UiStyle;
@@ -42,6 +65,7 @@ const STYLE_OPTIONS: Array<{
 
 export function AppearanceTab() {
   const { theme, setTheme, toggleTheme, uiStyle, setUiStyle } = useTheme();
+  const { layout, setLayout } = useLayout();
 
   const chooseStyle = (next: UiStyle) => {
     setUiStyle(next);
@@ -102,6 +126,60 @@ export function AppearanceTab() {
                       style={{ backgroundColor: color }}
                     />
                   ))}
+                </span>
+              </button>
+            );
+          })}
+        </div>
+      </section>
+
+      <section className="glass-section p-5">
+        <div className="flex items-start gap-3">
+          <div className="workbench-icon-tile flex h-10 w-10 shrink-0 items-center justify-center">
+            <LayoutGrid size={18} />
+          </div>
+          <div className="min-w-0">
+            <h3 className="text-base font-semibold text-text-strong">Chat Layout</h3>
+            <p className="mt-1 text-sm text-muted">
+              Pick the shell used by the Chat page. Classic stays the default;
+              Workspace is the new notebook-style layout — switch back anytime.
+            </p>
+          </div>
+        </div>
+
+        <div className="mt-5 grid gap-3 sm:grid-cols-2">
+          {LAYOUT_OPTIONS.map((option) => {
+            const active = layout === option.id;
+            const Icon = option.icon;
+            return (
+              <button
+                key={option.id}
+                type="button"
+                aria-label={option.label}
+                aria-pressed={active}
+                data-active={active ? "true" : undefined}
+                data-testid={`layout-option-${option.id}`}
+                onClick={() => setLayout(option.id)}
+                className="workbench-card flex min-h-28 flex-col items-start justify-between gap-3 p-4 text-left"
+              >
+                <span className="flex w-full items-start justify-between gap-3">
+                  <span className="flex items-start gap-3">
+                    <Icon size={18} className="mt-0.5 shrink-0" />
+                    <span>
+                      <span className="block text-sm font-semibold text-text-strong">
+                        {option.label}
+                      </span>
+                      <span className="mt-1 block text-xs leading-5 text-muted">
+                        {option.description}
+                      </span>
+                    </span>
+                  </span>
+                  {active && (
+                    <span className="workbench-status-pill" data-tone="accent">
+                      <Check size={13} />
+                      Active
+                    </span>
+                  )}
                 </span>
               </button>
             );


### PR DESCRIPTION
## What
Adds an opt-in **workspace** chat shell for `/chat` — sources left, agent center, artifacts/runs right (the notebook three-pane direction) — alongside the existing `ChatLayout`. **"classic" stays the default**; users switch in **Settings → Appearance → Chat Layout**.

Both shells wrap the same `ChatThread` inside the same `OctosRuntimeProvider`, so protocol behavior never diverges.

## Changes
- `src/hooks/use-layout.ts` — `classic | workspace` preference hook mirroring the `use-theme` storage contract (localStorage + CustomEvent + cross-tab `storage` sync).
- `src/layouts/workspace-layout.tsx` — the three-pane shell, reusing the **already-merged** `StudioSourcesPane` / `StudioRail` / `source-media` studio components.
- `src/settings/appearance-tab.tsx` — layout picker (Classic / Workspace Beta).
- `src/App.tsx` — pick the shell by preference for `/chat`.
- Tests: `use-layout.test.ts`, `workspace-layout.test.tsx`.

## Verification
- `tsc --noEmit` clean
- `vitest run`: **106 files / 1043 tests pass**

## Note on concurrent work
This is a separate "chat shell" layer from the studio-pane plumbing in #270 / #271 (alan0x's notebook source/asset PRs) — **no file overlap**, and this PR depends only on studio components already on `main`. Whoever lands second rebases over the other's `StudioSourcesPane` / `StudioRail` changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)