### PR TITLE
feat(projection): stage 0 — pure v2 envelope parser + wire-type fixtures (receive-only)

### DIFF
--- a/src/runtime/fixtures/projection-envelope-v2/README.md
+++ b/src/runtime/fixtures/projection-envelope-v2/README.md
@@ -1,0 +1,20 @@
+# Projection-envelope v2 fixtures
+
+These fixtures are hand-authored to the Rust wire types: `EnvelopeWire`,
+`Payload { tag = "type", content = "data" }`, and
+`UiCursor { stream, seq }`. They are not captures from a live server and are
+not client-normalized test data.
+
+The six standard fixtures (`user-message`, `assistant-delta`,
+`assistant-persisted-with-media`, `tool-outcome`, `terminal-error`, and
+`background-spawn-complete`) represent the current flattened
+`projection/envelope` `params` wire. They use the server field names and its
+1-based per-thread `seq`, and deliberately omit a top-level `cursor` because
+the server does not emit one today.
+
+`reconnect-cursor.json` is the one fixture for the v2 cursor addition. It
+shows the optional `UiCursor` shape that a future server may emit for
+reconnect/replay; it is not part of the current server wire.
+
+The Stage 0 parser tests decode every fixture in isolation. Nothing in this
+directory is wired into the live bridge or a renderer.

--- a/src/runtime/fixtures/projection-envelope-v2/assistant-delta.json
+++ b/src/runtime/fixtures/projection-envelope-v2/assistant-delta.json
@@ -1,0 +1,12 @@
+{
+  "session_id": "session-capture-001",
+  "topic": "planning",
+  "thread_id": "thread-capture-001",
+  "seq": 2,
+  "payload": {
+    "type": "assistant_delta",
+    "data": {
+      "text": "I will start by identifying the major flows."
+    }
+  }
+}

--- a/src/runtime/fixtures/projection-envelope-v2/assistant-persisted-with-media.json
+++ b/src/runtime/fixtures/projection-envelope-v2/assistant-persisted-with-media.json
@@ -1,0 +1,19 @@
+{
+  "session_id": "session-capture-001",
+  "topic": "planning",
+  "thread_id": "thread-capture-001",
+  "seq": 3,
+  "payload": {
+    "type": "assistant_persisted",
+    "data": {
+      "text": "I found three implementation milestones.",
+      "meta": {
+        "message_id": "msg-capture-003",
+        "persisted_at": "2026-07-18T22:10:03Z",
+        "media": [
+          "artifacts/implementation-plan.md"
+        ]
+      }
+    }
+  }
+}

--- a/src/runtime/fixtures/projection-envelope-v2/background-spawn-complete.json
+++ b/src/runtime/fixtures/projection-envelope-v2/background-spawn-complete.json
@@ -1,0 +1,28 @@
+{
+  "session_id": "session-capture-001",
+  "topic": "planning",
+  "thread_id": "thread-capture-001",
+  "seq": 6,
+  "payload": {
+    "type": "background/spawn_complete",
+    "data": {
+      "task_id": "task-capture-001",
+      "tool_call_id": "call-capture-002",
+      "response_to_client_message_id": "cmid-capture-001",
+      "message_id": "msg-capture-background-001",
+      "source": "background",
+      "persisted_at": "2026-07-18T22:10:09Z",
+      "content": "The background analysis is ready.",
+      "media": [
+        "artifacts/background-analysis.md"
+      ],
+      "meta": {
+        "message_id": "msg-capture-background-001",
+        "persisted_at": "2026-07-18T22:10:09Z",
+        "media": [
+          "artifacts/background-analysis.md"
+        ]
+      }
+    }
+  }
+}

--- a/src/runtime/fixtures/projection-envelope-v2/reconnect-cursor.json
+++ b/src/runtime/fixtures/projection-envelope-v2/reconnect-cursor.json
@@ -1,0 +1,15 @@
+{
+  "session_id": "session-capture-001",
+  "thread_id": "thread-capture-002",
+  "seq": 1,
+  "cursor": {
+    "stream": "session-capture-001",
+    "seq": 412
+  },
+  "payload": {
+    "type": "assistant_delta",
+    "data": {
+      "text": "This frame was replayed after reconnect."
+    }
+  }
+}

--- a/src/runtime/fixtures/projection-envelope-v2/terminal-error.json
+++ b/src/runtime/fixtures/projection-envelope-v2/terminal-error.json
@@ -1,0 +1,23 @@
+{
+  "session_id": "session-capture-001",
+  "topic": "planning",
+  "thread_id": "thread-capture-001",
+  "seq": 5,
+  "payload": {
+    "type": "turn_completed",
+    "data": {
+      "status": "error",
+      "token_usage": {
+        "input_tokens": 120,
+        "output_tokens": 37
+      },
+      "error": {
+        "code": "runtime_error",
+        "message": "The model provider stopped the turn.",
+        "data": {
+          "retryable": true
+        }
+      }
+    }
+  }
+}

--- a/src/runtime/fixtures/projection-envelope-v2/tool-outcome.json
+++ b/src/runtime/fixtures/projection-envelope-v2/tool-outcome.json
@@ -1,0 +1,14 @@
+{
+  "session_id": "session-capture-001",
+  "topic": "planning",
+  "thread_id": "thread-capture-001",
+  "seq": 4,
+  "payload": {
+    "type": "tool_end",
+    "data": {
+      "tool_call_id": "call-capture-001",
+      "status": "error",
+      "error": "workspace access was denied"
+    }
+  }
+}

