### PR TITLE
fix(build): unbreak tsc -b — thread-store TS2454

### DIFF
--- a/src/store/thread-store.ts
+++ b/src/store/thread-store.ts
@@ -3821,6 +3821,13 @@ export function loadHistory(
   const existing = loadingPromises.get(key);
   if (existing) return existing;
 
+  // The `finally` below compares against this promise's own identity, but the
+  // closure captures it before the assignment lands — a direct self-reference
+  // trips TS2454. A holder sidesteps that while keeping the binding `const`.
+  // Cleanup stays INSIDE the async body on purpose: the placeholder-refetch
+  // loop further down relies on the entry being gone the moment the load
+  // settles, not one microtask later.
+  const self: { current?: Promise<void> } = {};
   const promise = (async () => {
     try {
       // Issue #110.3: page through `getMessagesPage` so a session
@@ -3857,12 +3864,13 @@ export function loadHistory(
     } catch {
       loadedSessions.delete(key);
     } finally {
-      if (loadingPromises.get(key) === promise) {
+      if (loadingPromises.get(key) === self.current) {
         loadingPromises.delete(key);
       }
     }
   })();
 
+  self.current = promise;
   loadingPromises.set(key, promise);
   return promise;
 }


### PR DESCRIPTION
## 问题

`npm run build`（`tsc -b && vite build`）一直失败：

```
src/store/thread-store.ts(3860,40): error TS2454: Variable 'promise' is used before being assigned.
```

直接后果是 **Deploy to GitHub Pages 连续 4 次红**（`fbedc89`、`53c8668`、`2967d47`、`bf9150a`），#276 和 #277 的功能虽然已在 main，但线上没有更新。

注意 `tsconfig.json` 只是个 `files: []` 的 solution 文件，所以 `tsc --noEmit -p tsconfig.json` 是空跑、会误报通过；必须用 CI 的口径 `tsc -b` 才能复现。

## 原因

`loadHistory` 在 async body 的 `finally` 里拿"自己这个 promise"跟 map 里的条目比对，判断是否该清理：

```ts
const promise = (async () => {
  try { ... } finally {
    if (loadingPromises.get(key) === promise) loadingPromises.delete(key)
  }
})()
```

闭包在赋值完成之前就捕获了 `promise`。运行时是安全的（`finally` 必定在至少一次 `await` 之后才跑，那时 `set` 早已执行），但 TS 的确定赋值分析证明不了这点。

## 修法

把自引用绕过一个 holder，绑定保持 `const`：

```ts
const self: { current?: Promise<void> } = {}
const promise = (async () => { ... self.current ... })()
self.current = promise
```

清理逻辑**仍然留在 async body 内部**，这是有意的：下面 placeholder-refetch 循环的注释明确依赖"await 完成时 `loadingPromises` 条目已消失"才会发起 fresh 请求。若改成 `promise.then(cleanup)`，该保证会退化成微任务时序上的巧合。

## 验证

- `tsc -b` 通过
- `eslint` 通过（顺带说明：`prefer-const` 不认这种先读后赋值的写法，holder 写法从根上避开了，无需 inline disable）
- `vitest run` 106 文件 / 1043 测试全过，与修改前基线一致
- `npm run build` 成功产出 dist

🤖 Generated with [Claude Code](https://claude.com/claude-code)