### PR TITLE
fix(settings): repair Moonshot provider configuration

### DIFF
--- a/src/settings/llm-providers.test.ts
+++ b/src/settings/llm-providers.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect } from "vitest";
 import {
   buildCredentialEnvPatch,
   findProvider,
+  showsBaseUrl,
   usesJsonCredential,
 } from "./llm-providers";
 
@@ -16,6 +17,14 @@ describe("vertex provider entry", () => {
   it("treats normal providers as single-line API keys", () => {
     expect(usesJsonCredential(findProvider("openai"))).toBe(false);
     expect(usesJsonCredential(findProvider("google"))).toBe(false);
+  });
+});
+
+describe("moonshot provider entry", () => {
+  it("defaults to the China endpoint and allows editing the base URL", () => {
+    const moonshot = findProvider("moonshot");
+    expect(moonshot?.defaultBaseUrl).toBe("https://api.moonshot.cn/v1");
+    expect(showsBaseUrl(moonshot!)).toBe(true);
   });
 });
 

--- a/src/settings/llm-providers.ts
+++ b/src/settings/llm-providers.ts
@@ -90,7 +90,13 @@ export const LLM_PROVIDERS: LlmProvider[] = [
   },
   { id: "zhipu", name: "Zhipu (GLM)", envKey: "ZHIPU_API_KEY", models: [] },
   { id: "zai", name: "Z.ai (GLM)", envKey: "ZAI_API_KEY", models: [] },
