### PR TITLE
fix(chat): guide first-run users past the no-model dead end

### DIFF
--- a/src/api/client.ts
+++ b/src/api/client.ts
@@ -236,7 +236,7 @@ export async function request<T>(
       clearToken();
       // Redirect to login unless already there
       if (!window.location.pathname.endsWith("/login")) {
-        window.location.href = "/login?redirect=" + encodeURIComponent(window.location.pathname);
+        window.location.href = "/login?redirect=" + encodeURIComponent(window.location.pathname + window.location.search);
       }
     }
     const text = await resp.text();

--- a/src/auth/auth-guard.test.tsx
+++ b/src/auth/auth-guard.test.tsx
@@ -1,0 +1,61 @@
+import { cleanup, render, screen } from "@testing-library/react";
+import { MemoryRouter, Route, Routes, useLocation } from "react-router-dom";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { AuthGuard } from "./auth-guard";
+
+const authMocks = vi.hoisted(() => ({
+  token: null as string | null,
+  loading: false,
+}));
+
+vi.mock("./auth-context", () => ({
+  useAuth: () => ({ token: authMocks.token, loading: authMocks.loading }),
+}));
+
+function LoginProbe() {
+  const location = useLocation();
+  return (
+    <div data-testid="login-probe">{location.pathname + location.search}</div>
+  );
+}
+
+function renderGuard(initialPath: string) {
+  render(
+    <MemoryRouter initialEntries={[initialPath]}>
+      <Routes>
+        <Route path="/login" element={<LoginProbe />} />
+        <Route element={<AuthGuard />}>
+          <Route path="/" element={<div>home page</div>} />
+          <Route path="/chat" element={<div>chat page</div>} />
+        </Route>
+      </Routes>
+    </MemoryRouter>,
+  );
+}
+
+describe("AuthGuard", () => {
+  afterEach(() => {
+    cleanup();
+    authMocks.token = null;
+    authMocks.loading = false;
+  });
+
+  it("bounces unauthenticated deep links to /login with the destination preserved", () => {
+    renderGuard("/chat?topic=design");
+    expect(screen.getByTestId("login-probe").textContent).toBe(
+      `/login?redirect=${encodeURIComponent("/chat?topic=design")}`,
+    );
+  });
+
+  it("bounces the home path without a redundant redirect param", () => {
+    renderGuard("/");
+    expect(screen.getByTestId("login-probe").textContent).toBe("/login");
+  });
+
+  it("renders the protected route when a token is present", () => {
+    authMocks.token = "tok";
+    renderGuard("/chat");
+    expect(screen.getByText("chat page")).toBeTruthy();
+  });
+});

--- a/src/auth/auth-guard.tsx
+++ b/src/auth/auth-guard.tsx
@@ -1,10 +1,11 @@
-import { Navigate, Outlet } from "react-router-dom";
+import { Navigate, Outlet, useLocation } from "react-router-dom";
 import { useAuth } from "./auth-context";
 
 const skipAuth = import.meta.env.VITE_SKIP_AUTH === "true";
 
 export function AuthGuard() {
   const { token, loading } = useAuth();
+  const location = useLocation();
 
   // Only skip auth when explicitly configured via VITE_SKIP_AUTH=true
   if (skipAuth) return <Outlet />;
@@ -26,7 +27,13 @@ export function AuthGuard() {
   }
 
   if (!token) {
-    return <Navigate to="/login" replace />;
+    // Preserve the destination so a deep link (bookmarked /chat, a shared
+    // studio URL, …) survives the sign-in detour. LoginPage validates the
+    // `redirect` param (same-origin paths only) before honoring it.
+    const from = `${location.pathname}${location.search}`;
+    const to =
+      from === "/" ? "/login" : `/login?redirect=${encodeURIComponent(from)}`;
+    return <Navigate to={to} replace />;
   }
 
   return <Outlet />;

--- a/src/components/GhostBubble.test.tsx
+++ b/src/components/GhostBubble.test.tsx
@@ -200,4 +200,80 @@ describe("GhostBubble", () => {
     ).toContain("Send not confirmed");
     harness.unmount();
   });
