### PR TITLE
feat(chat): warn about missing model before the first send

### DIFF
--- a/src/components/chat-thread.tsx
+++ b/src/components/chat-thread.tsx
@@ -69,6 +69,7 @@ import { ToolProgressIndicator } from "./tool-progress-indicator";
 import { useTasks } from "@/store/task-store";
 import { SPAWN_ONLY_TOOL_NAMES } from "@/runtime/spawn-only-tools";
 import { GhostBubble } from "./GhostBubble";
+import { ModelSetupNotice } from "./model-setup-notice";
 import { UserBubbleShell } from "./user-bubble-shell";
 import { CopyMarkdownButton } from "./copy-markdown-button";
 import { ReaderViewTrigger } from "./reader-view-trigger";
@@ -1507,6 +1508,7 @@ function ChatThreadV2({
           `hasRunningToolCall || showLiveIndicators`) and it still
           surfaces for spawn_only — just anchored where the user
           expects it. */}
+      <ModelSetupNotice />
       <div className="shrink-0">
         <Composer
           mountGhost={mountGhost}

--- a/src/components/model-setup-notice.test.tsx
+++ b/src/components/model-setup-notice.test.tsx
@@ -1,0 +1,177 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import * as React from "react";
+import { act } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import type { Profile } from "@/settings/settings-api";
+import { ModelSetupNotice, isModelConfigured } from "./model-setup-notice";
+
+(globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT =
+  true;
+
+const apiMocks = vi.hoisted(() => ({
+  getMyProfile: vi.fn(),
+}));
+
+vi.mock("@/settings/settings-api", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("@/settings/settings-api")>()),
+  getMyProfile: apiMocks.getMyProfile,
+}));
+
+function profileWithPrimary(familyId: string, modelId: string): Profile {
+  return {
+    id: "p1",
+    name: "P1",
+    enabled: true,
+    data_dir: null,
+    created_at: "",
+    updated_at: "",
+    status: { running: false, pid: null, started_at: null, uptime_secs: null },
+    config: {
+      llm: { primary: { family_id: familyId, model_id: modelId }, fallbacks: [] },
+      channels: [],
+      gateway: {
+        max_history: null,
+        max_iterations: null,
+        system_prompt: null,
+        max_concurrent_sessions: null,
+        browser_timeout_secs: null,
+        max_output_tokens: null,
+      },
+      env_vars: {},
+      hooks: [],
+      email: null,
+      api_type: null,
+      admin_mode: false,
+      sandbox: { enabled: false } as Profile["config"]["sandbox"],
+      adaptive_routing: null,
+      content_routing: null,
+      plugins: { require_signed: false },
+    } as Profile["config"],
+  };
+}
+
+function blankProfile(): Profile {
+  const p = profileWithPrimary("", "");
+  return p;
+}
+
+function mount(node: React.ReactElement): {
+  container: HTMLDivElement;
+  unmount: () => void;
+} {
+  const container = document.createElement("div");
+  document.body.appendChild(container);
+  const root: Root = createRoot(container);
+  act(() => root.render(node));
+  return {
+    container,
+    unmount: () => {
+      act(() => root.unmount());
+      container.remove();
+    },
+  };
+}
+
+async function flush() {
+  await act(async () => {
+    await Promise.resolve();
+  });
+}
+
+describe("isModelConfigured", () => {
+  it("is false when the primary selection is empty", () => {
+    expect(isModelConfigured(blankProfile())).toBe(false);
+    expect(isModelConfigured(profileWithPrimary("  ", ""))).toBe(false);
+  });
+
+  it("is true when family or model is set (mirrors has_llm_selection)", () => {
+    expect(isModelConfigured(profileWithPrimary("anthropic", ""))).toBe(true);
+    expect(isModelConfigured(profileWithPrimary("", "claude-haiku-4-5"))).toBe(true);
+    // …and does not demand a stored key: host-env credentials never show
+    // up in config.env_vars but still work at bootstrap time.
+    expect(isModelConfigured(profileWithPrimary("anthropic", "claude-haiku-4-5"))).toBe(true);
+  });
+});
+
+describe("ModelSetupNotice", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    document.body.innerHTML = "";
+  });
+
+  it("shows the setup banner with a settings deep link when no model is selected", async () => {
+    apiMocks.getMyProfile.mockResolvedValue(blankProfile());
+    const harness = mount(<ModelSetupNotice />);
+    await flush();
+
+    const notice = harness.container.querySelector(
+      '[data-testid="model-setup-notice"]',
+    );
+    expect(notice?.textContent).toContain("No model is set up");
+    expect(
+      notice
+        ?.querySelector('[data-testid="model-setup-notice-link"]')
+        ?.getAttribute("href"),
+    ).toBe("/settings?tab=llm");
+    harness.unmount();
+  });
+
+  it("stays silent when a model is configured", async () => {
+    apiMocks.getMyProfile.mockResolvedValue(
+      profileWithPrimary("anthropic", "claude-haiku-4-5"),
+    );
+    const harness = mount(<ModelSetupNotice />);
+    await flush();
+    expect(
+      harness.container.querySelector('[data-testid="model-setup-notice"]'),
+    ).toBeNull();
+    harness.unmount();
+  });
+
+  it("stays silent when the profile cannot be loaded", async () => {
+    apiMocks.getMyProfile.mockRejectedValue(new Error("boom"));
+    const harness = mount(<ModelSetupNotice />);
+    await flush();
+    expect(
+      harness.container.querySelector('[data-testid="model-setup-notice"]'),
+    ).toBeNull();
+    harness.unmount();
+  });
+
+  it("dismisses on the close button and re-checks on window focus", async () => {
+    apiMocks.getMyProfile.mockResolvedValue(blankProfile());
+    const harness = mount(<ModelSetupNotice />);
+    await flush();
+    expect(
+      harness.container.querySelector('[data-testid="model-setup-notice"]'),
+    ).not.toBeNull();
+
+    act(() => {
+      (
+        harness.container.querySelector(
+          'button[aria-label="Dismiss"]',
+        ) as HTMLButtonElement
+      ).click();
+    });
+    expect(
+      harness.container.querySelector('[data-testid="model-setup-notice"]'),
+    ).toBeNull();
+
+    // After "configuring" elsewhere, focusing the window re-checks and (with
+    // dismissal still latched for the session) keeps the banner hidden — but
+    // the fetch itself must fire so a fresh mount reflects the new state.
+    apiMocks.getMyProfile.mockResolvedValue(
+      profileWithPrimary("anthropic", "claude-haiku-4-5"),
+    );
+    const callsBefore = apiMocks.getMyProfile.mock.calls.length;
+    await act(async () => {
+      window.dispatchEvent(new Event("focus"));
+      await Promise.resolve();
+    });
+    expect(apiMocks.getMyProfile.mock.calls.length).toBeGreaterThan(callsBefore);
+    harness.unmount();
+  });
+});