-  { id: "moonshot", name: "Moonshot", envKey: "MOONSHOT_API_KEY", models: [] },
+  {
+    id: "moonshot",
+    name: "Moonshot",
+    envKey: "MOONSHOT_API_KEY",
+    defaultBaseUrl: "https://api.moonshot.cn/v1",
+    models: [],
+  },
   { id: "perplexity", name: "Perplexity", envKey: "PERPLEXITY_API_KEY", models: [] },
   {
     id: "mistral",
@@ -119,6 +125,7 @@ export function showsBaseUrl(provider: LlmProvider): boolean {
   return (
     provider.id === "ollama" ||
     provider.id === "vllm" ||
+    provider.id === "moonshot" ||
     provider.id === "__custom_family__"
   );
 }

--- a/src/settings/llm-tab.tsx
+++ b/src/settings/llm-tab.tsx
@@ -201,7 +201,7 @@ export function LlmTab({ profile, onProfileUpdated }: LlmTabProps) {
     : isCustom;
   const isJsonCredential = usesJsonCredential(selectedProvider);
   // env_vars values come back masked; a non-empty entry means it's already set.
-  const saAlreadyConfigured = Boolean(
+  const credentialAlreadyConfigured = Boolean(
     selectedProvider?.envKey &&
       profile.config.env_vars?.[selectedProvider.envKey],
   );
@@ -221,7 +221,8 @@ export function LlmTab({ profile, onProfileUpdated }: LlmTabProps) {
     : form.family_id;
   const effectiveModelId = isCustom
     ? form.custom_model_id
-    : form.model_id === "__custom__"
+    : form.model_id === "__custom__" ||
+        (selectedProvider && providerModels.length === 0)
       ? form.custom_model_id
       : form.model_id;
 
@@ -293,7 +294,12 @@ export function LlmTab({ profile, onProfileUpdated }: LlmTabProps) {
 
   /* ── Test Connection ── */
   const handleTestConnection = async () => {
-    if (!effectiveFamilyId || !effectiveModelId) return;
+    if (!effectiveFamilyId) return;
+    if (!effectiveModelId.trim()) {
+      setTestStatus("failed");
+      setTestMessage("Select or enter a model ID before testing.");
+      return;
+    }
     setTestStatus("testing");
     setTestMessage(null);
     try {
@@ -324,9 +330,11 @@ export function LlmTab({ profile, onProfileUpdated }: LlmTabProps) {
         setTestStatus("failed");
         setTestMessage(resp.error || resp.message || "Connection failed");
       }
-    } catch {
+    } catch (err) {
       setTestStatus("failed");
-      setTestMessage("Connection test endpoint unavailable");
+      setTestMessage(
+        formatSettingsError(err, "Connection test endpoint unavailable"),
+      );
     }
     setTimeout(() => {
       setTestStatus("idle");
@@ -505,7 +513,7 @@ export function LlmTab({ profile, onProfileUpdated }: LlmTabProps) {
                   setForm((f) => ({ ...f, sa_json: e.target.value }))
                 }
                 placeholder={
-                  saAlreadyConfigured
+                  credentialAlreadyConfigured
                     ? "Stored in keychain — paste new JSON to replace"
                     : "Paste the full service-account JSON…"
                 }
@@ -514,7 +522,7 @@ export function LlmTab({ profile, onProfileUpdated }: LlmTabProps) {
                 className="w-full resize-y rounded-xl bg-surface-container px-4 py-3 font-mono text-xs text-text placeholder-muted/50 outline-none border border-transparent focus:border-accent/30 transition"
               />
               <p className="mt-2 flex items-center gap-1.5 text-xs text-muted">
-                {saAlreadyConfigured ? (
+                {credentialAlreadyConfigured ? (
                   <>
                     <CheckCircle2 size={13} className="text-green-400" />
                     Configured (stored in macOS Keychain). Leave blank to keep.
@@ -533,17 +541,34 @@ export function LlmTab({ profile, onProfileUpdated }: LlmTabProps) {
           {/* Env key hint (single-line API-key providers) */}
           {!isJsonCredential && selectedProvider?.envKey && (
             <div className="flex items-start gap-2 rounded-xl bg-surface-dark/50 px-4 py-3">
-              <AlertCircle
-                size={14}
-                className="mt-0.5 shrink-0 text-amber-400"
-              />
-              <span className="text-xs text-muted">
-                Requires{" "}
-                <code className="rounded bg-surface-container px-1.5 py-0.5 font-mono text-[11px] text-text">
-                  {selectedProvider.envKey}
-                </code>{" "}
-                in Environment Variables (see the API Keys tab)
-              </span>
+              {credentialAlreadyConfigured ? (
+                <>
+                  <CheckCircle2
+                    size={14}
+                    className="mt-0.5 shrink-0 text-green-400"
+                  />
+                  <span className="text-xs text-muted">
+                    <code className="rounded bg-surface-container px-1.5 py-0.5 font-mono text-[11px] text-text">
+                      {selectedProvider.envKey}
+                    </code>{" "}
+                    is configured in API Keys.
+                  </span>
+                </>
+              ) : (
+                <>
+                  <AlertCircle
+                    size={14}
+                    className="mt-0.5 shrink-0 text-amber-400"
+                  />
+                  <span className="text-xs text-muted">
+                    Requires{" "}
+                    <code className="rounded bg-surface-container px-1.5 py-0.5 font-mono text-[11px] text-text">
+                      {selectedProvider.envKey}
+                    </code>{" "}
+                    in Environment Variables (see the API Keys tab)
+                  </span>
+                </>
+              )}
             </div>
           )}
 
@@ -553,6 +578,7 @@ export function LlmTab({ profile, onProfileUpdated }: LlmTabProps) {
               <label className={labelClass}>Base URL</label>
               <input
                 type="text"
+                aria-label="Base URL"
                 value={form.base_url}
                 onChange={(e) =>
                   setForm((f) => ({ ...f, base_url: e.target.value }))
@@ -562,6 +588,12 @@ export function LlmTab({ profile, onProfileUpdated }: LlmTabProps) {
                 }
                 className={inputClass}
               />
+              {selectedProvider?.id === "moonshot" && (
+                <p className="mt-2 text-xs text-muted">
+                  China API keys use https://api.moonshot.cn/v1. Global API
+                  keys use https://api.moonshot.ai/v1.
+                </p>
+              )}
             </div>
           )}
 

--- a/tests/settings-tabs.spec.ts
+++ b/tests/settings-tabs.spec.ts
@@ -11,6 +11,7 @@ const TIMEOUT = 10_000;
 
 interface SettingsMockOptions {
   profile?: typeof mockProfile;
+  providerModels?: string[];
   profileUpdateError?: { status: number; body: unknown };
   allowedEmailDeleteError?: { status: number; body: unknown };
   operatorTasksError?: { status: number; body: unknown };
@@ -581,7 +582,9 @@ async function installServerSettingsMocks(
     providerModelsBody = route.request().postDataJSON();
     await route.fulfill({
       contentType: "application/json",
-      body: JSON.stringify(["gpt-5.4", "gpt-5.5-live"]),
+      body: JSON.stringify(
+        options.providerModels ?? ["gpt-5.4", "gpt-5.5-live"],
+      ),
     });
   });
 
@@ -911,6 +914,52 @@ test.describe("Settings page — tab smoke tests", () => {
       page.locator("h3", { hasText: "Fallback Models" }),
     ).toBeVisible({ timeout: TIMEOUT });
     await expect(page.locator('option[value="gpt-5.5-live"]')).toHaveCount(1);
+  });
+
+  test("LLM tab recognizes a provider key saved in API Keys", async ({ page }) => {
+    const profileWithMoonshotKey = {
+      ...mockProfile,
+      config: {
+        ...mockProfile.config,
+        env_vars: { MOONSHOT_API_KEY: "sk-m***key" },
+      },
+    };
+    const mocks = await installServerSettingsMocks(page, {
+      profile: profileWithMoonshotKey,
+      providerModels: [],
+    });
+    await seedAdminSession(page);
+
+    await page.goto("/settings", { waitUntil: "networkidle" });
+    await expect(page.locator(".animate-spin")).toBeHidden({ timeout: TIMEOUT });
+    await clickTab(page, "LLM");
+    await page.locator("select").first().selectOption("moonshot");
+
+    await expect(page.getByText("is configured in API Keys.")).toBeVisible({
+      timeout: TIMEOUT,
+    });
+    await expect(page.getByLabel("Base URL")).toHaveValue(
+      "https://api.moonshot.cn/v1",
+    );
+    await expect(
+      page.getByText("Requires MOONSHOT_API_KEY in Environment Variables"),
+    ).toHaveCount(0);
+
+    await page.getByRole("button", { name: "Test Connection" }).click();
+    await expect(
+      page.getByText("Select or enter a model ID before testing."),
+    ).toBeVisible({ timeout: TIMEOUT });
+    expect(mocks.getTestProviderBody()).toBeNull();
+
+    await page.getByPlaceholder("e.g. my-model-v2").fill("kimi-k2.6");
+    await page.getByRole("button", { name: "Test Connection" }).click();
+    await expect.poll(() => mocks.getTestProviderBody()).toEqual({
+      provider: "moonshot",
+      model: "kimi-k2.6",
+      api_key_env: "MOONSHOT_API_KEY",
+      base_url: "https://api.moonshot.cn/v1",
+      profile_id: "admin",
+    });
   });
 
   test("LLM tab tests provider with selected model and route data", async ({


### PR DESCRIPTION
## Summary

- recognize API keys already stored in the profile instead of showing a false missing-key warning
- use manually entered model IDs when a provider has no live/static model catalog
- surface validation and backend connection errors from Test Connection
- expose Moonshot Base URL and default China-region keys to `https://api.moonshot.cn/v1`

## Validation

- `pnpm exec vitest run src/settings/llm-providers.test.ts`
- `pnpm exec tsc --noEmit`
- ESLint on the changed Settings files and Playwright spec
- `git diff --check`