### PR TITLE
feat(smart-home): move device control/state calls onto the backend WS bridge

### DIFF
--- a/README.md
+++ b/README.md
@@ -386,11 +386,13 @@ The protocol contract lives in the octos repo (`crates/octos-core/src/ui_protoco
 | `BASE_URL` | Vite base path for subpath deploys (e.g. `/octos-web/`) |
 | `VITE_SKIP_AUTH` | Build-time: skip the auth guard — static/demo builds only |
 | `VITE_WEBHOOK_ORIGIN` / `VITE_PUBLIC_API_ORIGIN` | Origin used when displaying channel webhook URLs in settings (fallback order) |
-| `VITE_SMART_HOME_API_BASE` | Smart-home widget backend (dev proxy: `/smart-home-api` → `:8787`) |
 
 API and WebSocket traffic is always **same-origin** (`/api/...`) — serve the
 bundle behind the same host as `octos serve` (or a reverse proxy to it);
-there is no env var that repoints the API.
+there is no env var that repoints the API. The smart-home widget rides the
+same `/api/ui-protocol/ws` connection as everything else (`smart_home/*`
+methods) — the profile's bridge URL/token are configured server-side and
+never reach the browser.
 
 ## Deploying
 

--- a/src/home/smart-home.tsx
+++ b/src/home/smart-home.tsx
@@ -20,6 +20,8 @@ import { createPortal } from "react-dom";
 import type { CSSProperties, ReactNode } from "react";
 
 import { useHomeSettings } from "./home-settings-context";
+import { METHODS } from "@/runtime/ui-protocol-bridge";
+import { ensureAuxBridge } from "@/runtime/ui-protocol-runtime";
 
 type DeviceKind =
   | "camera"
@@ -107,11 +109,7 @@ interface SmartHomeLabels {
   readOnly: string;
 }
 
-const SMART_HOME_API_BASE =
-  (import.meta.env.VITE_SMART_HOME_API_BASE as string | undefined)?.replace(/\/$/, "") ||
-  "/smart-home-api";
 const POLL_MS = 4000;
-const REQUEST_TIMEOUT_MS = 3500;
 
 const LABELS: Record<"en" | "zh", SmartHomeLabels> = {
   en: {
@@ -190,10 +188,6 @@ const LABELS: Record<"en" | "zh", SmartHomeLabels> = {
   },
 };
 
-function apiPath(path: string): string {
-  return `${SMART_HOME_API_BASE}${path.startsWith("/") ? path : `/${path}`}`;
-}
-
 function numberOrZero(value: unknown): number {
   return typeof value === "number" && Number.isFinite(value) ? value : 0;
 }
@@ -202,32 +196,15 @@ function clampPercent(value: number): number {
   return Math.max(0, Math.min(100, Math.round(value)));
 }
 
-function postBody(params: Record<string, string | number | boolean>): URLSearchParams {
-  const body = new URLSearchParams();
-  Object.entries(params).forEach(([key, value]) => body.set(key, String(value)));
-  return body;
-}
-
-async function fetchJson<T>(url: string, init?: RequestInit): Promise<T> {
-  const controller = new AbortController();
-  const timer = window.setTimeout(() => controller.abort(), REQUEST_TIMEOUT_MS);
-  try {
-    const response = await fetch(url, {
-      cache: "no-store",
-      ...init,
-      signal: controller.signal,
-    });
-    const data = (await response.json().catch(() => ({}))) as T;
-    if (!response.ok) {
-      const error = data && typeof data === "object" && "error" in data
-        ? String((data as { error?: unknown }).error)
-        : `HTTP ${response.status}`;
-      throw new Error(error);
-    }
-    return data;
-  } finally {
-    window.clearTimeout(timer);
-  }
+/** Device control/state now lives in the backend's per-profile smart-home
+ *  bridge client; this widget reaches it over the same WS connection every
+ *  other auxiliary panel (memory/cron) uses rather than a direct REST
+ *  fetch. `ensureAuxBridge` reuses a connected session-scoped bridge when
+ *  one exists (the common case: this widget mounts inside `/home`'s
+ *  `ScopedRuntimeBridge`) and otherwise lazily starts a sessionless one. */
+async function callSmartHomeWs<T>(method: string, params: unknown): Promise<T> {
+  const bridge = await ensureAuxBridge();
+  return await bridge.callMethod<T>(method, params);
 }
 
 function useSmartHomeDevices() {
@@ -242,8 +219,12 @@ function useSmartHomeDevices() {
   const loadDevices = useCallback(async (silent = false) => {
     if (!silent) setLoading(true);
     try {
-      const data = await fetchJson<SmartHomeResponse>(apiPath("/devices"));
+      const result = await callSmartHomeWs<{ devices: SmartHomeResponse }>(
+        METHODS.SMART_HOME_DEVICE_LIST,
+        {},
+      );
       if (!aliveRef.current) return;
+      const data = result.devices;
       setDevices(Array.isArray(data.devices) ? data.devices : []);
       setSource(data.source ?? "home_assistant");
       setError(data.ok === false ? data.error ?? "Bridge error" : null);
@@ -269,10 +250,9 @@ function useSmartHomeDevices() {
     async (id: string, params: Record<string, string | number | boolean>) => {
       setActionId(id);
       try {
-        await fetchJson(apiPath(`/devices/${encodeURIComponent(id)}`), {
-          method: "POST",
-          headers: { "Content-Type": "application/x-www-form-urlencoded" },
-          body: postBody(params),
+        await callSmartHomeWs(METHODS.SMART_HOME_DEVICE_COMMAND, {
+          device_id: id,
+          params,
         });
         setError(null);
         await loadDevices(true);
@@ -288,15 +268,11 @@ function useSmartHomeDevices() {
   const startCamera = useCallback(async (id: string) => {
     setActionId(id);
     try {
-      const data = await fetchJson<CameraStreamInfo>(
-        apiPath(`/cameras/${encodeURIComponent(id)}/stream`),
-        {
-          method: "POST",
-          headers: { "Content-Type": "application/x-www-form-urlencoded" },
-          body: postBody({ quality: 2 }),
-        },
+      const result = await callSmartHomeWs<{ stream: CameraStreamInfo }>(
+        METHODS.SMART_HOME_CAMERA_STREAM_START,
+        { device_id: id, quality: 2 },
       );
-      setCameraStreams((prev) => ({ ...prev, [id]: data }));
+      setCameraStreams((prev) => ({ ...prev, [id]: result.stream }));
       setError(null);
       await loadDevices(true);
     } catch (err) {
@@ -309,8 +285,8 @@ function useSmartHomeDevices() {
   const stopCamera = useCallback(async (id: string) => {
     setActionId(id);
     try {
-      await fetchJson(apiPath(`/cameras/${encodeURIComponent(id)}/stop`), {
-        method: "POST",
+      await callSmartHomeWs(METHODS.SMART_HOME_CAMERA_STREAM_STOP, {
+        device_id: id,
       });
       setCameraStreams((prev) => {
         const next = { ...prev };

--- a/src/runtime/ui-protocol-bridge.ts
+++ b/src/runtime/ui-protocol-bridge.ts
@@ -190,6 +190,20 @@ export const METHODS = {
   MEMORY_ENTITY: "memory/entity",
   CRON_LIST: "cron/list",
   CRON_TOGGLE: "cron/toggle",
+  // Smart-home bridge integration: device control/state now lives
+  // server-side (a per-profile Home Assistant-style bridge) instead of the
+  // browser talking to it directly. Camera video stays a direct
+  // browser-to-bridge stream; these methods only return the playback URL,
+  // never bridge credentials. Unlike the auxiliary group above, these were
+  // never a REST route (no `/api/my/smart-home*` ever existed), so they're
+  // gated on their own `smart_home.v1` capability rather than
+  // `auxiliary.rest_to_ws.v1` — see `UI_PROTOCOL_FEATURES` below. Mirrors
+  // `crates/octos-core/src/ui_protocol.rs::methods`.
+  SMART_HOME_STATUS_GET: "smart_home/status.get",
+  SMART_HOME_DEVICE_LIST: "smart_home/device.list",
+  SMART_HOME_DEVICE_COMMAND: "smart_home/device.command",
+  SMART_HOME_CAMERA_STREAM_START: "smart_home/camera.stream_start",
+  SMART_HOME_CAMERA_STREAM_STOP: "smart_home/camera.stream_stop",
   // server → client
   // Bridge hygiene (parity audit P3): `user_question/requested` is a
   // NOTIFICATION the server pushes; it was mislisted in the
@@ -312,6 +326,14 @@ export const UI_PROTOCOL_FEATURES = [
   "coding.autonomy.v1",
   "coding.loop_runtime.v1",
   "coding.goal_runtime.v1",
+  // Smart-home bridge integration (octos smart-home backend migration):
+  // gates `smart_home/status.get`, `smart_home/device.list`,
+  // `smart_home/device.command`, `smart_home/camera.stream_start`,
+  // `smart_home/camera.stream_stop`. Always negotiated like the other
+  // narrow capabilities above — unlike `auxiliary.rest_to_ws.v1` this
+  // isn't a staged REST-to-WS migration with a client-side kill switch,
+  // it's a new capability with no prior REST route to fall back to.
+  "smart_home.v1",
 ] as const;
 
 /**

--- a/tests/ui-redesign-smoke.spec.ts
+++ b/tests/ui-redesign-smoke.spec.ts
@@ -112,7 +112,10 @@ type UiSmokeMessage = {
 
 async function installWorkbenchMocks(
   page: Page,
-  options: { messages?: UiSmokeMessage[] } = {},
+  options: {
+    messages?: UiSmokeMessage[];
+    onSmartHomeCommand?: (method: string, params: unknown) => void;
+  } = {},
 ) {
   const messages = options.messages ?? [];
   const contentEntry = {
@@ -309,47 +312,18 @@ async function installWorkbenchMocks(
     await fulfillJson(route, { ok: true });
   });
 
-  await page.route((url) => url.pathname.startsWith("/smart-home-api/"), async (route) => {
-    const path = new URL(route.request().url()).pathname;
-    if (path === "/smart-home-api/health") {
-      await fulfillJson(route, {
-        ok: true,
-        devices: mockSmartHomeDevices.length,
-        home_assistant: "connected",
-      });
-      return;
-    }
-    if (path === "/smart-home-api/devices") {
-      await fulfillJson(route, {
-        source: "home_assistant",
-        devices: mockSmartHomeDevices,
-      });
-      return;
-    }
-    if (path.startsWith("/smart-home-api/devices/")) {
-      await fulfillJson(route, { ok: true, source: "home_assistant" });
-      return;
-    }
-    if (path.startsWith("/smart-home-api/cameras/")) {
-      await fulfillJson(route, {
-        ok: true,
-        protocol: "rtc",
-        playback_url: "http://127.0.0.1:1984/stream.html?src=wangwang",
-      });
-      return;
-    }
-    await fulfillJson(route, { ok: true });
-  });
-
   await page.routeWebSocket(/\/api\/ui-protocol\/ws/, (ws) => {
     ws.onMessage((raw) => {
-      let message: { id?: string; method?: string };
+      let message: { id?: string; method?: string; params?: unknown };
       try {
         message = JSON.parse(raw.toString());
       } catch {
         return;
       }
       if (!message.id) return;
+      if (message.method?.startsWith("smart_home/")) {
+        options.onSmartHomeCommand?.(message.method, message.params);
+      }
       const result =
         message.method === "session/list"
           ? { sessions: [{ id: "web-ui-smoke", title: "Visual review", message_count: messages.length }] }
@@ -367,7 +341,21 @@ async function installWorkbenchMocks(
                       ? { files: [sessionFile] }
                       : message.method === "content/list"
                         ? { entries: [contentEntry], total: 1 }
-                        : { ok: true, replayed_envelopes: [] };
+                        : message.method === "smart_home/device.list"
+                          ? { devices: { source: "home_assistant", devices: mockSmartHomeDevices, ok: true } }
+                          : message.method === "smart_home/device.command"
+                            ? {}
+                            : message.method === "smart_home/camera.stream_start"
+                              ? {
+                                  stream: {
+                                    ok: true,
+                                    protocol: "rtc",
+                                    playback_url: "http://127.0.0.1:1984/stream.html?src=wangwang",
+                                  },
+                                }
+                              : message.method === "smart_home/camera.stream_stop"
+                                ? {}
+                                : { ok: true, replayed_envelopes: [] };
       ws.send(JSON.stringify({ jsonrpc: "2.0", id: message.id, result }));
     });
   });
@@ -381,8 +369,13 @@ async function expectNoHorizontalOverflow(page: Page) {
 }
 
 test.describe("UI redesign shell smoke", () => {
+  let smartHomeCommands: Array<{ method: string; params: unknown }> = [];
+
   test.beforeEach(async ({ page }) => {
-    await installWorkbenchMocks(page);
+    smartHomeCommands = [];
+    await installWorkbenchMocks(page, {
+      onSmartHomeCommand: (method, params) => smartHomeCommands.push({ method, params }),
+    });
   });
 
   for (const viewport of [
@@ -630,16 +623,19 @@ test.describe("UI redesign shell smoke", () => {
     await expect(panel).toContainText("HDMI 1");
     await expect(panel.getByRole("button", { name: "Living Room TV Vol +" })).toBeVisible();
     await expect(panel.getByRole("button", { name: "Living Room TV Home" })).toBeVisible();
-    const tvVolumeAction = page.waitForRequest((request) => {
-      const url = new URL(request.url());
-      return (
-        request.method() === "POST" &&
-        url.pathname === "/smart-home-api/devices/real_tv" &&
-        request.postData()?.includes("action=volume_up") === true
-      );
-    });
     await panel.getByRole("button", { name: "Living Room TV Vol +" }).click();
-    await tvVolumeAction;
+    await expect
+      .poll(() =>
+        smartHomeCommands.some((cmd) => {
+          const params = cmd.params as { device_id?: string; params?: { action?: string } } | undefined;
+          return (
+            cmd.method === "smart_home/device.command" &&
+            params?.device_id === "real_tv" &&
+            params?.params?.action === "volume_up"
+          );
+        }),
+      )
+      .toBe(true);
 
     await panel.getByRole("button", { name: "Living Room TV close controls" }).click();
     await page.getByRole("button", { name: "Bedroom AC controls" }).click();

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -24,11 +24,6 @@ export default defineConfig({
           });
         },
       },
-      "/smart-home-api": {
-        target: "http://localhost:8787",
-        changeOrigin: true,
-        rewrite: (path) => path.replace(/^\/smart-home-api/, "/api"),
-      },
     },
   },
   build: {


### PR DESCRIPTION
## Summary
- Device listing/control/camera-stream calls now ride the shared `/api/ui-protocol/ws` JSON-RPC connection (`smart_home/*` methods, gated on a dedicated `smart_home.v1` feature token) instead of hitting the browser-facing `/smart-home-api` REST proxy directly.
- Matches the companion `octos-org/octos` change that moves the smart-home bridge into the backend's per-profile config — device control/state now lives server-side; only camera **video streaming** stays a UI-only, WebSocket playback-URL handoff.
- Data model is unchanged (`SmartHomeDevice`/`CameraStreamInfo` mirror the backend structs byte-for-byte) — only the transport call sites in `useSmartHomeDevices()` move from REST to WS.
- Removes the now-dead `/smart-home-api` dev proxy rule (`vite.config.ts`) and `VITE_SMART_HOME_API_BASE` env var (`README.md`).

## Testing
- `tsc -b`, `eslint .` (0 new errors — 5 pre-existing errors in `smart-home.tsx` confirmed via `git stash` to sit entirely outside this diff), `vitest run` (661/661).
- `vite build` production build clean.
- Playwright (`tests/ui-redesign-smoke.spec.ts`): migrated the smart-home device-list/command mocks from REST-route interception to `page.routeWebSocket`, with a new `onSmartHomeCommand` capture hook (real `page.on("websocket")` doesn't fire for `routeWebSocket`-mocked connections, so outgoing commands are captured inside the existing `ws.onMessage` handler instead). Both smart-home tests pass; full-file run is 22/24 (2 pre-existing unrelated failures — slides-editor-composer, TTS smoke — confirmed via `git stash` to be baseline, unrelated to this change).
- Manual full-stack pass (see companion backend PR octos-org/octos#1821 for details): ran this branch's dev server against a real `octos serve` instance + a standalone mock smart-home bridge, and confirmed in a real browser that the device list renders from the real backend and a device command round-trips through real (non-mocked) backend code to the mock bridge.

## Test plan
- [x] Typecheck / lint / unit tests clean
- [x] Production build clean
- [x] Playwright smart-home specs migrated and passing
- [x] Manual full-stack verification against the real companion backend PR
- [ ] Companion PR: octos-org/octos#1821

🤖 Generated with [Claude Code](https://claude.com/claude-code)