### PR TITLE
feat(settings): add the Smart Home bridge configuration tab

### DIFF
--- a/src/settings/settings-api.ts
+++ b/src/settings/settings-api.ts
@@ -136,6 +136,15 @@ export interface CloudTtsConfig {
   endpoint?: string;
 }
 
+/** Per-profile smart-home bridge connection (self-hosted / same-LAN).
+ *  `token` comes back MASKED from the server; `save_with_merge` on the
+ *  backend restores a masked value, so echoing it back is safe. */
+export interface SmartHomeProfileConfig {
+  bridge_url?: string | null;
+  token?: string | null;
+  token_env?: string | null;
+}
+
 export interface ProfileConfig {
   llm: {
     primary: LlmPrimary;
@@ -156,6 +165,7 @@ export interface ProfileConfig {
   // `null` clears the per-profile override → inherit the server default.
   tts_provider?: string | null;
   tts_cloud?: CloudTtsConfig | null;
+  smart_home?: SmartHomeProfileConfig | null;
 }
 
 export interface ProfileStatus {
@@ -396,6 +406,9 @@ export function mergeProfileConfig(
   }
   if (patch.tts_cloud !== undefined) {
     next.tts_cloud = patch.tts_cloud;
+  }
+  if (patch.smart_home !== undefined) {
+    next.smart_home = patch.smart_home;
   }
 
   return next;

--- a/src/settings/settings-page.tsx
+++ b/src/settings/settings-page.tsx
@@ -4,6 +4,7 @@ import { useAuth } from "@/auth/auth-context";
 import {
   User,
   Cpu,
+  Home,
   Puzzle,
   Radio,
   Users,
@@ -33,6 +34,7 @@ import { LlmTab } from "./llm-tab";
 import { ApiKeysTab } from "./api-keys-tab";
 import { SkillsTab } from "./skills-tab";
 import { ChannelsTab } from "./channels-tab";
+import { SmartHomeTab } from "./smart-home-tab";
 import { UsersTab } from "./users-tab";
 import { SandboxTab } from "./sandbox-tab";
 import { ToolsTab } from "./tools-tab";
@@ -45,7 +47,7 @@ import { MemoryTab } from "./memory-tab";
 import { CronTab } from "./cron-tab";
 import { AuthenticationTab } from "./authentication-tab";
 
-type TabId = "profile" | "appearance" | "llm" | "api-keys" | "voice" | "memory" | "schedule" | "skills" | "channels" | "sandbox" | "tools" | "authentication" | "users" | "system" | "server" | "ominix";
+type TabId = "profile" | "appearance" | "llm" | "api-keys" | "voice" | "memory" | "schedule" | "skills" | "channels" | "smart-home" | "sandbox" | "tools" | "authentication" | "users" | "system" | "server" | "ominix";
 
 interface TabDef {
   id: TabId;
@@ -64,6 +66,7 @@ const TABS: TabDef[] = [
   { id: "schedule", label: "Schedule", icon: AlarmClock },
   { id: "skills", label: "Skills", icon: Puzzle },
   { id: "channels", label: "Channels", icon: Radio },
+  { id: "smart-home", label: "Smart Home", icon: Home },
   { id: "sandbox", label: "Sandbox", icon: Shield },
   { id: "tools", label: "Tools", icon: Wrench },
   { id: "authentication", label: "Authentication", icon: ShieldCheck, adminOnly: true },
@@ -238,6 +241,13 @@ export function AdminSettingsPage() {
                   {activeTab === "schedule" && <CronTab key={selectedProfileId} />}
                   {activeTab === "skills" && <SkillsTab />}
                   {activeTab === "channels" && <ChannelsTab profile={profile} onProfileUpdated={setProfile} />}
+                  {activeTab === "smart-home" && (
+                    <SmartHomeTab
+                      key={profile.id}
+                      profile={profile}
+                      onProfileUpdated={setProfile}
+                    />
+                  )}
                   {activeTab === "sandbox" && (
                     <SandboxTab profile={profile} onProfileUpdated={setProfile} />
                   )}

--- a/src/settings/smart-home-tab.test.tsx
+++ b/src/settings/smart-home-tab.test.tsx
@@ -1,0 +1,206 @@
+import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { SmartHomeTab } from "./smart-home-tab";
+import type { Profile } from "./settings-api";
+
+const apiMocks = vi.hoisted(() => ({
+  updateMyProfileConfig: vi.fn(),
+  formatSettingsError: vi.fn((err: unknown, fallback = "Request failed.") =>
+    err instanceof Error ? err.message : fallback,
+  ),
+}));
+
+vi.mock("./settings-api", () => apiMocks);
+
+const bridgeMocks = vi.hoisted(() => ({
+  callMethod: vi.fn(),
+}));
+
+vi.mock("@/runtime/ui-protocol-runtime", () => ({
+  ensureAuxBridge: vi.fn(async () => ({ callMethod: bridgeMocks.callMethod })),
+}));
+
+vi.mock("@/runtime/ui-protocol-bridge", () => ({
+  METHODS: { SMART_HOME_DEVICE_LIST: "smart_home/device.list" },
+}));
+
+function makeProfile(smartHome: Profile["config"]["smart_home"]): Profile {
+  return {
+    id: "p1",
+    name: "P1",
+    enabled: true,
+    data_dir: null,
+    config: {
+      llm: { primary: {}, fallbacks: [] },
+      channels: [],
+      gateway: {},
+      env_vars: {},
+      hooks: [],
+      email: null,
+      api_type: null,
+      admin_mode: false,
+      sandbox: {},
+      adaptive_routing: null,
+      content_routing: null,
+      plugins: { require_signed: false },
+      smart_home: smartHome,
+    },
+    created_at: "2026-01-01T00:00:00Z",
+    updated_at: "2026-01-01T00:00:00Z",
+  } as unknown as Profile;
+}
+
+describe("SmartHomeTab", () => {
+  beforeEach(() => {
+    cleanup();
+    apiMocks.updateMyProfileConfig.mockReset();
+    bridgeMocks.callMethod.mockReset();
+  });
+
+  it("prefills bridge url and token env from the profile", () => {
+    render(
+      <SmartHomeTab
+        profile={makeProfile({
+          bridge_url: "http://192.168.1.50:8787",
+          token: "abcd***xyz",
+          token_env: "SH_TOKEN",
+        })}
+        onProfileUpdated={vi.fn()}
+      />,
+    );
+
+    expect(
+      (screen.getByLabelText(/Bridge URL/) as HTMLInputElement).value,
+    ).toBe("http://192.168.1.50:8787");
+    expect(
+      (screen.getByLabelText(/Token env var/) as HTMLInputElement).value,
+    ).toBe("SH_TOKEN");
+    // Stored token is only echoed as a placeholder, never as input value.
+    const token = screen.getByLabelText(/Auth token/) as HTMLInputElement;
+    expect(token.value).toBe("");
+    expect(token.placeholder).toContain("unchanged");
+  });
+
+  it("saves a new bridge config, sending the typed token", async () => {
+    const onProfileUpdated = vi.fn();
+    const updated = makeProfile({ bridge_url: "http://10.0.0.2:8787" });
+    apiMocks.updateMyProfileConfig.mockResolvedValue(updated);
+
+    render(<SmartHomeTab profile={makeProfile(null)} onProfileUpdated={onProfileUpdated} />);
+
+    fireEvent.change(screen.getByLabelText(/Bridge URL/), {
+      target: { value: "http://10.0.0.2:8787" },
+    });
+    fireEvent.change(screen.getByLabelText(/Auth token/), {
+      target: { value: "fresh-token" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: "Save" }));
+
+    await waitFor(() => expect(apiMocks.updateMyProfileConfig).toHaveBeenCalled());
+    const [, patch] = apiMocks.updateMyProfileConfig.mock.calls[0];
+    expect(patch).toEqual({
+      smart_home: {
+        bridge_url: "http://10.0.0.2:8787",
+        token: "fresh-token",
+        token_env: null,
+      },
+    });
+    expect(onProfileUpdated).toHaveBeenCalledWith(updated);
+  });
+
+  it("echoes the stored masked token when the user does not type a new one", async () => {
+    apiMocks.updateMyProfileConfig.mockResolvedValue(
+      makeProfile({ bridge_url: "http://192.168.1.50:8787", token: "abcd***xyz" }),
+    );
+
+    render(
+      <SmartHomeTab
+        profile={makeProfile({
+          bridge_url: "http://192.168.1.50:8787",
+          token: "abcd***xyz",
+        })}
+        onProfileUpdated={vi.fn()}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "Save" }));
+
+    await waitFor(() => expect(apiMocks.updateMyProfileConfig).toHaveBeenCalled());
+    const [, patch] = apiMocks.updateMyProfileConfig.mock.calls[0];
+    // The masked echo is safe: the backend's save_with_merge restores it.
+    expect(patch.smart_home.token).toBe("abcd***xyz");
+  });
+
+  it("clears the whole section when the bridge url is emptied", async () => {
+    apiMocks.updateMyProfileConfig.mockResolvedValue(makeProfile(null));
+
+    render(
+      <SmartHomeTab
+        profile={makeProfile({ bridge_url: "http://192.168.1.50:8787" })}
+        onProfileUpdated={vi.fn()}
+      />,
+    );
+
+    fireEvent.change(screen.getByLabelText(/Bridge URL/), { target: { value: "" } });
+    fireEvent.click(screen.getByRole("button", { name: "Save" }));
+
+    await waitFor(() => expect(apiMocks.updateMyProfileConfig).toHaveBeenCalled());
+    const [, patch] = apiMocks.updateMyProfileConfig.mock.calls[0];
+    expect(patch).toEqual({ smart_home: null });
+  });
+
+  it("shows the save error when the request fails", async () => {
+    apiMocks.updateMyProfileConfig.mockRejectedValue(new Error("boom"));
+
+    render(
+      <SmartHomeTab
+        profile={makeProfile({ bridge_url: "http://192.168.1.50:8787" })}
+        onProfileUpdated={vi.fn()}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "Save" }));
+
+    await waitFor(() => expect(screen.getByRole("alert").textContent).toContain("boom"));
+  });
+
+  it("reports device count on a successful connection test", async () => {
+    bridgeMocks.callMethod.mockResolvedValue({
+      devices: { ok: true, devices: [{ id: "a" }, { id: "b" }] },
+    });
+
+    render(
+      <SmartHomeTab
+        profile={makeProfile({ bridge_url: "http://192.168.1.50:8787" })}
+        onProfileUpdated={vi.fn()}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "Test connection" }));
+
+    await waitFor(() =>
+      expect(screen.getByText(/Connected — 2 devices found\./)).toBeTruthy(),
+    );
+    expect(bridgeMocks.callMethod).toHaveBeenCalledWith("smart_home/device.list", {});
+  });
+
+  it("reports the bridge error on a failed connection test", async () => {
+    bridgeMocks.callMethod.mockResolvedValue({
+      devices: { ok: false, error: "hub unreachable" },
+    });
+
+    render(
+      <SmartHomeTab
+        profile={makeProfile({ bridge_url: "http://192.168.1.50:8787" })}
+        onProfileUpdated={vi.fn()}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "Test connection" }));
+
+    await waitFor(() =>
+      expect(screen.getByText(/Bridge error: hub unreachable/)).toBeTruthy(),
+    );
+  });
+});

