### PR TITLE
feat(voice): add diagnostics lab and learn tracing

### DIFF
--- a/src/home/voice/use-voice-capture.test.ts
+++ b/src/home/voice/use-voice-capture.test.ts
@@ -116,6 +116,38 @@ describe("useVoiceCapture", () => {
     unmount();
   });
 
+  it("reports the actually loaded model and per-frame speech probability for diagnostics", async () => {
+    const onModelLoaded = vi.fn();
+    const onFrameProcessed = vi.fn();
+    const { result, unmount } = renderHook(() => useVoiceCapture());
+
+    await act(async () => {
+      await result.current.start(vi.fn(), { onModelLoaded, onFrameProcessed });
+    });
+
+    expect(onModelLoaded).toHaveBeenCalledWith(expect.objectContaining({
+      library: "@ricky0123/vad-web",
+      libraryVersion: "0.0.30",
+      model: "legacy",
+      sampleRate: 16000,
+      frameSamples: 1536,
+      frameDurationMs: 96,
+    }));
+    await act(async () => {
+      (vadInstances[0].options.onFrameProcessed as (
+        probabilities: { isSpeech: number; notSpeech: number },
+        frame: Float32Array,
+      ) => void)({ isSpeech: 0.88, notSpeech: 0.12 }, new Float32Array(1536));
+      await Promise.resolve();
+    });
+    expect(onFrameProcessed).toHaveBeenCalledWith(expect.objectContaining({
+      speechProbability: 0.88,
+      nonSpeechProbability: 0.12,
+      frameSamples: 1536,
+    }));
+    unmount();
+  });
+
   it("reuses the active VAD and updates callbacks and thresholds", async () => {
     const firstUtterance = vi.fn();
     const secondUtterance = vi.fn();

--- a/src/home/voice/use-voice-capture.ts
+++ b/src/home/voice/use-voice-capture.ts
@@ -24,28 +24,92 @@ export interface VoiceCaptureStartOptions {
   onSpeechConfirmed?: () => void;
   onSpeechRealStart?: () => void;
   onVADMisfire?: () => void;
+  /** Per-frame Silero scores, used by the isolated Voice Lab only. */
+  onFrameProcessed?: (frame: VoiceCaptureFrame) => void;
+  /** Called after the browser grants the stream, for microphone diagnostics. */
+  onMediaStream?: (stream: MediaStream) => void;
+  /** Reports the model that successfully started, not merely the preference. */
+  onModelLoaded?: (model: VoiceCaptureModelInfo) => void;
 }
 
 const VAD_SAMPLE_RATE = 16000;
 const VAD_ASSET_TIMEOUT_MS = 5000;
+const VAD_WEB_DEFAULTS = {
+  // These are @ricky0123/vad-web 0.0.30 FrameProcessor defaults; production
+  // intentionally leaves them at the library values.
+  preSpeechPadMs: 800,
+  submitUserSpeechOnPause: false,
+} as const;
 type VadModel = "legacy" | "v5";
+
+export interface VoiceCaptureFrame {
+  /** Monotonic browser timestamp, measured with performance.now(). */
+  atMs: number;
+  speechProbability: number;
+  nonSpeechProbability: number;
+  frameSamples: number;
+}
+
+export interface VoiceCaptureModelInfo {
+  library: "@ricky0123/vad-web";
+  libraryVersion: "0.0.30";
+  model: VadModel;
+  modelAsset: string;
+  sampleRate: number;
+  frameSamples: number;
+  frameDurationMs: number;
+}
 
 // `all` is the standards-defined mode that asks the browser to remove every
 // system-played source from the microphone signal, including our local Web
 // Audio TTS. TypeScript's current lib.dom still models echoCancellation as a
 // boolean-only constraint, so keep the standards-compatible runtime value in
 // this narrowly cast object until that declaration catches up.
-const MIC_CONSTRAINTS_WITH_ALL_SYSTEM_AEC = {
+const REQUESTED_MIC_CONSTRAINTS = {
   channelCount: 1,
   echoCancellation: "all",
   autoGainControl: true,
   noiseSuppression: true,
-} as unknown as MediaTrackConstraints;
+} as const;
+const MIC_CONSTRAINTS_WITH_ALL_SYSTEM_AEC =
+  REQUESTED_MIC_CONSTRAINTS as unknown as MediaTrackConstraints;
 
-async function getEchoCancelledMicStream(): Promise<MediaStream> {
-  return navigator.mediaDevices.getUserMedia({
+export function getVoiceCaptureDiagnosticConfig(
+  options: VoiceCaptureStartOptions = {},
+) {
+  return {
+    requestedConstraints: { ...REQUESTED_MIC_CONSTRAINTS },
+    sampleRate: VAD_SAMPLE_RATE,
+    modelPreference: [...VAD_MODEL_PREFERENCE],
+    defaults: { ...VAD_WEB_DEFAULTS, ...frameProcessorOptions(options) },
+  };
+}
+
+function monotonicNow(): number {
+  return typeof performance !== "undefined" ? performance.now() : 0;
+}
+
+function modelInfo(model: VadModel): VoiceCaptureModelInfo {
+  const frameSamples = model === "legacy" ? 1536 : 512;
+  return {
+    library: "@ricky0123/vad-web",
+    libraryVersion: "0.0.30",
+    model,
+    modelAsset: model === "legacy" ? "silero_vad_legacy.onnx" : "silero_vad_v5.onnx",
+    sampleRate: VAD_SAMPLE_RATE,
+    frameSamples,
+    frameDurationMs: (frameSamples / VAD_SAMPLE_RATE) * 1000,
+  };
+}
+
+async function getEchoCancelledMicStream(
+  onMediaStream?: (stream: MediaStream) => void,
+): Promise<MediaStream> {
+  const stream = await navigator.mediaDevices.getUserMedia({
     audio: MIC_CONSTRAINTS_WITH_ALL_SYSTEM_AEC,
   });
+  onMediaStream?.(stream);
+  return stream;
 }
 
 let vadAssetCheckPromise: Promise<void> | null = null;
@@ -290,8 +354,12 @@ export function useVoiceCapture(): VoiceCapture {
           vad = await createVadWithModel(model, {
             baseAssetPath: VAD_BASE_ASSET_PATH,
             onnxWASMBasePath: VAD_ONNX_WASM_BASE_PATH,
-            getStream: getEchoCancelledMicStream,
-            resumeStream: getEchoCancelledMicStream,
+            getStream: () => getEchoCancelledMicStream(
+              callbacksRef.current?.options.onMediaStream,
+            ),
+            resumeStream: () => getEchoCancelledMicStream(
+              callbacksRef.current?.options.onMediaStream,
+            ),
             // Less trigger-happy than the defaults so transient noise (keyboard
             // clicks, taps) doesn't register as speech and kick off a turn:
             //  - require a higher speech probability to START,
@@ -324,6 +392,22 @@ export function useVoiceCapture(): VoiceCapture {
                 (current.options.onVADMisfire ?? noop)();
               }, setError);
             },
+            onFrameProcessed: (probabilities: {
+              isSpeech: number;
+              notSpeech: number;
+            }, frame: Float32Array) => {
+              if (gen !== startGenRef.current) return;
+              const current = callbacksRef.current;
+              if (!current?.options.onFrameProcessed) return;
+              runCallbackSafely("onFrameProcessed", () => {
+                current.options.onFrameProcessed?.({
+                  atMs: monotonicNow(),
+                  speechProbability: probabilities.isSpeech,
+                  nonSpeechProbability: probabilities.notSpeech,
+                  frameSamples: frame.length,
+                });
+              }, setError);
+            },
             onSpeechEnd: (audio: Float32Array) => {
               if (gen !== startGenRef.current) return;
               if (audio.length === 0) return;
@@ -340,6 +424,12 @@ export function useVoiceCapture(): VoiceCapture {
           if (gen !== startGenRef.current) {
             await vad.destroy().catch(() => undefined);
             return;
+          }
+          const current = callbacksRef.current;
+          if (current?.options.onModelLoaded) {
+            runCallbackSafely("onModelLoaded", () => {
+              current.options.onModelLoaded?.(modelInfo(model));
+            }, setError);
           }
           break;
         } catch (err) {

--- a/src/home/voice/use-voice-conversation.ts
+++ b/src/home/voice/use-voice-conversation.ts
@@ -17,6 +17,11 @@ import {
 } from "./use-camera-frame";
 import { playAudioBlob, stopAudio, unlockAudio } from "./audio-playback";
 import { stripLearningContext } from "@/learning/learning-context";
+import {
+  LISTENING_VAD_OPTIONS,
+  SPEAKING_INTERRUPT_VAD_OPTIONS,
+  THINKING_INTERRUPT_VAD_OPTIONS,
+} from "./vad-config";
 
 export type VoiceState = "idle" | "listening" | "thinking" | "speaking" | "error";
 
@@ -135,25 +140,6 @@ const AUDIO_EXT = /\.(wav|mp3|ogg|m4a|flac)$/i;
 const REPLY_TIMEOUT_MS = 90000;
 /** How long the "frame sent to the AI" thumbnail lingers before auto-hiding. */
 const SENT_FRAME_TTL_MS = 12000;
-const LISTENING_VAD_OPTIONS = {
-  positiveSpeechThreshold: 0.5,
-  negativeSpeechThreshold: 0.35,
-  minSpeechMs: 220,
-  redemptionMs: 700,
-};
-const THINKING_INTERRUPT_VAD_OPTIONS = {
-  positiveSpeechThreshold: 0.75,
-  negativeSpeechThreshold: 0.55,
-  minSpeechMs: 700,
-  redemptionMs: 650,
-};
-const SPEAKING_INTERRUPT_VAD_OPTIONS = {
-  positiveSpeechThreshold: 0.68,
-  negativeSpeechThreshold: 0.48,
-  minSpeechMs: 620,
-  redemptionMs: 700,
-};
-
 /** Find the most recent unplayed assistant audio from threads. Exported for unit tests. */
 export function pickFreshAudio(
   threads: Thread[],

--- a/src/home/voice/vad-config.ts
+++ b/src/home/voice/vad-config.ts
@@ -1,0 +1,25 @@
+/**
+ * VAD presets shared by the production voice conversation and diagnostics.
+ * Keeping the baseline preset here lets Voice Lab measure the same normal
+ * listening behavior without importing the turn/Agent conversation module.
+ */
+export const LISTENING_VAD_OPTIONS = {
+  positiveSpeechThreshold: 0.5,
+  negativeSpeechThreshold: 0.35,
+  minSpeechMs: 220,
+  redemptionMs: 700,
+} as const;
+
+export const THINKING_INTERRUPT_VAD_OPTIONS = {
+  positiveSpeechThreshold: 0.75,
+  negativeSpeechThreshold: 0.55,
+  minSpeechMs: 700,
+  redemptionMs: 650,
+} as const;
+
+export const SPEAKING_INTERRUPT_VAD_OPTIONS = {
+  positiveSpeechThreshold: 0.68,
+  negativeSpeechThreshold: 0.48,
+  minSpeechMs: 620,
+  redemptionMs: 700,
+} as const;

--- a/src/learning/learn-diagnostics.ts
+++ b/src/learning/learn-diagnostics.ts
@@ -1,0 +1,55 @@
+export interface LearnDiagnosticEntry {
+  timestamp: string;
+  elapsedMs: number;
+  event: string;
+  data: Record<string, unknown>;
+}
+
+declare global {
+  interface Window {
+    __OCTOS_LEARN_TRACE__?: LearnDiagnosticEntry[];
+    __OCTOS_EXPORT_LEARN_TRACE__?: () => string;
+  }
+}
+
+const TRACE_LIMIT = 600;
+const traceStart = globalThis.performance?.now?.() ?? Date.now();
+
+function traceBuffer(): LearnDiagnosticEntry[] | null {
+  if (
+    !import.meta.env.DEV ||
+    import.meta.env.MODE === "test" ||
+    typeof window === "undefined"
+  ) {
+    return null;
+  }
+  window.__OCTOS_LEARN_TRACE__ ??= [];
+  window.__OCTOS_EXPORT_LEARN_TRACE__ = () =>
+    JSON.stringify(window.__OCTOS_LEARN_TRACE__ ?? [], null, 2);
+  return window.__OCTOS_LEARN_TRACE__;
+}
+
+/**
+ * Development-only, bounded diagnostics for the /learn delivery pipeline.
+ * Callers deliberately provide metadata rather than learner content, images,
+ * audio, tokens, or complete narration text.
+ */
+export function traceLearnDiagnostic(
+  event: string,
+  data: Record<string, unknown> = {},
+): void {
+  const buffer = traceBuffer();
+  if (!buffer) return;
+  const now = globalThis.performance?.now?.() ?? Date.now();
+  const entry: LearnDiagnosticEntry = {
+    timestamp: new Date().toISOString(),
+    elapsedMs: Math.round(now - traceStart),
+    event,
+    data,
+  };
+  buffer.push(entry);
+  if (buffer.length > TRACE_LIMIT) {
+    buffer.splice(0, buffer.length - TRACE_LIMIT);
+  }
+  console.info(`[learn-trace] ${event}`, data);
+}

--- a/src/learning/learning-page.tsx
+++ b/src/learning/learning-page.tsx
@@ -37,6 +37,7 @@ import {
   stripLearningContext,
 } from "./learning-context";
 import { LearningWorkspace } from "./learning-workspace";
+import { traceLearnDiagnostic } from "./learn-diagnostics";
 import type { LearningBoardContext } from "./board/session-board";
 import {
   createProvisionalLearningSession,
@@ -541,7 +542,12 @@ export function LearningPage() {
       buildTurnText,
       playReplyAudio: false,
       showExistingTurns: true,
-      onTurnStart: () => {
+      onTurnStart: (turnId) => {
+        traceLearnDiagnostic("voice.turn_started", {
+          sessionId: record.id,
+          turnId,
+          action: "leave_review_mode",
+        });
         setReviewSessionId((current) =>
           current === record.id ? null : current,
         );

--- a/src/learning/learning-workspace.tsx
+++ b/src/learning/learning-workspace.tsx
@@ -30,6 +30,7 @@ import { useRenderThreads } from "@/store/projection-render-adapter";
 import type { Thread } from "@/store/thread-store";
 import { InfiniteBoard } from "./board/infinite-board";
 import { CameraSettingsDialog } from "./camera-settings-dialog";
+import { traceLearnDiagnostic } from "./learn-diagnostics";
 import {
   mergeSessionBoardPackets,
   type LearningBoardContext,
@@ -124,6 +125,22 @@ export function LearningWorkspace({
     ),
     [persistedOllArtifacts, threads],
   );
+  const artifactDiagnosticSignatureRef = useRef("");
+  useEffect(() => {
+    const artifacts = ollArtifacts.map((artifact) => ({
+      filename: artifact.filename,
+      threadId: artifact.threadId,
+      turnId: artifact.turnId,
+      source: artifact.id.startsWith("persisted:") ? "durable" : "projection",
+    }));
+    const signature = JSON.stringify({ sessionId, artifacts });
+    if (artifactDiagnosticSignatureRef.current === signature) return;
+    artifactDiagnosticSignatureRef.current = signature;
+    traceLearnDiagnostic("artifact.references_changed", {
+      sessionId,
+      artifacts,
+    });
+  }, [ollArtifacts, sessionId]);
   const requestedOllArtifactsRef = useRef(new Set<string>());
   const ollArtifactRequestsRef = useRef(new Map<string, AbortController>());
   const deliveredOllLessons = useMemo(() => {
@@ -189,11 +206,12 @@ export function LearningWorkspace({
     !lessonDeliverySettled &&
     pausedLessonSource !== ollOpenSource;
   const handleTurnComplete = useCallback((turnId: string) => {
+    traceLearnDiagnostic("turn.completed", { sessionId, turnId });
     setPlainReply(null);
     setPlainReplySpoken(false);
     setCompletedTurnId(turnId);
     conversationOptions?.onTurnComplete?.(turnId);
-  }, [conversationOptions]);
+  }, [conversationOptions, sessionId]);
   const voiceConversationOptions = useMemo(
     () => ({
       ...conversationOptions,
@@ -326,13 +344,29 @@ export function LearningWorkspace({
     let requestVersion = 0;
     const loadPersistedArtifacts = async () => {
       const version = ++requestVersion;
+      traceLearnDiagnostic("artifact.durable_list_requested", {
+        sessionId,
+        version,
+      });
       try {
         const files = await getSessionFiles(sessionId);
         if (cancelled || version !== requestVersion) return;
-        setPersistedOllArtifacts(collectPersistedOllLessonArtifacts(files));
+        const artifacts = collectPersistedOllLessonArtifacts(files);
+        traceLearnDiagnostic("artifact.durable_list_received", {
+          sessionId,
+          version,
+          totalFiles: files.length,
+          artifacts: artifacts.map((artifact) => artifact.filename),
+        });
+        setPersistedOllArtifacts(artifacts);
         setFileListError(null);
       } catch (cause) {
         if (cancelled || version !== requestVersion) return;
+        traceLearnDiagnostic("artifact.durable_list_failed", {
+          sessionId,
+          version,
+          error: cause instanceof Error ? cause.message : String(cause),
+        });
         setFileListError(
           cause instanceof Error
             ? cause.message
@@ -391,10 +425,25 @@ export function LearningWorkspace({
     pending.forEach((artifact) => {
       const artifactIdentity = ollArtifactIdentity(artifact);
       const controller = new AbortController();
+      traceLearnDiagnostic("artifact.load_started", {
+        sessionId,
+        identity: artifactIdentity,
+        filename: artifact.filename,
+        threadId: artifact.threadId,
+        turnId: artifact.turnId,
+        source: artifact.id.startsWith("persisted:") ? "durable" : "projection",
+      });
       requestedOllArtifactsRef.current.add(artifactIdentity);
       ollArtifactRequestsRef.current.set(artifactIdentity, controller);
       loadOllLessonArtifact(artifact, sessionId, controller.signal)
         .then((events) => {
+          traceLearnDiagnostic("artifact.load_succeeded", {
+            sessionId,
+            identity: artifactIdentity,
+            filename: artifact.filename,
+            eventCount: events.length,
+            stepCount: events.filter((event) => event.event === "lesson.step").length,
+          });
           setLoadedOllArtifacts((current) => ({
             ...current,
             [artifactIdentity]: events,
@@ -402,6 +451,12 @@ export function LearningWorkspace({
         })
         .catch((cause) => {
           if (controller.signal.aborted) return;
+          traceLearnDiagnostic("artifact.load_failed", {
+            sessionId,
+            identity: artifactIdentity,
+            filename: artifact.filename,
+            error: cause instanceof Error ? cause.message : String(cause),
+          });
           setRejectedOllArtifactIds((current) => {
             const next = new Set(current);
             next.add(artifactIdentity);
@@ -427,6 +482,37 @@ export function LearningWorkspace({
   );
   const appendOllEvents = ollLesson?.appendEvents;
 
+  const appendDiagnosedOllEvents = useCallback(
+    (events: CanonicalEvent[], mode: "live" | "review") => {
+      if (!appendOllEvents) return;
+      const sequences = events.map((event) => event.sequence);
+      traceLearnDiagnostic("runtime.append_started", {
+        sessionId,
+        mode,
+        eventCount: events.length,
+        sequences,
+      });
+      try {
+        const result = appendOllEvents(events);
+        traceLearnDiagnostic("runtime.append_succeeded", {
+          sessionId,
+          mode,
+          sequences,
+          ...result,
+        });
+      } catch (cause) {
+        traceLearnDiagnostic("runtime.append_failed", {
+          sessionId,
+          mode,
+          sequences,
+          error: cause instanceof Error ? cause.message : String(cause),
+        });
+        throw cause;
+      }
+    },
+    [appendOllEvents, sessionId],
+  );
+
   useEffect(() => {
     if (!activeOllEvents || !appendOllEvents) return;
     if (appendedOllEventCountRef.current > activeOllEvents.length) {
@@ -434,7 +520,7 @@ export function LearningWorkspace({
     }
     if (playbackMode === "review") {
       const pending = activeOllEvents.slice(appendedOllEventCountRef.current);
-      if (pending.length > 0) appendOllEvents(pending);
+      if (pending.length > 0) appendDiagnosedOllEvents(pending, "review");
       appendedOllEventCountRef.current = activeOllEvents.length;
       return;
     }
@@ -443,7 +529,7 @@ export function LearningWorkspace({
     const appendNext = () => {
       const event = activeOllEvents[eventIndex] as CanonicalEvent | undefined;
       if (!event) return;
-      appendOllEvents([event]);
+      appendDiagnosedOllEvents([event], "live");
       eventIndex += 1;
       appendedOllEventCountRef.current = eventIndex;
       if (eventIndex < activeOllEvents.length) {
@@ -454,7 +540,33 @@ export function LearningWorkspace({
     return () => {
       if (timer !== undefined) window.clearTimeout(timer);
     };
-  }, [activeOllEvents, appendOllEvents, playbackMode]);
+  }, [activeOllEvents, appendDiagnosedOllEvents, appendOllEvents, playbackMode]);
+  const runtimeDiagnosticStateRef = useRef("");
+  useEffect(() => {
+    const signature = JSON.stringify({
+      playbackMode,
+      status: ollLesson?.status ?? "missing",
+      playing: ollLesson?.playing ?? false,
+      currentBeatId: ollLesson?.currentBeatId ?? null,
+      narrationLength: ollLesson?.activeSpeech.length ?? 0,
+      totalOperations: ollLesson?.totalOperations ?? 0,
+    });
+    if (runtimeDiagnosticStateRef.current === signature) return;
+    runtimeDiagnosticStateRef.current = signature;
+    traceLearnDiagnostic("runtime.state_changed", {
+      sessionId,
+      playbackMode,
+      status: ollLesson?.status ?? "missing",
+      playing: ollLesson?.playing ?? false,
+      waiting: ollLesson?.waiting ?? false,
+      completed: ollLesson?.completed ?? false,
+      cursor: ollLesson?.cursor ?? 0,
+      totalOperations: ollLesson?.totalOperations ?? 0,
+      currentStepId: ollLesson?.currentStepId ?? null,
+      currentBeatId: ollLesson?.currentBeatId ?? null,
+      narrationLength: ollLesson?.activeSpeech.length ?? 0,
+    });
+  });
   useEffect(() => {
     if (ollLesson) {
       onBoardContextChange?.({
@@ -481,6 +593,7 @@ export function LearningWorkspace({
     completeOllNarration?.(narrationId);
   }, [completeOllNarration]);
   const ollNarrationTts = useOllNarrationTts({
+    sessionId,
     enabled: narrationAudioEnabled && (Boolean(ollLesson) || Boolean(plainReply)),
     playing: lessonOwnsNarration
       ? ollNarrationActive

--- a/src/learning/oll/use-oll-narration-tts.ts
+++ b/src/learning/oll/use-oll-narration-tts.ts
@@ -4,8 +4,10 @@ import {
   playAudioBlob,
   stopAudio,
 } from "@/home/voice/audio-playback";
+import { traceLearnDiagnostic } from "../learn-diagnostics";
 
 export interface OllNarrationTtsOptions {
+  sessionId?: string;
   enabled: boolean;
   playing: boolean;
   text: string;
@@ -25,6 +27,7 @@ export interface OllNarrationTtsState {
  * therefore share this exact synthesis, cancellation, and playback path.
  */
 export function useOllNarrationTts({
+  sessionId,
   enabled,
   playing,
   text,
@@ -42,6 +45,10 @@ export function useOllNarrationTts({
     const completePlayback = () => {
       if (!current || completed || !narrationId) return;
       completed = true;
+      traceLearnDiagnostic("tts.playback_completed", {
+        sessionId,
+        narrationId,
+      });
       onPlaybackComplete?.(narrationId);
     };
 
@@ -55,9 +62,20 @@ export function useOllNarrationTts({
       };
     }
 
+    traceLearnDiagnostic("tts.request_started", {
+      sessionId,
+      narrationId: narrationId ?? null,
+      textLength: normalizedText.length,
+    });
     void synthesizeSpeech(normalizedText, request.signal)
       .then(async (audio) => {
         if (!current || request.signal.aborted) return;
+        traceLearnDiagnostic("tts.synthesis_succeeded", {
+          sessionId,
+          narrationId: narrationId ?? null,
+          audioBytes: audio.size,
+          audioType: audio.type,
+        });
         setFailure(null);
         onSpeakingChange?.(true);
         const started = await playAudioBlob(
@@ -68,6 +86,13 @@ export function useOllNarrationTts({
             completePlayback();
           },
           request.signal,
+        );
+        traceLearnDiagnostic(
+          started ? "tts.playback_started" : "tts.playback_rejected",
+          {
+            sessionId,
+            narrationId: narrationId ?? null,
+          },
         );
         if (!started && current) {
           onSpeakingChange?.(false);
@@ -84,11 +109,23 @@ export function useOllNarrationTts({
           return;
         }
         onSpeakingChange?.(false);
+        traceLearnDiagnostic("tts.request_failed", {
+          sessionId,
+          narrationId: narrationId ?? null,
+          error: cause instanceof Error ? cause.message : String(cause),
+        });
         setFailure("课程语音暂时不可用，旁白仍会显示。");
         completePlayback();
       });
 
     return () => {
+      if (!completed) {
+        traceLearnDiagnostic("tts.cancelled", {
+          sessionId,
+          narrationId: narrationId ?? null,
+          willAbortRequest: !request.signal.aborted,
+        });
+      }
       current = false;
       request.abort();
       onSpeakingChange?.(false);
@@ -101,6 +138,7 @@ export function useOllNarrationTts({
     onPlaybackComplete,
     onSpeakingChange,
     playing,
+    sessionId,
   ]);
 
   return {

--- a/src/settings/voice-lab-data.test.ts
+++ b/src/settings/voice-lab-data.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it } from "vitest";
+import {
+  VOICE_LAB_METRICS,
+  VOICE_LAB_SCENARIOS,
+  createVoiceLabLabel,
+} from "./voice-lab-data";
+
+describe("Voice Lab acceptance data", () => {
+  it("includes every agreed speech and non-speech acceptance scenario", () => {
+    expect(VOICE_LAB_SCENARIOS.map((scenario) => scenario.id)).toEqual(
+      expect.arrayContaining([
+        "normal-chinese",
+        "short-command",
+        "quiet-far-whisper",
+        "speech-with-keyboard",
+        "tts-double-talk",
+        "single-keypress",
+        "continuous-typing",
+        "impact-and-door",
+        "ambient-noise",
+        "music",
+        "tts-only",
+        "non-linguistic-human-sound",
+      ]),
+    );
+    expect(VOICE_LAB_METRICS.map((metric) => metric.id)).toEqual(
+      expect.arrayContaining([
+        "normal-speech-recall",
+        "short-phrase-recall",
+        "non-speech-candidate-rate",
+        "speech-boundary-truncation",
+        "vad-start-latency",
+        "vad-end-latency",
+        "asr-non-speech-hallucination-rate",
+        "asr-speech-empty-text-rate",
+        "speech-to-formal-input-latency",
+      ]),
+    );
+  });
+
+  it("creates an intentionally unlabeled, structured recording label", () => {
+    expect(createVoiceLabLabel()).toEqual({
+      containsSpeech: null,
+      expectedText: "",
+      scenario: "normal-chinese",
+      notes: "",
+    });
+  });
+});

--- a/src/settings/voice-lab-data.ts
+++ b/src/settings/voice-lab-data.ts
@@ -1,0 +1,89 @@
+/**
+ * Machine-readable acceptance catalogue for the voice-input project. These
+ * records are deliberately independent of a detector or ASR implementation so
+ * later baseline runs can compare models against exactly the same labels.
+ */
+export type VoiceLabScenarioId =
+  | "normal-chinese"
+  | "short-command"
+  | "quiet-far-whisper"
+  | "speech-with-keyboard"
+  | "tts-double-talk"
+  | "single-keypress"
+  | "continuous-typing"
+  | "impact-and-door"
+  | "ambient-noise"
+  | "music"
+  | "tts-only"
+  | "non-linguistic-human-sound";
+
+export interface VoiceLabScenario {
+  id: VoiceLabScenarioId;
+  label: string;
+  containsSpeech: boolean;
+  description: string;
+}
+
+export const VOICE_LAB_SCENARIOS: readonly VoiceLabScenario[] = [
+  { id: "normal-chinese", label: "正常中文语音", containsSpeech: true, description: "自然说话。" },
+  { id: "short-command", label: "短句（你好／停／继续）", containsSpeech: true, description: "1–4 字语言语音。" },
+  { id: "quiet-far-whisper", label: "低音量／远场／耳语", containsSpeech: true, description: "困难但有效的语言语音。" },
+  { id: "speech-with-keyboard", label: "说话同时键盘声", containsSpeech: true, description: "语言语音和键盘同时存在。" },
+  { id: "tts-double-talk", label: "TTS 播放时用户插话", containsSpeech: true, description: "双讲场景中的用户语言语音。" },
+  { id: "single-keypress", label: "单次键盘敲击", containsSpeech: false, description: "不应形成语言输入。" },
+  { id: "continuous-typing", label: "连续打字", containsSpeech: false, description: "不应形成语言输入。" },
+  { id: "impact-and-door", label: "鼠标／敲桌／开关门", containsSpeech: false, description: "冲击与机械声音。" },
+  { id: "ambient-noise", label: "风扇和环境噪声", containsSpeech: false, description: "持续环境声音。" },
+  { id: "music", label: "音乐", containsSpeech: false, description: "不应形成语言输入。" },
+  { id: "tts-only", label: "只有 Octos TTS", containsSpeech: false, description: "用户未说话时的播放残留。" },
+  { id: "non-linguistic-human-sound", label: "咳嗽／呼吸／笑声", containsSpeech: false, description: "非语言的人体声音。" },
+];
+
+export type VoiceLabMetricId =
+  | "normal-speech-recall"
+  | "short-phrase-recall"
+  | "non-speech-candidate-rate"
+  | "speech-boundary-truncation"
+  | "vad-start-latency"
+  | "vad-end-latency"
+  | "asr-non-speech-hallucination-rate"
+  | "asr-speech-empty-text-rate"
+  | "speech-to-formal-input-latency";
+
+export interface VoiceLabMetric {
+  id: VoiceLabMetricId;
+  label: string;
+  stage: "vad" | "asr" | "end-to-end";
+}
+
+export const VOICE_LAB_METRICS: readonly VoiceLabMetric[] = [
+  { id: "normal-speech-recall", label: "正常语音召回率", stage: "vad" },
+  { id: "short-phrase-recall", label: "短句召回率", stage: "vad" },
+  { id: "non-speech-candidate-rate", label: "非语音 candidate 产生率", stage: "vad" },
+  { id: "speech-boundary-truncation", label: "语音首尾截断", stage: "vad" },
+  { id: "vad-start-latency", label: "VAD 开始延迟", stage: "vad" },
+  { id: "vad-end-latency", label: "VAD 结束延迟", stage: "vad" },
+  { id: "asr-non-speech-hallucination-rate", label: "ASR 非语音幻觉率", stage: "asr" },
+  { id: "asr-speech-empty-text-rate", label: "ASR 真人语音空文本率", stage: "asr" },
+  { id: "speech-to-formal-input-latency", label: "说完到正式输入总延迟", stage: "end-to-end" },
+];
+
+export interface VoiceLabLabel {
+  containsSpeech: boolean | null;
+  expectedText: string;
+  scenario: VoiceLabScenarioId;
+  notes: string;
+}
+
+export function createVoiceLabLabel(): VoiceLabLabel {
+  return {
+    containsSpeech: null,
+    expectedText: "",
+    scenario: "normal-chinese",
+    notes: "",
+  };
+}
+
+export function wavDurationMs(size: number, sampleRate = 16000): number {
+  return Math.max(0, ((size - 44) / (sampleRate * 2)) * 1000);
+}

--- a/src/settings/voice-lab.test.tsx
+++ b/src/settings/voice-lab.test.tsx
@@ -1,0 +1,86 @@
+import { act, fireEvent, render, screen } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { VoiceLab } from "./voice-lab";
+
+const { captureStart, captureStop, sendMessage } = vi.hoisted(() => ({
+  captureStart: vi.fn(),
+  captureStop: vi.fn(),
+  sendMessage: vi.fn(),
+}));
+
+vi.mock("@/home/voice/use-voice-capture", () => ({
+  getVoiceCaptureDiagnosticConfig: () => ({
+    requestedConstraints: {
+      channelCount: 1,
+      echoCancellation: "all",
+      autoGainControl: true,
+      noiseSuppression: true,
+    },
+    sampleRate: 16000,
+    modelPreference: ["legacy", "v5"],
+    defaults: {
+      positiveSpeechThreshold: 0.5,
+      negativeSpeechThreshold: 0.35,
+      redemptionMs: 700,
+      preSpeechPadMs: 800,
+      submitUserSpeechOnPause: false,
+    },
+  }),
+  useVoiceCapture: () => ({
+    capturing: false,
+    start: captureStart,
+    stop: captureStop,
+    error: null,
+  }),
+}));
+
+vi.mock("@/home/voice/vad-config", () => ({
+  LISTENING_VAD_OPTIONS: {
+    positiveSpeechThreshold: 0.5,
+    negativeSpeechThreshold: 0.35,
+    minSpeechMs: 220,
+    redemptionMs: 700,
+  },
+}));
+
+// The Lab must not import or call the production turn bridge. Keeping this
+// explicit guards against accidentally wiring a diagnostic recording to a turn.
+vi.mock("@/runtime/ui-protocol-send", () => ({ sendMessage }));
+
+describe("VoiceLab", () => {
+  beforeEach(() => {
+    captureStart.mockReset();
+    captureStop.mockReset();
+    sendMessage.mockReset();
+    URL.createObjectURL = vi.fn(() => "blob:voice-lab") as typeof URL.createObjectURL;
+    URL.revokeObjectURL = vi.fn();
+  });
+
+  it("records through the shared capture hook without starting a production turn", async () => {
+    render(<VoiceLab />);
+
+    fireEvent.click(screen.getByRole("button", { name: /start microphone diagnostic/i }));
+
+    expect(captureStart).toHaveBeenCalledTimes(1);
+    expect(captureStart.mock.calls[0][1]).toEqual(
+      expect.objectContaining({
+        onSpeechStart: expect.any(Function),
+        onSpeechConfirmed: expect.any(Function),
+        onFrameProcessed: expect.any(Function),
+        positiveSpeechThreshold: 0.5,
+        minSpeechMs: 220,
+      }),
+    );
+    expect(sendMessage).not.toHaveBeenCalled();
+
+    await act(async () => {
+      captureStart.mock.calls[0][0](new Blob([new Uint8Array(32044)], {
+        type: "audio/wav",
+      }));
+    });
+
+    expect(screen.getByText(/recorded candidate/i)).toBeTruthy();
+    expect(screen.getByText(/1\.00 s/)).toBeTruthy();
+    expect(sendMessage).not.toHaveBeenCalled();
+  });
+});

--- a/src/settings/voice-lab.tsx
+++ b/src/settings/voice-lab.tsx
@@ -1,0 +1,336 @@
+import { useEffect, useRef, useState } from "react";
+import { Download, Mic, Square, Waves } from "lucide-react";
+import {
+  getVoiceCaptureDiagnosticConfig,
+  type VoiceCaptureFrame,
+  type VoiceCaptureModelInfo,
+} from "@/home/voice/use-voice-capture";
+import { useVoiceCapture } from "@/home/voice/use-voice-capture";
+import { LISTENING_VAD_OPTIONS } from "@/home/voice/vad-config";
+import {
+  VOICE_LAB_METRICS,
+  VOICE_LAB_SCENARIOS,
+  createVoiceLabLabel,
+  wavDurationMs,
+  type VoiceLabLabel,
+} from "./voice-lab-data";
+
+type LabEventKind =
+  | "candidate_started"
+  | "candidate_confirmed"
+  | "candidate_ended"
+  | "candidate_misfire";
+
+interface LabEvent {
+  id: number;
+  kind: LabEventKind;
+  atMs: number;
+}
+
+interface RecordedCandidate {
+  id: string;
+  blob: Blob;
+  url: string;
+  durationMs: number;
+  size: number;
+}
+
+interface MicrophoneDiagnostics {
+  settings: MediaTrackSettings;
+  constraints: MediaTrackConstraints;
+  deviceLabel: string | null;
+}
+
+const MAX_FRAMES = 600;
+const MAX_EVENTS = 100;
+
+function now(): number {
+  return typeof performance !== "undefined" ? performance.now() : 0;
+}
+
+function formatMs(value: number): string {
+  return `${Math.max(0, value).toFixed(0)} ms`;
+}
+
+function formatBytes(value: number): string {
+  if (value < 1024) return `${value} B`;
+  return `${(value / 1024).toFixed(1)} KiB`;
+}
+
+function download(blob: Blob, filename: string) {
+  const url = URL.createObjectURL(blob);
+  const anchor = document.createElement("a");
+  anchor.href = url;
+  anchor.download = filename;
+  anchor.click();
+  URL.revokeObjectURL(url);
+}
+
+function supportedConstraints(): MediaTrackSupportedConstraints {
+  return navigator.mediaDevices?.getSupportedConstraints?.() ?? {};
+}
+
+export function VoiceLab() {
+  const capture = useVoiceCapture();
+  // Baseline runs intentionally mirror normal production listening, while the
+  // component itself remains isolated from the production turn pipeline.
+  const config = getVoiceCaptureDiagnosticConfig(LISTENING_VAD_OPTIONS);
+  const startedAtRef = useRef(0);
+  const candidateSequenceRef = useRef(0);
+  const activeCandidateRef = useRef<string | null>(null);
+  const candidateUrlRef = useRef<string | null>(null);
+  const [events, setEvents] = useState<LabEvent[]>([]);
+  const [frames, setFrames] = useState<VoiceCaptureFrame[]>([]);
+  const [model, setModel] = useState<VoiceCaptureModelInfo | null>(null);
+  const [microphone, setMicrophone] = useState<MicrophoneDiagnostics | null>(null);
+  const [candidate, setCandidate] = useState<RecordedCandidate | null>(null);
+  const [label, setLabel] = useState<VoiceLabLabel>(createVoiceLabLabel);
+  const [supports] = useState<MediaTrackSupportedConstraints>(supportedConstraints);
+
+  useEffect(() => {
+    return () => {
+      if (candidateUrlRef.current) URL.revokeObjectURL(candidateUrlRef.current);
+    };
+  }, []);
+
+  const relativeNow = () => now() - startedAtRef.current;
+  const addEvent = (kind: LabEventKind) => {
+    setEvents((current) => [
+      ...current.slice(-(MAX_EVENTS - 1)),
+      { id: current.length + 1, kind, atMs: relativeNow() },
+    ]);
+  };
+
+  const readMicrophone = (stream: MediaStream) => {
+    const track = stream.getAudioTracks()[0];
+    if (!track) return;
+    const settings = track.getSettings();
+    const constraints = track.getConstraints();
+    const deviceId = settings.deviceId;
+    void navigator.mediaDevices.enumerateDevices().then((devices) => {
+      const deviceLabel = devices.find(
+        (device) => device.kind === "audioinput" && device.deviceId === deviceId,
+      )?.label ?? null;
+      setMicrophone({ settings, constraints, deviceLabel });
+    }).catch(() => {
+      setMicrophone({ settings, constraints, deviceLabel: null });
+    });
+  };
+
+  const recordCandidate = (blob: Blob) => {
+    const id = activeCandidateRef.current ?? `lab-candidate-${candidateSequenceRef.current + 1}`;
+    activeCandidateRef.current = null;
+    addEvent("candidate_ended");
+    if (candidateUrlRef.current) URL.revokeObjectURL(candidateUrlRef.current);
+    const url = URL.createObjectURL(blob);
+    candidateUrlRef.current = url;
+    setCandidate({
+      id,
+      blob,
+      url,
+      size: blob.size,
+      durationMs: wavDurationMs(blob.size, config.sampleRate),
+    });
+  };
+
+  const start = async () => {
+    startedAtRef.current = now();
+    activeCandidateRef.current = null;
+    setEvents([]);
+    setFrames([]);
+    await capture.start(recordCandidate, {
+      ...LISTENING_VAD_OPTIONS,
+      onSpeechStart: () => {
+        candidateSequenceRef.current += 1;
+        activeCandidateRef.current = `lab-candidate-${candidateSequenceRef.current}`;
+        addEvent("candidate_started");
+      },
+      onSpeechConfirmed: () => addEvent("candidate_confirmed"),
+      onVADMisfire: () => {
+        activeCandidateRef.current = null;
+        addEvent("candidate_misfire");
+      },
+      onFrameProcessed: (frame) => {
+        setFrames((current) => [...current.slice(-(MAX_FRAMES - 1)), {
+          ...frame,
+          atMs: frame.atMs - startedAtRef.current,
+        }]);
+      },
+      onMediaStream: readMicrophone,
+      onModelLoaded: setModel,
+    });
+  };
+
+  const exportJson = () => {
+    const report = {
+      schemaVersion: 1,
+      exportedAt: new Date().toISOString(),
+      privacy: "Audio remains in this browser unless the user explicitly downloads the WAV.",
+      microphone: microphone ? {
+        settings: microphone.settings,
+        constraints: microphone.constraints,
+        deviceLabel: microphone.deviceLabel,
+      } : null,
+      requestedConstraints: config.requestedConstraints,
+      vad: { config: config.defaults, model, frames, events },
+      candidate: candidate ? {
+        id: candidate.id,
+        durationMs: candidate.durationMs,
+        wavBytes: candidate.size,
+        sampleRate: config.sampleRate,
+      } : null,
+      label,
+      metricsTracked: VOICE_LAB_METRICS,
+    };
+    download(
+      new Blob([JSON.stringify(report, null, 2)], { type: "application/json" }),
+      "octos-voice-lab.json",
+    );
+  };
+
+  const latestProbability = frames.at(-1)?.speechProbability;
+
+  return (
+    <section className="glass-section rounded-lg p-6">
+      <div className="flex flex-wrap items-start justify-between gap-4">
+        <div className="flex items-start gap-3">
+          <div className="flex h-10 w-10 shrink-0 items-center justify-center rounded-xl bg-accent/10 text-accent">
+            <Waves size={20} />
+          </div>
+          <div>
+            <h3 id="voice-lab-title" className="text-sm font-semibold text-text-strong">Voice Lab</h3>
+            <p className="mt-1 text-xs text-muted">
+              Browser-only microphone and VAD diagnostics. It never starts a chat turn, Agent, tool, Memory, or Learning task.
+            </p>
+          </div>
+        </div>
+        <div className="flex gap-2">
+          <button type="button" onClick={() => void start()} disabled={capture.capturing} className="flex items-center gap-2 rounded-xl bg-accent px-3 py-2 text-xs font-medium text-white disabled:opacity-40">
+            <Mic size={14} /> Start microphone diagnostic
+          </button>
+          <button type="button" onClick={() => void capture.stop()} disabled={!capture.capturing} className="flex items-center gap-2 rounded-xl border border-border px-3 py-2 text-xs font-medium text-muted disabled:opacity-40">
+            <Square size={13} /> Stop
+          </button>
+        </div>
+      </div>
+
+      <p className="mt-4 rounded-lg bg-surface-container px-3 py-2 text-xs text-muted">
+        Privacy: recordings stay only in page memory and are discarded when this page closes. No audio is uploaded; JSON excludes audio bytes, and WAV downloads only after your explicit action.
+      </p>
+      {capture.error && <p role="alert" className="mt-3 text-xs text-red-400">{capture.error}</p>}
+
+      <div className="mt-6 grid gap-4 lg:grid-cols-2">
+        <DiagnosticList title="Browser supported audio constraints" value={supports} />
+        <DiagnosticList title="Octos requested constraints" value={config.requestedConstraints} />
+        <DiagnosticList title="Actual MediaStreamTrack settings" value={microphone?.settings ?? null} />
+        <DiagnosticList title="Actual track constraints" value={microphone?.constraints ?? null} />
+      </div>
+      <p className="mt-2 text-xs text-muted">
+        Input device: {microphone?.deviceLabel || microphone?.settings.deviceId || "start a diagnostic to inspect"}
+      </p>
+
+      <div className="mt-6 grid gap-4 lg:grid-cols-2">
+        <div className="rounded-lg bg-surface-container p-4">
+          <h4 className="text-xs font-semibold text-text-strong">Loaded Silero VAD</h4>
+          {model ? (
+            <dl className="mt-3 grid grid-cols-2 gap-x-3 gap-y-2 text-xs">
+              <Term label="Library" value={`${model.library} ${model.libraryVersion}`} />
+              <Term label="Model" value={`${model.model} (${model.modelAsset})`} />
+              <Term label="Sample rate" value={`${model.sampleRate} Hz`} />
+              <Term label="Frame" value={`${model.frameSamples} samples / ${model.frameDurationMs} ms`} />
+            </dl>
+          ) : <p className="mt-3 text-xs text-muted">Start a diagnostic to report the model that actually loaded.</p>}
+        </div>
+        <div className="rounded-lg bg-surface-container p-4">
+          <h4 className="text-xs font-semibold text-text-strong">Current VAD configuration</h4>
+          <dl className="mt-3 grid grid-cols-2 gap-x-3 gap-y-2 text-xs">
+            <Term label="Positive threshold" value={String(config.defaults.positiveSpeechThreshold)} />
+            <Term label="Negative threshold" value={String(config.defaults.negativeSpeechThreshold)} />
+            <Term label="Min speech" value={formatMs(config.defaults.minSpeechMs)} />
+            <Term label="Redemption" value={formatMs(config.defaults.redemptionMs)} />
+            <Term label="Pre-speech padding" value={formatMs(config.defaults.preSpeechPadMs)} />
+            <Term label="Submit on pause" value={String(config.defaults.submitUserSpeechOnPause)} />
+          </dl>
+          <p className="mt-3 text-xs text-muted">Live speech probability: {latestProbability == null ? "waiting" : latestProbability.toFixed(3)}</p>
+        </div>
+      </div>
+
+      <div className="mt-3 rounded-lg bg-surface-container p-4">
+        <h4 className="text-xs font-semibold text-text-strong">Actual input summary</h4>
+        <dl className="mt-3 grid grid-cols-2 gap-x-3 gap-y-2 text-xs md:grid-cols-4">
+          <Term label="AEC" value={String(microphone?.settings.echoCancellation ?? "not reported")} />
+          <Term label="Noise suppression" value={String(microphone?.settings.noiseSuppression ?? "not reported")} />
+          <Term label="Auto gain" value={String(microphone?.settings.autoGainControl ?? "not reported")} />
+          <Term label="Sample rate" value={microphone?.settings.sampleRate ? `${microphone.settings.sampleRate} Hz` : "not reported"} />
+          <Term label="Channels" value={String(microphone?.settings.channelCount ?? "not reported")} />
+          <Term label="Input device" value={microphone?.deviceLabel || microphone?.settings.deviceId || "not reported"} />
+        </dl>
+      </div>
+
+      <div className="mt-6 rounded-lg bg-surface-container p-4">
+        <h4 className="text-xs font-semibold text-text-strong">Candidate timeline</h4>
+        {events.length === 0 ? <p className="mt-3 text-xs text-muted">Speak a test sound to see candidate_started, candidate_confirmed, and candidate_ended events.</p> : (
+          <ol className="mt-3 space-y-2 text-xs">
+            {events.map((event, index) => (
+              <li key={event.id} className="flex justify-between gap-4 rounded bg-surface px-3 py-2">
+                <code>{event.kind}</code>
+                <span>{formatMs(event.atMs)}{index > 0 ? ` (+${formatMs(event.atMs - events[index - 1].atMs)})` : ""}</span>
+              </li>
+            ))}
+          </ol>
+        )}
+        <p className="mt-3 text-xs text-muted">{frames.length} VAD frames captured (keeps the newest {MAX_FRAMES}); the library supplies a speech probability per frame.</p>
+      </div>
+
+      {candidate && (
+        <div className="mt-6 rounded-lg bg-surface-container p-4">
+          <div className="flex flex-wrap items-center justify-between gap-3">
+            <div>
+              <h4 className="text-xs font-semibold text-text-strong">Recorded candidate</h4>
+              <p className="mt-1 text-xs text-muted">{candidate.id} · {(candidate.durationMs / 1000).toFixed(2)} s · {formatBytes(candidate.size)} WAV</p>
+            </div>
+            <button type="button" onClick={() => download(candidate.blob, `${candidate.id}.wav`)} className="flex items-center gap-2 rounded-xl border border-border px-3 py-2 text-xs font-medium text-muted">
+              <Download size={14} /> Download WAV
+            </button>
+          </div>
+          <audio className="mt-3 w-full" controls src={candidate.url} />
+        </div>
+      )}
+
+      <div className="mt-6 rounded-lg bg-surface-container p-4">
+        <h4 className="text-xs font-semibold text-text-strong">Human label</h4>
+        <div className="mt-3 grid gap-3 md:grid-cols-2">
+          <label className="text-xs text-muted">containsSpeech
+            <select value={label.containsSpeech === null ? "unknown" : String(label.containsSpeech)} onChange={(event) => setLabel((current) => ({ ...current, containsSpeech: event.target.value === "unknown" ? null : event.target.value === "true" }))} className="mt-1 block w-full rounded-lg bg-surface px-3 py-2 text-sm text-text">
+              <option value="unknown">Unlabeled</option><option value="true">Yes</option><option value="false">No</option>
+            </select>
+          </label>
+          <label className="text-xs text-muted">Scenario
+            <select value={label.scenario} onChange={(event) => setLabel((current) => ({ ...current, scenario: event.target.value as VoiceLabLabel["scenario"] }))} className="mt-1 block w-full rounded-lg bg-surface px-3 py-2 text-sm text-text">
+              {VOICE_LAB_SCENARIOS.map((scenario) => <option key={scenario.id} value={scenario.id}>{scenario.label}</option>)}
+            </select>
+          </label>
+          <label className="text-xs text-muted">expectedText
+            <input value={label.expectedText} onChange={(event) => setLabel((current) => ({ ...current, expectedText: event.target.value }))} className="mt-1 block w-full rounded-lg bg-surface px-3 py-2 text-sm text-text" />
+          </label>
+          <label className="text-xs text-muted">notes
+            <input value={label.notes} onChange={(event) => setLabel((current) => ({ ...current, notes: event.target.value }))} className="mt-1 block w-full rounded-lg bg-surface px-3 py-2 text-sm text-text" />
+          </label>
+        </div>
+      </div>
+
+      <div className="mt-5 flex flex-wrap items-center justify-between gap-3">
+        <p className="text-xs text-muted">Tracks {VOICE_LAB_METRICS.length} agreed VAD, ASR, and end-to-end acceptance metrics for later baseline analysis.</p>
+        <button type="button" onClick={exportJson} className="flex items-center gap-2 rounded-xl border border-border px-3 py-2 text-xs font-medium text-muted"><Download size={14} /> Export experiment JSON</button>
+      </div>
+    </section>
+  );
+}
+
+function DiagnosticList({ title, value }: { title: string; value: Record<string, unknown> | null }) {
+  return <div className="rounded-lg bg-surface-container p-4"><h4 className="text-xs font-semibold text-text-strong">{title}</h4>{value ? <dl className="mt-3 space-y-1 text-xs">{Object.entries(value).map(([key, entry]) => <Term key={key} label={key} value={String(entry)} />)}</dl> : <p className="mt-3 text-xs text-muted">Not available until microphone access is granted.</p>}</div>;
+}
+
+function Term({ label, value }: { label: string; value: string }) {
+  return <div className="flex justify-between gap-3"><dt className="text-muted">{label}</dt><dd className="break-all text-right text-text">{value}</dd></div>;
+}

--- a/src/settings/voice-tab.tsx
+++ b/src/settings/voice-tab.tsx
@@ -14,6 +14,7 @@ import {
   type Profile,
   type CloudTtsConfig,
 } from "./settings-api";
+import { VoiceLab } from "./voice-lab";
 
 const TOKEN_ENV = "VOLC_TTS_TOKEN";
 // `inherit` maps to a null `tts_provider` (no per-profile override → use the
@@ -254,6 +255,8 @@ export function VoiceTab({
           </div>
         </div>
       )}
+
+      <VoiceLab />
 
       {/* Save actions */}
       <div className="flex items-center gap-3">


### PR DESCRIPTION
## Summary
- add an isolated Settings Voice Lab with microphone, VAD, candidate, label, and export diagnostics
- expose shared capture diagnostics and align Lab with production listening VAD settings
- add bounded development diagnostics for Learn/OLL delivery and narration playback

## Validation
- pnpm test:unit targeted voice/settings suites (55 tests)
- pnpm exec tsc --noEmit

Generated local reports and dependency caches are intentionally excluded.