--- a/src/components/model-setup-notice.tsx
+++ b/src/components/model-setup-notice.tsx
@@ -1,0 +1,90 @@
+/**
+ * Proactive "no model configured" notice for the chat surface.
+ *
+ * First-run solo profiles have no LLM selection, so their very first chat
+ * message used to be how they found out — a doomed send answered by a raw
+ * `rpc-error[-32603] No ProfileRuntime registered…`. The backend gate is
+ * knowable up front (`ProfileConfig::has_llm_selection`), and the runtime
+ * lazily bootstraps on the next send once a selection is saved, so this
+ * banner can warn before the fact and clear itself when the user comes
+ * back from Settings.
+ */
+
+import { useEffect, useState } from "react";
+import { X } from "lucide-react";
+import { getMyProfile, type Profile } from "@/settings/settings-api";
+
+/** Mirrors the backend's `ProfileConfig::has_llm_selection` gate
+ *  (octos-cli `profiles.rs`): the chat runtime lazily bootstraps only when
+ *  the primary LLM selection is non-empty.
+ *
+ *  Deliberately does NOT inspect credentials: a key supplied via the host
+ *  process env never appears in `config.env_vars`, so demanding a stored
+ *  key here would false-alarm on every host-env self-hosted setup. The
+ *  selection-missing case is the one the backend reports with the
+ *  "No ProfileRuntime registered" error this notice prevents. */
+export function isModelConfigured(profile: Profile): boolean {
+  const primary = profile.config?.llm?.primary;
+  return Boolean(primary?.family_id?.trim() || primary?.model_id?.trim());
+}
+
+const LLM_SETTINGS_HREF = "/settings?tab=llm";
+
+export function ModelSetupNotice(): React.ReactElement | null {
+  const [unconfigured, setUnconfigured] = useState(false);
+  const [dismissed, setDismissed] = useState(false);
+
+  useEffect(() => {
+    let active = true;
+    async function check() {
+      try {
+        const profile = await getMyProfile();
+        // Unknown state (null profile, older backend, network blip) stays
+        // silent — a false alarm on a working setup is worse than no banner.
+        if (active) setUnconfigured(profile ? !isModelConfigured(profile) : false);
+      } catch {
+        // same: stay silent
+      }
+    }
+    check();
+    // Re-check on focus so "open Settings → save a provider → come back"
+    // clears the notice without a reload.
+    window.addEventListener("focus", check);
+    return () => {
+      active = false;
+      window.removeEventListener("focus", check);
+    };
+  }, []);
+
+  if (!unconfigured || dismissed) return null;
+
+  return (
+    <div
+      data-testid="model-setup-notice"
+      role="status"
+      className="mx-4 mb-2 flex shrink-0 items-center gap-2 rounded-[10px] border border-(--workbench-warning-border) bg-(--workbench-warning-bg) px-3 py-2 text-xs text-(--workbench-warning-text)"
+    >
+      <span className="min-w-0 flex-1">
+        No model is set up yet — your messages can&apos;t be answered until you
+        add a provider and API key.
+      </span>
+      {/* Plain anchor, same reasoning as GhostBubble's setup link: leaving
+          the page is safe, session state reloads from the server. */}
+      <a
+        data-testid="model-setup-notice-link"
+        href={LLM_SETTINGS_HREF}
+        className="shrink-0 rounded-md border border-(--workbench-warning-border) px-2 py-1 font-medium hover:underline"
+      >
+        Set up a model
+      </a>
+      <button
+        type="button"
+        aria-label="Dismiss"
+        onClick={() => setDismissed(true)}
+        className="shrink-0 rounded-md p-1 hover:bg-(--workbench-warning-border)"
+      >
+        <X size={14} />
+      </button>
+    </div>
+  );
+}