--- a/src/settings/smart-home-tab.tsx
+++ b/src/settings/smart-home-tab.tsx
@@ -1,0 +1,231 @@
+// Smart Home tab — the configuration surface for the per-profile
+// smart-home bridge (`config.smart_home`). Until this existed the bridge
+// could only be configured by hand-editing the profile JSON or a raw
+// `PUT /api/my/profile`, even though the backend, the dashboard widget,
+// and the conversation skill were all wired up (the skill's SKILL.md
+// already pointed users at "Settings → Smart Home").
+//
+// Save goes through the same generic profile-config JSON-merge-patch as
+// every other tab. The token comes back MASKED from the server; the
+// backend's `save_with_merge` restores a masked echo, so this tab only
+// sends a new token value when the user actually types one.
+import { useState } from "react";
+import { Home, Loader2, PlugZap } from "lucide-react";
+
+import { METHODS } from "@/runtime/ui-protocol-bridge";
+import { ensureAuxBridge } from "@/runtime/ui-protocol-runtime";
+import {
+  formatSettingsError,
+  updateMyProfileConfig,
+  type Profile,
+  type SmartHomeProfileConfig,
+} from "./settings-api";
+
+const INPUT_CLASS =
+  "w-full rounded-xl bg-surface-container px-4 py-2.5 text-sm text-text placeholder-muted/50 outline-none border border-transparent focus:border-accent/30 transition";
+
+function Field({
+  label,
+  htmlFor,
+  hint,
+  children,
+}: {
+  label: string;
+  htmlFor: string;
+  hint?: string;
+  children: React.ReactNode;
+}) {
+  return (
+    <div>
+      <label htmlFor={htmlFor} className="mb-1.5 block text-xs font-medium text-muted">
+        {label}
+      </label>
+      {children}
+      {hint ? <p className="mt-1.5 text-xs text-muted/80">{hint}</p> : null}
+    </div>
+  );
+}
+
+interface DeviceListProbe {
+  devices: {
+    ok?: boolean;
+    error?: string;
+    devices?: unknown[];
+  };
+}
+
+export function SmartHomeTab({
+  profile,
+  onProfileUpdated,
+}: {
+  profile: Profile;
+  onProfileUpdated: (p: Profile) => void;
+}) {
+  const current: SmartHomeProfileConfig = profile.config.smart_home ?? {};
+  const [bridgeUrl, setBridgeUrl] = useState(current.bridge_url ?? "");
+  // Empty input = leave the stored (masked) token untouched.
+  const [tokenInput, setTokenInput] = useState("");
+  const [tokenEnv, setTokenEnv] = useState(current.token_env ?? "");
+  const [saving, setSaving] = useState(false);
+  const [saved, setSaved] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [testing, setTesting] = useState(false);
+  const [testResult, setTestResult] = useState<string | null>(null);
+
+  const tokenSet = Boolean(current.token);
+
+  async function save() {
+    setSaving(true);
+    setSaved(false);
+    setError(null);
+    try {
+      const trimmedUrl = bridgeUrl.trim();
+      const trimmedEnv = tokenEnv.trim();
+      // Whole-section value: `null` clears the section entirely.
+      const section: SmartHomeProfileConfig | null = trimmedUrl
+        ? {
+            bridge_url: trimmedUrl,
+            // Echo the masked value unless the user typed a new token —
+            // `save_with_merge` restores a masked echo to the real secret.
+            token: tokenInput ? tokenInput : (current.token ?? null),
+            token_env: trimmedEnv ? trimmedEnv : null,
+          }
+        : null;
+      const updated = await updateMyProfileConfig(profile, { smart_home: section });
+      onProfileUpdated(updated);
+      setTokenInput("");
+      setSaved(true);
+      setTimeout(() => setSaved(false), 2000);
+    } catch (err) {
+      setError(formatSettingsError(err, "Failed to update smart-home config."));
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  async function testConnection() {
+    setTesting(true);
+    setTestResult(null);
+    setError(null);
+    try {
+      const bridge = await ensureAuxBridge();
+      const result = await bridge.callMethod<DeviceListProbe>(
+        METHODS.SMART_HOME_DEVICE_LIST,
+        {},
+      );
+      const data = result.devices;
+      if (data.ok === false) {
+        setTestResult(`Bridge error: ${data.error ?? "unknown error"}`);
+      } else {
+        const count = Array.isArray(data.devices) ? data.devices.length : 0;
+        setTestResult(`Connected — ${count} device${count === 1 ? "" : "s"} found.`);
+      }
+    } catch (err) {
+      setTestResult(formatSettingsError(err, "Bridge is not reachable."));
+    } finally {
+      setTesting(false);
+    }
+  }
+
+  return (
+    <div className="space-y-6">
+      <div className="glass-section rounded-lg p-6">
+        <div className="mb-6 flex items-center gap-3">
+          <div className="flex h-10 w-10 items-center justify-center rounded-xl bg-accent/10 text-accent">
+            <Home size={18} />
+          </div>
+          <div>
+            <h2 className="text-sm font-semibold">Smart Home Bridge</h2>
+            <p className="text-xs text-muted">
+              Self-hosted bridge (e.g. Home Assistant) on your own network. Powers the
+              home dashboard widget and lets the agent list and control devices in chat.
+            </p>
+          </div>
+        </div>
+
+        <div className="space-y-5">
+          <Field
+            label="Bridge URL"
+            htmlFor="sh-bridge-url"
+            hint="Base URL of the bridge on your LAN. Leave empty to disconnect."
+          >
+            <input
+              id="sh-bridge-url"
+              value={bridgeUrl}
+              placeholder="http://192.168.1.50:8787"
+              onChange={(e) => setBridgeUrl(e.target.value)}
+              className={INPUT_CLASS}
+            />
+          </Field>
+
+          <Field
+            label={`Auth token${tokenSet ? " (set)" : ""}`}
+            htmlFor="sh-token"
+            hint="Sent as a Bearer token. Leave empty to keep the current one."
+          >
+            <input
+              id="sh-token"
+              type="password"
+              value={tokenInput}
+              placeholder={tokenSet ? "•••••• (unchanged)" : "Optional"}
+              onChange={(e) => setTokenInput(e.target.value)}
+              className={INPUT_CLASS}
+            />
+          </Field>
+
+          <Field
+            label="Token env var"
+            htmlFor="sh-token-env"
+            hint="Alternative to a literal token: the name of a profile env var holding it."
+          >
+            <input
+              id="sh-token-env"
+              value={tokenEnv}
+              placeholder="SMART_HOME_TOKEN"
+              onChange={(e) => setTokenEnv(e.target.value)}
+              className={INPUT_CLASS}
+            />
+          </Field>
+        </div>
+
+        <div className="mt-6 flex items-center gap-3">
+          <button
+            type="button"
+            onClick={() => void save()}
+            disabled={saving}
+            className="flex items-center gap-2 rounded-xl bg-accent px-5 py-2.5 text-sm font-medium text-white hover:bg-accent-dim disabled:opacity-30 transition"
+          >
+            {saving ? <Loader2 size={14} className="animate-spin" /> : null}
+            {saving ? "Saving…" : "Save"}
+          </button>
+          <button
+            type="button"
+            onClick={() => void testConnection()}
+            disabled={testing}
+            className="inline-flex items-center gap-2 rounded-xl border border-border px-4 py-2 text-sm font-medium transition hover:bg-surface-container disabled:opacity-50"
+          >
+            {testing ? <Loader2 size={14} className="animate-spin" /> : <PlugZap size={14} />}
+            {testing ? "Testing…" : "Test connection"}
+          </button>
+          {saved ? <span className="text-sm text-accent">Saved.</span> : null}
+        </div>
+
+        {testResult ? <p className="mt-3 text-sm text-muted">{testResult}</p> : null}
+        {error ? (
+          <p role="alert" className="mt-3 text-xs text-red-400">
+            {error}
+          </p>
+        ) : null}
+      </div>
+
+      <div className="glass-section rounded-lg p-6">
+        <h3 className="mb-2 text-sm font-semibold">Using it in chat</h3>
+        <p className="text-xs leading-relaxed text-muted">
+          Once a bridge is configured, the agent's smart-home skill can answer
+          "turn on the living room lamp" style requests: it lists devices through
+          the bridge, then sends the command. Camera video stays dashboard-only.
+        </p>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary

The smart-home stack was fully wired (backend bridge client, `smart_home/*` WS methods, dashboard widget, conversation skill) but had **no settings UI** — the skill's SKILL.md pointed users at "Settings → Smart Home", which didn't exist. Configuring a bridge required hand-editing the profile JSON or a raw `PUT /api/my/profile`.

- New **Smart Home** tab (between Channels and Sandbox): bridge URL, auth token, token env var. Saves through the same generic profile-config merge-patch every other tab uses (`updateMyProfileConfig`).
- **Test connection** button probes the bridge via the existing `smart_home/device.list` WS method and reports device count or the bridge error.
- Token handling follows the voice-tab convention: the stored token is only shown as a masked placeholder; an empty input echoes the masked value, which the backend's `save_with_merge` restores to the real secret (fix landed in octos-org/octos#1927).
- `ProfileConfig` gains a typed `smart_home` section + merge handling in `mergeProfileConfig`.

## Test plan

- `pnpm vitest run src/settings/smart-home-tab.test.tsx` — 7/7 ✅ (prefill, save shapes, masked echo, section clear, error, test-connection success/error)
- `pnpm lint` — 0 errors ✅
- `pnpm test:unit` — 815/815 ✅
- `pnpm run build` — tsc + vite ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)