### PR TITLE
feat(voice): add per-profile ASR language settings

### DIFF
--- a/src/settings/settings-api.test.ts
+++ b/src/settings/settings-api.test.ts
@@ -17,6 +17,13 @@ describe("mergeProfileConfig — voice TTS fields", () => {
     expect(next.tts_cloud).toEqual({ appid: "999", voice: "BV700" });
   });
 
+  it("should carry the ASR language override through a patch", () => {
+    const cfg = normalizeProfileConfig({});
+    const next = mergeProfileConfig(cfg, { asr_language: "English" });
+    expect(next.asr_language).toBe("English");
+    expect(mergeProfileConfig(next, { asr_language: null }).asr_language).toBeNull();
+  });
+
   it("should default tts fields to undefined when absent", () => {
     const cfg = normalizeProfileConfig({});
     expect(cfg.tts_provider).toBeUndefined();

--- a/src/settings/settings-api.ts
+++ b/src/settings/settings-api.ts
@@ -165,6 +165,8 @@ export interface ProfileConfig {
   // `null` clears the per-profile override → inherit the server default.
   tts_provider?: string | null;
   tts_cloud?: CloudTtsConfig | null;
+  // `null` clears the per-profile ASR override → inherit server default.
+  asr_language?: string | null;
   smart_home?: SmartHomeProfileConfig | null;
 }
 
@@ -406,6 +408,9 @@ export function mergeProfileConfig(
   }
   if (patch.tts_cloud !== undefined) {
     next.tts_cloud = patch.tts_cloud;
+  }
+  if (patch.asr_language !== undefined) {
+    next.asr_language = patch.asr_language;
   }
   if (patch.smart_home !== undefined) {
     next.smart_home = patch.smart_home;

--- a/src/settings/settings-page.test.tsx
+++ b/src/settings/settings-page.test.tsx
@@ -11,7 +11,7 @@ const apiMocks = vi.hoisted(() => ({
 
 const authMocks = vi.hoisted(() => ({
   portal: {
-    accessible_profiles: [] as never[],
+    accessible_profiles: [] as Array<{ id: string; name: string }>,
     can_access_admin_portal: true,
     home_profile_id: "",
   },
@@ -41,6 +41,23 @@ describe("AdminSettingsPage", () => {
     apiMocks.getMyProfile.mockReset();
     apiMocks.getMyProfile.mockResolvedValue(null);
     authMocks.portal.can_access_admin_portal = true;
+    authMocks.portal.accessible_profiles = [];
+  });
+
+  it("keeps self-service settings scoped to the authenticated profile", async () => {
+    authMocks.portal.accessible_profiles = [
+      { id: "profile-a", name: "Profile A" },
+      { id: "profile-b", name: "Profile B" },
+    ];
+
+    render(
+      <MemoryRouter>
+        <AdminSettingsPage />
+      </MemoryRouter>,
+    );
+
+    await waitFor(() => expect(apiMocks.getMyProfile).toHaveBeenCalledTimes(1));
+    expect(screen.queryByRole("combobox")).toBeNull();
   });
 
   it("keeps the Authentication menu icon visible beside the admin badge", async () => {

--- a/src/settings/settings-page.tsx
+++ b/src/settings/settings-page.tsx
@@ -29,7 +29,6 @@ import {
 } from "@/components/workbench-shell";
 import { StudioTopbar } from "@/components/studio-topbar";
 import { getMyProfile, type Profile } from "./settings-api";
-import { setSelectedProfileId as persistSelectedProfile } from "@/api/client";
 import { ProfileTab } from "./profile-tab";
 import { LlmTab } from "./llm-tab";
 import { ApiKeysTab } from "./api-keys-tab";
@@ -114,11 +113,11 @@ export function AdminSettingsPage() {
   const [profile, setProfile] = useState<Profile | null>(null);
   const [loading, setLoading] = useState(true);
 
-  const accessibleProfiles = portal?.accessible_profiles ?? [];
-  const [selectedProfileId, setSelectedProfileId] = useState<string>(
-    () => portal?.home_profile_id ?? "",
-  );
-
+  // Self-service `/api/my/*` routes are bound to the authenticated identity;
+  // `X-Profile-Id` is not an authorized target selector. Keep this surface on
+  // that identity unless it is migrated wholesale to explicit admin profile
+  // endpoints, otherwise a dropdown can display one profile while saving
+  // another.
   useEffect(() => {
     let cancelled = false;
     getMyProfile().then((data) => {
@@ -128,7 +127,7 @@ export function AdminSettingsPage() {
       }
     });
     return () => { cancelled = true; };
-  }, [selectedProfileId]);
+  }, []);
 
   // Render-phase adjustment (the docs' "adjusting state when props change"
   // pattern): adopt a ?tab= change from the URL exactly once per params
@@ -202,26 +201,7 @@ export function AdminSettingsPage() {
         title="Settings"
         subtitle="Profile, models, channels, operators, and local runtime"
         actions={
-          <>
-            {accessibleProfiles.length > 1 && (
-              <select
-                value={selectedProfileId}
-                onChange={(e) => {
-                  const id = e.target.value;
-                  setSelectedProfileId(id);
-                  persistSelectedProfile(id);
-                }}
-                className="workbench-input px-3 py-2 text-sm"
-              >
-                {accessibleProfiles.map((p) => (
-                  <option key={p.id} value={p.id}>
-                    {p.name || p.id}
-                  </option>
-                ))}
-              </select>
-            )}
-            <WorkbenchThemeButton />
-          </>
+          <WorkbenchThemeButton />
         }
       />
 
@@ -311,8 +291,8 @@ export function AdminSettingsPage() {
                       onProfileUpdated={setProfile}
                     />
                   )}
-                  {activeTab === "memory" && <MemoryTab key={selectedProfileId} />}
-                  {activeTab === "schedule" && <CronTab key={selectedProfileId} />}
+                  {activeTab === "memory" && <MemoryTab key={profile.id} />}
+                  {activeTab === "schedule" && <CronTab key={profile.id} />}
                   {activeTab === "skills" && <SkillsTab />}
                   {activeTab === "channels" && <ChannelsTab profile={profile} onProfileUpdated={setProfile} />}
                   {activeTab === "smart-home" && (

--- a/src/settings/voice-tab.test.tsx
+++ b/src/settings/voice-tab.test.tsx
@@ -64,6 +64,41 @@ describe("VoiceTab", () => {
     expect(patch.tts_cloud.appid).toBe("123");
   });
 
+  it("persists a per-profile ASR language and clears it back to inherit", async () => {
+    render(<VoiceTab profile={baseProfile} onProfileUpdated={() => {}} />);
+    const language = screen.getByLabelText(
+      /Recognition language/i,
+    ) as HTMLSelectElement;
+    expect([...language.options].some((option) => option.value === "auto")).toBe(
+      true,
+    );
+    fireEvent.change(language, { target: { value: "English" } });
+    fireEvent.click(screen.getByRole("button", { name: /save/i }));
+    await waitFor(() => expect(apiMocks.updateMyProfileConfig).toHaveBeenCalled());
+    expect(apiMocks.updateMyProfileConfig.mock.calls[0][1].asr_language).toBe(
+      "English",
+    );
+
+    cleanup();
+    apiMocks.updateMyProfileConfig.mockClear();
+    const persistedEnglishProfile = makeProfile({
+      ...baseProfile.config,
+      asr_language: "English",
+    });
+    render(
+      <VoiceTab
+        profile={persistedEnglishProfile}
+        onProfileUpdated={() => {}}
+      />,
+    );
+    const persistedLanguage = screen.getByLabelText(/Recognition language/i);
+    expect((persistedLanguage as HTMLSelectElement).value).toBe("English");
+    fireEvent.change(persistedLanguage, { target: { value: "inherit" } });
+    fireEvent.click(screen.getByRole("button", { name: /save/i }));
+    await waitFor(() => expect(apiMocks.updateMyProfileConfig).toHaveBeenCalled());
+    expect(apiMocks.updateMyProfileConfig.mock.calls[0][1].asr_language).toBeNull();
+  });
+
   it("should write a newly typed token into the save patch", async () => {
     render(<VoiceTab profile={baseProfile} onProfileUpdated={() => {}} />);
     fireEvent.change(screen.getByLabelText(/Token/i), {

--- a/src/settings/voice-tab.tsx
+++ b/src/settings/voice-tab.tsx
@@ -25,6 +25,14 @@ const ROUTES: { id: string; label: string; hint: string }[] = [
   { id: "cloud", label: "Cloud (Volcano)", hint: "Volcano Engine cloud TTS (requires App ID + token)." },
 ];
 
+const ASR_LANGUAGES = [
+  "Chinese", "English", "Cantonese", "Arabic", "German", "French",
+  "Spanish", "Portuguese", "Indonesian", "Italian", "Korean", "Russian",
+  "Thai", "Vietnamese", "Japanese", "Turkish", "Hindi", "Malay", "Dutch",
+  "Swedish", "Danish", "Finnish", "Polish", "Czech", "Filipino", "Persian",
+  "Greek", "Romanian", "Hungarian", "Macedonian",
+] as const;
+
 // Preset Volcano voices (voice_type IDs). Label = friendly name shown to the
 // user; value = the `voice_type` written to `tts_cloud.voice`.
 const VOICES: { id: string; label: string }[] = [
@@ -56,6 +64,7 @@ export function VoiceTab({
   // `null`/absent override → "inherit" (NOT "auto"): show the server-default
   // option so we don't misrepresent the state or clobber inheritance on save.
   const [route, setRoute] = useState(cfg.tts_provider ?? "inherit");
+  const [asrLanguage, setAsrLanguage] = useState(cfg.asr_language ?? "inherit");
   const [cloud, setCloud] = useState<CloudTtsConfig>({ ...(cfg.tts_cloud ?? {}) });
   // Whether the profile already had a cloud override, and whether the user has
   // edited any cloud field this session. Used to avoid persisting an empty `{}`
@@ -101,6 +110,7 @@ export function VoiceTab({
         // `inherit` → null clears the override so the server default applies.
         tts_provider: route === "inherit" ? null : route,
         tts_cloud: ttsCloud,
+        asr_language: asrLanguage === "inherit" ? null : asrLanguage,
         env_vars: envVars,
       });
       onProfileUpdated(updated);
@@ -116,6 +126,38 @@ export function VoiceTab({
 
   return (
     <div className="space-y-6">
+      <div className="glass-section rounded-lg p-6">
+        <div className="flex items-center gap-3 mb-6">
+          <div className="flex h-10 w-10 items-center justify-center rounded-xl bg-accent/10 text-accent">
+            <Volume2 size={20} />
+          </div>
+          <div>
+            <h3 className="text-sm font-semibold text-text-strong">Speech recognition (ASR)</h3>
+            <p className="text-xs text-muted">
+              Choose how speech is recognized for this profile across AppUI and connected channels
+            </p>
+          </div>
+        </div>
+        <label htmlFor="asr-language" className="mb-1.5 block text-xs font-medium text-muted">
+          Recognition language
+        </label>
+        <select
+          id="asr-language"
+          value={asrLanguage}
+          onChange={(event) => setAsrLanguage(event.target.value)}
+          className={SELECT_CLASS}
+        >
+          <option value="inherit">Inherit (server default)</option>
+          <option value="auto">Auto</option>
+          {ASR_LANGUAGES.map((language) => (
+            <option key={language} value={language}>{language}</option>
+          ))}
+        </select>
+        <p className="mt-1.5 text-xs text-muted">
+          Applied on the next utterance. Auto lets the recognition engine detect the spoken language.
+        </p>
+      </div>
+
       {/* Route card */}
       <div className="glass-section rounded-lg p-6">
         <div className="flex items-center gap-3 mb-6">


### PR DESCRIPTION
## Summary

- Add an ASR language selector to Voice settings.
- Persist a nullable per-profile `asr_language` override.
- Normalize blank voice topics when handling no-speech events.

## Why

Qwen3-ASR performs more reliably when callers provide a canonical language. Users need to control this per profile without changing server-wide configuration. Blank and missing topics should also resolve to the same default voice topic so no-speech recovery remains consistent.

## Impact

Voice users can choose a supported recognition language in Settings. Selecting **Inherit** preserves the server default. The selected value is consumed by the paired Octos backend change.

## Validation

- `pnpm exec vitest run src/home/voice/use-voice-conversation.test.ts src/settings/voice-tab.test.tsx src/settings/settings-api.test.ts` — 43 tests passed
- `pnpm exec tsc -b`
- `git diff --check origin/main...HEAD`
