### PR TITLE
fix(protocol): negotiate projection.envelope.v1 alongside v2

### DIFF
--- a/src/runtime/ui-protocol-bridge.test.ts
+++ b/src/runtime/ui-protocol-bridge.test.ts
@@ -2047,6 +2047,16 @@ describe("notification dispatch", () => {
     await bridge.stop();
   });
 
+  it("negotiates the canonical projection envelope server token", () => {
+    // The octos-one server gates `projection/envelope` on
+    // `projection.envelope.v1` only (octos-cli api/ui_protocol.rs:1331);
+    // the web-side v2 token names the frame shape, not a server
+    // capability. Both must be offered or the canonical projection path
+    // never activates.
+    expect(UI_PROTOCOL_FEATURES).toContain("projection.envelope.v1");
+    expect(UI_PROTOCOL_FEATURES).toContain("projection.envelope.v2");
+  });
+
   it("negotiates the M15 autonomy capabilities incl. the umbrella token", () => {
     // codex #263 round 1 P1: once ANY tokens are sent the server
     // requires `coding.autonomy.v1` AND the runtime child — children

--- a/src/runtime/ui-protocol-bridge.ts
+++ b/src/runtime/ui-protocol-bridge.ts
@@ -275,6 +275,14 @@ export const METHODS = {
  */
 export const UI_PROTOCOL_FEATURES = [
   ProjectionStore.PROJECTION_ENVELOPE_V2_FEATURE,
+  // The octos-one server gates the canonical `projection/envelope`
+  // notification on `projection.envelope.v1` only (octos-cli
+  // `api/ui_protocol.rs:1331`, echo at :1401-1403). The web-side "v2"
+  // token names the flattened frame shape, not a server capability —
+  // sending v2 alone negotiated nothing and left the canonical
+  // projection path permanently inactive. Send both; unknown tokens are
+  // ignored by older servers, so this is additive/backwards-compatible.
+  ProjectionStore.PROJECTION_ENVELOPE_V1_FEATURE,
   "approval.typed.v1",
   "user_question.v1",
   "pane.snapshots.v1",

--- a/src/store/projection-store.ts
+++ b/src/store/projection-store.ts
@@ -18,6 +18,24 @@ import type {
 
 export const PROJECTION_ENVELOPE_V2_FEATURE = "projection.envelope.v2";
 
+/**
+ * Canonical projection envelope capability as negotiated by the octos-one
+ * server (`octos_core::ui_protocol::UI_PROTOCOL_FEATURE_PROJECTION_ENVELOPE_V1`,
+ * octos-one `crates/octos-core/src/ui_protocol.rs:180`). The server's
+ * capability map sets `projection_envelope` only from this exact token
+ * (octos-one `crates/octos-cli/src/api/ui_protocol.rs:1331`) and echoes it
+ * into `supported_features` (`ui_protocol.rs:1401-1403`); unknown tokens
+ * such as the client-side `projection.envelope.v2` are silently ignored.
+ *
+ * The "v2" name on the web side refers to the flattened EnvelopeWire frame
+ * shape the server itself emits (its `EnvelopeNotification` docs name
+ * "the octos-web bridge" as the tolerant top-level decoder) — it is NOT a
+ * server-known capability token. Sending BOTH tokens lets the server's
+ * capability check pass while the bridge keeps gating the v2 render path
+ * on its own token being echoed back.
+ */
+export const PROJECTION_ENVELOPE_V1_FEATURE = "projection.envelope.v1";
+
 export interface ProjectionIngestResult {
   accepted: boolean;
   duplicate: boolean;


### PR DESCRIPTION
## Problem

The octos-one server gates the canonical `projection/envelope` notification on the client feature token **`projection.envelope.v1` only**:

- Token definition: `octos/crates/octos-core/src/ui_protocol.rs:180`
- Capability negotiation: `octos/crates/octos-cli/src/api/ui_protocol.rs:1219-1223`, `:1331`
- Echo into `supported_features`: `:1401-1403`

octos-web offered only **`projection.envelope.v2`** — which names the flattened *frame shape*, not a server capability. Unknown client tokens are silently ignored, so the handshake negotiated nothing: `projection_envelope=false` server-side, the server never emits `projection/envelope`, and the bridge's `negotiatedProjectionV2` check never passes — the canonical projection path never activates and the bridge falls back on every connect.

(Note: current octos main @ `967cd909`+ does know v2 — but octos-one's pinned submodule @ `594c205` predates it by a day. Offering both tokens interops with stale-pinned *and* latest servers.)

## Fix

Additive: `UI_PROTOCOL_FEATURES` now offers both `projection.envelope.v1` and `projection.envelope.v2`. Unknown tokens are silently ignored by servers, so this is backwards-compatible in both directions.

The web's v2 parser is wire-compatible with accepting v1: the server's own `EnvelopeNotification` docs (`ui_protocol.rs:3867-3879`) name the octos-web bridge as the intended decoder of the flattened wire format, and the parser reads exactly those top-level keys.

## Testing

- New regression test: asserts both tokens remain in the negotiated feature set (`ui-protocol-bridge.test.ts`)
- `npx tsc -b --noEmit` → exit 0
- `npx vitest run src/runtime/ui-protocol-bridge.test.ts` → 108/108 passed

## Server-side follow-up (root cause)

Bump octos-one's octos submodule pin to ≥ `967cd909` (2026-07-18, Stage-1 v2) — ideally current main — so the pinned server recognizes v2 natively. This PR is the client-side interop safety net; the submodule bump is the root-cause fix.