### PR TITLE
ci: unify action versions; fix all eslint errors and gate lint in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,12 +19,15 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 20
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: pnpm/action-setup@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
           node-version: 22
           cache: pnpm
       - run: pnpm install --frozen-lockfile
+      # eslint exits nonzero only on errors; the react-hooks v6 strict rules
+      # are intentionally warnings (see eslint.config.js).
+      - run: pnpm lint
       - run: pnpm test:unit
       - run: pnpm run build

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -18,9 +18,9 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: pnpm/action-setup@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
           node-version: 22
           cache: pnpm
@@ -33,10 +33,10 @@ jobs:
       # Build mdBook
       - uses: peaceiris/actions-mdbook@v2
         with:
-          mdbook-version: latest
+          mdbook-version: '0.5.4'
       - run: mdbook build book
       - run: mv book/build dist/book
-      - uses: actions/upload-pages-artifact@v3
+      - uses: actions/upload-pages-artifact@v4
         with:
           path: dist
 

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -19,5 +19,20 @@ export default defineConfig([
       ecmaVersion: 2020,
       globals: globals.browser,
     },
+    rules: {
+      // eslint-plugin-react-hooks v6 folded the React Compiler strict rules
+      // into `recommended`. This codebase predates them, and fixing ~87 hits
+      // properly means restructuring effects one by one. Keep them visible
+      // as warnings (ratchet: fix a rule, then restore it to 'error') while
+      // the classic bug-catching rules (rules-of-hooks, exhaustive-deps)
+      // stay errors and gate CI.
+      'react-hooks/set-state-in-effect': 'warn',
+      'react-hooks/refs': 'warn',
+      'react-hooks/immutability': 'warn',
+      'react-hooks/purity': 'warn',
+      'react-hooks/static-components': 'warn',
+      // Fast-refresh ergonomics, not correctness.
+      'react-refresh/only-export-components': 'warn',
+    },
   },
 ])

--- a/src/components/markdown-renderer.tsx
+++ b/src/components/markdown-renderer.tsx
@@ -1,5 +1,5 @@
-import { Component, memo, useEffect, useRef, useState, type ReactNode, type ErrorInfo } from "react";
-import ReactMarkdown from "react-markdown";
+import { Component, memo, useEffect, useRef, useState, type ComponentProps, type ReactNode, type ErrorInfo } from "react";
+import ReactMarkdown, { type Components } from "react-markdown";
 import remarkGfm from "remark-gfm";
 import remarkMath from "remark-math";
 import rehypeKatex from "rehype-katex";
