### PR TITLE
docs(readme): receive Octos self-hosting & deployment guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,276 @@ Octos Cloud is the best choice if you want:
 - public access without running your own VPS
 - a hosted signup and tunnel flow
 
-Multi-tenant accounts, per-user isolation, and the admin surfaces for them are web-client territory; the terminal client stays single-user. **Operators**: the server-side infrastructure behind this — the portal host, relay, and wildcard TLS — is deployed from the octos repo; see [self-hosted cloud + tenant pair](https://github.com/octos-org/octos#option-3-self-hosted-cloud--tenant-pair).
+Multi-tenant accounts, per-user isolation, and the admin surfaces for them are web-client territory; the terminal client stays single-user. **Operators**: the server-side infrastructure behind this — the portal host, relay, and wildcard TLS — is deployed from the octos repo; see [self-hosted cloud + tenant pair](#option-3-self-hosted-cloud--tenant-pair).
+
+## Self-hosting & deployment
+
+Run your own Octos **server** — on one machine, or as a public cloud + tenant
+pair. (To develop or customize the web *client* in this repo instead, jump to
+[Develop the client](#develop-the-client).)
+
+### Choose a setup path
+
+If you just want an assistant on your own machine, you already have it — the [Start here](https://github.com/octos-org/octos#start-here) steps in the octos repo are Option 2 in its simplest form. The paths below matter when you want a managed signup, a background service, or public internet access.
+
+| Option | Machines involved | Public internet access | Who manages the infrastructure | Best fit |
+| --- | --- | --- | --- | --- |
+| **1. Octos Cloud signup** | Your device + Octos Cloud | Yes | Octos Cloud + you | Hosted accounts — [see above](#octos-cloud) |
+| **2. Self-hosted local-only** | One machine | No | You | Local/private use |
+| **3. Self-hosted cloud + tenant pair** | Your VPS + your device | Yes | You | Full self-hosting with remote access |
+
+Visual overview:
+
+<img src="https://raw.githubusercontent.com/octos-org/octos/main/images/octos-options.jpg" alt="Three ways to run Octos: Octos Cloud signup, self-hosted local-only, and self-hosted cloud plus tenant pair" width="100%" />
+
+### Option 1: Sign up on Octos Cloud
+
+Octos Cloud is the hosted, multi-tenant way in: register with your email at
+[octos.cloud](https://octos.cloud) (or a self-hosted operator's portal), pick a
+node name, and run one generated setup command on your device. The signup and account experience is part of the **web client** —
+the walkthrough is in the [Octos Cloud](#octos-cloud) section above.
+
+The **server infrastructure** an operator runs to offer it is below: see [Option 3](#option-3-self-hosted-cloud--tenant-pair)
+for deploying the cloud host (portal, relay, wildcard TLS) yourself.
+
+### Option 2: Self-hosted local-only
+
+Choose this if you want Octos on your own machine with no public exposure. Your dashboard is available only on the machine itself or your local network.
+
+```bash
+# macOS / Linux
+curl -fsSL https://github.com/octos-org/octos/releases/latest/download/install.sh | bash
+```
+
+```powershell
+# Windows (PowerShell)
+irm https://github.com/octos-org/octos/releases/latest/download/install.ps1 | iex
+```
+
+This installs the binary, sets up `octos serve` as a service, and starts the local dashboard at `http://localhost:8080/admin/`. The end-user web app is served same-origin at `http://localhost:8080/app/` (embedded in the binary — no separate web server needed).
+
+**First login to the dashboard.** The install summary prints your credential once:
+
+```text
+Auth token: 3f2a…64-hex…c9d1
+```
+
+Open `http://localhost:8080/admin/`, switch the login screen to the
+**"Login with admin token"** tab, and paste that token — you're in as the
+admin user. (The email-code tab needs the server's SMTP configured, so the
+token tab is the way in on a fresh local install.)
+
+Lost the token? It's kept in the service definition the installer wrote:
+
+```bash
+# macOS
+grep -A1 OCTOS_AUTH_TOKEN /Library/LaunchDaemons/io.octos.serve.plist
+# Linux
+grep OCTOS_AUTH_TOKEN /etc/systemd/system/octos-serve.service
+```
+
+Alternatively, install just the binaries (the `octos` server plus its bundled skills) via a package manager:
+
+```bash
+# Homebrew (macOS Apple Silicon, Linux x86_64/ARM64) — this repo is its own tap
+brew tap octos-org/octos https://github.com/octos-org/octos
+brew install octos-org/octos/octos
+
+# npm (macOS Apple Silicon, Linux x86_64/ARM64, Windows x64)
+npm install -g @octos-org/octos
+```
+
+Both install the full release bundle — the `octos` server (with the web app and dashboard embedded) and its bundled skills (`news_fetch`, `deep-search`, `deep_crawl`, `send_email`, `account_manager`, `clock`, `weather`, plus the `voice` platform-skill) kept side-by-side so `octos serve` discovers them at startup. Unlike `install.sh`, they do not set up a background service; run `octos serve` yourself.
+
+Supported platforms: **macOS ARM64**, **Linux x86_64**, **Linux ARM64**, and **Windows x64**.
+
+Choose this path if you want:
+
+- the simplest self-hosted setup
+- one machine only
+- local-network access only
+- the option to upgrade later to tenant mode
+
+### Option 3: Self-hosted cloud + tenant pair
+
+Choose this if you want full self-hosting but still want your own device accessible from anywhere on the public internet.
+
+This mode uses two machines:
+
+- a **cloud VPS** that runs the public relay and HTTPS entrypoint
+- your **tenant device** that runs your own Octos instance
+
+The tenant device connects outbound to the VPS using `frpc`. The VPS runs the public components, including TLS and routing. This gives you ngrok-style public access, but through your own infrastructure.
+
+For production use, the VPS also needs wildcard HTTPS. The current setup uses Caddy plus Cloudflare DNS challenge, or another supported DNS provider, to issue and manage certificates for the main domain and tenant subdomains.
+
+Requirements for this option:
+
+1. **Your own hosted domain name**
+   Example: `octos.example.com`
+2. **A DNS provider / authoritative DNS API**
+   Its role here is specifically the ACME `DNS-01` solver used by Caddy's internal ACME client to mint the wildcard certificate for `*.octos.example.com`, which is what tenant subdomains use. If you stay HTTP-only with `--http-only`, or if you only need the apex domain, this wildcard-DNS flow is not required.
+3. **An SMTP service**
+   This is needed so the cloud host can send OTP emails to tenants during portal signup and login.
+
+#### 1. Bootstrap the VPS
+
+On a Linux VPS with DNS already pointed at it, you can either:
+
+- run the script with full flags for a mostly non-interactive flow, or
+- run `bash scripts/cloud-host-deploy.sh` with no flags and let it prompt you interactively
+
+Before running it, export the environment variables needed by your chosen providers. For example:
+
+```bash
+export CF_API_TOKEN=xxx
+export SMTP_PASSWORD=xxx
+```
+
+Notes:
+
+- For Cloudflare, the script expects `CF_API_TOKEN` for the DNS provider token.
+- For SMTP, you can pre-export `SMTP_PASSWORD` so the bootstrap does not need that secret entered later.
+- If you enable SMTP, the script will also prompt for or use the rest of the SMTP settings such as host, port, username, and from-address.
+
+Example using explicit flags:
+
+```bash
+git clone https://github.com/octos-org/octos.git
+cd octos
+bash scripts/cloud-host-deploy.sh \
+    --domain octos.example.com \
+    --https --dns-provider cloudflare
+```
+
+Interactive mode:
+
+```bash
+git clone https://github.com/octos-org/octos.git
+cd octos
+bash scripts/cloud-host-deploy.sh
+```
+
+This wraps three host-side steps:
+
+- `scripts/install.sh` — installs `octos serve` and sets `mode = "cloud"`
+- `scripts/frp/setup-frps.sh` — installs and configures `frps`
+- `scripts/frp/setup-caddy.sh` — configures public routing and wildcard HTTPS
+
+Windows Server targets use the PowerShell deploy script from an operator machine
+with OpenSSH access to the server:
+
+```powershell
+.\scripts\deploy.ps1 `
+    -HostName win.example.com `
+    -User Administrator `
+    -Version latest `
+    -RemoteRoot 'C:\octos' `
+    -ServiceName OctosServe
+```
+
+Run the same command with `-DryRun` first to print the remote commands without
+connecting. The script deploys the `octos-bundle-x86_64-pc-windows-msvc.zip`
+release bundle, installs `octos.exe` under `C:\octos\bin`, stores runtime data in
+`C:\octos\data`, writes logs under `C:\octos\logs`, and registers `OctosServe` as
+an auto-start Windows service through NSSM. Use `-LocalBundle <zip>` to deploy a
+locally built bundle over `scp`, and `-Uninstall [-Purge]` to remove the service
+and optionally delete the remote install root.
+
+Recommended DNS split:
+
+- `octos.example.com` and `*.octos.example.com` for the portal and tenant dashboards
+- `frps.octos.example.com` as `DNS only` so tenant machines can reach the FRP control port
+
+#### 2. Register or create a tenant
+
+Once the VPS is up, the cloud host can issue a personalized tenant setup command. That command includes the tenant name, per-tenant tunnel token, SSH port, dashboard auth token, domain, and relay address. The user receives this command directly in the portal and also by email.
+
+#### 3. Run the tenant setup command on your own device
+
+Use the exact command provided in step 2. The example below is reference only, to show what kind of command the portal issues:
+
+```bash
+curl -fsSL https://github.com/octos-org/octos/releases/latest/download/install.sh | bash -s -- \
+    --tunnel \
+    --tenant-name alice \
+    --frps-token <per-tenant-uuid> \
+    --ssh-port 6001 \
+    --domain octos.example.com \
+    --frps-server frps.octos.example.com \
+    --auth-token <dashboard-token>
+```
+
+The installer writes the tenant tunnel configuration, installs `frpc`, and starts the public tunnel alongside `octos serve`. The `--auth-token` in your personalized command doubles as your dashboard login: open `https://<your-name>.<domain>/admin/` and paste it into the **"Login with admin token"** tab (the same command also arrives by email, so the token is recoverable there).
+
+### Can I start local and upgrade later?
+
+Yes.
+
+A local-only self-hosted machine can be upgraded later to tenant mode once you have a cloud host available. The saved installers support this directly:
+
+```bash
+# macOS / Linux
+~/.octos/bin/install.sh --tunnel
+~/.octos/bin/install.sh --doctor
+```
+
+```powershell
+# Windows
+& "$HOME\.octos\bin\install.ps1" -Tunnel
+& "$HOME\.octos\bin\install.ps1" -Doctor
+```
+
+That upgrade path is intentional: start with one machine, then add a VPS only when you need internet-facing access.
+
+### Optional self-hosted features
+
+```bash
+# Auto-install runtime dependencies (git, node, python, ffmpeg, chromium)
+curl ... | bash -s -- --install-deps
+
+# Set up Caddy reverse proxy with HTTPS for self-hosted local deployments
+curl ... | bash -s -- --caddy-domain crew.example.com
+```
+
+### Uninstall
+
+Use the matching uninstall flag on the machine you want to remove:
+
+```bash
+# Tenant or local machine (macOS / Linux)
+~/.octos/bin/install.sh --uninstall
+
+# Tenant or local machine (Windows PowerShell)
+& "$HOME\.octos\bin\install.ps1" -Uninstall
+
+# Cloud VPS — removes octos serve, frps, and Caddy
+bash scripts/cloud-host-deploy.sh --uninstall
+
+# Cloud VPS + wipe data directory (~/.octos) as well
+bash scripts/cloud-host-deploy.sh --uninstall --purge
+```
+
+### Where config lives
+
+User config + credentials live **outside** the install dir so reinstalls/upgrades never touch them:
+
+- **macOS + Linux:** `~/.config/octos/` (`config.json`, `auth.json`) — honours `$XDG_CONFIG_HOME`
+- **Windows:** `%APPDATA%\octos\`
+- **Override:** set `OCTOS_CONFIG_DIR` to put config/auth anywhere
+- `~/.octos/` holds only the **install + runtime state** (binaries, bundled skills, sessions, logs). The installer writes only there.
+
+An existing `~/.octos/config.json` from older versions is auto-migrated to `~/.config/octos/` on first run (copied, not moved — the original stays as a backup).
+
+### Runtime deployment modes
+
+Octos uses `"mode"` in `config.json` (see *Where config lives* above) to describe how a running node behaves:
+
+- **`local`** — standalone machine
+- **`tenant`** — end-user machine with an optional public tunnel
+- **`cloud`** — VPS relay with tenant management and public signup
+
+`scripts/install.sh` and `scripts/install.ps1` create local or tenant configs. `scripts/cloud-host-deploy.sh` creates or updates cloud-host configs with `mode = "cloud"` plus `tunnel_domain` and `frps_server`.
 
 ## Surfaces
 
@@ -126,7 +395,7 @@ there is no env var that repoints the API.
 ## Deploying
 
 - **Static canary** — `.github/workflows/deploy.yml` publishes the app to GitHub Pages (`BASE_URL=/octos-web/`, SPA `404.html` fallback), plus the `book/` mdBook of sample research reports under `/book`. The workflow does not set `VITE_SKIP_AUTH`, so the Pages build still shows the login screen; export it yourself for an auth-free demo build.
-- **Production** — build with `npm run build` and serve `dist/` from any static host or reverse proxy in front of `octos serve` (the octos repo's deploy docs cover the fleet setup). The app is a pure static bundle; all state lives in the server.
+- **Production** — build with `npm run build` and serve `dist/` from any static host or reverse proxy in front of `octos serve` (see [Self-hosting & deployment](#self-hosting--deployment) for the server/fleet setup). The app is a pure static bundle; all state lives in the server.
 
 ## Repository layout
 


### PR DESCRIPTION
Moves the **self-hosting & deployment** guide from the [octos](https://github.com/octos-org/octos) repo README into this one (paired with octos-org/octos#1780), so the user-facing hosting docs live alongside octos-web's existing *Just want to use it?* / *Octos Cloud* sections.

New **## Self-hosting & deployment** section (between *Octos Cloud* and *Surfaces*): setup-path table, Options 1/2/3 (Cloud signup, self-hosted local, self-hosted cloud + tenant pair), install scripts, first dashboard login, upgrade path, optional features, uninstall, config locations, runtime modes.

Link hygiene:
- Option 1 body → the existing *Octos Cloud* section (`#octos-cloud`); overview image → octos raw URL; *Start here* → octos repo.
- Existing *Octos Cloud* operator note and *Deploying* section repointed to the new internal anchors.
- Anchor-integrity checked (0 broken internal links); typos-clean.

Docs only.