### PR TITLE
ci: validate pull requests with unit tests and production build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,29 @@
+name: CI
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: web-ci-${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  verify:
+    name: unit tests and production build
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+      - run: npm ci
+      - run: npm run test:unit
+      - run: npm run build


### PR DESCRIPTION
## What changed

- run CI for pull requests, pushes to `main`, and manual dispatches
- install the locked npm dependency graph with `npm ci`
- run the complete Vitest unit suite
- run the production build, including `tsc -b`
- cancel superseded runs for the same pull request
- keep workflow permissions read-only

## Why

The repository currently deploys GitHub Pages from `main`, but pull requests do not receive a repository-owned unit/build check. That lets a TypeScript, unit-test, or production-bundle failure reach merge before the deploy workflow discovers it.

This is the first repository-local promotion gate for #289 and #290. It deliberately stays independent from a live Core instance; paired Core/Web conformance remains follow-up work.

## Validation

- `npm ci`
- `npm run test:unit` — 100 test files, 661 tests passed
- `npm run build`
- parsed `.github/workflows/ci.yml` with `js-yaml`

## Lint baseline

`npm run lint` currently reports 105 pre-existing errors on unmodified `main`. This PR does not make lint required yet because that would block every pull request on historical debt. Lint should be restored in subsystem-sized follow-ups, then added to this required gate.