@@ -89,8 +89,8 @@ class MarkdownErrorBoundary extends Component<{ children: ReactNode; fallback: s
 const remarkPlugins = [remarkGfm, remarkMath];
 const rehypePlugins = [rehypeKatex];
 
-const mdComponents: Record<string, any> = {
-  img: ({ src, alt }: any) => {
+const mdComponents: Components = {
+  img: ({ src, alt }) => {
     if (!src) return null;
     return (
       <a href={src} target="_blank" rel="noopener noreferrer" className="block my-2">
@@ -98,7 +98,7 @@ const mdComponents: Record<string, any> = {
       </a>
     );
   },
-  a: ({ href, children }: any) => {
+  a: ({ href, children }) => {
     if (!href) return <>{children}</>;
     if (/\.(mp3|wav|ogg|webm|m4a|aac|flac)$/i.test(href))
       return <a href={href} download className="inline-flex items-center gap-1 rounded-md bg-surface-light px-2 py-1 text-xs text-link hover:bg-accent/20 hover:text-accent"><Download size={12} />🎵 {children}</a>;
@@ -108,35 +108,37 @@ const mdComponents: Record<string, any> = {
       return <a href={href} download className="inline-flex items-center gap-1 rounded-md bg-surface-light px-2 py-1 text-xs text-link hover:bg-accent/20 hover:text-accent"><Download size={12} />{children}</a>;
     return <a href={href} target="_blank" rel="noopener noreferrer" className="text-link hover:text-accent hover:underline">{children}</a>;
   },
-  pre: ({ children }: any) => <>{children}</>,
-  code: ({ children, className: cn, inline }: any) => {
+  pre: ({ children }) => <>{children}</>,
+  // react-markdown v10 no longer passes `inline`, but keep accepting it so
+  // the branch below stays truthful if a plugin reintroduces the prop.
+  code: ({ children, className: cn, inline }: ComponentProps<"code"> & { inline?: boolean }) => {
     if (inline || (!cn && typeof children === "string" && !children.includes("\n"))) {
       return <code className="rounded bg-code-inline/15 px-1.5 py-0.5 text-xs text-code-inline">{children}</code>;
     }
     return <CodeBlock className={cn}>{children}</CodeBlock>;
   },
-  table: ({ children }: any) => (
+  table: ({ children }) => (
     <div className="my-3 overflow-x-auto rounded-lg bg-surface-container"><table className="min-w-full text-xs">{children}</table></div>
   ),
-  th: ({ children }: any) => <th className="border-b border-outline bg-surface-elevated px-4 py-2 text-left font-medium text-text-strong">{children}</th>,
-  td: ({ children }: any) => <td className="border-b border-border px-4 py-2">{children}</td>,
-  p: ({ children }: any) => <p className="mb-3 last:mb-0 leading-relaxed">{children}</p>,
-  ul: ({ children }: any) => <ul className="mb-3 list-disc pl-5 space-y-1">{children}</ul>,
-  ol: ({ children }: any) => <ol className="mb-3 list-decimal pl-5 space-y-1">{children}</ol>,
-  li: ({ children }: any) => <li className="leading-relaxed">{children}</li>,
-  h1: ({ children }: any) => <h1 className="mb-3 mt-5 text-xl font-bold text-heading-accent border-b-2 border-accent-dim pb-1">{children}</h1>,
-  h2: ({ children }: any) => <h2 className="mb-2 mt-4 text-lg font-bold text-heading">{children}</h2>,
-  h3: ({ children }: any) => <h3 className="mb-2 mt-3 text-base font-semibold text-heading">{children}</h3>,
-  h4: ({ children }: any) => <h4 className="mb-1 mt-2 text-sm font-semibold text-text-strong">{children}</h4>,
-  blockquote: ({ children }: any) => (
+  th: ({ children }) => <th className="border-b border-outline bg-surface-elevated px-4 py-2 text-left font-medium text-text-strong">{children}</th>,
+  td: ({ children }) => <td className="border-b border-border px-4 py-2">{children}</td>,
+  p: ({ children }) => <p className="mb-3 last:mb-0 leading-relaxed">{children}</p>,
+  ul: ({ children }) => <ul className="mb-3 list-disc pl-5 space-y-1">{children}</ul>,
+  ol: ({ children }) => <ol className="mb-3 list-decimal pl-5 space-y-1">{children}</ol>,
+  li: ({ children }) => <li className="leading-relaxed">{children}</li>,
+  h1: ({ children }) => <h1 className="mb-3 mt-5 text-xl font-bold text-heading-accent border-b-2 border-accent-dim pb-1">{children}</h1>,
+  h2: ({ children }) => <h2 className="mb-2 mt-4 text-lg font-bold text-heading">{children}</h2>,
+  h3: ({ children }) => <h3 className="mb-2 mt-3 text-base font-semibold text-heading">{children}</h3>,
+  h4: ({ children }) => <h4 className="mb-1 mt-2 text-sm font-semibold text-text-strong">{children}</h4>,
+  blockquote: ({ children }) => (
     <blockquote className="my-3 border-l-3 border-blockquote-border pl-4 text-muted italic">{children}</blockquote>
   ),
   hr: () => <hr className="my-4 border-border" />,
-  strong: ({ children }: any) => <strong className="font-semibold text-text-strong">{children}</strong>,
-  em: ({ children }: any) => <em className="italic">{children}</em>,
-  del: ({ children }: any) => <del className="text-muted line-through">{children}</del>,
+  strong: ({ children }) => <strong className="font-semibold text-text-strong">{children}</strong>,
+  em: ({ children }) => <em className="italic">{children}</em>,
+  del: ({ children }) => <del className="text-muted line-through">{children}</del>,
   // Task list checkboxes (GFM)
-  input: ({ checked, ...props }: any) => (
+  input: ({ checked, ...props }) => (
     <input type="checkbox" checked={checked} readOnly className="mr-1.5 accent-accent" {...props} />
   ),
 };

--- a/src/runtime/use-mode-state.test.tsx
+++ b/src/runtime/use-mode-state.test.tsx
@@ -10,7 +10,7 @@
 import { afterEach, describe, expect, it } from "vitest";
 import * as React from "react";
 import { act } from "react";
-import { createRoot, type Root } from "react-dom/client";
+import { createRoot } from "react-dom/client";
 import { useModeState } from "./session-context";
 
 (globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT =

--- a/src/sites/components/sites-task-status-indicator.tsx
+++ b/src/sites/components/sites-task-status-indicator.tsx
@@ -14,7 +14,6 @@ function isActiveStatus(status: BackgroundTaskInfo["status"]): boolean {
 export function SitesTaskStatusIndicator({
   sessionId,
   historyTopic,
-  profileId: _profileId,
 }: {
   sessionId: string;
   historyTopic?: string;

--- a/src/store/content-store.ts
+++ b/src/store/content-store.ts
@@ -25,13 +25,11 @@ let total = 0;
 let loading = false;
 let error: string | null = null;
 let currentFilters: ContentFilters = {};
-let version = 0;
 
 const listeners = new Set<() => void>();
 let snapshot: { entries: ContentEntry[]; total: number; loading: boolean; error: string | null } = { entries, total, loading, error };
 
 function notify() {
-  version++;
   snapshot = { entries: [...entries], total, loading, error };
   listeners.forEach((fn) => fn());
 }
@@ -113,7 +111,10 @@ export function initContentStore(filters: ContentFilters = {}) {
 if (typeof window !== "undefined") {
   window.addEventListener("crew:file", () => {
     // Debounce: wait 2s for potential batch of files
-    clearTimeout((window as any).__contentRefreshTimer);
-    (window as any).__contentRefreshTimer = setTimeout(refreshContent, 2000);
+    const w = window as unknown as {
+      __contentRefreshTimer?: ReturnType<typeof setTimeout>;
+    };
+    clearTimeout(w.__contentRefreshTimer);
+    w.__contentRefreshTimer = setTimeout(refreshContent, 2000);
   });
 }

--- a/src/tools/generic-tool.tsx
+++ b/src/tools/generic-tool.tsx
@@ -14,6 +14,7 @@ export const GenericToolUI = makeAssistantToolUI<
 >({
   toolName: "*",
   render: ({ args, result, status, toolName }) => {
+    // eslint-disable-next-line react-hooks/rules-of-hooks -- assistant-ui invokes this render prop as a component; the hook call is unconditional
     const [expanded, setExpanded] = useState(status.type === "running");
 
     return (

--- a/src/tools/shell-tool.tsx
+++ b/src/tools/shell-tool.tsx
@@ -15,6 +15,7 @@ export const ShellToolUI = makeAssistantToolUI<
 >({
   toolName: "shell",
   render: ({ args, result, status }) => {
+    // eslint-disable-next-line react-hooks/rules-of-hooks -- assistant-ui invokes this render prop as a component; the hook call is unconditional
     const [expanded, setExpanded] = useState(status.type === "running");
     const command = args?.command ?? "...";
     const output = result?.output ?? "";

--- a/tests/audio-autoplay.spec.ts
+++ b/tests/audio-autoplay.spec.ts
@@ -35,15 +35,18 @@ test("audio files do NOT auto-play on page load or after delivery", async ({
 
   // Inject a MutationObserver to catch ALL audio elements and monitor play events
   await page.evaluate(() => {
+    type AudioPlayReporter = Window & {
+      __reportAudioPlay: (src: string) => void;
+    };
     function monitorAudio(audio: HTMLAudioElement) {
       const origPlay = audio.play.bind(audio);
       audio.play = function () {
-        (window as any).__reportAudioPlay(audio.src || audio.currentSrc || "unknown");
+        (window as AudioPlayReporter).__reportAudioPlay(audio.src || audio.currentSrc || "unknown");
         return origPlay();
       };
       // Also listen for the 'play' event (catches autoplay)
       audio.addEventListener("play", () => {
-        (window as any).__reportAudioPlay(
+        (window as AudioPlayReporter).__reportAudioPlay(
           `[event] ${audio.src || audio.currentSrc || "unknown"}`,
         );
       });

--- a/tests/background-task-scope.spec.ts
+++ b/tests/background-task-scope.spec.ts
@@ -1,5 +1,5 @@
 import { expect, test } from "@playwright/test";
-import { login, createNewSession, SEL } from "./helpers";
+import { login, createNewSession } from "./helpers";
 
 test.describe("background task scoping", () => {
   test("failed task notification stays in its originating session", async ({ page }) => {

--- a/tests/chat-fixes.spec.ts
+++ b/tests/chat-fixes.spec.ts
@@ -19,8 +19,6 @@ import {
   countAssistantBubbles
 } from "./helpers";
 
-const BASE_URL = process.env.BASE_URL || "http://localhost:5174";
-
 test.beforeEach(async ({ page }) => {
   await login(page);
   await createNewSession(page);
@@ -40,7 +38,6 @@ test("IME guard: isComposing check exists in keydown handler", async ({
     // by testing the actual behavior: compositionstart sets isComposing=true
     // on subsequent keydown events in real browsers.
     // Here we verify the textarea has the onKeyDown handler attached.
-    const events = (el as any).__reactEvents || {};
     return el.hasAttribute("data-testid"); // basic sanity check
   });
   expect(hasGuard).toBe(true);

--- a/tests/concurrent-messages.spec.ts
+++ b/tests/concurrent-messages.spec.ts
@@ -8,13 +8,10 @@
 import { test, expect } from "@playwright/test";
 import {
   login,
-  sendAndWait,
   SEL,
   createNewSession,
   getInput,
-  getSendButton,
-  markLogPosition,
-  adminShell
+  getSendButton
 } from "./helpers";
 
 /** Get all message bubbles with role and text. */

--- a/tests/deep-research.spec.ts
+++ b/tests/deep-research.spec.ts
@@ -1,5 +1,5 @@
 import { test, expect } from "@playwright/test";
-import { login, sendAndWait, SEL } from "./helpers";
+import { login, sendAndWait } from "./helpers";
 
 test.describe("Deep research pipeline", () => {
   test.setTimeout(900_000); // 10 min — pipelines are slow
@@ -10,9 +10,6 @@ test.describe("Deep research pipeline", () => {
 
   test("pipeline executes and produces structured output", async ({ page }) => {
     // Solo-mode servers have no pipeline daemon — skip gracefully.
-    const soloToken = process.env.AUTH_TOKEN || process.env.OCTOS_AUTH_TOKEN || "";
-    const baseUrl = process.env.BASE_URL || "http://127.0.0.1:5173";
-
     // Probe: send a pipeline-ish prompt and check if the server actually
     // routes it to a pipeline tool (indicated by a tool-call chip or
     // progress bar appearing). On solo servers with no pipeline config,

--- a/tests/file-upload.spec.ts
+++ b/tests/file-upload.spec.ts
@@ -1,5 +1,5 @@
 import { test, expect } from "@playwright/test";
-import { login, sendAndWait, createNewSession, SEL } from "./helpers";
+import { login, sendAndWait, createNewSession } from "./helpers";
 import path from "node:path";
 import fs from "node:fs";
 import { fileURLToPath } from "node:url";

--- a/tests/helpers.ts
+++ b/tests/helpers.ts
@@ -1,4 +1,4 @@
-import { type Page, type Route, expect, test } from "@playwright/test";
+import { type Page, type Route } from "@playwright/test";
 
 const AUTH_TOKEN = process.env.AUTH_TOKEN || "e2e-test-2026";
 const ADMIN_TOKEN = process.env.ADMIN_TOKEN || "octos-admin-2026";
@@ -1300,7 +1300,10 @@ export async function getLogsSince(
   if (!result?.stdout) return [];
   return result.stdout
     .split("\n")
-    .map((line) => line.replace(/\x1b\[[0-9;]*m/g, "").trim())
+    .map((line) =>
+      // eslint-disable-next-line no-control-regex -- deliberately strips ANSI escape sequences from server log lines
+      line.replace(/\x1b\[[0-9;]*m/g, "").trim(),
+    )
     .filter(Boolean);
 }
 

--- a/tests/m10-harden-reload-midstream.spec.ts
+++ b/tests/m10-harden-reload-midstream.spec.ts
@@ -56,7 +56,9 @@ function attachWsTap(page: import("@playwright/test").Page) {
         ) {
           frames.push({ dir: "<", method: m, ts: Date.now(), sample: s.slice(0, 240) });
         }
-      } catch {}
+      } catch {
+        // Not a JSON frame (e.g. binary payload) — nothing to record.
+      }
     });
     ws.on("framesent", (data) => {
       const s = typeof data.payload === "string" ? data.payload : data.payload.toString("utf8");
@@ -66,7 +68,9 @@ function attachWsTap(page: import("@playwright/test").Page) {
         if (/turn\/start|session\/(open|hydrate)/.test(m)) {
           frames.push({ dir: ">", method: m, ts: Date.now(), sample: s.slice(0, 240) });
         }
-      } catch {}
+      } catch {
+        // Not a JSON frame (e.g. binary payload) — nothing to record.
+      }
     });
   });
   return frames;

--- a/tests/slides-workflow.spec.ts
+++ b/tests/slides-workflow.spec.ts
@@ -13,8 +13,6 @@ import {
   getInput,
   getSendButton,
   SEL,
-  countUserBubbles,
-  countAssistantBubbles,
   createNewSession
 } from "./helpers";
 
@@ -66,7 +64,6 @@ test("Round 1: /new slides creates project and agent follows design-first workfl
 test("Round 2: modify slide content before generating", async ({ page }) => {
   // Assume we're in a slides session from Round 1
   // First create a fresh project
-  const input = getInput(page);
   await issueSlidesCommand(page, "/new slides update-test");
 
   // Create initial 3-slide deck
@@ -98,7 +95,6 @@ test("Round 2: modify slide content before generating", async ({ page }) => {
 // ── Round 3: Generate PPTX ──────────────────────────────────────
 
 test("Round 3: generate PPTX on explicit command", async ({ page }) => {
-  const input = getInput(page);
   await issueSlidesCommand(page, "/new slides gen-test");
 
   // Create a minimal 2-slide deck
@@ -147,7 +143,6 @@ test("Round 3: generate PPTX on explicit command", async ({ page }) => {
 test("Round 4: incremental update deletes only changed slide PNG", async ({
   page
 }) => {
-  const input = getInput(page);
   await issueSlidesCommand(page, "/new slides delta-test");
 
   // Create and generate a 2-slide deck

--- a/tests/tts-file-delivery.spec.ts
+++ b/tests/tts-file-delivery.spec.ts
@@ -1,17 +1,27 @@
-import { test, expect, type Page } from "@playwright/test";
+import { test, expect } from "@playwright/test";
 import {
   login,
   sendAndWait,
-  SEL,
-  createNewSession,
   getInput,
   getSendButton,
   markLogPosition,
   assertLogContains,
-  assertLogDoesNotContain,
-  waitForLog,
-  adminShell
+  assertLogDoesNotContain
 } from "./helpers";
+
+/** Shape of the `crew:file` CustomEvent detail (mirrors
+ *  src/runtime/file-events.ts `dispatchCrewFileEvent`). */
+interface CapturedFileEvent {
+  fileUrl: string;
+  filename?: string;
+  caption?: string;
+  sessionId?: string;
+  topic?: string;
+}
+
+type FileEventWindow = Window & {
+  __capturedFileEvents?: CapturedFileEvent[];
+};
 
 test.describe("TTS file delivery", () => {
   test.beforeEach(async ({ page }) => {
@@ -29,13 +39,12 @@ test.describe("TTS file delivery", () => {
     console.log(`Log marker: ${logMark}`);
 
     // Capture crew:file DOM events
-    const fileEvents: any[] = [];
     await page.evaluate(() => {
-      (window as any).__capturedFileEvents = [];
+      (window as FileEventWindow).__capturedFileEvents = [];
       window.addEventListener("crew:file", (e: Event) => {
-        const detail = (e as CustomEvent).detail;
+        const detail = (e as CustomEvent<CapturedFileEvent>).detail;
         console.log("[test] crew:file event received:", JSON.stringify(detail));
-        (window as any).__capturedFileEvents.push(detail);
+        (window as FileEventWindow).__capturedFileEvents?.push(detail);
       });
     });
 
@@ -54,7 +63,7 @@ test.describe("TTS file delivery", () => {
     for (let i = 0; i < 20; i++) {
       await page.waitForTimeout(3000);
 
-      const events = await page.evaluate(() => (window as any).__capturedFileEvents);
+      const events = await page.evaluate(() => (window as FileEventWindow).__capturedFileEvents ?? []);
       console.log(`  ${i * 3}s: ${events.length} file events`);
 
       if (events.length > 0) {
@@ -72,8 +81,8 @@ test.describe("TTS file delivery", () => {
     expect(fileReceived).toBe(true);
 
     const uniqueFileUrls = await page.evaluate(() => {
-      const events = (window as any).__capturedFileEvents || [];
-      return [...new Set(events.map((event: any) => event.fileUrl))];
+      const events = (window as FileEventWindow).__capturedFileEvents ?? [];
+      return [...new Set(events.map((event) => event.fileUrl))];
     });
     expect(uniqueFileUrls).toHaveLength(1);
 

--- a/tests/tts-no-duplicates.spec.ts
+++ b/tests/tts-no-duplicates.spec.ts
@@ -11,8 +11,6 @@ import {
   sendAndWait,
   SEL,
   createNewSession,
-  getInput,
-  getSendButton,
   getRenderedAudioAttachments,
   getRenderedThreadBubbles
 } from "./helpers";


### PR DESCRIPTION
## Summary
- **Version unification**: checkout@v6, setup-node@v6, upload-pages-artifact@v4; mdbook pinned to `0.5.4` (was `latest`).
- **eslint 157 errors → 0**:
  - 63 real fixes: unused variables/imports across 10 test specs, `any` types in markdown-renderer replaced with react-markdown's `Components` typing, content-store cleanups.
  - react-hooks v6 folded the React Compiler strict rules into `recommended`; this codebase predates them (~87 hits). Downgraded to `warn` with a ratchet comment — fix a rule, restore it to `error`. The classic bug-catching rules (`rules-of-hooks`, `exhaustive-deps`) remain errors and gate CI.
  - 2 assistant-ui `makeAssistantToolUI({render})` render-prop false positives get targeted inline disables (assistant-ui invokes the render prop as a component; the hook call is unconditional).
- **`pnpm lint` added to CI** — it previously ran nowhere, which is how 157 errors accumulated invisibly.

## Test plan
- `pnpm lint`: 0 errors / 92 warnings, exit 0
- `pnpm test:unit`: 776/776 passed
- `pnpm build`: green
- [ ] This PR's own CI run is the end-to-end validation

🤖 Generated with [Claude Code](https://claude.com/claude-code)