+
+  it("strips the rpc-error protocol prefix from display but keeps it in the tooltip", () => {
+    const harness = mount(
+      <GhostBubble
+        clientMessageId="cmid-prefixed"
+        text="hi"
+        files={[]}
+        sessionId={sessionId}
+        failure="rpc-error[-32603] turn/start rejected by gateway"
+        onSettle={() => {}}
+      />,
+    );
+    const row = harness.container.querySelector(
+      '[data-testid="ghost-bubble-error"]',
+    );
+    expect(row?.textContent).toContain("turn/start rejected by gateway");
+    expect(row?.textContent).not.toContain("rpc-error[");
+    expect(row?.querySelector("span")?.getAttribute("title")).toContain(
+      "rpc-error[-32603]",
+    );
+    harness.unmount();
+  });
+
+  it("turns a missing-runtime failure into setup guidance with a settings link", () => {
+    const onRetry = vi.fn();
+    const harness = mount(
+      <GhostBubble
+        clientMessageId="cmid-no-model"
+        text="hello"
+        files={[]}
+        sessionId={sessionId}
+        failure="rpc-error[-32603] No ProfileRuntime registered for profile 'yao'. Set up the profile with an API key in the dashboard."
+        onSettle={() => {}}
+        onRetry={onRetry}
+      />,
+    );
+    const row = harness.container.querySelector(
+      '[data-testid="ghost-bubble-error"]',
+    );
+    // Friendly copy replaces the internal jargon…
+    expect(row?.textContent).toContain("No model is set up");
+    expect(row?.textContent).not.toContain("ProfileRuntime");
+    expect(row?.textContent).not.toContain("rpc-error[");
+    // …and the primary action deep-links into the LLM settings tab.
+    const link = row?.querySelector(
+      '[data-testid="ghost-bubble-setup-link"]',
+    ) as HTMLAnchorElement | null;
+    expect(link?.getAttribute("href")).toBe("/settings?tab=llm");
+    // Retry stays available (it succeeds once a key is saved).
+    expect(row?.querySelector('[data-testid="ghost-bubble-retry"]')).not.toBeNull();
+    harness.unmount();
+  });
+
+  it("offers the same setup guidance on a settled terminal failure", () => {
+    const harness = mount(
+      <GhostBubble
+        clientMessageId="cmid-terminal-no-model"
+        text="hi"
+        files={[]}
+        sessionId={sessionId}
+        settled
+        failure="rpc-error[-32603] No ProfileRuntime registered for profile 'yao'."
+        onSettle={() => {}}
+      />,
+    );
+    const row = harness.container.querySelector(
+      '[data-testid="ghost-bubble-terminal-error"]',
+    );
+    expect(row?.textContent).toContain("No model is set up");
+    expect(
+      row
+        ?.querySelector('[data-testid="ghost-bubble-setup-link"]')
+        ?.getAttribute("href"),
+    ).toBe("/settings?tab=llm");
+    harness.unmount();
+  });
 });

--- a/src/components/GhostBubble.tsx
+++ b/src/components/GhostBubble.tsx
@@ -96,6 +96,24 @@ function formatGhostTimestamp(ts: number): string {
   return `${d.getFullYear()}-${pad(d.getMonth() + 1)}-${pad(d.getDate())} ${pad(d.getHours())}:${pad(d.getMinutes())}:${pad(d.getSeconds())}`;
 }
 
+/** Backend RPC failures arrive as `rpc-error[code] message`. The protocol
+ *  prefix is noise for users — strip it for display (the full raw string
+ *  stays in the `title` tooltip for debugging). */
+function displayFailureMessage(raw: string): string {
+  return raw.replace(/^rpc-error\[[^\]]+\]\s*/, "");
+}
+
+/** "No ProfileRuntime registered" means the profile has no model/API key —
+ *  a setup gap, not a transient send failure. Point the user at the fix
+ *  (Settings → LLM) instead of leaving them with jargon and a Retry that
+ *  can only fail again. */
+const MODEL_NOT_CONFIGURED = /No ProfileRuntime registered/i;
+
+/** Deep link into the LLM settings tab. A plain anchor (not router `<Link>`)
+ *  keeps this component renderable outside a Router in tests; leaving the
+ *  page is harmless here because the session state reloads from the server. */
+const LLM_SETTINGS_HREF = "/settings?tab=llm";
+
 // ---------------------------------------------------------------------------
 // Component
 // ---------------------------------------------------------------------------