--- a/src/runtime/fixtures/projection-envelope-v2/user-message.json
+++ b/src/runtime/fixtures/projection-envelope-v2/user-message.json
@@ -1,0 +1,20 @@
+{
+  "session_id": "session-capture-001",
+  "topic": "planning",
+  "thread_id": "thread-capture-001",
+  "seq": 1,
+  "client_message_id": "cmid-capture-001",
+  "payload": {
+    "type": "user_message",
+    "data": {
+      "text": "Please turn this screenshot into an implementation plan.",
+      "files": [
+        {
+          "path": "uploads/capture-001.png",
+          "mime": "image/png",
+          "size_bytes": 2048
+        }
+      ]
+    }
+  }
+}

--- a/src/runtime/projection-envelope-v2.test.ts
+++ b/src/runtime/projection-envelope-v2.test.ts
@@ -1,0 +1,368 @@
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { beforeEach, describe, expect, it } from "vitest";
+import { createUiProtocolBridge } from "./ui-protocol-bridge";
+import {
+  parseProjectionEnvelopeV2,
+  type ProjectionEnvelopeV2,
+} from "./projection-envelope-v2";
+import {
+  __resetProjectionCacheForTesting,
+  projectWithMetrics,
+} from "../store/projection";
+import type { Envelope } from "./ui-protocol-types";
+
+const fixtureDirectory = resolve(__dirname, "fixtures/projection-envelope-v2");
+
+const currentWireFixtureNames = [
+  "user-message.json",
+  "assistant-delta.json",
+  "assistant-persisted-with-media.json",
+  "tool-outcome.json",
+  "terminal-error.json",
+  "background-spawn-complete.json",
+] as const;
+
+type FixtureName =
+  | (typeof currentWireFixtureNames)[number]
+  | "reconnect-cursor.json";
+
+function readFixture(name: FixtureName): unknown {
+  return JSON.parse(readFileSync(resolve(fixtureDirectory, name), "utf8")) as unknown;
+}
+
+function parseFixture(name: FixtureName): ProjectionEnvelopeV2 {
+  const parsed = parseProjectionEnvelopeV2(readFixture(name));
+  if (!parsed.ok) {
+    throw new Error(`${name} did not decode: ${parsed.error.path} ${parsed.error.message}`);
+  }
+  return parsed.value;
+}
+
+function frameWithPayload(payload: unknown): unknown {
+  const currentWire = readFixture("assistant-delta.json") as Record<string, unknown>;
+  return { ...currentWire, payload };
+}
+
+class ReceiveOnlySocket {
+  static instances: ReceiveOnlySocket[] = [];
+
+  static readonly CONNECTING = 0;
+  static readonly OPEN = 1;
+  static readonly CLOSING = 2;
+  static readonly CLOSED = 3;
+
+  readonly CONNECTING = ReceiveOnlySocket.CONNECTING;
+  readonly OPEN = ReceiveOnlySocket.OPEN;
+  readonly CLOSING = ReceiveOnlySocket.CLOSING;
+  readonly CLOSED = ReceiveOnlySocket.CLOSED;
+
+  readyState = ReceiveOnlySocket.CONNECTING;
+  onopen: ((event: Event) => void) | null = null;
+  onmessage: ((event: MessageEvent) => void) | null = null;
+  onerror: ((event: Event) => void) | null = null;
+  onclose: ((event: CloseEvent) => void) | null = null;
+
+  constructor(url: string) {
+    void url;
+    ReceiveOnlySocket.instances.push(this);
+  }
+
+  send(data: string): void {
+    void data;
+  }
+
+  close(): void {
+    this.readyState = ReceiveOnlySocket.CLOSED;
+  }
+
+  open(): void {
+    this.readyState = ReceiveOnlySocket.OPEN;
+    this.onopen?.(new Event("open"));
+  }
+
+  receive(value: unknown): void {
+    this.onmessage?.(
+      new MessageEvent("message", { data: JSON.stringify(value) }),
+    );
+  }
+}
+
+beforeEach(() => {
+  ReceiveOnlySocket.instances = [];
+  __resetProjectionCacheForTesting();
+});
+
+describe("projection-envelope v2 parser — current wire and v2 extension fixtures", () => {
+  for (const fixtureName of currentWireFixtureNames) {
+    it(`decodes the current cursor-absent wire fixture ${fixtureName}`, () => {
+      const envelope = parseFixture(fixtureName);
+
+      expect(envelope.session_id).toBe("session-capture-001");
+      expect(envelope.seq).toBeGreaterThanOrEqual(1);
+      expect(envelope.cursor).toBeUndefined();
+    });
+  }
+
+  it("preserves the typed user-message root and its client id", () => {
+    const envelope = parseFixture("user-message.json");
+
+    expect(envelope).toMatchObject({
+      topic: "planning",
+      thread_id: "thread-capture-001",
+      seq: 1,
+      client_message_id: "cmid-capture-001",
+      payload: {
+        type: "user_message",
+        data: {
+          text: "Please turn this screenshot into an implementation plan.",
+          files: [
+            {
+              path: "uploads/capture-001.png",
+              mime: "image/png",
+              size_bytes: 2048,
+            },
+          ],
+        },
+      },
+    });
+    expect(envelope.cursor).toBeUndefined();
+  });
+
+  it("preserves assistant delta and durable persisted media", () => {
+    const delta = parseFixture("assistant-delta.json");
+    const persisted = parseFixture("assistant-persisted-with-media.json");
+
+    expect(delta.payload).toEqual({
+      type: "assistant_delta",
+      data: { text: "I will start by identifying the major flows." },
+    });
+    expect(persisted.payload).toMatchObject({
+      type: "assistant_persisted",
+      data: {
+        text: "I found three implementation milestones.",
+        meta: {
+          message_id: "msg-capture-003",
+          persisted_at: "2026-07-18T22:10:03Z",
+          media: ["artifacts/implementation-plan.md"],
+        },
+      },
+    });
+  });
+
+  it("preserves tool outcomes and a terminal error as separate typed payloads", () => {
+    const toolOutcome = parseFixture("tool-outcome.json");
+    const terminal = parseFixture("terminal-error.json");
+
+    expect(toolOutcome.payload).toEqual({
+      type: "tool_end",
+      data: {
+        tool_call_id: "call-capture-001",
+        status: "error",
+        error: "workspace access was denied",
+      },
+    });
+    expect(terminal.payload).toMatchObject({
+      type: "turn_completed",
+      data: {
+        status: "error",
+        token_usage: { input_tokens: 120, output_tokens: 37 },
+        error: {
+          code: "runtime_error",
+          message: "The model provider stopped the turn.",
+          data: { retryable: true },
+        },
+      },
+    });
+  });
+
+  it("also accepts the v2 reconnect cursor independently of the thread sequence", () => {
+    const envelope = parseFixture("reconnect-cursor.json");
+
+    expect(envelope.seq).toBe(1);
+    expect(envelope.cursor).toEqual({
+      stream: "session-capture-001",
+      seq: 412,
+    });
+    expect(envelope.topic).toBeUndefined();
+  });
+
+  it("decodes a background spawn completion with its content and media", () => {
+    const envelope = parseFixture("background-spawn-complete.json");
+
+    expect(envelope.payload).toMatchObject({
+      type: "background/spawn_complete",
+      data: {
+        task_id: "task-capture-001",
+        tool_call_id: "call-capture-002",
+        content: "The background analysis is ready.",
+        media: ["artifacts/background-analysis.md"],
+      },
+    });
+  });
+
+  it("decodes the remaining canonical payload variants without a live route", () => {
+    const cases = [
+      {
+        input: frameWithPayload({
+          type: "reasoning_delta",
+          data: { text: "I need to inspect the wire before changing it." },
+        }),
+        payload: {
+          type: "reasoning_delta",
+          data: { text: "I need to inspect the wire before changing it." },
+        },
+      },
+      {
+        input: frameWithPayload({
+          type: "tool_start",
+          data: {
+            tool_call_id: "call-capture-start",
+            name: "workspace.inspect",
+            arguments: { depth: 2 },
+          },
+        }),
+        payload: {
+          type: "tool_start",
+          data: {
+            tool_call_id: "call-capture-start",
+            name: "workspace.inspect",
+            arguments: { depth: 2 },
+          },
+        },
+      },
+      {
+        input: frameWithPayload({
+          type: "tool_progress",
+          data: {
+            tool_call_id: "call-capture-progress",
+            message: "Reading protocol definitions",
+          },
+        }),
+        payload: {
+          type: "tool_progress",
+          data: {
+            tool_call_id: "call-capture-progress",
+            message: "Reading protocol definitions",
+          },
+        },
+      },
+      {
+        input: frameWithPayload({
+          type: "file_attached",
+          data: {
+            path: "artifacts/projection-plan.md",
+            mime: "text/markdown",
+            size_bytes: 512,
+          },
+        }),
+        payload: {
+          type: "file_attached",
+          data: {
+            path: "artifacts/projection-plan.md",
+            mime: "text/markdown",
+            size_bytes: 512,
+          },
+        },
+      },
+    ];
+
+    for (const { input, payload } of cases) {
+      expect(parseProjectionEnvelopeV2(input)).toMatchObject({
+        ok: true,
+        value: { payload },
+      });
+    }
+  });
+
+  it("is pure: parsing does not mutate a fixture and repeats deterministically", () => {
+    const fixture = readFixture("assistant-persisted-with-media.json");
+    const before = JSON.stringify(fixture);
+
+    expect(parseProjectionEnvelopeV2(fixture)).toEqual(
+      parseProjectionEnvelopeV2(fixture),
+    );
+    expect(JSON.stringify(fixture)).toBe(before);
+  });
+
+  it("rejects the old zero-based sequence and a nested envelope shape", () => {
+    const zeroBased = readFixture("user-message.json") as Record<string, unknown>;
+    zeroBased.seq = 0;
+    const zeroResult = parseProjectionEnvelopeV2(zeroBased);
+    expect(zeroResult).toMatchObject({
+      ok: false,
+      error: { code: "invalid_field", path: "$.seq" },
+    });
+
+    const nested = { envelope: readFixture("user-message.json") };
+    const nestedResult = parseProjectionEnvelopeV2(nested);
+    expect(nestedResult).toMatchObject({
+      ok: false,
+      error: { code: "missing_field", path: "$.session_id" },
+    });
+  });
+});
+
+describe("projection-envelope v2 parser — shadow incompatibility guard", () => {
+  it("documents that the legacy shadow decoder rejects the real flattened wire because it requires turn_id", async () => {
+    // This is intentionally a receive-only characterization test. The Stage 0
+    // parser above neither imports nor calls the bridge; this assertion pins
+    // the known incompatibility: the shadow decoder requires its legacy
+    // `turn_id`, while the real EnvelopeWire carries `thread_id`. A later
+    // migration must explicitly replace the shadow path.
+    const bridge = createUiProtocolBridge({
+      origin: "https://test.local",
+      getToken: () => "test-token",
+      getProfileId: () => null,
+      features: [],
+      webSocketImpl: ReceiveOnlySocket as unknown as typeof WebSocket,
+    });
+    const warnings: string[] = [];
+    bridge.onWarning((warning) => warnings.push(warning.reason));
+
+    await bridge.start({});
+    const socket = ReceiveOnlySocket.instances[0];
+    if (!socket) throw new Error("test bridge did not create a socket");
+    socket.open();
+
+    for (const fixtureName of currentWireFixtureNames) {
+      socket.receive({
+        jsonrpc: "2.0",
+        method: "projection/envelope",
+        params: readFixture(fixtureName),
+      });
+    }
+
+    expect(warnings).toEqual(
+      currentWireFixtureNames.map(() => "invalid_event:projection/envelope"),
+    );
+    await bridge.stop();
+  });
+
+  it("documents the shadow projection's separate seq-0 assumption", () => {
+    // The old pure projection initializes `expectedNextSeq` to zero. Feeding
+    // it a valid server frame beginning at seq=1 only buffers that root and
+    // leaves the user view empty. This test is a regression guard, not a
+    // dependency of the Stage 0 parser or any production receive path.
+    const v2 = parseFixture("user-message.json");
+    if (v2.payload.type !== "user_message") {
+      throw new Error("user-message fixture decoded to an unexpected payload");
+    }
+    const legacyEnvelope: Envelope = {
+      thread_id: v2.thread_id,
+      seq: v2.seq,
+      client_message_id: v2.client_message_id,
+      payload: {
+        type: "user_message",
+        data: {
+          text: v2.payload.data.text,
+          files: v2.payload.data.files,
+        },
+      },
+    };
+
+    const shadow = projectWithMetrics([legacyEnvelope]);
+    expect(shadow.metrics.outOfOrder).toBe(1);
+    expect(shadow.view.threads[0]?.user).toBeNull();
+  });
+});

