### PR TITLE
fix(learn): keep camera with the active course

### DIFF
--- a/src/learning/oll/oll-lesson-runtime.tsx
+++ b/src/learning/oll/oll-lesson-runtime.tsx
@@ -522,7 +522,10 @@ export function LearningWhiteboard({
   useEffect(() => {
     if (!playbackCourseTarget) return;
     coursesObservedInProgressRef.current.add(playbackCourseTarget.courseId);
-    cameraControllerRef.current?.markCourseActive(playbackCourseTarget.courseId);
+    cameraControllerRef.current?.markCourseActive(
+      playbackCourseTarget.courseId,
+      true,
+    );
     mountedRef.current?.view.releaseHostCamera();
   }, [playbackCourseTarget]);
   const variableControls = runtime ? variableControlModels(runtime.board) : [];
@@ -1686,15 +1689,33 @@ export function LearningWhiteboard({
     const reachedCourseEnd = runtime.deliverySettled
       && (runtime.waiting || runtime.completed);
     if (!reachedCourseEnd) {
+      const currentStepBelongsToCourse = Boolean(
+        runtime.currentStepId
+        && topic.steps.some((step) => step.id === runtime.currentStepId),
+      );
+      // Appending a new course briefly publishes its outline before the
+      // player has entered that course's first Step. Keep the camera on the
+      // new question/loading area during that hand-off; otherwise the last
+      // focus operation from the previous course becomes visible for one
+      // frame before the new course starts.
+      if (!currentStepBelongsToCourse) return;
       // A restored lesson can briefly report delivery as unsettled while the
       // host hydrates it. Wait for hydration before choosing the last course;
       // otherwise the initial partial board can produce the wrong footprint.
       if (!runtime.completed) {
-        if (!coursesObservedInProgressRef.current.has(courseId)) {
+        const cameraController = cameraControllerRef.current;
+        if (cameraController && !cameraController.canActivateCourse(courseId)) {
+          return;
+        }
+        const enteredLoadingCourse = cameraController
+          ?.markCourseActive(courseId) ?? false;
+        if (
+          enteredLoadingCourse
+          || !coursesObservedInProgressRef.current.has(courseId)
+        ) {
           mountedRef.current?.view.releaseHostCamera();
         }
         coursesObservedInProgressRef.current.add(courseId);
-        cameraControllerRef.current?.markCourseActive(courseId);
       }
       return;
     }

--- a/src/learning/whiteboard-camera-controller.test.ts
+++ b/src/learning/whiteboard-camera-controller.test.ts
@@ -70,6 +70,40 @@ describe("WhiteboardCameraController", () => {
     );
   });
 
+  it("keeps an older course from reclaiming the camera after new-course loading was shown", () => {
+    const probe = controllerProbe();
+
+    probe.controller.request(request("question-loading", "loading-2", "course-2"));
+    probe.flush();
+    expect(
+      probe.controller.request(request("course-end", "late-end-1", "course-1")),
+    ).toBe(false);
+    probe.flush();
+
+    expect(probe.apply).toHaveBeenCalledTimes(1);
+    expect(probe.apply).toHaveBeenCalledWith(
+      request("question-loading", "loading-2", "course-2"),
+    );
+    expect(probe.decisions).toContainEqual(expect.objectContaining({
+      action: "ignored",
+      reason: "inactive-course",
+      request: expect.objectContaining({ key: "late-end-1" }),
+    }));
+  });
+
+  it("reports when the loaded course actually enters playback", () => {
+    const probe = controllerProbe();
+
+    probe.controller.request(request("question-loading", "loading-2", "course-2"));
+    probe.flush();
+
+    expect(probe.controller.canActivateCourse("course-1")).toBe(false);
+    expect(probe.controller.canActivateCourse("course-2")).toBe(true);
+    expect(probe.controller.markCourseActive("course-1")).toBe(false);
+    expect(probe.controller.markCourseActive("course-2")).toBe(true);
+    expect(probe.controller.markCourseActive("course-2")).toBe(false);
+  });
+
   it("allows task framing again after replay makes the course active", () => {
     const probe = controllerProbe();
 

--- a/src/learning/whiteboard-camera-controller.ts
+++ b/src/learning/whiteboard-camera-controller.ts
@@ -16,7 +16,7 @@ export interface WhiteboardCameraRequest {
 export interface WhiteboardCameraDecision {
   action: "queued" | "replaced" | "ignored" | "applied";
   request: WhiteboardCameraRequest;
-  reason?: "duplicate" | "course-settled" | "lower-priority";
+  reason?: "duplicate" | "course-settled" | "inactive-course" | "lower-priority";
 }
 
 type ScheduleFrame = (callback: () => void) => number;
@@ -47,6 +47,8 @@ export class WhiteboardCameraController {
   private pending: WhiteboardCameraRequest | null = null;
   private frame: number | null = null;
   private settledCourseId: string | null = null;
+  private activeCourseId: string | null = null;
+  private loadingCourseId: string | null = null;
   private readonly appliedKeys = new Set<string>();
   private readonly apply: (request: WhiteboardCameraRequest) => void;
   private readonly scheduleFrame: ScheduleFrame;
@@ -65,13 +67,37 @@ export class WhiteboardCameraController {
     this.report = report;
   }
 
-  markCourseActive(courseId: string): void {
+  markCourseActive(courseId: string, force = false): boolean {
+    if (
+      !force
+      && this.loadingCourseId !== null
+      && this.loadingCourseId !== courseId
+    ) return false;
+    const enteredLoadingCourse = this.loadingCourseId === courseId;
+    this.activeCourseId = courseId;
+    if (enteredLoadingCourse || force) this.loadingCourseId = null;
     if (this.settledCourseId === courseId) this.settledCourseId = null;
+    return enteredLoadingCourse;
+  }
+
+  canActivateCourse(courseId: string): boolean {
+    return this.loadingCourseId === null || this.loadingCourseId === courseId;
   }
 
   request(request: WhiteboardCameraRequest): boolean {
     if (!validRect(request.rect) || this.appliedKeys.has(request.key)) {
       this.report?.({ action: "ignored", request, reason: "duplicate" });
+      return false;
+    }
+
+    if (request.source === "question-loading") {
+      this.activeCourseId = request.courseId;
+      this.loadingCourseId = request.courseId;
+    } else if (
+      this.activeCourseId !== null
+      && request.courseId !== this.activeCourseId
+    ) {
+      this.report?.({ action: "ignored", request, reason: "inactive-course" });
       return false;
     }
 


### PR DESCRIPTION
## What changed

- A newly loading course now takes ownership of the whiteboard camera immediately.
- Late step, focus, or completion requests from an older course can no longer pull the camera back to that course.
- The runtime marks a course as the current camera owner only when playback actually reaches one of its steps.
- An explicit user replay can still force the camera to switch to the selected course.

## Problem solved

When a new course was started on a whiteboard that already contained another course, late asynchronous camera requests from the older course could move the view back to the previous course before returning to the new one. Camera ownership now follows the course that is loading or playing, and stale requests are rejected.

## Validation

- `pnpm test:unit`
- `pnpm run lint` (0 errors; existing repository warnings are unchanged)
- `pnpm run build`
- Added regression coverage for late camera requests from an older course and camera ownership transfer to a new course
