### PR TITLE
fix(voice): preserve ASR and TTS projection delivery

### DIFF
--- a/src/home/voice/use-voice-conversation.test.ts
+++ b/src/home/voice/use-voice-conversation.test.ts
@@ -15,6 +15,7 @@ import {
   useVoiceConversation,
 } from "./use-voice-conversation";
 import type { Thread } from "@/store/thread-store";
+import * as VoiceTranscriptStore from "@/store/voice-transcript-store";
 
 // ---------------------------------------------------------------------------
 // Hook-level harness (start() cancellation — post-unmount mic re-acquire).
@@ -113,7 +114,7 @@ vi.mock("@/store/projection-store", () => ({
   projectionStoreKey: (sessionId: string, topic?: string) =>
     `${sessionId}\u0000${topic ?? ""}`,
   clientMessageIdForTurn: (_storeKey: string, turnId: string) => turnId,
-  onEnvelopeAdmitted: (
+  onEnvelopeObserved: (
     listener: (storeKey: string, envelope: Record<string, unknown>) => void,
   ) => {
     projectionStoreMock.listener = listener;
@@ -224,6 +225,24 @@ describe("pickFreshAudio", () => {
 });
 
 describe("buildVoiceTurns", () => {
+  it("shows a provisional ASR turn before any canonical thread exists", () => {
+    expect(
+      buildVoiceTurns(
+        [],
+        0,
+        new Map([["turn-provisional", "先显示识别文字"]]),
+        ["turn-provisional"],
+      ),
+    ).toEqual([
+      {
+        id: "turn-provisional",
+        userText: "先显示识别文字",
+        assistantText: "",
+        awaitingTranscript: false,
+      },
+    ]);
+  });
+
   it("uses a live ASR transcript when the canonical user row is still empty", () => {
     const threads = [
       {
@@ -450,40 +469,23 @@ describe("farewellAudioActive (fallback must not cut off the goodbye)", () => {
 describe("live ASR transcript projection", () => {
   afterEach(() => {
     threadsMock.value = [];
+    VoiceTranscriptStore.__resetVoiceTranscriptStoreForTests();
   });
 
   it("updates the visible turn before canonical history contains the transcript", () => {
-    threadsMock.value = [
-      {
-        id: "turn-live-asr",
-        userMsg: {
-          text: "",
-          files: [{ path: "uploads/utterance.wav" }],
-        },
-        pendingAssistant: null,
-        responses: [],
-      },
-    ];
-    const { result, unmount } = renderHook(() =>
+    threadsMock.value = [];
+    const { result, rerender, unmount } = renderHook(() =>
       useVoiceConversation("voice-live-asr"),
     );
 
-    expect(result.current.turns[0]).toEqual(
-      expect.objectContaining({
-        userText: "",
-        awaitingTranscript: true,
-      }),
-    );
+    expect(result.current.turns).toEqual([]);
 
     act(() => {
-      window.dispatchEvent(
-        new CustomEvent("crew:voice_transcript", {
-          detail: {
-            sessionId: "voice-live-asr",
-            threadId: "turn-live-asr",
-            transcript: "提前显示这句话",
-          },
-        }),
+      VoiceTranscriptStore.upsert(
+        "voice-live-asr",
+        undefined,
+        "turn-live-asr",
+        "提前显示这句话",
       );
     });
 
@@ -494,6 +496,54 @@ describe("live ASR transcript projection", () => {
       }),
     );
     expect(result.current.lastUserText).toBe("提前显示这句话");
+
+    threadsMock.value = [
+      {
+        id: "turn-live-asr",
+        turnId: "turn-live-asr",
+        userMsg: {
+          text: "",
+          files: [{ path: "uploads/utterance.wav" }],
+        },
+        pendingAssistant: {
+          role: "assistant",
+          text: "稍后出现回答",
+          files: [],
+        },
+        responses: [],
+      },
+    ];
+    rerender();
+    expect(result.current.turns).toHaveLength(1);
+    expect(result.current.turns[0]).toEqual(
+      expect.objectContaining({
+        userText: "提前显示这句话",
+        assistantText: "稍后出现回答",
+      }),
+    );
+    unmount();
+  });
+
+  it("replays a transcript that arrived before the voice hook subscribed", () => {
+    VoiceTranscriptStore.upsert(
+      "voice-asr-before-mount",
+      undefined,
+      "turn-before-mount",
+      "订阅之前已经到达",
+    );
+
+    const { result, unmount } = renderHook(() =>
+      useVoiceConversation("voice-asr-before-mount"),
+    );
+
+    expect(result.current.turns).toEqual([
+      {
+        id: "turn-before-mount",
+        userText: "订阅之前已经到达",
+        assistantText: "",
+        awaitingTranscript: false,
+      },
+    ]);
     unmount();
   });
 });
@@ -513,7 +563,7 @@ describe("canonical reply-audio delivery", () => {
     getActiveBridgeMock.mockReturnValue(undefined);
   });
 
-  it("plays an admitted audio envelope even when it is absent from the terminal projection", async () => {
+  it("plays every observed sentence file even when consecutive files reuse a seq", async () => {
     vi.stubGlobal(
       "fetch",
       vi.fn(async () => ({
@@ -551,9 +601,26 @@ describe("canonical reply-audio delivery", () => {
           payload: {
             type: "file_attached",
             data: {
-              path: "reply-after-terminal.mp3",
+              path: "reply-first.mp3",
               mime: "audio/mpeg",
               size_bytes: 42,
+            },
+          },
+        },
+      );
+      projectionStoreMock.listener?.(
+        "voice-post-terminal-audio\u0000",
+        {
+          session_id: "voice-post-terminal-audio",
+          thread_id: "turn-post-terminal",
+          turn_id: "turn-post-terminal",
+          seq: 4,
+          payload: {
+            type: "file_attached",
+            data: {
+              path: "reply-second.mp3",
+              mime: "audio/mpeg",
+              size_bytes: 44,
             },
           },
         },
@@ -562,11 +629,24 @@ describe("canonical reply-audio delivery", () => {
     });
 
     expect(fetch).toHaveBeenCalledWith(
-      "reply-after-terminal.mp3?session=voice-post-terminal-audio",
+      "reply-first.mp3?session=voice-post-terminal-audio",
       { headers: {} },
     );
     expect(audioMock.playAudioBlob).toHaveBeenCalledTimes(1);
     expect(result.current.state).toBe("speaking");
+
+    await act(async () => {
+      const finishFirst = audioMock.state.onEnded;
+      audioMock.state.onEnded = null;
+      finishFirst?.();
+      for (let i = 0; i < 8; i++) await Promise.resolve();
+    });
+
+    expect(fetch).toHaveBeenCalledWith(
+      "reply-second.mp3?session=voice-post-terminal-audio",
+      { headers: {} },
+    );
+    expect(audioMock.playAudioBlob).toHaveBeenCalledTimes(2);
     unmount();
   });
 });

--- a/src/home/voice/use-voice-conversation.ts
+++ b/src/home/voice/use-voice-conversation.ts
@@ -1,4 +1,10 @@
-import { useCallback, useEffect, useRef, useState } from "react";
+import {
+  useCallback,
+  useEffect,
+  useRef,
+  useState,
+  useSyncExternalStore,
+} from "react";
 import { uploadFiles } from "@/api/chat";
 import {
   interruptActiveTurn,
@@ -8,6 +14,7 @@ import { getActiveBridge } from "@/runtime/ui-protocol-runtime";
 import type { Thread, ThreadMessage } from "@/store/thread-store";
 import { useRenderThreads } from "@/store/projection-render-adapter";
 import * as ProjectionStore from "@/store/projection-store";
+import * as VoiceTranscriptStore from "@/store/voice-transcript-store";
 import { buildFileUrl } from "@/api/files";
 import { buildApiHeaders } from "@/api/client";
 import { useVoiceCapture } from "./use-voice-capture";
@@ -211,8 +218,15 @@ export function buildVoiceTurns(
   threads: Thread[],
   baseline = 0,
   liveTranscripts: ReadonlyMap<string, string> = new Map(),
+  provisionalTurnIds: readonly string[] = [],
 ): VoiceConversationTurn[] {
-  return threads.slice(baseline).filter((thread) => !thread.backgroundChild).map((thread) => {
+  const visibleThreads = threads
+    .slice(baseline)
+    .filter((thread) => !thread.backgroundChild);
+  const canonicalIds = new Set<string>();
+  const canonicalTurns = visibleThreads.map((thread) => {
+    canonicalIds.add(thread.id);
+    if (thread.turnId) canonicalIds.add(thread.turnId);
     const assistants: ThreadMessage[] = [
       ...thread.responses.filter((m) => m.role === "assistant"),
       ...(thread.pendingAssistant ? [thread.pendingAssistant] : []),
@@ -221,7 +235,9 @@ export function buildVoiceTurns(
       [...assistants].reverse().find((m) => m.text.trim().length > 0)?.text ?? "",
     );
     const userText = stripLearningContext(
-      liveTranscripts.get(thread.id) ?? thread.userMsg.text,
+      liveTranscripts.get(thread.id) ??
+        (thread.turnId ? liveTranscripts.get(thread.turnId) : undefined) ??
+        thread.userMsg.text,
     );
     const awaitingTranscript =
       userText.length === 0 &&
@@ -233,6 +249,18 @@ export function buildVoiceTurns(
       awaitingTranscript,
     };
   });
+  const provisionalTurns = provisionalTurnIds
+    .filter((turnId) => !canonicalIds.has(turnId))
+    .map((turnId) => {
+      const userText = stripLearningContext(liveTranscripts.get(turnId) ?? "");
+      return {
+        id: turnId,
+        userText,
+        assistantText: "",
+        awaitingTranscript: userText.length === 0,
+      };
+    });
+  return [...canonicalTurns, ...provisionalTurns];
 }
 
 const HTML_EXT = /\.html?$/i;
@@ -358,9 +386,14 @@ export function useVoiceConversation(
   const resetCameraSettings = camera.resetSettings;
   const [state, setState] = useState<VoiceState>("idle");
   const [lastAssistantText, setLastAssistantText] = useState("");
-  const [liveTranscripts, setLiveTranscripts] = useState<
-    ReadonlyMap<string, string>
-  >(() => new Map());
+  const [provisionalTurnIds, setProvisionalTurnIds] = useState<readonly string[]>(
+    [],
+  );
+  const transcriptSnapshot = useSyncExternalStore(
+    VoiceTranscriptStore.subscribe,
+    () => VoiceTranscriptStore.getSnapshot(sessionId, historyTopic),
+    () => VoiceTranscriptStore.getSnapshot(sessionId, historyTopic),
+  );
   const [visual, setVisual] = useState<VisualArtifact | null>(null);
   const [generating, setGenerating] = useState(false);
   const [exiting, setExiting] = useState(false);
@@ -519,6 +552,9 @@ export function useVoiceConversation(
     async (wav: Blob, includeCamera?: boolean) => {
       try {
         const turnId = crypto.randomUUID();
+        setProvisionalTurnIds((current) =>
+          current.includes(turnId) ? current : [...current, turnId],
+        );
         activeTurnIdRef.current = turnId;
         stateRef.current = "thinking";
         setState("thinking");
@@ -581,6 +617,12 @@ export function useVoiceConversation(
         }, REPLY_TIMEOUT_MS);
       } catch (e) {
         console.error("[voice] upload/send failed", e);
+        const failedTurnId = activeTurnIdRef.current;
+        if (failedTurnId) {
+          setProvisionalTurnIds((current) =>
+            current.filter((turnId) => turnId !== failedTurnId),
+          );
+        }
         setState("error");
       }
     },
@@ -808,6 +850,8 @@ export function useVoiceConversation(
     turnBaselineRef.current = baseline;
     setTurnBaseline(baseline);
     setLastAssistantText("");
+    setProvisionalTurnIds([]);
+    VoiceTranscriptStore.clearScope(sessionId, historyTopic);
     // Rich output: mark pre-existing artifacts as seen so re-entry doesn't
     // re-surface a prior turn's visual; reset the live visual/generating state.
     seenVisualsRef.current = new Set(
@@ -903,6 +947,8 @@ export function useVoiceConversation(
     setVisual(null);
     setGenerating(false);
     clearTimeout(exitFallbackTimerRef.current);
+    setProvisionalTurnIds([]);
+    VoiceTranscriptStore.clearScope(sessionId, historyTopic);
     void captureStop();
     cameraStop();
     clearSentFrame();
@@ -915,6 +961,8 @@ export function useVoiceConversation(
     clearSentFrame,
     playReplyAudio,
     releaseAudio,
+    historyTopic,
+    sessionId,
   ]);
 
   // Leave the voice screen: one-shot. Tears down capture/audio/camera, then
@@ -979,7 +1027,7 @@ export function useVoiceConversation(
       sessionId,
       historyTopic,
     );
-    return ProjectionStore.onEnvelopeAdmitted((storeKey, envelope) => {
+    return ProjectionStore.onEnvelopeObserved((storeKey, envelope) => {
       if (!playReplyAudio) return;
       if (
         storeKey !== projectionKey ||
@@ -997,9 +1045,9 @@ export function useVoiceConversation(
       if (ignoredTurnIdsRef.current.has(renderThreadId)) return;
 
       // Reply audio is an interaction side effect, not durable chat content.
-      // Observe the admitted envelope directly so a TTS file that lands after
-      // the canonical turn terminal can still play without weakening the
-      // projection's hard post-terminal rendering barrier.
+      // Playback is a path-idempotent interaction side effect. Observe before
+      // canonical seq dedupe so older servers that assign the same seq to
+      // consecutive sentence files cannot truncate the spoken reply.
       playedPathsRef.current.add(path);
       audioTurnByPathRef.current.set(path, renderThreadId);
       audioQueueRef.current.push(path);
@@ -1203,12 +1251,12 @@ export function useVoiceConversation(
       const threadId = detail.threadId ?? detail.turnId ?? "";
       const transcript = detail.transcript?.trim() ?? "";
       if (!threadId || !transcript) return;
-      setLiveTranscripts((current) => {
-        if (current.get(threadId) === transcript) return current;
-        const next = new Map(current);
-        next.set(threadId, transcript);
-        return next;
-      });
+      VoiceTranscriptStore.upsert(
+        sessionId,
+        historyTopic,
+        threadId,
+        transcript,
+      );
     };
     window.addEventListener("crew:voice_transcript", onTranscript);
     return () =>
@@ -1242,6 +1290,13 @@ export function useVoiceConversation(
       audioQueueRef.current = [];
       audioTurnByPathRef.current.clear();
       speakingTurnIdRef.current = null;
+      const silentTurnId = detail?.threadId ?? detail?.turnId;
+      if (silentTurnId) {
+        VoiceTranscriptStore.remove(sessionId, historyTopic, silentTurnId);
+        setProvisionalTurnIds((current) =>
+          current.filter((turnId) => turnId !== silentTurnId),
+        );
+      }
       if (stateRef.current === "thinking") {
         void beginListeningRef.current();
       }
@@ -1257,18 +1312,19 @@ export function useVoiceConversation(
   stopRef.current = stop;
   useEffect(() => () => stopRef.current(), []);
 
-  const latestUserThread = threads
-    .slice(turnBaseline)
-    .reverse()
-    .find((thread) => !thread.backgroundChild);
-  const lastUserText = stripLearningContext(
-    (latestUserThread
-      ? liveTranscripts.get(latestUserThread.id)
-      : undefined) ??
-      latestUserThread?.userMsg.text ??
-      "",
+  const visibleTurnIds = [
+    ...provisionalTurnIds,
+    ...transcriptSnapshot.turnIds.filter(
+      (turnId) => !provisionalTurnIds.includes(turnId),
+    ),
+  ];
+  const turns = buildVoiceTurns(
+    threads,
+    turnBaseline,
+    transcriptSnapshot.transcripts,
+    visibleTurnIds,
   );
-  const turns = buildVoiceTurns(threads, turnBaseline, liveTranscripts);
+  const lastUserText = turns.at(-1)?.userText ?? "";
 
   const dismissVisual = useCallback(() => setVisual(null), []);
 

--- a/src/runtime/ui-protocol-bridge.test.ts
+++ b/src/runtime/ui-protocol-bridge.test.ts
@@ -47,6 +47,7 @@ import type {
   WarningEvent,
 } from "./ui-protocol-types";
 import * as ProjectionStore from "@/store/projection-store";
+import * as VoiceTranscriptStore from "@/store/voice-transcript-store";
 
 // ---------------------------------------------------------------------------
 // MockWebSocket
@@ -203,6 +204,7 @@ afterEach(() => {
   vi.useRealTimers();
   vi.unstubAllGlobals();
   ProjectionStore.__resetProjectionForTests();
+  VoiceTranscriptStore.__resetVoiceTranscriptStoreForTests();
 });
 
 // ---------------------------------------------------------------------------
@@ -2596,6 +2598,31 @@ describe("notification dispatch", () => {
     expect(progressed).toHaveLength(1);
     expect(completed).toHaveLength(1);
     expect(updates).toHaveLength(1);
+  });
+
+  it("retains voice transcripts at the WebSocket boundary before router subscribers run", async () => {
+    const { ws } = await freshConnected();
+
+    ws.triggerMessage({
+      jsonrpc: "2.0",
+      method: METHODS.PROGRESS_UPDATED,
+      params: {
+        session_id: "sess-1",
+        turn_id: "server-turn-1",
+        metadata: {
+          kind: "voice_transcript",
+          message: "WebSocket 直接写入",
+          client_message_id: "client-turn-1",
+          transcript: "WebSocket 直接写入",
+        },
+      },
+    });
+
+    const snapshot = VoiceTranscriptStore.getSnapshot("sess-1");
+    expect(snapshot.transcripts.get("client-turn-1")).toBe(
+      "WebSocket 直接写入",
+    );
+    expect(snapshot.turnIds).toEqual(["client-turn-1"]);
   });
 
   it("Wave4-A: routes router/status, router/failover, queue/state through the new subscribers", async () => {

--- a/src/runtime/ui-protocol-bridge.ts
+++ b/src/runtime/ui-protocol-bridge.ts
@@ -21,6 +21,7 @@ import {
   type ProjectionEnvelopeV2TerminalOutcome,
 } from "./projection-envelope-v2";
 import * as ProjectionStore from "@/store/projection-store";
+import * as VoiceTranscriptStore from "@/store/voice-transcript-store";
 import {
   AUX_REST_TO_WS_V1_FEATURE,
 } from "@/lib/feature-flags";
@@ -1931,7 +1932,44 @@ class UiProtocolBridgeImpl implements UiProtocolBridge {
     },
     [METHODS.PROGRESS_UPDATED]: {
       guard: guardProgressUpdated,
-      emit: (v) => this.subProgressUpdated.emit(v as ProgressUpdatedEvent),
+      emit: (v) => {
+        const event = v as ProgressUpdatedEvent;
+        if (event.metadata.kind === "voice_transcript") {
+          const transcript =
+            typeof event.metadata.transcript === "string"
+              ? event.metadata.transcript
+              : typeof event.metadata.message === "string"
+                ? event.metadata.message
+                : "";
+          const turnId =
+            typeof event.metadata.client_message_id === "string" &&
+            event.metadata.client_message_id.length > 0
+              ? event.metadata.client_message_id
+              : event.turn_id;
+          if (turnId && transcript.trim()) {
+            VoiceTranscriptStore.upsert(
+              event.session_id,
+              this.topicScope ?? undefined,
+              turnId,
+              transcript,
+            );
+          }
+        } else if (event.metadata.kind === "voice_no_speech") {
+          const turnId =
+            typeof event.metadata.client_message_id === "string" &&
+            event.metadata.client_message_id.length > 0
+              ? event.metadata.client_message_id
+              : event.turn_id;
+          if (turnId) {
+            VoiceTranscriptStore.remove(
+              event.session_id,
+              this.topicScope ?? undefined,
+              turnId,
+            );
+          }
+        }
+        this.subProgressUpdated.emit(event);
+      },
     },
     [METHODS.ROUTER_STATUS]: {
       guard: guardRouterStatus,

--- a/src/store/projection-store.test.ts
+++ b/src/store/projection-store.test.ts
@@ -43,6 +43,41 @@ afterEach(() => {
 });
 
 describe("ProjectionStore canonical admission", () => {
+  it("observes distinct interaction side effects even when they reuse a canonical seq", () => {
+    const key = ProjectionStore.projectionStoreKey("session-store");
+    const observed = vi.fn();
+    const admitted = vi.fn();
+    const disposeObserved = ProjectionStore.onEnvelopeObserved(observed);
+    const disposeAdmitted = ProjectionStore.onEnvelopeAdmitted(admitted);
+    const first = frame(1, {
+      type: "file_attached",
+      data: {
+        path: "reply-first.mp3",
+        mime: "audio/mpeg",
+        size_bytes: 10,
+        attachment_owner: { assistant_segment_id: "segment-store" },
+      },
+    });
+    const second = frame(1, {
+      type: "file_attached",
+      data: {
+        path: "reply-second.mp3",
+        mime: "audio/mpeg",
+        size_bytes: 12,
+        attachment_owner: { assistant_segment_id: "segment-store" },
+      },
+    });
+
+    ProjectionStore.ingest(key, first);
+    ProjectionStore.ingest(key, second);
+
+    expect(observed).toHaveBeenNthCalledWith(1, key, first);
+    expect(observed).toHaveBeenNthCalledWith(2, key, second);
+    expect(admitted).toHaveBeenCalledTimes(1);
+    disposeObserved();
+    disposeAdmitted();
+  });
+
   it("starts at seq 1, buffers a gap, and requests rehydrate until it closes", () => {
     const key = ProjectionStore.projectionStoreKey("session-store");
     const request = vi.fn();

--- a/src/store/projection-store.ts
+++ b/src/store/projection-store.ts
@@ -59,6 +59,9 @@ const listeners = new Set<() => void>();
 const admittedEnvelopeListeners = new Set<
   (storeKey: string, envelope: ProjectionEnvelopeV2) => void
 >();
+const observedEnvelopeListeners = new Set<
+  (storeKey: string, envelope: ProjectionEnvelopeV2) => void
+>();
 const rehydrateListeners = new Set<(storeKey: string, watermark: ProjectionEnvelopeV2Cursor | null) => void>();
 const persistentRehydrateListeners = new Set<
   (storeKey: string, watermark: ProjectionEnvelopeV2Cursor | null) => void
@@ -120,6 +123,23 @@ function notifyEnvelopeAdmitted(
       listener(storeKey, envelope);
     } catch (error) {
       console.error("projection-store admitted-envelope listener threw", error);
+    }
+  }
+}
+
+/** Notify interaction consumers about every validated live envelope before
+ * canonical `(thread_id, seq)` deduplication. Durable rendering must never use
+ * this signal, but one-shot side effects such as TTS playback cannot discard a
+ * distinct attachment merely because an older server reused its sequence. */
+function notifyEnvelopeObserved(
+  storeKey: string,
+  envelope: ProjectionEnvelopeV2,
+): void {
+  for (const listener of [...observedEnvelopeListeners]) {
+    try {
+      listener(storeKey, envelope);
+    } catch (error) {
+      console.error("projection-store observed-envelope listener threw", error);
     }
   }
 }
@@ -357,6 +377,7 @@ export function ingest(
   storeKey: string,
   envelope: ProjectionEnvelopeV2,
 ): ProjectionIngestResult {
+  notifyEnvelopeObserved(storeKey, envelope);
   const state = stateFor(storeKey);
   if (state.hydrating) {
     state.bufferedLive.push(envelope);
@@ -547,6 +568,16 @@ export function onEnvelopeAdmitted(
   return () => admittedEnvelopeListeners.delete(listener);
 }
 
+/** Subscribe to validated live envelopes before canonical sequence dedupe.
+ * Use only for idempotent interaction side effects; render state belongs to
+ * `onEnvelopeAdmitted` / `getProjection`. */
+export function onEnvelopeObserved(
+  listener: (storeKey: string, envelope: ProjectionEnvelopeV2) => void,
+): () => void {
+  observedEnvelopeListeners.add(listener);
+  return () => observedEnvelopeListeners.delete(listener);
+}
+
 export function onRehydrateRequested(
   listener: (storeKey: string, watermark: ProjectionEnvelopeV2Cursor | null) => void,
   options: { persistent?: boolean } = {},
@@ -592,6 +623,7 @@ export function __resetProjectionForTests(): void {
   states.clear();
   listeners.clear();
   admittedEnvelopeListeners.clear();
+  observedEnvelopeListeners.clear();
   rehydrateListeners.clear();
   // Runtime owns a process-lifetime recovery hook. Keep that hook installed
   // across state resets so tests exercising reconnect/gap recovery still use

--- a/src/store/voice-transcript-store.test.ts
+++ b/src/store/voice-transcript-store.test.ts
@@ -1,0 +1,55 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import * as VoiceTranscriptStore from "./voice-transcript-store";
+
+afterEach(() => {
+  VoiceTranscriptStore.__resetVoiceTranscriptStoreForTests();
+});
+
+describe("voice transcript receive store", () => {
+  it("retains a transcript for consumers that subscribe later", () => {
+    VoiceTranscriptStore.upsert(
+      "voice-session",
+      undefined,
+      "turn-1",
+      "先到达的识别文字",
+    );
+
+    expect(
+      VoiceTranscriptStore.getSnapshot("voice-session").transcripts.get(
+        "turn-1",
+      ),
+    ).toBe("先到达的识别文字");
+    expect(
+      VoiceTranscriptStore.getSnapshot("voice-session").turnIds,
+    ).toEqual(["turn-1"]);
+  });
+
+  it("notifies subscribers and isolates session/topic scopes", () => {
+    const listener = vi.fn();
+    const unsubscribe = VoiceTranscriptStore.subscribe(listener);
+
+    VoiceTranscriptStore.upsert("voice-session", "lesson", "turn-1", "一");
+
+    expect(listener).toHaveBeenCalledTimes(1);
+    expect(
+      VoiceTranscriptStore.getSnapshot("voice-session", "lesson").transcripts,
+    ).toEqual(new Map([["turn-1", "一"]]));
+    expect(
+      VoiceTranscriptStore.getSnapshot("voice-session").transcripts,
+    ).toEqual(new Map());
+
+    unsubscribe();
+  });
+
+  it("does not collide when a session id contains the topic separator", () => {
+    VoiceTranscriptStore.upsert("voice#lesson", undefined, "turn-1", "甲");
+    VoiceTranscriptStore.upsert("voice", "lesson", "turn-2", "乙");
+
+    expect(
+      VoiceTranscriptStore.getSnapshot("voice#lesson").transcripts,
+    ).toEqual(new Map([["turn-1", "甲"]]));
+    expect(
+      VoiceTranscriptStore.getSnapshot("voice", "lesson").transcripts,
+    ).toEqual(new Map([["turn-2", "乙"]]));
+  });
+});

--- a/src/store/voice-transcript-store.ts
+++ b/src/store/voice-transcript-store.ts
@@ -1,0 +1,99 @@
+/**
+ * Durable-in-memory receive store for voice ASR progress.
+ *
+ * `progress/updated(kind=voice_transcript)` can arrive several seconds before
+ * the first canonical user/assistant envelope. A one-shot DOM event is not a
+ * render source: consumers that subscribe after the dispatch permanently miss
+ * it. This store records the latest transcript at the WebSocket boundary and
+ * exposes a stable snapshot through `useSyncExternalStore`.
+ */
+
+export interface VoiceTranscriptSnapshot {
+  transcripts: ReadonlyMap<string, string>;
+  turnIds: readonly string[];
+}
+
+interface MutableVoiceTranscriptState {
+  transcripts: Map<string, string>;
+  turnIds: string[];
+  snapshot: VoiceTranscriptSnapshot;
+}
+
+const EMPTY_SNAPSHOT: VoiceTranscriptSnapshot = {
+  transcripts: new Map(),
+  turnIds: [],
+};
+const states = new Map<string, MutableVoiceTranscriptState>();
+const listeners = new Set<() => void>();
+
+function storeKey(sessionId: string, topic?: string): string {
+  const trimmedTopic = topic?.trim();
+  return `${sessionId}\u0000${trimmedTopic ?? ""}`;
+}
+
+function publish(state: MutableVoiceTranscriptState): void {
+  state.snapshot = {
+    transcripts: new Map(state.transcripts),
+    turnIds: state.turnIds.slice(),
+  };
+  for (const listener of [...listeners]) listener();
+}
+
+export function upsert(
+  sessionId: string,
+  topic: string | undefined,
+  turnId: string,
+  transcript: string,
+): void {
+  const text = transcript.trim();
+  if (!sessionId || !turnId || !text) return;
+  const key = storeKey(sessionId, topic);
+  let state = states.get(key);
+  if (!state) {
+    state = {
+      transcripts: new Map(),
+      turnIds: [],
+      snapshot: EMPTY_SNAPSHOT,
+    };
+    states.set(key, state);
+  }
+  if (state.transcripts.get(turnId) === text) return;
+  if (!state.transcripts.has(turnId)) state.turnIds.push(turnId);
+  state.transcripts.set(turnId, text);
+  publish(state);
+}
+
+export function remove(
+  sessionId: string,
+  topic: string | undefined,
+  turnId: string,
+): void {
+  const state = states.get(storeKey(sessionId, topic));
+  if (!state?.transcripts.has(turnId)) return;
+  state.transcripts.delete(turnId);
+  state.turnIds = state.turnIds.filter((id) => id !== turnId);
+  publish(state);
+}
+
+export function clearScope(sessionId: string, topic?: string): void {
+  const key = storeKey(sessionId, topic);
+  if (!states.delete(key)) return;
+  for (const listener of [...listeners]) listener();
+}
+
+export function getSnapshot(
+  sessionId: string,
+  topic?: string,
+): VoiceTranscriptSnapshot {
+  return states.get(storeKey(sessionId, topic))?.snapshot ?? EMPTY_SNAPSHOT;
+}
+
+export function subscribe(listener: () => void): () => void {
+  listeners.add(listener);
+  return () => listeners.delete(listener);
+}
+
+export function __resetVoiceTranscriptStoreForTests(): void {
+  states.clear();
+  listeners.clear();
+}


### PR DESCRIPTION
## Summary
- retain live ASR transcripts at the WebSocket receive boundary and expose them through a replayable external store
- render ASR text before a canonical user/assistant projection exists, then merge it into the canonical turn
- observe TTS attachment envelopes before canonical sequence deduplication while keeping playback path-idempotent
- add regression coverage for pre-subscription ASR delivery and repeated attachment sequence numbers

## Root cause
`voice_transcript` arrived several seconds before the first canonical projection, but `/voice` depended on a lossy compatibility event and a projection thread that did not exist yet. Separately, older servers could reuse a projection sequence for consecutive TTS files, causing canonical deduplication to hide later sentences from playback.

Backend companion: https://github.com/octos-org/octos/pull/1917

## Tests
- `pnpm test:unit` (808 tests)
- `pnpm run build`
- targeted ESLint (0 errors; existing warnings only)