--- a/src/runtime/projection-envelope-v2.ts
+++ b/src/runtime/projection-envelope-v2.ts
@@ -1,0 +1,655 @@
+/**
+ * Stage 0 receive-only decoder for the server's flattened
+ * `projection/envelope` params shape.
+ *
+ * This module deliberately has no bridge, store, subscription, or feature
+ * negotiation dependency. It is a pure boundary decoder only; wiring its
+ * result into a live path is a later migration stage.
+ *
+ * The server's per-thread `seq` starts at 1. The current wire does not carry
+ * a durable ledger `cursor`; a future v2 envelope may add one for
+ * reconnect/replay, so the decoder preserves it when present without
+ * conflating it with the per-thread sequence.
+ */
+
+type JsonObject = Record<string, unknown>;
+
+export interface ProjectionEnvelopeV2Cursor {
+  stream: string;
+  seq: number;
+}
+
+export interface ProjectionEnvelopeV2FileRef {
+  path: string;
+  mime: string;
+  size_bytes: number;
+}
+
+export interface ProjectionEnvelopeV2MessageMeta {
+  message_id: string;
+  persisted_at: string;
+  media?: string[];
+}
+
+export interface ProjectionEnvelopeV2TokenUsage {
+  input_tokens?: number;
+  output_tokens?: number;
+  reasoning_tokens?: number;
+  cache_read_tokens?: number;
+  cache_write_tokens?: number;
+}
+
+export interface ProjectionEnvelopeV2TerminalError {
+  code: string;
+  message: string;
+  data?: unknown;
+}
+
+export type ProjectionEnvelopeV2ToolEndStatus =
+  | "complete"
+  | "error"
+  | "skipped"
+  | "aborted";
+
+export type ProjectionEnvelopeV2TurnStatus =
+  | "completed"
+  | "error"
+  | "errored"
+  | "interrupted"
+  | "cancelled";
+
+export interface ProjectionEnvelopeV2UserMessagePayload {
+  type: "user_message";
+  data: {
+    text: string;
+    files: ProjectionEnvelopeV2FileRef[];
+  };
+}
+
+export interface ProjectionEnvelopeV2AssistantDeltaPayload {
+  type: "assistant_delta";
+  data: { text: string };
+}
+
+export interface ProjectionEnvelopeV2ReasoningDeltaPayload {
+  type: "reasoning_delta";
+  data: { text: string };
+}
+
+export interface ProjectionEnvelopeV2AssistantPersistedPayload {
+  type: "assistant_persisted";
+  data: {
+    text: string;
+    meta: ProjectionEnvelopeV2MessageMeta;
+  };
+}
+
+export interface ProjectionEnvelopeV2ToolStartPayload {
+  type: "tool_start";
+  data: {
+    tool_call_id: string;
+    name: string;
+    arguments?: unknown;
+  };
+}
+
+export interface ProjectionEnvelopeV2ToolProgressPayload {
+  type: "tool_progress";
+  data: {
+    tool_call_id: string;
+    message: string;
+  };
+}
+
+export interface ProjectionEnvelopeV2ToolEndPayload {
+  type: "tool_end";
+  data: {
+    tool_call_id: string;
+    status: ProjectionEnvelopeV2ToolEndStatus;
+    error?: string;
+    reason?: string;
+  };
+}
+
+export interface ProjectionEnvelopeV2FileAttachedPayload {
+  type: "file_attached";
+  data: ProjectionEnvelopeV2FileRef;
+}
+
+export interface ProjectionEnvelopeV2TurnCompletedPayload {
+  type: "turn_completed";
+  data: {
+    token_usage: ProjectionEnvelopeV2TokenUsage;
+    status?: ProjectionEnvelopeV2TurnStatus;
+    error?: ProjectionEnvelopeV2TerminalError;
+    reason?: string;
+  };
+}
+
+/** Completion emitted by the background/spawn path after the foreground
+ * turn has already settled. `content` is the durable assistant body; media
+ * is optional because a background task can complete with text only. */
+export interface ProjectionEnvelopeV2BackgroundSpawnCompletePayload {
+  type: "background/spawn_complete";
+  data: {
+    task_id: string;
+    content: string;
+    tool_call_id?: string;
+    response_to_client_message_id?: string;
+    message_id?: string;
+    source?: string;
+    persisted_at?: string;
+    media?: string[];
+    meta?: ProjectionEnvelopeV2MessageMeta;
+  };
+}
+
+export type ProjectionEnvelopeV2Payload =
+  | ProjectionEnvelopeV2UserMessagePayload
+  | ProjectionEnvelopeV2AssistantDeltaPayload
+  | ProjectionEnvelopeV2ReasoningDeltaPayload
+  | ProjectionEnvelopeV2AssistantPersistedPayload
+  | ProjectionEnvelopeV2ToolStartPayload
+  | ProjectionEnvelopeV2ToolProgressPayload
+  | ProjectionEnvelopeV2ToolEndPayload
+  | ProjectionEnvelopeV2FileAttachedPayload
+  | ProjectionEnvelopeV2TurnCompletedPayload
+  | ProjectionEnvelopeV2BackgroundSpawnCompletePayload;
+
+/** The actual flattened notification params shape. There is intentionally no
+ * nested `envelope` object and no `turn_id` field. */
+export interface ProjectionEnvelopeV2 {
+  session_id: string;
+  topic?: string;
+  thread_id: string;
+  /** Server-assigned per-thread order; the first envelope is 1, not 0. */
+  seq: number;
+  client_message_id?: string;
+  /** V2 reconnect/replay addition; absent from the current EnvelopeWire. */
+  cursor?: ProjectionEnvelopeV2Cursor;
+  payload: ProjectionEnvelopeV2Payload;
+}
+
+export type ProjectionEnvelopeV2ParseErrorCode =
+  | "not_object"
+  | "missing_field"
+  | "invalid_field"
+  | "unknown_payload";
+
+export interface ProjectionEnvelopeV2ParseError {
+  code: ProjectionEnvelopeV2ParseErrorCode;
+  path: string;
+  message: string;
+}
+
+export type ProjectionEnvelopeV2ParseResult =
+  | { ok: true; value: ProjectionEnvelopeV2 }
+  | { ok: false; error: ProjectionEnvelopeV2ParseError };
+
+type ParseStep<T> =
+  | { ok: true; value: T }
+  | { ok: false; error: ProjectionEnvelopeV2ParseError };
+
+function ok<T>(value: T): ParseStep<T> {
+  return { ok: true, value };
+}
+
+function fail(
+  code: ProjectionEnvelopeV2ParseErrorCode,
+  path: string,
+  message: string,
+): ParseStep<never> {
+  return { ok: false, error: { code, path, message } };
+}
+
+function isPlainObject(value: unknown): value is JsonObject {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function hasOwn(object: JsonObject, key: string): boolean {
+  return Object.prototype.hasOwnProperty.call(object, key);
+}
+
+function readObject(
+  object: JsonObject,
+  key: string,
+  path: string,
+): ParseStep<JsonObject> {
+  if (!hasOwn(object, key)) {
+    return fail("missing_field", `${path}.${key}`, "field is required");
+  }
+  if (!isPlainObject(object[key])) {
+    return fail("invalid_field", `${path}.${key}`, "expected an object");
+  }
+  return ok(object[key]);
+}
+
+function readString(
+  object: JsonObject,
+  key: string,
+  path: string,
+  options: { nonEmpty?: boolean } = {},
+): ParseStep<string> {
+  if (!hasOwn(object, key)) {
+    return fail("missing_field", `${path}.${key}`, "field is required");
+  }
+  const value = object[key];
+  if (typeof value !== "string") {
+    return fail("invalid_field", `${path}.${key}`, "expected a string");
+  }
+  if (options.nonEmpty && value.length === 0) {
+    return fail("invalid_field", `${path}.${key}`, "expected a non-empty string");
+  }
+  return ok(value);
+}
+
+function readOptionalString(
+  object: JsonObject,
+  key: string,
+  path: string,
+  options: { nonEmpty?: boolean } = {},
+): ParseStep<string | undefined> {
+  if (!hasOwn(object, key)) return ok(undefined);
+  const value = object[key];
+  if (typeof value !== "string") {
+    return fail("invalid_field", `${path}.${key}`, "expected a string");
+  }
+  if (options.nonEmpty && value.length === 0) {
+    return fail("invalid_field", `${path}.${key}`, "expected a non-empty string");
+  }
+  return ok(value);
+}
+
+function readNonNegativeInteger(
+  object: JsonObject,
+  key: string,
+  path: string,
+  minimum: number,
+): ParseStep<number> {
+  if (!hasOwn(object, key)) {
+    return fail("missing_field", `${path}.${key}`, "field is required");
+  }
+  const value = object[key];
+  if (!Number.isSafeInteger(value) || (value as number) < minimum) {
+    return fail(
+      "invalid_field",
+      `${path}.${key}`,
+      `expected a safe integer greater than or equal to ${minimum}`,
+    );
+  }
+  return ok(value as number);
+}
+
+function readOptionalNonNegativeInteger(
+  object: JsonObject,
+  key: string,
+  path: string,
+): ParseStep<number | undefined> {
+  if (!hasOwn(object, key)) return ok(undefined);
+  const value = object[key];
+  if (!Number.isSafeInteger(value) || (value as number) < 0) {
+    return fail(
+      "invalid_field",
+      `${path}.${key}`,
+      "expected a non-negative safe integer",
+    );
+  }
+  return ok(value as number);
+}
+
+function readOptionalStringArray(
+  object: JsonObject,
+  key: string,
+  path: string,
+): ParseStep<string[] | undefined> {
+  if (!hasOwn(object, key)) return ok(undefined);
+  const value = object[key];
+  if (!Array.isArray(value) || value.some((item) => typeof item !== "string")) {
+    return fail("invalid_field", `${path}.${key}`, "expected an array of strings");
+  }
+  return ok(value.slice());
+}
+
+function parseCursor(value: unknown, path: string): ParseStep<ProjectionEnvelopeV2Cursor> {
+  if (!isPlainObject(value)) {
+    return fail("invalid_field", path, "expected an object");
+  }
+  const stream = readString(value, "stream", path, { nonEmpty: true });
+  if (!stream.ok) return stream;
+  const seq = readNonNegativeInteger(value, "seq", path, 0);
+  if (!seq.ok) return seq;
+  return ok({ stream: stream.value, seq: seq.value });
+}
+
+function parseFileRef(value: unknown, path: string): ParseStep<ProjectionEnvelopeV2FileRef> {
+  if (!isPlainObject(value)) {
+    return fail("invalid_field", path, "expected an object");
+  }
+  const filePath = readString(value, "path", path, { nonEmpty: true });
+  if (!filePath.ok) return filePath;
+  const mime = readString(value, "mime", path, { nonEmpty: true });
+  if (!mime.ok) return mime;
+  const sizeBytes = readNonNegativeInteger(value, "size_bytes", path, 0);
+  if (!sizeBytes.ok) return sizeBytes;
+  return ok({ path: filePath.value, mime: mime.value, size_bytes: sizeBytes.value });
+}
+
+function parseFileRefs(
+  object: JsonObject,
+  key: string,
+  path: string,
+): ParseStep<ProjectionEnvelopeV2FileRef[]> {
+  if (!hasOwn(object, key)) return ok([]);
+  const value = object[key];
+  if (!Array.isArray(value)) {
+    return fail("invalid_field", `${path}.${key}`, "expected an array");
+  }
+  const files: ProjectionEnvelopeV2FileRef[] = [];
+  for (let index = 0; index < value.length; index += 1) {
+    const parsed = parseFileRef(value[index], `${path}.${key}[${index}]`);
+    if (!parsed.ok) return parsed;
+    files.push(parsed.value);
+  }
+  return ok(files);
+}
+
+function parseMessageMeta(
+  value: unknown,
+  path: string,
+): ParseStep<ProjectionEnvelopeV2MessageMeta> {
+  if (!isPlainObject(value)) {
+    return fail("invalid_field", path, "expected an object");
+  }
+  const messageId = readString(value, "message_id", path, { nonEmpty: true });
+  if (!messageId.ok) return messageId;
+  const persistedAt = readString(value, "persisted_at", path, { nonEmpty: true });
+  if (!persistedAt.ok) return persistedAt;
+  const media = readOptionalStringArray(value, "media", path);
+  if (!media.ok) return media;
+  return ok({
+    message_id: messageId.value,
+    persisted_at: persistedAt.value,
+    ...(media.value !== undefined ? { media: media.value } : {}),
+  });
+}
+
+function parseTokenUsage(
+  value: unknown,
+  path: string,
+): ParseStep<ProjectionEnvelopeV2TokenUsage> {
+  if (!isPlainObject(value)) {
+    return fail("invalid_field", path, "expected an object");
+  }
+  const usage: ProjectionEnvelopeV2TokenUsage = {};
+  for (const key of [
+    "input_tokens",
+    "output_tokens",
+    "reasoning_tokens",
+    "cache_read_tokens",
+    "cache_write_tokens",
+  ] as const) {
+    const valueForKey = readOptionalNonNegativeInteger(value, key, path);
+    if (!valueForKey.ok) return valueForKey;
+    if (valueForKey.value !== undefined) usage[key] = valueForKey.value;
+  }
+  return ok(usage);
+}
+
+function parseTerminalError(
+  value: unknown,
+  path: string,
+): ParseStep<ProjectionEnvelopeV2TerminalError> {
+  if (!isPlainObject(value)) {
+    return fail("invalid_field", path, "expected an object");
+  }
+  const code = readString(value, "code", path, { nonEmpty: true });
+  if (!code.ok) return code;
+  const message = readString(value, "message", path, { nonEmpty: true });
+  if (!message.ok) return message;
+  return ok({
+    code: code.value,
+    message: message.value,
+    ...(hasOwn(value, "data") ? { data: value.data } : {}),
+  });
+}
+
+function parsePayload(value: unknown): ParseStep<ProjectionEnvelopeV2Payload> {
+  const path = "$.payload";
+  if (!isPlainObject(value)) {
+    return fail("invalid_field", path, "expected an object");
+  }
+  const type = readString(value, "type", path, { nonEmpty: true });
+  if (!type.ok) return type;
+  const data = readObject(value, "data", path);
+  if (!data.ok) return data;
+  const dataPath = `${path}.data`;
+
+  switch (type.value) {
+    case "user_message": {
+      const text = readString(data.value, "text", dataPath);
+      if (!text.ok) return text;
+      const files = parseFileRefs(data.value, "files", dataPath);
+      if (!files.ok) return files;
+      return ok({
+        type: "user_message",
+        data: { text: text.value, files: files.value },
+      });
+    }
+    case "assistant_delta":
+    case "reasoning_delta": {
+      const text = readString(data.value, "text", dataPath);
+      if (!text.ok) return text;
+      return ok({ type: type.value, data: { text: text.value } });
+    }
+    case "assistant_persisted": {
+      const text = readString(data.value, "text", dataPath);
+      if (!text.ok) return text;
+      const meta = parseMessageMeta(data.value.meta, `${dataPath}.meta`);
+      if (!meta.ok) return meta;
+      return ok({
+        type: "assistant_persisted",
+        data: { text: text.value, meta: meta.value },
+      });
+    }
+    case "tool_start": {
+      const toolCallId = readString(data.value, "tool_call_id", dataPath, {
+        nonEmpty: true,
+      });
+      if (!toolCallId.ok) return toolCallId;
+      const name = readString(data.value, "name", dataPath, { nonEmpty: true });
+      if (!name.ok) return name;
+      return ok({
+        type: "tool_start",
+        data: {
+          tool_call_id: toolCallId.value,
+          name: name.value,
+          ...(hasOwn(data.value, "arguments")
+            ? { arguments: data.value.arguments }
+            : {}),
+        },
+      });
+    }
+    case "tool_progress": {
+      const toolCallId = readString(data.value, "tool_call_id", dataPath, {
+        nonEmpty: true,
+      });
+      if (!toolCallId.ok) return toolCallId;
+      const message = readString(data.value, "message", dataPath);
+      if (!message.ok) return message;
+      return ok({
+        type: "tool_progress",
+        data: { tool_call_id: toolCallId.value, message: message.value },
+      });
+    }
+    case "tool_end": {
+      const toolCallId = readString(data.value, "tool_call_id", dataPath, {
+        nonEmpty: true,
+      });
+      if (!toolCallId.ok) return toolCallId;
+      const status = readString(data.value, "status", dataPath, { nonEmpty: true });
+      if (!status.ok) return status;
+      if (
+        status.value !== "complete" &&
+        status.value !== "error" &&
+        status.value !== "skipped" &&
+        status.value !== "aborted"
+      ) {
+        return fail("invalid_field", `${dataPath}.status`, "unknown tool outcome status");
+      }
+      const error = readOptionalString(data.value, "error", dataPath);
+      if (!error.ok) return error;
+      const reason = readOptionalString(data.value, "reason", dataPath);
+      if (!reason.ok) return reason;
+      return ok({
+        type: "tool_end",
+        data: {
+          tool_call_id: toolCallId.value,
+          status: status.value,
+          ...(error.value !== undefined ? { error: error.value } : {}),
+          ...(reason.value !== undefined ? { reason: reason.value } : {}),
+        },
+      });
+    }
+    case "file_attached": {
+      const file = parseFileRef(data.value, dataPath);
+      if (!file.ok) return file;
+      return ok({ type: "file_attached", data: file.value });
+    }
+    case "turn_completed": {
+      const tokenUsage = parseTokenUsage(data.value.token_usage, `${dataPath}.token_usage`);
+      if (!tokenUsage.ok) return tokenUsage;
+      const status = readOptionalString(data.value, "status", dataPath);
+      if (!status.ok) return status;
+      if (
+        status.value !== undefined &&
+        status.value !== "completed" &&
+        status.value !== "error" &&
+        status.value !== "errored" &&
+        status.value !== "interrupted" &&
+        status.value !== "cancelled"
+      ) {
+        return fail("invalid_field", `${dataPath}.status`, "unknown terminal status");
+      }
+      let error: ProjectionEnvelopeV2TerminalError | undefined;
+      if (hasOwn(data.value, "error")) {
+        const parsedError = parseTerminalError(data.value.error, `${dataPath}.error`);
+        if (!parsedError.ok) return parsedError;
+        error = parsedError.value;
+      }
+      const reason = readOptionalString(data.value, "reason", dataPath);
+      if (!reason.ok) return reason;
+      return ok({
+        type: "turn_completed",
+        data: {
+          token_usage: tokenUsage.value,
+          ...(status.value !== undefined ? { status: status.value } : {}),
+          ...(error !== undefined ? { error } : {}),
+          ...(reason.value !== undefined ? { reason: reason.value } : {}),
+        },
+      });
+    }
+    case "background/spawn_complete": {
+      const taskId = readString(data.value, "task_id", dataPath, { nonEmpty: true });
+      if (!taskId.ok) return taskId;
+      const content = readString(data.value, "content", dataPath);
+      if (!content.ok) return content;
+      const toolCallId = readOptionalString(data.value, "tool_call_id", dataPath, {
+        nonEmpty: true,
+      });
+      if (!toolCallId.ok) return toolCallId;
+      const responseToClientMessageId = readOptionalString(
+        data.value,
+        "response_to_client_message_id",
+        dataPath,
+        { nonEmpty: true },
+      );
+      if (!responseToClientMessageId.ok) return responseToClientMessageId;
+      const messageId = readOptionalString(data.value, "message_id", dataPath, {
+        nonEmpty: true,
+      });
+      if (!messageId.ok) return messageId;
+      const source = readOptionalString(data.value, "source", dataPath, {
+        nonEmpty: true,
+      });
+      if (!source.ok) return source;
+      const persistedAt = readOptionalString(data.value, "persisted_at", dataPath, {
+        nonEmpty: true,
+      });
+      if (!persistedAt.ok) return persistedAt;
+      const media = readOptionalStringArray(data.value, "media", dataPath);
+      if (!media.ok) return media;
+      let meta: ProjectionEnvelopeV2MessageMeta | undefined;
+      if (hasOwn(data.value, "meta")) {
+        const parsedMeta = parseMessageMeta(data.value.meta, `${dataPath}.meta`);
+        if (!parsedMeta.ok) return parsedMeta;
+        meta = parsedMeta.value;
+      }
+      return ok({
+        type: "background/spawn_complete",
+        data: {
+          task_id: taskId.value,
+          content: content.value,
+          ...(toolCallId.value !== undefined ? { tool_call_id: toolCallId.value } : {}),
+          ...(responseToClientMessageId.value !== undefined
+            ? { response_to_client_message_id: responseToClientMessageId.value }
+            : {}),
+          ...(messageId.value !== undefined ? { message_id: messageId.value } : {}),
+          ...(source.value !== undefined ? { source: source.value } : {}),
+          ...(persistedAt.value !== undefined ? { persisted_at: persistedAt.value } : {}),
+          ...(media.value !== undefined ? { media: media.value } : {}),
+          ...(meta !== undefined ? { meta } : {}),
+        },
+      });
+    }
+    default:
+      return fail("unknown_payload", `${path}.type`, `unsupported payload type: ${type.value}`);
+  }
+}
+
+/**
+ * Decode a server `projection/envelope` params object.
+ *
+ * The function does not throw for malformed JSON-shaped input. Callers can
+ * safely handle the discriminated result at a receive boundary without any
+ * subscription, store write, or other runtime effect.
+ */
+export function parseProjectionEnvelopeV2(input: unknown): ProjectionEnvelopeV2ParseResult {
+  if (!isPlainObject(input)) {
+    return fail("not_object", "$", "expected an object");
+  }
+  const sessionId = readString(input, "session_id", "$", { nonEmpty: true });
+  if (!sessionId.ok) return sessionId;
+  const topic = readOptionalString(input, "topic", "$", { nonEmpty: true });
+  if (!topic.ok) return topic;
+  const threadId = readString(input, "thread_id", "$", { nonEmpty: true });
+  if (!threadId.ok) return threadId;
+  const seq = readNonNegativeInteger(input, "seq", "$", 1);
+  if (!seq.ok) return seq;
+  const clientMessageId = readOptionalString(input, "client_message_id", "$", {
+    nonEmpty: true,
+  });
+  if (!clientMessageId.ok) return clientMessageId;
+  let cursor: ProjectionEnvelopeV2Cursor | undefined;
+  if (hasOwn(input, "cursor")) {
+    const parsedCursor = parseCursor(input.cursor, "$.cursor");
+    if (!parsedCursor.ok) return parsedCursor;
+    cursor = parsedCursor.value;
+  }
+  const payload = parsePayload(input.payload);
+  if (!payload.ok) return payload;
+
+  return {
+    ok: true,
+    value: {
+      session_id: sessionId.value,
+      ...(topic.value !== undefined ? { topic: topic.value } : {}),
+      thread_id: threadId.value,
+      seq: seq.value,
+      ...(clientMessageId.value !== undefined
+        ? { client_message_id: clientMessageId.value }
+        : {}),
+      ...(cursor !== undefined ? { cursor } : {}),
+      payload: payload.value,
+    },
+  };
+}


### PR DESCRIPTION
First step of migrating the octos UI protocol down to a **single** protocol (canonical `projection/envelope`), retiring the legacy `message/persisted` content path. Per the migration plan, this stage is **behavior-neutral**: it locks the real wire contract and builds the compatibility harness before any renderer or server change.

## What this adds (all new files, nothing production touched)
- `src/runtime/projection-envelope-v2.ts` — a **pure, side-effect-free** parser for the actual flattened envelope wire: `{ session_id, topic?, thread_id, seq, client_message_id?, payload }`, decoding every payload variant (user_message, assistant_delta, assistant_persisted+meta/media, tool start/progress/end, file_attached, turn_completed, background spawn_complete) into typed results or typed parse errors. `cursor` is **optional** — the current server wire omits it; a dedicated `reconnect-cursor` fixture exercises the v2 cursor addition.
- 7 golden fixtures hand-authored to the **Rust wire types** (`Payload { tag=type, content=data }`, `UiCursor { stream, seq }`), with a README stating they are wire-type goldens, not live captures.
- A receive-only test suite (16 tests) that decodes every fixture and **documents that the existing shadow decoder mis-handles the real wire** — it wrongly requires a nested `turn_id` and waits for `seq: 0` while the server starts at `seq: 1`.

## Hard guarantees (verified)
- No capability added to `UI_PROTOCOL_FEATURES`; `getThreads()`, `ThreadStore`, renderers, and the `octos_projection_v1` flag are **untouched**; the parser is **not** wired into the live bridge. Net production behavior change: **zero**.
- Full suite green (107 files / 1064 tests), `tsc -b` clean, `build` clean, eslint clean on the new files.

This is the risk-free entry point: it exposes the current wire mismatch as a regression guard and gives the subsequent core/server v2 PR a stable compatibility harness, with no way to blank the production dashboard.