### PR DESCRIPTION
## The gap

A first-run solo profile has no LLM selection, so until now the user's **first chat message was how they found out** — a doomed send answered by `rpc-error[-32603] No ProfileRuntime registered…`. #300 made that error human and actionable, but it still only fires *after* the failure.

## This PR

Adds a proactive `<ModelSetupNotice>` above the composer (shared by `/chat` and `/studio/:id`, both render `ChatThread`):

- **Gate mirrors the backend exactly**: `ProfileConfig::has_llm_selection` (octos-cli `profiles.rs`) — the same condition that decides whether the chat runtime can lazily bootstrap. Fetched via the existing `GET /api/my/profile`.
- **Zero-false-alarm design**: deliberately does *not* demand a stored credential — host-env API keys never appear in `config.env_vars` but work fine at bootstrap, so a key check would false-alarm on self-hosted setups. Unknown state (fetch failure, older backend) stays silent for the same reason.
- **Self-clearing**: re-checks on window focus, so "open Settings → save a provider → come back" dismisses the notice without a reload (the runtime lazily bootstraps on the next send — verified in `ensure_session_profile_runtime`).
- Dismissible per session; deep-links to `/settings?tab=llm`; uses the `--workbench-warning-*` semantic tokens (readable in both themes).

## Verification

- 782 vitest green (6 new: gate logic ×3, banner render/link, silent-when-configured, silent-on-error, dismiss + focus recheck)
- tsc clean; eslint 0 errors (1 pre-existing warning untouched, 1 fast-refresh warning matching GhostBubble's export precedent)
- Playwright frames: banner visible **before any send** on /chat and /studio, dismiss works, link lands on Settings → LLM

🤖 Generated with [Claude Code](https://claude.com/claude-code)