@@ -217,24 +235,53 @@ export function GhostBubble({
     </>
   ) : null;
 
-  const failureMessage = failure ?? (timedOut ? "Send not confirmed within 30s." : null);
+  const rawFailure = failure ?? (timedOut ? "Send not confirmed within 30s." : null);
+  const modelMissing = rawFailure ? MODEL_NOT_CONFIGURED.test(rawFailure) : false;
+  const failureMessage = rawFailure
+    ? modelMissing
+      ? "No model is set up for this profile yet — add a provider and API key to start chatting."
+      : displayFailureMessage(rawFailure)
+    : null;
+
+  // "Set up a model" is the primary action when configuration is the
+  // problem; Retry stays (it works once a key is saved) but steps back to
+  // a quieter outline so it no longer invites a guaranteed re-failure.
+  const errorActions = (
+    <>
+      {modelMissing && (
+        <a
+          data-testid="ghost-bubble-setup-link"
+          href={LLM_SETTINGS_HREF}
+          className="shrink-0 rounded-md bg-red-600 px-2 py-0.5 text-[11px] font-medium text-white hover:bg-red-700"
+        >
+          Set up a model
+        </a>
+      )}
+      {onRetry && (
+        <button
+          data-testid="ghost-bubble-retry"
+          type="button"
+          onClick={handleRetry}
+          className={
+            modelMissing
+              ? "shrink-0 rounded-md border border-red-500/40 px-2 py-0.5 text-[11px] font-medium hover:bg-red-500/10"
+              : "shrink-0 rounded-md bg-red-600 px-2 py-0.5 text-[11px] font-medium text-white hover:bg-red-700"
+          }
+        >
+          Retry
+        </button>
+      )}
+    </>
+  );
+
   const trailing = failureMessage ? (
     <div
       data-testid="ghost-bubble-error"
       role="alert"
       className="mt-1.5 flex items-center gap-2 rounded-[10px] border border-red-500/20 bg-red-500/12 px-3 py-1.5 text-[11px] text-red-400"
     >
-      <span>{failureMessage}</span>
-      {onRetry && (
-        <button
-          data-testid="ghost-bubble-retry"
-          type="button"
-          onClick={handleRetry}
-          className="rounded-md bg-red-600 px-2 py-0.5 text-[11px] font-medium text-white hover:bg-red-700"
-        >
-          Retry
-        </button>
-      )}
+      <span title={rawFailure ?? undefined}>{failureMessage}</span>
+      {errorActions}
     </div>
   ) : null;
 
@@ -248,17 +295,8 @@ export function GhostBubble({
         role="alert"
         className="mx-4 mt-2 flex items-center gap-2 rounded-[10px] border border-red-500/20 bg-red-500/12 px-3 py-1.5 text-[11px] text-red-400"
       >
-        <span>{failureMessage}</span>
-        {onRetry && (
-          <button
-            data-testid="ghost-bubble-retry"
-            type="button"
-            onClick={handleRetry}
-            className="rounded-md bg-red-600 px-2 py-0.5 text-[11px] font-medium text-white hover:bg-red-700"
-          >
-            Retry
-          </button>
-        )}
+        <span title={rawFailure ?? undefined}>{failureMessage}</span>
+        {errorActions}
       </div>
     );
   }


### PR DESCRIPTION
## What broke (found by re-walking the solo first-run journey)

**1. Deep links died at the login wall.** `AuthGuard` bounced to bare `/login`, so a bookmarked `/chat` (or any protected URL) dumped the user on the home page after sign-in instead of where they were headed.

**2. First chat message hit a jargon dead end.** A first-run solo profile has no model configured, so the very first message failed with:

> `rpc-error[-32603] No ProfileRuntime registered for profile 'yao'. Set up the profile with an API key in the dashboard.`

…plus a **Retry** button that could only fail again, and no path to the fix.

## Fixes

- `AuthGuard` preserves the destination via the existing `?redirect=` param (LoginPage already validates it: same-origin paths only, `//` rejected). The 401 reaper in `api/client.ts` now includes the query string too.
- `GhostBubble` strips the `rpc-error[code]` protocol prefix from display (full string stays in the `title` tooltip), and maps the missing-runtime failure to plain guidance — *"No model is set up for this profile yet — add a provider and API key to start chatting."* — with a primary **Set up a model** action deep-linking to `/settings?tab=llm`. Retry remains as a secondary action (it succeeds once a key is saved).

## Verification

- 776 vitest green (incl. 6 new: prefix stripping, setup guidance on both ghost error variants, redirect preservation in AuthGuard)
- tsc + eslint clean
- Frame-by-frame Playwright regression: friendly error → click **Set up a model** → lands on Settings → LLM provider picker; logged-out `/chat` → login → lands back on `/chat`

🤖 Generated with [Claude Code](https://claude.com/claude-code)