### PR TITLE
feat(auth): streamline solo onboarding and rebuild login hierarchy

### DIFF
--- a/public/images/octos-logo-color.svg
+++ b/public/images/octos-logo-color.svg
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<svg id="_图层_1" data-name="图层_1" xmlns="http://www.w3.org/2000/svg" version="1.1" viewBox="0 0 778.96 444.57">
+<svg id="_图层_1" data-name="图层_1" xmlns="http://www.w3.org/2000/svg" version="1.1" viewBox="290.10 144.35 197.76 165.36">
   <!-- Generator: Adobe Illustrator 29.6.1, SVG Export Plug-In . SVG Version: 2.1.1 Build 9)  -->
   <defs>
     <style>

--- a/src/api/auth.ts
+++ b/src/api/auth.ts
@@ -38,9 +38,10 @@ export async function logout(): Promise<void> {
 
 // No-password solo login (Local-mode host opted in via `octos serve --solo`,
 // loopback peer). `soloLogin` re-logs the existing owner — it rejects with an
-// "HTTP 404" error when no solo profile exists yet, which the login page uses
+// ApiError(404) when no solo profile exists yet, which the login page uses
 // to fall through to the create form. `soloCreate` onboards a local profile
-// and logs in atomically.
+// and logs in atomically. `username`/`email` are optional: the server derives
+// them from `name` when omitted, so first-run only asks for a display name.
 export async function soloLogin(): Promise<SoloLoginResult> {
   // publicRequest: a solo 403/404 is a policy denial, not a dead session — do
   // NOT let the /api/auth/* token reaper clear a signed-in user's tokens.
@@ -49,8 +50,8 @@ export async function soloLogin(): Promise<SoloLoginResult> {
 
 export async function soloCreate(body: {
   name: string;
-  username: string;
-  email: string;
+  username?: string;
+  email?: string;
 }): Promise<SoloCreateResult> {
   return publicRequest("/api/auth/solo/create", {
     method: "POST",

--- a/src/api/client.ts
+++ b/src/api/client.ts
@@ -240,7 +240,7 @@ export async function request<T>(
       }
     }
     const text = await resp.text();
-    throw new Error(text || `HTTP ${resp.status}`);
+    throw new ApiError(resp.status, errorBodyMessage(resp.status, text));
   }
 
   if (resp.status === 204) {
@@ -271,9 +271,46 @@ export async function requestBlob(
   });
   if (!resp.ok) {
     const text = await resp.text();
-    throw new Error(text || `HTTP ${resp.status}`);
+    throw new ApiError(resp.status, errorBodyMessage(resp.status, text));
   }
   return resp.blob();
+}
+
+/**
+ * Error thrown by API requests. Carries the HTTP `status` so callers can
+ * branch structurally (`err instanceof ApiError && err.status === 404`)
+ * instead of matching on message text — the message is the human-readable
+ * body and is NOT a stable machine signal (a proxy can rewrite it, which
+ * previously broke the solo first-run fallthrough).
+ */
+export class ApiError extends Error {
+  readonly status: number;
+  constructor(status: number, message: string) {
+    super(message);
+    this.name = "ApiError";
+    this.status = status;
+  }
+}
+
+/** Pull a displayable message out of an error response body: prefers the
+ *  `{error}` / `{message}` fields of a JSON body; falls back to raw text,
+ *  then to a bare `HTTP <status>`. */
+function errorBodyMessage(status: number, text: string): string {
+  const trimmed = text.trim();
+  if (trimmed.startsWith("{")) {
+    try {
+      const parsed = JSON.parse(trimmed) as {
+        error?: unknown;
+        message?: unknown;
+        detail?: unknown;
+      };
+      const msg = parsed.error ?? parsed.message ?? parsed.detail;
+      if (typeof msg === "string" && msg.trim()) return msg;
+    } catch {
+      // not actually JSON — fall through to raw text
+    }
+  }
+  return trimmed || `HTTP ${status}`;
 }
 
 /**
@@ -283,7 +320,7 @@ export async function requestBlob(
  * 403 is a POLICY denial (not opted in, proxied, non-loopback), NOT proof that
  * an existing session token is dead. Routing those through `request()` would
  * clear the user's tokens and bounce them to `/login` (see solo-login codex
- * review). 404 (no solo profile yet) and 403 simply throw, like `request`.
+ * review). 404 (no solo profile yet) and 403 throw an {@link ApiError}.
  */
 export async function publicRequest<T>(
   path: string,
@@ -296,7 +333,7 @@ export async function publicRequest<T>(
   const resp = await fetch(`${API_BASE}${path}`, { ...options, headers });
   if (!resp.ok) {
     const text = await resp.text();
-    throw new Error(text || `HTTP ${resp.status}`);
+    throw new ApiError(resp.status, errorBodyMessage(resp.status, text));
   }
   if (resp.status === 204) {
     return undefined as T;

--- a/src/api/types.ts
+++ b/src/api/types.ts
@@ -124,6 +124,10 @@ export interface AuthStatusResponse {
    *  without a password". The server still enforces a loopback,
    *  non-proxied request at call time — see the backend `api::solo_auth`. */
   local_solo_enabled?: boolean;
+  /** Present only when `local_solo_enabled` — whether a solo owner has
+   *  already onboarded. `false` means the login page should show the
+   *  first-run create form directly (no doomed solo-login round trip). */
+  solo_profile_exists?: boolean | null;
   scoped_profile?: ScopedAuthTarget | null;
 }
 

--- a/src/auth/auth-context.tsx
+++ b/src/auth/auth-context.tsx
@@ -29,8 +29,9 @@ interface AuthState {
    *  "HTTP 404" error when no solo profile exists yet — the caller then shows
    *  the create form. */
   soloLogin: () => Promise<void>;
-  /** Onboard a local profile AND log in (no password). */
-  soloCreate: (body: { name: string; username: string; email: string }) => Promise<void>;
+  /** Onboard a local profile AND log in (no password). The server derives
+   *  username/email from `name` when omitted. */
+  soloCreate: (body: { name: string; username?: string; email?: string }) => Promise<void>;
   logout: () => Promise<void>;
   /** Re-validate the stored token against `/api/auth/me`. Call this from
    *  any code path that sees an authenticated request rejected (e.g. the
@@ -179,8 +180,10 @@ export function AuthProvider({ children }: { children: ReactNode }) {
       setTokenState(null);
       setUser(null);
       setPortal(null);
-      const msg = err instanceof Error ? err.message : "Token validation failed";
-      throw new Error(msg);
+      // Rethrow the ORIGINAL error so callers keep structural info (e.g.
+      // ApiError.status 401 → "wrong token" copy) instead of a flattened
+      // message string.
+      throw err instanceof Error ? err : new Error("Token validation failed");
     }
   }, [syncMe]);
 
@@ -202,7 +205,7 @@ export function AuthProvider({ children }: { children: ReactNode }) {
   }, [syncMe]);
 
   const soloCreate = useCallback(
-    async (body: { name: string; username: string; email: string }) => {
+    async (body: { name: string; username?: string; email?: string }) => {
       const resp = await authApi.soloCreate(body);
       setToken(resp.token);
       setTokenState(resp.token);

--- a/src/auth/auth-guard.tsx
+++ b/src/auth/auth-guard.tsx
@@ -10,9 +10,17 @@ export function AuthGuard() {
   if (skipAuth) return <Outlet />;
 
   if (loading) {
+    // Branded splash while the stored token is validated against /me —
+    // replaces the old bare "Loading..." on a hard-coded dark background
+    // (which also ignored the user's theme).
     return (
-      <div className="flex h-screen items-center justify-center bg-surface-dark">
-        <div className="text-muted">Loading...</div>
+      <div className="workbench-shell flex h-screen flex-col items-center justify-center gap-4 px-4">
+        <img
+          src="/images/octos-logo-color.svg"
+          alt="Octos"
+          className="h-10 w-auto animate-pulse select-none"
+        />
+        <span className="text-sm text-muted">Loading…</span>
       </div>
     );
   }

--- a/src/auth/login-page.test.tsx
+++ b/src/auth/login-page.test.tsx
@@ -107,4 +107,61 @@ describe("LoginPage registration guidance", () => {
       screen.queryByText(/email otp login is not enabled on this host/i),
     ).toBeNull();
   });
+
+  it("never promises email sign-in when email login is disabled", async () => {
+    authMocks.authStatus = {
+      bootstrap_mode: false,
+      email_login_enabled: false,
+      admin_token_login_enabled: true,
+      allow_self_registration: false,
+      local_solo_enabled: true,
+      scoped_profile: null,
+    };
+    apiMocks.status.mockResolvedValue(authMocks.authStatus);
+
+    render(
+      <MemoryRouter>
+        <LoginPage />
+      </MemoryRouter>,
+    );
+
+    expect(
+      await screen.findByText(/continue with the local profile/i),
+    ).toBeTruthy();
+    expect(screen.queryByText(/email/i)).toBeNull();
+  });
+
+  it("offers a retry when the auth status probe fails", async () => {
+    authMocks.authStatus = null;
+    apiMocks.status.mockRejectedValue(new Error("connection refused"));
+
+    render(
+      <MemoryRouter>
+        <LoginPage />
+      </MemoryRouter>,
+    );
+
+    expect(
+      await screen.findByText(/can't reach the server/i),
+    ).toBeTruthy();
+    expect(screen.queryByText(/checking sign-in options/i)).toBeNull();
+
+    // The probe recovers on retry.
+    apiMocks.status.mockResolvedValue({
+      bootstrap_mode: false,
+      email_login_enabled: true,
+      admin_token_login_enabled: false,
+      allow_self_registration: true,
+      local_solo_enabled: false,
+      scoped_profile: null,
+    } satisfies AuthStatusResponse);
+    screen.getByText("Retry").click();
+
+    expect(
+      await screen.findByText(
+        /verify your email to create an account and sign in/i,
+      ),
+    ).toBeTruthy();
+    expect(apiMocks.status).toHaveBeenCalledTimes(2);
+  });
 });

--- a/src/auth/login-page.tsx
+++ b/src/auth/login-page.tsx
@@ -21,6 +21,8 @@ export function LoginPage() {
   const [authStatus, setAuthStatus] = useState<AuthStatusResponse | null>(
     initialAuthStatus,
   );
+  const [statusError, setStatusError] = useState(false);
+  const [statusTick, setStatusTick] = useState(0);
   const [showToken, setShowToken] = useState(false);
   const [email, setEmail] = useState("");
   const [code, setCode] = useState("");
@@ -40,12 +42,14 @@ export function LoginPage() {
         if (active) setAuthStatus(status);
       })
       .catch(() => {
-        // Leave the page usable even if auth status probing fails.
+        // Surface the failure with a retry instead of spinning forever on
+        // "Checking sign-in options…" when the server is down.
+        if (active) setStatusError(true);
       });
     return () => {
       active = false;
     };
-  }, []);
+  }, [statusTick]);
 
   // Resend-code countdown tick.
   useEffect(() => {
@@ -145,11 +149,21 @@ export function LoginPage() {
     ? "This login is scoped to the addressed account. Use the exact email registered for this sub-account."
     : soloFirstRun || step === "solo"
       ? "A local, single-user workspace. Set it up in one step."
-      : authStatus?.bootstrap_mode
-        ? "Bootstrap admin access is enabled on this host."
-        : authStatus?.allow_self_registration
-          ? "Verify your email to create an account and sign in."
-          : "Use an allowed or registered email to sign in.";
+      : authStatus === null
+        ? statusError
+          ? ""
+          : "Sign in to your workspace."
+        : authStatus.bootstrap_mode
+          ? "Bootstrap admin access is enabled on this host."
+          : !emailLoginEnabled
+            ? soloEnabled
+              ? "Continue with the local profile on this machine."
+              : tokenModeEnabled
+                ? "Sign in with your admin auth token."
+                : "" // no methods — the warning box below says so
+            : authStatus.allow_self_registration
+              ? "Verify your email to create an account and sign in."
+              : "Use an allowed or registered email to sign in.";
 
   const emailSection = (
     <>
@@ -256,21 +270,44 @@ export function LoginPage() {
         <img
           src="/images/octos-logo-color.svg"
           alt="Octos"
-          className="mb-4 h-9 w-auto select-none"
+          className="mb-4 h-11 w-auto select-none"
         />
         <h1 className="text-2xl font-semibold tracking-tight text-text-strong">
           {scopedProfile
             ? `Sign in to ${scopedProfile.name}`
             : soloFirstRun || step === "solo"
-              ? "Welcome to octos"
-              : "octos"}
+              ? "Welcome to Octos"
+              : "Octos"}
         </h1>
-        <p className="mb-6 mt-2 text-sm text-muted">{subtitle}</p>
+        {subtitle ? (
+          <p className="mb-6 mt-2 text-sm text-muted">{subtitle}</p>
+        ) : (
+          // Keep the vertical rhythm when there is no subtitle to show.
+          <div className="mb-6 mt-2" />
+        )}
 
         {authStatus === null ? (
-          // The available sign-in methods are server-driven; don't flash the
-          // wrong set while probing.
-          <p className="text-sm text-muted">Checking sign-in options…</p>
+          statusError ? (
+            <div className="space-y-4">
+              <div className="rounded-lg border border-(--workbench-danger-border) bg-(--workbench-danger-bg) p-3 text-sm text-(--workbench-danger-text)">
+                Can't reach the server to load the sign-in options. Check
+                that it is running, then retry.
+              </div>
+              <button
+                onClick={() => {
+                  setStatusError(false);
+                  setStatusTick((t) => t + 1);
+                }}
+                className="workbench-button workbench-button-primary w-full py-3 font-medium"
+              >
+                Retry
+              </button>
+            </div>
+          ) : (
+            // The available sign-in methods are server-driven; don't flash
+            // the wrong set while probing.
+            <p className="text-sm text-muted">Checking sign-in options…</p>
+          )
         ) : (
           <>
             {/* Primary block: solo (first-run form or one-click continue) */}
@@ -312,7 +349,7 @@ export function LoginPage() {
             ) : null}
 
             {error && (
-              <div data-testid="login-error" className="mb-4 rounded-lg border border-red-500/25 bg-red-500/10 p-3 text-sm text-red-300">
+              <div data-testid="login-error" className="mb-4 rounded-lg border border-(--workbench-danger-border) bg-(--workbench-danger-bg) p-3 text-sm text-(--workbench-danger-text)">
                 {error}
               </div>
             )}
@@ -345,7 +382,7 @@ export function LoginPage() {
                   ))}
 
                 {visibleMethods === 0 && (
-                  <div className="rounded-lg border border-amber-500/25 bg-amber-500/10 p-3 text-sm text-amber-200">
+                  <div className="rounded-lg border border-(--workbench-warning-border) bg-(--workbench-warning-bg) p-3 text-sm text-(--workbench-warning-text)">
                     No sign-in method is enabled on this host yet. Check the
                     server configuration.
                   </div>

--- a/src/auth/login-page.tsx
+++ b/src/auth/login-page.tsx
@@ -3,7 +3,10 @@ import { useNavigate, useSearchParams } from "react-router-dom";
 import { useAuth } from "./auth-context";
 import { SoloProfileForm } from "./solo-profile-form";
 import * as authApi from "@/api/auth";
+import { ApiError } from "@/api/client";
 import type { AuthStatusResponse } from "@/api/types";
+
+const RESEND_COUNTDOWN_S = 30;
 
 export function LoginPage() {
   const { login, loginWithToken, soloLogin, authStatus: initialAuthStatus } =
@@ -18,13 +21,14 @@ export function LoginPage() {
   const [authStatus, setAuthStatus] = useState<AuthStatusResponse | null>(
     initialAuthStatus,
   );
-  const [mode, setMode] = useState<"otp" | "token">("otp");
+  const [showToken, setShowToken] = useState(false);
   const [email, setEmail] = useState("");
   const [code, setCode] = useState("");
   const [adminToken, setAdminToken] = useState("");
   const [step, setStep] = useState<"email" | "code" | "solo">("email");
   const [error, setError] = useState("");
   const [sending, setSending] = useState(false);
+  const [resendIn, setResendIn] = useState(0);
 
   useEffect(() => {
     // The context value provides the initial render. Always refresh it because
@@ -43,6 +47,13 @@ export function LoginPage() {
     };
   }, []);
 
+  // Resend-code countdown tick.
+  useEffect(() => {
+    if (resendIn <= 0) return;
+    const timer = setTimeout(() => setResendIn((s) => s - 1), 1000);
+    return () => clearTimeout(timer);
+  }, [resendIn]);
+
   const scopedProfile = authStatus?.scoped_profile ?? null;
   const tokenModeEnabled = useMemo(
     () => !scopedProfile && Boolean(authStatus?.admin_token_login_enabled),
@@ -50,8 +61,13 @@ export function LoginPage() {
   );
   const emailLoginEnabled = authStatus?.email_login_enabled ?? true;
   const soloEnabled = authStatus?.local_solo_enabled ?? false;
+  // First run: solo is offered and the server says nobody has onboarded yet.
+  // Show the create form as the primary content instead of making the user
+  // click a button that fires a doomed 404 request.
+  const soloFirstRun =
+    soloEnabled && authStatus?.solo_profile_exists === false;
 
-  const activeMode = mode === "token" && !tokenModeEnabled ? "otp" : mode;
+  const visibleMethods = [soloEnabled, emailLoginEnabled, tokenModeEnabled].filter(Boolean).length;
 
   async function handleSendCode() {
     setError("");
@@ -63,6 +79,7 @@ export function LoginPage() {
         return;
       }
       setStep("code");
+      setResendIn(RESEND_COUNTDOWN_S);
     } catch (e) {
       setError(e instanceof Error ? e.message : "Failed to send code");
     } finally {
@@ -90,7 +107,13 @@ export function LoginPage() {
       await loginWithToken(adminToken.trim());
       navigate(redirectTo || "/", { replace: true });
     } catch (e) {
-      setError(e instanceof Error ? e.message : "Invalid token");
+      setError(
+        e instanceof ApiError && (e.status === 401 || e.status === 403)
+          ? "That token didn't work — check it and try again."
+          : e instanceof Error
+            ? e.message
+            : "Invalid token",
+      );
     }
   }
 
@@ -99,20 +122,133 @@ export function LoginPage() {
     setSending(true);
     try {
       // Re-login the existing local owner. First run (no profile yet) comes
-      // back as an "HTTP 404" error → drop into the create form.
+      // back as a 404 → drop into the create form. Newer backends advertise
+      // `solo_profile_exists` up front so this request is never wasted; the
+      // fallthrough stays for older backends.
       await soloLogin();
       navigate(redirectTo || "/", { replace: true });
     } catch (e) {
-      const msg = e instanceof Error ? e.message : "";
-      if (msg.includes("404")) {
+      const is404 =
+        (e instanceof ApiError && e.status === 404) ||
+        (e instanceof Error && e.message.includes("404"));
+      if (is404) {
         setStep("solo");
       } else {
-        setError(msg || "Solo login failed");
+        setError(e instanceof Error ? e.message : "Solo login failed");
       }
     } finally {
       setSending(false);
     }
   }
+
+  const subtitle = scopedProfile
+    ? "This login is scoped to the addressed account. Use the exact email registered for this sub-account."
+    : soloFirstRun || step === "solo"
+      ? "A local, single-user workspace. Set it up in one step."
+      : authStatus?.bootstrap_mode
+        ? "Bootstrap admin access is enabled on this host."
+        : authStatus?.allow_self_registration
+          ? "Verify your email to create an account and sign in."
+          : "Use an allowed or registered email to sign in.";
+
+  const emailSection = (
+    <>
+      {step === "email" ? (
+        <div className="space-y-4">
+          <input
+            type="email"
+            placeholder={
+              scopedProfile
+                ? "Registered account email"
+                : "Email address"
+            }
+            value={email}
+            onChange={(e) => setEmail(e.target.value)}
+            onKeyDown={(e) =>
+              e.key === "Enter" &&
+              isValidEmail(email) &&
+              emailLoginEnabled &&
+              handleSendCode()
+            }
+            autoComplete="email"
+            className="workbench-input w-full px-4 py-3 placeholder-muted"
+          />
+          <button
+            onClick={handleSendCode}
+            disabled={!isValidEmail(email) || sending || !emailLoginEnabled}
+            className="workbench-button workbench-button-primary w-full py-3 font-medium disabled:opacity-50"
+          >
+            {sending ? "Sending..." : "Send Code"}
+          </button>
+        </div>
+      ) : (
+        <div className="space-y-4">
+          <p className="text-sm text-muted">
+            Code sent to <span className="text-text-strong">{email}</span>
+          </p>
+          <input
+            type="text"
+            placeholder="6-digit code"
+            value={code}
+            onChange={(e) => setCode(e.target.value.replace(/\D/g, ""))}
+            onKeyDown={(e) => e.key === "Enter" && handleVerify()}
+            maxLength={6}
+            autoFocus
+            inputMode="numeric"
+            autoComplete="one-time-code"
+            className="workbench-input w-full px-4 py-3 text-center text-2xl tracking-widest placeholder-muted"
+          />
+          <button
+            onClick={handleVerify}
+            disabled={code.length < 6 || sending}
+            className="workbench-button workbench-button-primary w-full py-3 font-medium disabled:opacity-50"
+          >
+            {sending ? "Verifying..." : "Verify"}
+          </button>
+          <div className="flex items-center justify-between text-sm">
+            <button
+              onClick={() => {
+                setStep("email");
+                setCode("");
+              }}
+              className="text-muted hover:text-text-strong"
+            >
+              Back
+            </button>
+            <button
+              onClick={handleSendCode}
+              disabled={resendIn > 0 || sending}
+              className="text-muted hover:text-text-strong disabled:opacity-50"
+            >
+              {resendIn > 0 ? `Resend code (${resendIn}s)` : "Resend code"}
+            </button>
+          </div>
+        </div>
+      )}
+    </>
+  );
+
+  const tokenSection = (
+    <div className="space-y-4">
+      <input
+        data-testid="token-input"
+        type="password"
+        placeholder="Admin auth token"
+        value={adminToken}
+        onChange={(e) => setAdminToken(e.target.value)}
+        onKeyDown={(e) => e.key === "Enter" && handleTokenLogin()}
+        className="workbench-input w-full px-4 py-3 placeholder-muted"
+      />
+      <button
+        data-testid="login-button"
+        onClick={handleTokenLogin}
+        disabled={!adminToken.trim()}
+        className="workbench-button workbench-button-primary w-full py-3 font-medium disabled:opacity-50"
+      >
+        Login
+      </button>
+    </div>
+  );
 
   return (
     <div className="workbench-shell flex h-screen items-center justify-center px-4">
@@ -123,176 +259,100 @@ export function LoginPage() {
           className="mb-4 h-9 w-auto select-none"
         />
         <h1 className="text-2xl font-semibold tracking-tight text-text-strong">
-          {scopedProfile ? `Sign in to ${scopedProfile.name}` : "octos"}
-        </h1>
-        <p className="mb-6 mt-2 text-sm text-muted">
           {scopedProfile
-            ? "This login is scoped to the addressed account. Use the exact email registered for this sub-account."
-            : authStatus?.bootstrap_mode
-              ? "Bootstrap admin access is enabled on this host."
-              : authStatus?.allow_self_registration
-                ? "Verify your email to create an account and sign in."
-                : "Use an allowed or registered email to sign in."}
-        </p>
+            ? `Sign in to ${scopedProfile.name}`
+            : soloFirstRun || step === "solo"
+              ? "Welcome to octos"
+              : "octos"}
+        </h1>
+        <p className="mb-6 mt-2 text-sm text-muted">{subtitle}</p>
 
-        {soloEnabled && step !== "solo" && (
-          <div className="mb-6">
-            <button
-              data-testid="solo-continue"
-              onClick={handleSoloContinue}
-              disabled={sending}
-              className="workbench-button workbench-button-primary w-full py-3 font-medium disabled:opacity-50"
-            >
-              {sending ? "Continuing..." : "Continue without a password"}
-            </button>
-            <p className="mt-2 text-center text-xs text-muted">
-              Solo mode — local, single-user, stays on this machine.
-            </p>
-            <div className="my-4 flex items-center gap-3 text-xs text-muted">
-              <span className="h-px flex-1 bg-border" />
-              or sign in with email
-              <span className="h-px flex-1 bg-border" />
-            </div>
-          </div>
-        )}
-
-        {/* Mode tabs */}
-        {step !== "solo" && (
-        <div className="mb-6 flex gap-2">
-          <button
-            onClick={() => setMode("otp")}
-            className={`flex-1 rounded-lg py-2 text-sm font-medium transition ${
-              activeMode === "otp"
-                ? "bg-accent text-on-accent"
-                : "bg-surface-container text-muted hover:text-text-strong"
-            }`}
-          >
-            Email OTP
-          </button>
-          {tokenModeEnabled && (
-            <button
-              onClick={() => setMode("token")}
-              className={`flex-1 rounded-lg py-2 text-sm font-medium transition ${
-                activeMode === "token"
-                  ? "bg-accent text-on-accent"
-                  : "bg-surface-container text-muted hover:text-text-strong"
-              }`}
-            >
-              Auth Token
-            </button>
-          )}
-        </div>
-        )}
-
-        {error && (
-          <div data-testid="login-error" className="mb-4 rounded-lg border border-red-500/25 bg-red-500/10 p-3 text-sm text-red-300">
-            {error}
-          </div>
-        )}
-
-        {!emailLoginEnabled && (
-          <div className="mb-4 rounded-lg border border-amber-500/25 bg-amber-500/10 p-3 text-sm text-amber-300">
-            {scopedProfile
-              ? "Email OTP login is not enabled for this account yet."
-              : "Email OTP login is not enabled on this host."}
-          </div>
-        )}
-
-        {step === "solo" ? (
-          <div className="space-y-4">
-            <SoloProfileForm
-              onDone={() => navigate(redirectTo || "/", { replace: true })}
-            />
-            <button
-              onClick={() => {
-                setStep("email");
-                setError("");
-              }}
-              className="w-full text-sm text-muted hover:text-text-strong"
-            >
-              Back
-            </button>
-          </div>
-        ) : activeMode === "otp" ? (
-          step === "email" ? (
-            <div className="space-y-4">
-              <input
-                type="email"
-                placeholder={
-                  scopedProfile
-                    ? "Registered account email"
-                    : "Email address"
-                }
-                value={email}
-                onChange={(e) => setEmail(e.target.value)}
-                onKeyDown={(e) =>
-                  e.key === "Enter" &&
-                  isValidEmail(email) &&
-                  emailLoginEnabled &&
-                  handleSendCode()
-                }
-                className="workbench-input w-full px-4 py-3 placeholder-muted"
-              />
-              <button
-                onClick={handleSendCode}
-                disabled={!isValidEmail(email) || sending || !emailLoginEnabled}
-                className="workbench-button workbench-button-primary w-full py-3 font-medium disabled:opacity-50"
-              >
-                {sending ? "Sending..." : "Send Code"}
-              </button>
-            </div>
-          ) : (
-            <div className="space-y-4">
-              <p className="text-sm text-muted">
-                Code sent to <span className="text-text-strong">{email}</span>
-              </p>
-              <input
-                type="text"
-                placeholder="6-digit code"
-                value={code}
-                onChange={(e) => setCode(e.target.value)}
-                onKeyDown={(e) => e.key === "Enter" && handleVerify()}
-                maxLength={6}
-                className="workbench-input w-full px-4 py-3 text-center text-2xl tracking-widest placeholder-muted"
-              />
-              <button
-                onClick={handleVerify}
-                disabled={code.length < 6 || sending}
-                className="workbench-button workbench-button-primary w-full py-3 font-medium disabled:opacity-50"
-              >
-                {sending ? "Verifying..." : "Verify"}
-              </button>
-              <button
-                onClick={() => {
-                  setStep("email");
-                  setCode("");
-                }}
-                className="w-full text-sm text-muted hover:text-text-strong"
-              >
-                Back
-              </button>
-            </div>
-          )
+        {authStatus === null ? (
+          // The available sign-in methods are server-driven; don't flash the
+          // wrong set while probing.
+          <p className="text-sm text-muted">Checking sign-in options…</p>
         ) : (
-          <div className="space-y-4">
-            <input
-              data-testid="token-input"
-              type="password"
-              placeholder="Admin auth token"
-              value={adminToken}
-              onChange={(e) => setAdminToken(e.target.value)}
-              onKeyDown={(e) => e.key === "Enter" && handleTokenLogin()}
-              className="workbench-input w-full px-4 py-3 placeholder-muted"
-            />
-            <button
-              data-testid="login-button"
-              onClick={handleTokenLogin}
-              disabled={!adminToken.trim()}
-              className="workbench-button workbench-button-primary w-full py-3 font-medium disabled:opacity-50"
-            >
-              Login
-            </button>
-          </div>
+          <>
+            {/* Primary block: solo (first-run form or one-click continue) */}
+            {step === "solo" ? (
+              <div className="mb-6 space-y-4">
+                <SoloProfileForm
+                  onDone={() => navigate(redirectTo || "/", { replace: true })}
+                />
+                <button
+                  onClick={() => {
+                    setStep("email");
+                    setError("");
+                  }}
+                  className="w-full text-sm text-muted hover:text-text-strong"
+                >
+                  Back
+                </button>
+              </div>
+            ) : soloFirstRun ? (
+              <div className="mb-6">
+                <SoloProfileForm
+                  onDone={() => navigate(redirectTo || "/", { replace: true })}
+                />
+              </div>
+            ) : soloEnabled ? (
+              <div className="mb-6">
+                <button
+                  data-testid="solo-continue"
+                  onClick={handleSoloContinue}
+                  disabled={sending}
+                  className="workbench-button workbench-button-primary w-full py-3 font-medium disabled:opacity-50"
+                >
+                  {sending ? "Continuing..." : "Continue without a password"}
+                </button>
+                <p className="mt-2 text-center text-xs text-muted">
+                  Solo mode — local, single-user, stays on this machine.
+                </p>
+              </div>
+            ) : null}
+
+            {error && (
+              <div data-testid="login-error" className="mb-4 rounded-lg border border-red-500/25 bg-red-500/10 p-3 text-sm text-red-300">
+                {error}
+              </div>
+            )}
+
+            {/* Secondary methods — only rendered when actually enabled. A
+                disabled email login used to show a full (dead) form plus a
+                low-contrast warning; now it simply doesn't appear. */}
+            {step !== "solo" && (
+              <>
+                {soloEnabled && (emailLoginEnabled || tokenModeEnabled) && (
+                  <div className="mb-6 flex items-center gap-3 text-xs text-muted">
+                    <span className="h-px flex-1 bg-border" />
+                    or sign in another way
+                    <span className="h-px flex-1 bg-border" />
+                  </div>
+                )}
+
+                {emailLoginEnabled && emailSection}
+
+                {tokenModeEnabled &&
+                  (visibleMethods === 1 || showToken ? (
+                    tokenSection
+                  ) : (
+                    <button
+                      onClick={() => setShowToken(true)}
+                      className="mt-4 w-full text-center text-sm text-muted hover:text-text-strong"
+                    >
+                      Use an auth token
+                    </button>
+                  ))}
+
+                {visibleMethods === 0 && (
+                  <div className="rounded-lg border border-amber-500/25 bg-amber-500/10 p-3 text-sm text-amber-200">
+                    No sign-in method is enabled on this host yet. Check the
+                    server configuration.
+                  </div>
+                )}
+              </>
+            )}
+          </>
         )}
       </div>
     </div>

--- a/src/auth/solo-profile-form.test.tsx
+++ b/src/auth/solo-profile-form.test.tsx
@@ -53,7 +53,7 @@ afterEach(() => {
 });
 
 describe("SoloProfileForm", () => {
-  it("keeps submit disabled until name/username/email are valid, then submits trimmed values", async () => {
+  it("keeps submit disabled until a name is entered, then submits the trimmed name", async () => {
     soloCreate.mockResolvedValue(undefined);
     const onDone = vi.fn();
     const { container } = mount(
@@ -65,33 +65,39 @@ describe("SoloProfileForm", () => {
     expect(submitBtn(container).disabled).toBe(true);
 
     setInput(container, "solo-name", "  Ada Lovelace ");
-    setInput(container, "solo-username", " ada ");
-    expect(submitBtn(container).disabled).toBe(true); // email still missing
-
-    setInput(container, "solo-email", " ada@example.com ");
     expect(submitBtn(container).disabled).toBe(false);
 
     await act(async () => {
       submitBtn(container).click();
     });
 
-    expect(soloCreate).toHaveBeenCalledWith({
-      name: "Ada Lovelace",
-      username: "ada",
-      email: "ada@example.com",
-    });
+    expect(soloCreate).toHaveBeenCalledWith({ name: "Ada Lovelace" });
     expect(onDone).toHaveBeenCalled();
   });
 
-  it("keeps submit disabled for an invalid username", () => {
+  it("keeps submit disabled for a whitespace-only name", () => {
     const { container } = mount(
       <MemoryRouter>
         <SoloProfileForm />
       </MemoryRouter>,
     );
-    setInput(container, "solo-name", "Ada");
-    setInput(container, "solo-username", "has space");
-    setInput(container, "solo-email", "ada@example.com");
+    setInput(container, "solo-name", "   ");
+    expect(submitBtn(container).disabled).toBe(true);
+  });
+
+  it("shows a length hint for an over-long name", () => {
+    const { container } = mount(
+      <MemoryRouter>
+        <SoloProfileForm />
+      </MemoryRouter>,
+    );
+    const el = container.querySelector('[data-testid="solo-name"]')!;
+    act(() => {
+      // React's onBlur delegates to the "focusout" event type.
+      el.dispatchEvent(new FocusEvent("focusout", { bubbles: true }));
+    });
+    setInput(container, "solo-name", "x".repeat(129));
+    expect(container.textContent).toContain("128 characters");
     expect(submitBtn(container).disabled).toBe(true);
   });
 
@@ -103,8 +109,6 @@ describe("SoloProfileForm", () => {
       </MemoryRouter>,
     );
     setInput(container, "solo-name", "Ada");
-    setInput(container, "solo-username", "ada");
-    setInput(container, "solo-email", "ada@example.com");
     await act(async () => {
       submitBtn(container).click();
     });

--- a/src/auth/solo-profile-form.test.tsx
+++ b/src/auth/solo-profile-form.test.tsx
@@ -115,4 +115,16 @@ describe("SoloProfileForm", () => {
     const err = container.querySelector('[data-testid="solo-error"]');
     expect(err?.textContent).toContain("username taken");
   });
+
+  it("gives the name input an accessible name (placeholder is not a label)", () => {
+    const { container } = mount(
+      <MemoryRouter>
+        <SoloProfileForm />
+      </MemoryRouter>,
+    );
+    const el = container.querySelector(
+      '[data-testid="solo-name"]',
+    ) as HTMLInputElement;
+    expect(el.getAttribute("aria-label")).toBe("What should we call you?");
+  });
 });

--- a/src/auth/solo-profile-form.tsx
+++ b/src/auth/solo-profile-form.tsx
@@ -2,90 +2,75 @@ import { useState } from "react";
 import { useNavigate } from "react-router-dom";
 import { useAuth } from "./auth-context";
 
-// Client-side mirror of the backend validators (`validate_local_name`,
-// `normalize_local_username`, `validate_local_email`). UX nicety only — the
-// server stays authoritative and any rejection it returns is shown below.
-const USERNAME_RE = /^[A-Za-z0-9._-]+$/;
-const EMAIL_RE = /^[^\s@]+@[^\s@]+$/;
-
 /**
- * The solo onboarding form: full name / username / email → `soloCreate`.
- * On success calls `onDone` if provided, otherwise navigates to `/`.
+ * The solo onboarding form: just a display name → `soloCreate`. The server
+ * derives the username/email from the name (see `derive_solo_credentials`)
+ * — a local, password-free profile should not make a first-time user fill
+ * out three fields and a username regex.
+ *
+ * Renders a real <form> so Enter submits. On success calls `onDone` if
+ * provided, otherwise navigates to `/`.
  */
 export function SoloProfileForm({ onDone }: { onDone?: () => void }) {
   const { soloCreate } = useAuth();
   const navigate = useNavigate();
   const [name, setName] = useState("");
-  const [username, setUsername] = useState("");
-  const [email, setEmail] = useState("");
   const [error, setError] = useState("");
+  const [touched, setTouched] = useState(false);
   const [submitting, setSubmitting] = useState(false);
 
-  const nameOk = name.trim().length > 0 && name.trim().length <= 128;
-  const usernameOk =
-    username.trim().length > 0 &&
-    username.trim().length <= 64 &&
-    USERNAME_RE.test(username.trim());
-  const emailOk = EMAIL_RE.test(email.trim());
-  const canSubmit = nameOk && usernameOk && emailOk && !submitting;
+  const trimmed = name.trim();
+  const nameOk = trimmed.length > 0 && trimmed.length <= 128;
+  const showNameHint = touched && trimmed.length > 128;
+  const canSubmit = nameOk && !submitting;
 
-  async function handleSubmit() {
+  async function handleSubmit(event: React.FormEvent) {
+    event.preventDefault();
+    setTouched(true);
     if (!canSubmit) return;
     setError("");
     setSubmitting(true);
     try {
-      await soloCreate({
-        name: name.trim(),
-        username: username.trim(),
-        email: email.trim(),
-      });
+      await soloCreate({ name: trimmed });
       if (onDone) onDone();
       else navigate("/", { replace: true });
     } catch (e) {
       setError(e instanceof Error ? e.message : "Could not create profile");
-    } finally {
       setSubmitting(false);
     }
   }
 
   return (
-    <div className="space-y-4" data-testid="solo-profile-form">
+    <form
+      className="space-y-4"
+      data-testid="solo-profile-form"
+      onSubmit={handleSubmit}
+      noValidate
+    >
       <p className="text-sm text-muted">
-        Create a local profile. It stays on this machine — no email code is sent.
+        This stays on this machine — no password, no email code.
       </p>
-      <input
-        data-testid="solo-name"
-        type="text"
-        placeholder="Full name"
-        value={name}
-        onChange={(e) => setName(e.target.value)}
-        disabled={submitting}
-        autoFocus
-        className="workbench-input w-full px-4 py-3 placeholder-muted"
-      />
       <div>
         <input
-          data-testid="solo-username"
+          data-testid="solo-name"
           type="text"
-          placeholder="Username"
-          value={username}
-          onChange={(e) => setUsername(e.target.value)}
+          placeholder="What should we call you?"
+          value={name}
+          onChange={(e) => setName(e.target.value)}
+          onBlur={() => setTouched(true)}
           disabled={submitting}
-          className="workbench-input w-full px-4 py-3 font-mono placeholder-muted"
+          autoFocus
+          autoComplete="name"
+          aria-invalid={showNameHint}
+          aria-describedby={showNameHint ? "solo-name-hint" : undefined}
+          className="workbench-input w-full px-4 py-3 placeholder-muted"
         />
-        <p className="mt-1 text-xs text-muted">
-          Letters, digits, dot, hyphen or underscore.
-        </p>
+        {showNameHint && (
+          <p id="solo-name-hint" className="mt-1 text-xs text-red-400">
+            Keep it under 128 characters.
+          </p>
+        )}
       </div>
-      <input
-        data-testid="solo-email"
-        type="email"
-        placeholder="Email"
-        value={email}
-        onChange={(e) => setEmail(e.target.value)}
-        disabled={submitting}
-        className="workbench-input w-full px-4 py-3 placeholder-muted"
-      />
       {error && (
         <p data-testid="solo-error" className="text-sm text-red-400">
           {error}
@@ -93,12 +78,12 @@ export function SoloProfileForm({ onDone }: { onDone?: () => void }) {
       )}
       <button
         data-testid="solo-submit"
-        onClick={handleSubmit}
+        type="submit"
         disabled={!canSubmit}
         className="workbench-button workbench-button-primary w-full py-3 font-medium disabled:opacity-50"
       >
         {submitting ? "Creating…" : "Create profile & continue"}
       </button>
-    </div>
+    </form>
   );
 }

--- a/src/auth/solo-profile-form.tsx
+++ b/src/auth/solo-profile-form.tsx
@@ -54,6 +54,7 @@ export function SoloProfileForm({ onDone }: { onDone?: () => void }) {
         <input
           data-testid="solo-name"
           type="text"
+          aria-label="What should we call you?"
           placeholder="What should we call you?"
           value={name}
           onChange={(e) => setName(e.target.value)}

--- a/src/components/studio-nav.tsx
+++ b/src/components/studio-nav.tsx
@@ -107,7 +107,7 @@ export function StudioNav({ actions }: { actions?: ReactNode }) {
               src="/images/octos-logo-color.svg"
               alt=""
               aria-hidden="true"
-              className="h-6 w-6"
+              className="h-6 w-auto"
             />
             <span className="studio-headline text-lg font-bold">Octos</span>
           </Link>

--- a/src/components/workbench-shell.tsx
+++ b/src/components/workbench-shell.tsx
@@ -67,7 +67,7 @@ export function WorkbenchBrand() {
       <img
         src="/images/octos-logo-color.svg"
         alt="Octos"
-        className="workbench-brand-logo h-8 w-8 shrink-0 select-none object-cover"
+        className="h-8 w-auto shrink-0 select-none"
       />
       <span className="text-base font-semibold text-text-strong max-sm:hidden">
         Octos

--- a/src/components/workbench-shell.tsx
+++ b/src/components/workbench-shell.tsx
@@ -130,8 +130,11 @@ export function WorkbenchUserActions() {
 
   return (
     <div className="flex min-w-0 items-center gap-2">
+      {/* Prefer the display name the user gave at onboarding; fall back to
+          email (which for derived solo credentials is a `*.solo.local`
+          placeholder nobody wants to read). */}
       <span className="max-w-[18rem] truncate text-sm text-muted max-xl:hidden">
-        {user.email}
+        {user.name?.trim() || user.email}
       </span>
       <button
         type="button"

--- a/src/layouts/chat-layout.tsx
+++ b/src/layouts/chat-layout.tsx
@@ -157,7 +157,9 @@ export function ChatLayout({ children }: { children: ReactNode }) {
               <div className="flex items-center justify-between gap-3">
                 <div className="min-w-0 flex-1">
                   <div className="truncate text-sm font-medium text-text">
-                    {user.email}
+                    {/* Display name first — derived solo emails are
+                        `*.solo.local` placeholders. */}
+                    {user.name?.trim() || user.email}
                   </div>
                 </div>
                 <div className="flex items-center gap-2">

--- a/src/learning/learning-page.tsx
+++ b/src/learning/learning-page.tsx
@@ -6,7 +6,7 @@ import {
   useState,
   type ReactNode,
 } from "react";
-import { BookOpen, Menu, Pencil, Plus, Trash2 } from "lucide-react";
+import { ArrowLeft, BookOpen, Menu, Pencil, Plus, Trash2 } from "lucide-react";
 import { useNavigate } from "react-router-dom";
 import {
   deleteSession,
@@ -347,6 +347,9 @@ export function LearningPage() {
   const [skillState, setSkillState] = useState<
     "checking" | "ready" | "missing" | "outdated" | "error"
   >(ollFixture ? "ready" : "checking");
+  // Bumped by the gate's "重新检查" button to re-run the skill probe without
+  // a full page reload.
+  const [skillCheckTick, setSkillCheckTick] = useState(0);
   const [serverSyncReady, setServerSyncReady] = useState(Boolean(ollFixture));
   const [sidebarOpen, setSidebarOpen] = useState(false);
   const markerSentRef = useRef(false);
@@ -444,7 +447,12 @@ export function LearningPage() {
     return () => {
       cancelled = true;
     };
-  }, [hasTabLease, ollFixture]);
+  }, [hasTabLease, ollFixture, skillCheckTick]);
+
+  const recheckSkill = useCallback(() => {
+    setSkillState("checking");
+    setSkillCheckTick((tick) => tick + 1);
+  }, []);
 
   const buildTurnText = useCallback<NonNullable<VoiceConversationOptions["buildTurnText"]>>(
     (context) => {
@@ -624,7 +632,15 @@ export function LearningPage() {
 
   if (!hasTabLease) {
     return (
-      <div className="flex h-screen w-screen items-center justify-center bg-black px-6 text-white">
+      <div className="relative flex h-screen w-screen items-center justify-center bg-black px-6 text-white">
+        <button
+          type="button"
+          onClick={() => navigate("/")}
+          className="absolute left-5 top-6 flex items-center gap-2 rounded-full border border-white/15 px-4 py-2 text-sm text-white/60 transition hover:border-white/30 hover:text-white"
+        >
+          <ArrowLeft size={16} />
+          返回首页
+        </button>
         <div className="max-w-md text-center">
           <h1 className="text-xl font-semibold">学习助手已在另一个标签页中使用</h1>
           <p className="mt-3 text-sm leading-6 text-white/55">
@@ -637,7 +653,15 @@ export function LearningPage() {
 
   if (skillState !== "ready") {
     return (
-      <div className="flex h-screen w-screen items-center justify-center bg-black px-6 text-white">
+      <div className="relative flex h-screen w-screen items-center justify-center bg-black px-6 text-white">
+        <button
+          type="button"
+          onClick={() => navigate("/")}
+          className="absolute left-5 top-6 flex items-center gap-2 rounded-full border border-white/15 px-4 py-2 text-sm text-white/60 transition hover:border-white/30 hover:text-white"
+        >
+          <ArrowLeft size={16} />
+          返回首页
+        </button>
         <div className="w-full max-w-md text-center">
           <BookOpen className="mx-auto mb-5 text-cyan-300" size={36} />
           <h1 className="text-xl font-semibold">
@@ -653,16 +677,29 @@ export function LearningPage() {
             <>
               <p className="mt-3 text-sm leading-6 text-white/55">
                 {skillState === "outdated"
-                  ? "学习课堂需要 learning-coach 0.8.4 或更高版本；更新后请重启 Gateway。"
-                  : "学习页依赖这套教学与记忆规则；安装后请按提示重启 Gateway。"}
+                  ? "学习课堂需要 learning-coach 0.8.4 或更高版本。更新后回到这里重新检查；如提示需重启 Gateway，按提示操作即可。"
+                  : skillState === "missing"
+                    ? "学习课堂由 learning-coach 教学技能驱动。前往 设置 → Skills 安装后回到这里重新检查；如提示需重启 Gateway，按提示操作即可。"
+                    : "可能是网络或服务暂时不可用，请稍后重新检查。"}
               </p>
-              <button
-                type="button"
-                onClick={() => navigate("/settings?tab=skills")}
-                className="mt-6 rounded-full bg-white px-5 py-3 text-sm font-medium text-black"
-              >
-                打开 Skill 设置
-              </button>
+              <div className="mt-6 flex items-center justify-center gap-3">
+                {(skillState === "missing" || skillState === "outdated") && (
+                  <button
+                    type="button"
+                    onClick={() => navigate("/settings?tab=skills")}
+                    className="rounded-full bg-white px-5 py-3 text-sm font-medium text-black"
+                  >
+                    打开 Skill 设置
+                  </button>
+                )}
+                <button
+                  type="button"
+                  onClick={recheckSkill}
+                  className="rounded-full border border-white/20 px-5 py-3 text-sm font-medium text-white/80 transition hover:border-white/40 hover:text-white"
+                >
+                  重新检查
+                </button>
+              </div>
             </>
           )}
         </div>

--- a/src/pages/home-page.tsx
+++ b/src/pages/home-page.tsx
@@ -244,6 +244,7 @@ type LauncherTab = "all" | "shared" | "archive";
 
 function WarmWorkbenchHomePage() {
   const navigate = useNavigate();
+  const { authStatus } = useAuth();
   const { projects, toggleFavorite, setArchived } = useProjects();
   const { create: createDeck } = useSlidesProjects();
   const [chooserOpen, setChooserOpen] = useState(false);
@@ -253,6 +254,10 @@ function WarmWorkbenchHomePage() {
   const recentProjects = projects.filter((p) => !p.archived).slice(0, 12);
   const archivedProjects = projects.filter((p) => p.archived).slice(0, 12);
   const favoriteProjects = projects.filter((p) => p.favorite && !p.archived);
+  // Solo is single-user by definition — "Shared with Me" can never have
+  // content there, so don't offer the dead tab.
+  const isSolo = authStatus?.local_solo_enabled ?? false;
+  const isFirstRun = projects.length === 0;
 
   const startStudioSession = () => {
     const id = `web-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
@@ -337,11 +342,12 @@ function WarmWorkbenchHomePage() {
         <main className="mx-auto flex w-full max-w-[1024px] flex-col gap-16 px-10 py-14 max-sm:px-4">
           <header className="flex flex-col items-center gap-3 text-center">
             <h1 className="studio-display text-5xl max-sm:text-4xl">
-              Octos Home
+              {isFirstRun ? "Welcome to Octos" : "Octos Home"}
             </h1>
             <p className="max-w-2xl text-lg text-muted">
-              Your digital sanctuary for deep work. Organize, collaborate, and
-              launch your next big idea.
+              {isFirstRun
+                ? "Your AI workbench is ready. Pick a starting point below — or just open Chat and ask for anything."
+                : "Your digital sanctuary for deep work. Organize, collaborate, and launch your next big idea."}
             </p>
           </header>
 
@@ -359,7 +365,7 @@ function WarmWorkbenchHomePage() {
                 Create new project
               </span>
               <span className="block text-sm text-muted">
-                Start with a blank canvas or choose a template.
+                Three ways to start — pick whichever fits.
               </span>
             </button>
             {chooserOpen && (
@@ -368,6 +374,8 @@ function WarmWorkbenchHomePage() {
                   type="button"
                   onClick={startStudioSession}
                   className="studio-skill-tile"
+                  aria-label="Studio session"
+                  aria-describedby="tile-desc-studio"
                 >
                   <span className="studio-skill-tile-icon">
                     <Sparkles size={18} aria-hidden="true" />
@@ -375,26 +383,49 @@ function WarmWorkbenchHomePage() {
                   <span className="studio-skill-tile-label">
                     Studio session
                   </span>
+                  <span
+                    id="tile-desc-studio"
+                    className="mt-1 block text-xs font-normal normal-case tracking-normal text-muted"
+                  >
+                    A full AI workspace for open-ended work — chat, files, and
+                    artifacts side by side.
+                  </span>
                 </button>
                 <button
                   type="button"
                   onClick={startSlideDeck}
                   className="studio-skill-tile"
+                  aria-label="Slide deck"
+                  aria-describedby="tile-desc-slides"
                 >
                   <span className="studio-skill-tile-icon">
                     <Presentation size={18} aria-hidden="true" />
                   </span>
                   <span className="studio-skill-tile-label">Slide deck</span>
+                  <span
+                    id="tile-desc-slides"
+                    className="mt-1 block text-xs font-normal normal-case tracking-normal text-muted"
+                  >
+                    Build a presentation with AI, then edit and present it.
+                  </span>
                 </button>
                 <button
                   type="button"
                   onClick={() => navigate("/sites")}
                   className="studio-skill-tile"
+                  aria-label="Site"
+                  aria-describedby="tile-desc-site"
                 >
                   <span className="studio-skill-tile-icon">
                     <Globe size={18} aria-hidden="true" />
                   </span>
                   <span className="studio-skill-tile-label">Site</span>
+                  <span
+                    id="tile-desc-site"
+                    className="mt-1 block text-xs font-normal normal-case tracking-normal text-muted"
+                  >
+                    Create a website or landing page from a prompt.
+                  </span>
                 </button>
               </div>
             )}
@@ -411,15 +442,17 @@ function WarmWorkbenchHomePage() {
               >
                 All Projects
               </button>
-              <button
-                type="button"
-                className="studio-tab"
-                data-active={tab === "shared"}
-                aria-pressed={tab === "shared"}
-                onClick={() => setTab("shared")}
-              >
-                Shared with Me
-              </button>
+              {!isSolo && (
+                <button
+                  type="button"
+                  className="studio-tab"
+                  data-active={tab === "shared"}
+                  aria-pressed={tab === "shared"}
+                  onClick={() => setTab("shared")}
+                >
+                  Shared with Me
+                </button>
+              )}
               <button
                 type="button"
                 className="studio-tab"


### PR DESCRIPTION
## Why

A 28-scene walkthrough of the onboarding flow (first-run solo, returning user, token, OTP, scoped profile, mobile, server errors) found the first-run path broken and the login page overloaded:

- **Real bug**: the solo 404 fallthrough matched `err.message.includes("404")`, but the error message is the response *body* — a JSON error body from any proxy broke first-run entirely (user sees raw JSON, dead end).
- First run asked for name **and** username **and** email (the email is never used — solo sends no codes), with no validation feedback and no Enter-to-submit.
- The login page rendered five competing blocks: bootstrap banner, solo button, email divider, OTP/token tabs, and a **dead email form** (with a nearly unreadable low-contrast warning) when email login was disabled.
- Post-login: no welcome, the top bar showed the derived placeholder email instead of the name the user just typed, and solo users saw an always-empty "Shared with Me" tab.

## What

**Structured errors**
- `ApiError` carries the HTTP status; `request` / `publicRequest` / `requestBlob` all throw it, parsing `{error, message, detail}` out of JSON bodies. Callers branch on `status`, not message text.

**First-run solo** (paired with octos-org/octos#1905)
- `solo_profile_exists === false` → the single-field create form renders directly ("What should we call you?"), no doomed request. The 404 fallthrough stays for older backends.
- Real `<form>` (Enter submits), autoFocus, blur-touched length hint; username/email derived server-side.

**Login hierarchy**
- While `authStatus` probes: "Checking sign-in options…" instead of flashing a default method set.
- Only server-enabled methods render; token login demoted behind a "Use an auth token" text link; friendly 401/403 copy ("That token didn't work — check it and try again.").
- OTP code step: autoFocus, `inputMode=numeric`, `autoComplete=one-time-code`, digit filtering, 30s resend countdown.

**Post-login**
- Zero-project users get a "Welcome to Octos" header; chooser tiles carry one-line descriptions (aria-label + aria-describedby keeps accessible names short).
- Top bar shows `user.name`; solo users don't see the Shared tab.
- AuthGuard loading is a themed branded splash (logo pulse + "Loading…") instead of hard-coded dark "Loading...".

**/learn gate**
- The full-screen "install learning-coach" wall gained a way back home, an explanation of what to install and where, and a "重新检查" button (no manual page reload).

## Verification

- 117 test files / **761 tests pass**; `tsc --noEmit` clean; eslint: no new issues (2 pre-existing in auth-context.tsx, present on a clean tree).
- 16-frame Playwright regression (real backend + mocked states + mobile 390px + OTP full flow + scoped profile), every frame reviewed; programmatic assertions for the JSON-404 fallthrough, resend countdown, autofocus, digit filtering, and scoped-profile token hiding.

🤖 Generated with [Claude Code](https://claude.com/claude-code)