### PR TITLE
Improve Learn board layout and ink synchronization

### DIFF
--- a/patches/octos-lesson-language@0.1.0-rc.1.patch
+++ b/patches/octos-lesson-language@0.1.0-rc.1.patch
@@ -166,3 +166,77 @@ index 9ecf2c58f2e93f6af42b4054475f4bf5decc2486..25c2c6bb8676b17be44c724f1835f4f9
          nodes[node.id] = candidate;
      }
      for (const groupId of Object.keys(state.groups))
+diff --git a/dist/packages/ink-runtime/src/runtime.js b/dist/packages/ink-runtime/src/runtime.js
+--- a/dist/packages/ink-runtime/src/runtime.js
++++ b/dist/packages/ink-runtime/src/runtime.js
+@@ -22,6 +22,9 @@ export class InkRuntime {
+     changeRevision = 0;
+     savedChangeRevision = 0;
+     saveTimer;
++    pixelRatioTimer;
++    pendingPixelRatio;
++    appliedPixelRatio;
+     saveQueue = Promise.resolve(null);
+     destroyPromise;
+     restoreFailure;
+@@ -158,8 +161,21 @@ export class InkRuntime {
+         }
+         const hostWindow = this.options.viewport.ownerDocument.defaultView;
+         if (hostWindow) {
+-            const effectivePixelRatio = Math.max(.1, Math.min(4, hostWindow.devicePixelRatio * camera.scale));
+-            void this.editor.display.setDevicePixelRatio(effectivePixelRatio);
++            const requestedPixelRatio = hostWindow.devicePixelRatio * camera.scale;
++            const edgeLimitedPixelRatio = Math.min(8192 / this.layerBounds.width, 8192 / this.layerBounds.height);
++            const areaLimitedPixelRatio = Math.sqrt(16 * 1024 * 1024 / (this.layerBounds.width * this.layerBounds.height));
++            this.pendingPixelRatio = Math.max(.08, Math.min(4, requestedPixelRatio, edgeLimitedPixelRatio, areaLimitedPixelRatio));
++            if (this.pixelRatioTimer)
++                clearTimeout(this.pixelRatioTimer);
++            this.pixelRatioTimer = setTimeout(() => {
++                this.pixelRatioTimer = undefined;
++                const ratio = this.pendingPixelRatio;
++                if (ratio === undefined
++                    || (this.appliedPixelRatio !== undefined && Math.abs(ratio - this.appliedPixelRatio) < .02))
++                    return;
++                this.appliedPixelRatio = ratio;
++                void this.editor.display.setDevicePixelRatio(ratio);
++            }, 120);
+         }
+     }
+     prepareBoardInput() {
+@@ -514,6 +530,8 @@ export class InkRuntime {
+             return this.destroyPromise;
+         if (this.saveTimer)
+             clearTimeout(this.saveTimer);
++        if (this.pixelRatioTimer)
++            clearTimeout(this.pixelRatioTimer);
+         this.unsubscribeCamera();
+         this.removeInputListeners();
+         this.options.board.setInputOwner("runtime");
+diff --git a/dist/packages/web-runtime/src/board-view.js b/dist/packages/web-runtime/src/board-view.js
+--- a/dist/packages/web-runtime/src/board-view.js
++++ b/dist/packages/web-runtime/src/board-view.js
+@@ -1526,7 +1526,8 @@ export class InfiniteBoardView {
+     scheduleCameraNotifications() {
+         if (this.cameraListeners.size === 0)
+             return;
+-        this.cameraNotifyUntil = Math.max(this.cameraNotifyUntil, this.hostWindow.performance.now() + 760);
++        const transitionDuration = this.viewport.classList.contains("manual-navigation") ? 0 : 760;
++        this.cameraNotifyUntil = Math.max(this.cameraNotifyUntil, this.hostWindow.performance.now() + transitionDuration);
+         if (this.cameraFrame !== undefined)
+             return;
+         const notify = (timestamp) => {
+@@ -1582,7 +1583,7 @@ export class InfiniteBoardView {
+         this.transform();
+     }
+     onWheel(event) {
+-        if (this.inputOwner !== "runtime"
++        if (this.inputOwner === "course-object"
+             || boardInputTargetsInteractiveUi(event.composedPath()))
+             return;
+         event.preventDefault();
+diff --git a/packages/ink-runtime/styles.css b/packages/ink-runtime/styles.css
+--- a/packages/ink-runtime/styles.css
++++ b/packages/ink-runtime/styles.css
+@@ -28,1 +28,2 @@
+ .oll-ink-layer .imageEditorRenderArea { background: transparent; }
++.oll-ink-layer .imageEditorRenderArea canvas { background: transparent; }

--- a/patches/octos-lesson-language@0.1.0-rc.1.patch
+++ b/patches/octos-lesson-language@0.1.0-rc.1.patch
@@ -169,89 +169,164 @@ index 9ecf2c58f2e93f6af42b4054475f4bf5decc2486..25c2c6bb8676b17be44c724f1835f4f9
 diff --git a/dist/packages/ink-runtime/src/runtime.js b/dist/packages/ink-runtime/src/runtime.js
 --- a/dist/packages/ink-runtime/src/runtime.js
 +++ b/dist/packages/ink-runtime/src/runtime.js
-@@ -22,6 +22,10 @@ export class InkRuntime {
+@@ -5,7 +5,6 @@ import { coalesceInkOccupiedBounds } from "./occupied-bounds.js";
+ import { createInkSelectionSnapshot } from "./selection.js";
+ import { inkSelectionPathRegion, inkSelectionRectangleRegion, inkSelectionSourceExists, } from "./selection-record.js";
+ import { lockSelectionTransform, } from "./selection-lock.js";
+-import { planInkWorldLayerBounds, viewportPointToInkSurface, } from "./world-layer.js";
+ export class InkRuntime {
+     options;
+     host;
+@@ -22,11 +21,15 @@ export class InkRuntime {
      changeRevision = 0;
      savedChangeRevision = 0;
      saveTimer;
-+    pixelRatioTimer;
++    cameraRenderTimer;
 +    pendingCamera;
 +    appliedPixelRatio;
-+    compactedScale;
++    cameraRenderRevision = 0;
      saveQueue = Promise.resolve(null);
      destroyPromise;
      restoreFailure;
-@@ -38,6 +42,7 @@ export class InkRuntime {
+     suppressSave = false;
+-    layerBounds;
++    renderedCamera;
+     expectedViewportTransform = Mat33.identity;
+     activePointers = new Map();
+     selectionGesture = [];
+@@ -34,10 +37,10 @@ export class InkRuntime {
+     unmountWorldLayer;
+     removeInputListeners;
+     unsubscribeCamera;
+-    constructor(options, host, layerBounds, unmountWorldLayer) {
++    constructor(options, host, renderedCamera, unmountWorldLayer) {
          this.options = options;
          this.host = host;
-         this.layerBounds = layerBounds;
-+        this.compactedScale = options.board.getCameraState().scale;
+-        this.layerBounds = layerBounds;
++        this.renderedCamera = renderedCamera;
          this.editor = this.createEditor();
          this.prepareEditor();
          this.unmountWorldLayer = unmountWorldLayer;
-@@ -161,8 +166,40 @@ export class InkRuntime {
+@@ -55,29 +58,20 @@ export class InkRuntime {
+         const host = options.viewport.ownerDocument.createElement("div");
+         host.className = "oll-ink-layer";
+         host.dataset.ollInkLayer = "";
+-        const layerBounds = planInkWorldLayerBounds({
+-            camera: options.board.getCameraState(),
+-            viewport: {
+-                width: options.viewport.clientWidth,
+-                height: options.viewport.clientHeight,
+-            },
+-        });
+-        InkRuntime.applyWorldLayerBounds(host, layerBounds);
+-        const unmountWorldLayer = options.board.mountWorldLayer(host);
++        host.style.inset = "0";
++        host.style.width = "100%";
++        host.style.height = "100%";
++        const renderedCamera = options.board.getCameraState();
++        options.viewport.append(host);
++        const unmountWorldLayer = () => host.remove();
+         try {
+-            return new InkRuntime(options, host, layerBounds, unmountWorldLayer);
++            return new InkRuntime(options, host, renderedCamera, unmountWorldLayer);
          }
-         const hostWindow = this.options.viewport.ownerDocument.defaultView;
-         if (hostWindow) {
--            const effectivePixelRatio = Math.max(.1, Math.min(4, hostWindow.devicePixelRatio * camera.scale));
--            void this.editor.display.setDevicePixelRatio(effectivePixelRatio);
-+            this.pendingCamera = { ...camera };
-+            if (this.pixelRatioTimer)
-+                clearTimeout(this.pixelRatioTimer);
-+            this.pixelRatioTimer = setTimeout(() => {
-+                this.pixelRatioTimer = undefined;
-+                const settledCamera = this.pendingCamera;
-+                if (!settledCamera)
-+                    return;
-+                const viewport = {
-+                    width: this.options.viewport.clientWidth,
-+                    height: this.options.viewport.clientHeight,
-+                };
-+                let settledBounds = this.layerBounds;
-+                if (settledCamera.scale !== this.compactedScale) {
-+                    settledBounds = planInkWorldLayerBounds({ camera: settledCamera, viewport });
-+                    if (settledBounds.left !== this.layerBounds.left
-+                        || settledBounds.top !== this.layerBounds.top
-+                        || settledBounds.width !== this.layerBounds.width
-+                        || settledBounds.height !== this.layerBounds.height) {
-+                        this.layerBounds = settledBounds;
-+                        InkRuntime.applyWorldLayerBounds(this.host, settledBounds);
-+                        this.resetEditorViewport();
-+                    }
-+                    this.compactedScale = settledCamera.scale;
-+                }
-+                const requestedPixelRatio = hostWindow.devicePixelRatio * settledCamera.scale;
-+                const edgeLimitedPixelRatio = Math.min(8192 / settledBounds.width, 8192 / settledBounds.height);
-+                const areaLimitedPixelRatio = Math.sqrt(32 * 1024 * 1024 / (settledBounds.width * settledBounds.height));
-+                const ratio = Math.max(.08, Math.min(4, requestedPixelRatio, edgeLimitedPixelRatio, areaLimitedPixelRatio));
-+                if (this.appliedPixelRatio !== undefined && Math.abs(ratio - this.appliedPixelRatio) < .02)
-+                    return;
-+                this.appliedPixelRatio = ratio;
-+                void this.editor.display.setDevicePixelRatio(ratio);
-+            }, 120);
+         catch (cause) {
+             unmountWorldLayer();
+             throw cause;
          }
      }
+-    static applyWorldLayerBounds(host, bounds) {
+-        host.style.left = `${bounds.left}px`;
+-        host.style.top = `${bounds.top}px`;
+-        host.style.width = `${bounds.width}px`;
+-        host.style.height = `${bounds.height}px`;
+-    }
+     createEditor() {
+         const documentLocale = this.host.ownerDocument.documentElement.lang;
+         const userLocales = this.options.locale
+@@ -142,28 +136,42 @@ export class InkRuntime {
+         });
+     }
+     resetEditorViewport() {
+-        this.expectedViewportTransform = Mat33.translation(Vec2.of(-this.layerBounds.left, -this.layerBounds.top));
++        this.expectedViewportTransform = Mat33.translation(Vec2.of(this.renderedCamera.panX, this.renderedCamera.panY))
++            .rightMul(Mat33.scaling2D(this.renderedCamera.scale));
+         this.editor.viewport.resetTransform(this.expectedViewportTransform);
+     }
+     updateWorldLayer(camera) {
+-        const nextBounds = planInkWorldLayerBounds({
+-            camera,
+-            viewport: {
+-                width: this.options.viewport.clientWidth,
+-                height: this.options.viewport.clientHeight,
+-            },
+-            current: this.layerBounds,
+-        });
+-        if (nextBounds !== this.layerBounds) {
+-            this.layerBounds = nextBounds;
+-            InkRuntime.applyWorldLayerBounds(this.host, nextBounds);
++        const scale = camera.scale / this.renderedCamera.scale;
++        const translateX = camera.panX - scale * this.renderedCamera.panX;
++        const translateY = camera.panY - scale * this.renderedCamera.panY;
++        const editorRoot = this.editor.getRootElement();
++        editorRoot.style.transformOrigin = "0 0";
++        editorRoot.style.transform = `matrix(${scale}, 0, 0, ${scale}, ${translateX}, ${translateY})`;
++        this.pendingCamera = { ...camera };
++        if (this.cameraRenderTimer)
++            clearTimeout(this.cameraRenderTimer);
++        this.cameraRenderTimer = setTimeout(() => {
++            this.cameraRenderTimer = undefined;
++            const settledCamera = this.pendingCamera;
++            if (!settledCamera)
++                return;
++            const revision = ++this.cameraRenderRevision;
++            this.renderedCamera = { ...settledCamera };
+             this.resetEditorViewport();
+-        }
+-        const hostWindow = this.options.viewport.ownerDocument.defaultView;
+-        if (hostWindow) {
+-            const effectivePixelRatio = Math.max(.1, Math.min(4, hostWindow.devicePixelRatio * camera.scale));
+-            void this.editor.display.setDevicePixelRatio(effectivePixelRatio);
+-        }
++            const hostWindow = this.options.viewport.ownerDocument.defaultView;
++            if (hostWindow) {
++                const ratio = Math.max(.1, Math.min(4, hostWindow.devicePixelRatio));
++                if (this.appliedPixelRatio === undefined || Math.abs(ratio - this.appliedPixelRatio) >= .02) {
++                    this.appliedPixelRatio = ratio;
++                    void this.editor.display.setDevicePixelRatio(ratio);
++                }
++            }
++            void this.editor.queueRerender().then(() => {
++                if (revision !== this.cameraRenderRevision)
++                    return;
++                editorRoot.style.transform = "";
++            });
++        }, 120);
+     }
      prepareBoardInput() {
-@@ -514,6 +551,8 @@ export class InkRuntime {
+         const inputTarget = this.options.viewport;
+@@ -192,10 +200,8 @@ export class InkRuntime {
+             return this.options.board.viewportToBoard(point);
+         };
+         const mappedPointer = (event, down) => {
+-            const camera = this.options.board.getCameraState();
+             const boardPoint = pointerBoardPoint(event);
+-            const surfacePoint = viewportPointToInkSurface(this.options.board.boardToViewport(boardPoint), camera, this.layerBounds);
+-            return Pointer.ofCanvasPoint(Vec2.of(surfacePoint.x + this.layerBounds.left, surfacePoint.y + this.layerBounds.top), down, this.editor.viewport, event.pointerId, pointerDevice(event), event.isPrimary, event.pressure, event.timeStamp);
++            return Pointer.ofCanvasPoint(Vec2.of(boardPoint.x, boardPoint.y), down, this.editor.viewport, event.pointerId, pointerDevice(event), event.isPrimary, event.pressure, event.timeStamp);
+         };
+         const allPointers = () => [...this.activePointers.values()];
+         const onPointerDown = (rawEvent) => {
+@@ -514,6 +520,9 @@ export class InkRuntime {
              return this.destroyPromise;
          if (this.saveTimer)
              clearTimeout(this.saveTimer);
-+        if (this.pixelRatioTimer)
-+            clearTimeout(this.pixelRatioTimer);
++        if (this.cameraRenderTimer)
++            clearTimeout(this.cameraRenderTimer);
++        this.cameraRenderRevision += 1;
          this.unsubscribeCamera();
          this.removeInputListeners();
          this.options.board.setInputOwner("runtime");
-diff --git a/dist/packages/ink-runtime/src/world-layer.js b/dist/packages/ink-runtime/src/world-layer.js
---- a/dist/packages/ink-runtime/src/world-layer.js
-+++ b/dist/packages/ink-runtime/src/world-layer.js
-@@ -25,7 +25,7 @@ export function planInkWorldLayerBounds(options) {
-         throw new Error("Ink world layer requires a positive finite camera scale");
-     }
-     const visible = visibleBoardRect(camera, viewport);
--    const bufferPixels = Math.max(320, Math.min(900, Math.max(viewport.width, viewport.height) * .5));
-+    const bufferPixels = Math.max(320, Math.min(520, Math.max(viewport.width, viewport.height) * .35));
-     const buffer = bufferPixels / camera.scale;
-     const guard = Math.min(buffer * .35, 240 / camera.scale);
-     if (current && contains(current, visible, guard))
 diff --git a/dist/packages/web-runtime/src/board-view.js b/dist/packages/web-runtime/src/board-view.js
 --- a/dist/packages/web-runtime/src/board-view.js
 +++ b/dist/packages/web-runtime/src/board-view.js

--- a/patches/octos-lesson-language@0.1.0-rc.1.patch
+++ b/patches/octos-lesson-language@0.1.0-rc.1.patch
@@ -1,0 +1,168 @@
+diff --git a/dist/packages/web-runtime/src/layout.d.ts b/dist/packages/web-runtime/src/layout.d.ts
+index 70a9b74083d43d0e42b5f14a0e66ad496ce4c017..076a2ecb402ea9fc18da2e534ede878f2d2b8d80 100644
+--- a/dist/packages/web-runtime/src/layout.d.ts
++++ b/dist/packages/web-runtime/src/layout.d.ts
+@@ -18,6 +18,12 @@ export interface RegionLayoutConstraint {
+     y: number;
+     /** Space reserved for a progressively delivered course before every node exists. */
+     reservedWidth?: number;
++    /**
++     * Arrange top-level lesson cards as a stable visual lane plus a reading
++     * lane. This is computed at render time, so saved semantic boards also
++     * receive the updated course composition.
++     */
++    flow?: "semantic" | "reading";
+ }
+ export interface BoardLayoutOptions {
+     regions?: Record<string, RegionLayoutConstraint>;
+diff --git a/dist/packages/web-runtime/src/layout.js b/dist/packages/web-runtime/src/layout.js
+index 9ecf2c58f2e93f6af42b4054475f4bf5decc2486..25c2c6bb8676b17be44c724f1835f4f9e4e3c6e6 100644
+--- a/dist/packages/web-runtime/src/layout.js
++++ b/dist/packages/web-runtime/src/layout.js
+@@ -1,5 +1,6 @@
+ const GAP = { compact: 28, normal: 54, spacious: 88 };
+ const TOPIC_GUTTER = 180;
++const VISUAL_LANE_KINDS = new Set(["geometry", "scene3d", "plot", "image", "diagram"]);
+ function visibleContentLength(value) {
+     if (value === null || value === undefined)
+         return 0;
+@@ -67,6 +68,27 @@ export function computeBoardLayout(state, measuredNodeSizes = {}, options = {})
+     const nodes = {};
+     const groups = {};
+     const regionCursors = new Map();
++    const regionFlowProfiles = new Map();
++    for (const node of Object.values(state.nodes)) {
++        const regionId = typeof node.region_id === "string" && node.region_id
++            ? node.region_id
++            : "__legacy__";
++        if (options.regions?.[regionId]?.flow !== "reading")
++            continue;
++        if (["inside", "overlay"].includes(node.placement?.relation ?? ""))
++            continue;
++        const kind = String(node.kind ?? "text");
++        const profile = regionFlowProfiles.get(regionId) ?? {
++            hasVisual: false,
++            visualWidth: 0,
++        };
++        if (VISUAL_LANE_KINDS.has(kind)) {
++            const size = measuredNodeSizes[node.id] ?? measureSemanticNode(node);
++            profile.hasVisual = true;
++            profile.visualWidth = Math.max(profile.visualWidth, size.width);
++        }
++        regionFlowProfiles.set(regionId, profile);
++    }
+     const endpointId = (endpoint) => {
+         if (typeof endpoint === "string")
+             return endpoint;
+@@ -125,19 +147,82 @@ export function computeBoardLayout(state, measuredNodeSizes = {}, options = {})
+         ];
+     };
+     for (const node of Object.values(state.nodes)) {
+-        const size = measuredNodeSizes[node.id] ?? measureSemanticNode(node);
++        let size = measuredNodeSizes[node.id] ?? measureSemanticNode(node);
+         const placement = node.placement ?? { relation: "new_region" };
+         const anchor = placement.anchor ? nodes[placement.anchor] ?? groupRect(placement.anchor) : undefined;
+         const gap = GAP[placement.gap] ?? GAP.normal;
++        const regionId = typeof node.region_id === "string" && node.region_id
++            ? node.region_id
++            : "__legacy__";
++        const constraint = options.regions?.[regionId];
++        const readingFlow = constraint?.flow === "reading"
++            && !["inside", "overlay"].includes(placement.relation);
++        let flowLane;
++        let flowRegion;
+         let x = 100;
+         let y = 90;
+-        if (!anchor || placement.relation === "new_region") {
+-            const regionId = typeof node.region_id === "string" && node.region_id
+-                ? node.region_id
+-                : "__legacy__";
++        if (readingFlow) {
++            let region = regionCursors.get(regionId);
++            if (!region) {
++                const occupied = collisionRects(node.id);
++                const reservedRightEdges = [...regionCursors.values()].map((cursor) => cursor.x + cursor.reservedWidth);
++                const right = occupied.length || reservedRightEdges.length
++                    ? Math.max(...occupied.map((rect) => rect.x + rect.width), ...reservedRightEdges)
++                    : 100 - TOPIC_GUTTER;
++                region = {
++                    x: constraint?.x ?? (regionCursors.size === 0 ? 100 : right + TOPIC_GUTTER),
++                    y: constraint?.y ?? 90,
++                    reservedWidth: Math.max(0, constraint?.reservedWidth ?? 0),
++                    itemIndex: 0,
++                    rowY: constraint?.y ?? 90,
++                    rowHeight: 0,
++                    firstColumnWidth: 0,
++                    visualBottom: undefined,
++                    narrativeBottom: undefined,
++                };
++                regionCursors.set(regionId, region);
++            }
++            const profile = regionFlowProfiles.get(regionId) ?? {
++                hasVisual: false,
++                visualWidth: 0,
++            };
++            flowLane = VISUAL_LANE_KINDS.has(String(node.kind ?? "text"))
++                ? "visual"
++                : "narrative";
++            flowRegion = region;
++            if (
++                flowLane === "narrative"
++                && profile.hasVisual
++                && region.reservedWidth > profile.visualWidth + GAP.normal
++            ) {
++                // The host reserves one logical course region before the
++                // complete lesson has arrived. Keep both reading lanes inside
++                // that reservation so reflowing an older course cannot invade
++                // the next persisted course region on the infinite board.
++                const availableWidth = region.reservedWidth
++                    - profile.visualWidth
++                    - GAP.normal;
++                if (availableWidth >= 280)
++                    size = { ...size, width: Math.min(size.width, availableWidth) };
++            }
++            if (flowLane === "visual") {
++                x = region.x;
++                y = region.visualBottom === undefined
++                    ? region.y
++                    : region.visualBottom + GAP.normal;
++            }
++            else {
++                x = region.x + (profile.hasVisual
++                    ? profile.visualWidth + GAP.normal
++                    : 0);
++                y = region.narrativeBottom === undefined
++                    ? region.y
++                    : region.narrativeBottom + GAP.compact;
++            }
++        }
++        else if (!anchor || placement.relation === "new_region") {
+             let region = regionCursors.get(regionId);
+             if (!region) {
+-                const constraint = options.regions?.[regionId];
+                 const occupied = collisionRects(node.id);
+                 const reservedRightEdges = [...regionCursors.values()].map((cursor) => cursor.x + cursor.reservedWidth);
+                 const right = occupied.length || reservedRightEdges.length
+@@ -202,9 +287,9 @@ export function computeBoardLayout(state, measuredNodeSizes = {}, options = {})
+             x = anchor.x + 24;
+             y = anchor.y + 24;
+         }
+-        if (placement.align === "center" && anchor && ["below", "above"].includes(placement.relation))
++        if (!readingFlow && placement.align === "center" && anchor && ["below", "above"].includes(placement.relation))
+             x = anchor.x + (anchor.width - size.width) / 2;
+-        if (placement.align === "end" && anchor && ["below", "above"].includes(placement.relation))
++        if (!readingFlow && placement.align === "end" && anchor && ["below", "above"].includes(placement.relation))
+             x = anchor.x + anchor.width - size.width;
+         let candidate = { x, y, ...size };
+         if (!["inside", "overlay"].includes(placement.relation)) {
+@@ -214,6 +299,10 @@ export function computeBoardLayout(state, measuredNodeSizes = {}, options = {})
+                 guard += 1;
+             }
+         }
++        if (flowRegion && flowLane === "visual")
++            flowRegion.visualBottom = candidate.y + candidate.height;
++        if (flowRegion && flowLane === "narrative")
++            flowRegion.narrativeBottom = candidate.y + candidate.height;
+         nodes[node.id] = candidate;
+     }
+     for (const groupId of Object.keys(state.groups))

--- a/patches/octos-lesson-language@0.1.0-rc.1.patch
+++ b/patches/octos-lesson-language@0.1.0-rc.1.patch
@@ -174,28 +174,43 @@ diff --git a/dist/packages/ink-runtime/src/runtime.js b/dist/packages/ink-runtim
      savedChangeRevision = 0;
      saveTimer;
 +    pixelRatioTimer;
-+    pendingPixelRatio;
++    pendingCamera;
 +    appliedPixelRatio;
      saveQueue = Promise.resolve(null);
      destroyPromise;
      restoreFailure;
-@@ -158,8 +161,21 @@ export class InkRuntime {
+@@ -161,8 +164,36 @@ export class InkRuntime {
          }
          const hostWindow = this.options.viewport.ownerDocument.defaultView;
          if (hostWindow) {
 -            const effectivePixelRatio = Math.max(.1, Math.min(4, hostWindow.devicePixelRatio * camera.scale));
 -            void this.editor.display.setDevicePixelRatio(effectivePixelRatio);
-+            const requestedPixelRatio = hostWindow.devicePixelRatio * camera.scale;
-+            const edgeLimitedPixelRatio = Math.min(8192 / this.layerBounds.width, 8192 / this.layerBounds.height);
-+            const areaLimitedPixelRatio = Math.sqrt(16 * 1024 * 1024 / (this.layerBounds.width * this.layerBounds.height));
-+            this.pendingPixelRatio = Math.max(.08, Math.min(4, requestedPixelRatio, edgeLimitedPixelRatio, areaLimitedPixelRatio));
++            this.pendingCamera = { ...camera };
 +            if (this.pixelRatioTimer)
 +                clearTimeout(this.pixelRatioTimer);
 +            this.pixelRatioTimer = setTimeout(() => {
 +                this.pixelRatioTimer = undefined;
-+                const ratio = this.pendingPixelRatio;
-+                if (ratio === undefined
-+                    || (this.appliedPixelRatio !== undefined && Math.abs(ratio - this.appliedPixelRatio) < .02))
++                const settledCamera = this.pendingCamera;
++                if (!settledCamera)
++                    return;
++                const viewport = {
++                    width: this.options.viewport.clientWidth,
++                    height: this.options.viewport.clientHeight,
++                };
++                const settledBounds = planInkWorldLayerBounds({ camera: settledCamera, viewport });
++                if (settledBounds.left !== this.layerBounds.left
++                    || settledBounds.top !== this.layerBounds.top
++                    || settledBounds.width !== this.layerBounds.width
++                    || settledBounds.height !== this.layerBounds.height) {
++                    this.layerBounds = settledBounds;
++                    InkRuntime.applyWorldLayerBounds(this.host, settledBounds);
++                    this.resetEditorViewport();
++                }
++                const requestedPixelRatio = hostWindow.devicePixelRatio * settledCamera.scale;
++                const edgeLimitedPixelRatio = Math.min(8192 / settledBounds.width, 8192 / settledBounds.height);
++                const areaLimitedPixelRatio = Math.sqrt(32 * 1024 * 1024 / (settledBounds.width * settledBounds.height));
++                const ratio = Math.max(.08, Math.min(4, requestedPixelRatio, edgeLimitedPixelRatio, areaLimitedPixelRatio));
++                if (this.appliedPixelRatio !== undefined && Math.abs(ratio - this.appliedPixelRatio) < .02)
 +                    return;
 +                this.appliedPixelRatio = ratio;
 +                void this.editor.display.setDevicePixelRatio(ratio);
@@ -203,7 +218,7 @@ diff --git a/dist/packages/ink-runtime/src/runtime.js b/dist/packages/ink-runtim
          }
      }
      prepareBoardInput() {
-@@ -514,6 +530,8 @@ export class InkRuntime {
+@@ -514,6 +545,8 @@ export class InkRuntime {
              return this.destroyPromise;
          if (this.saveTimer)
              clearTimeout(this.saveTimer);
@@ -212,6 +227,18 @@ diff --git a/dist/packages/ink-runtime/src/runtime.js b/dist/packages/ink-runtim
          this.unsubscribeCamera();
          this.removeInputListeners();
          this.options.board.setInputOwner("runtime");
+diff --git a/dist/packages/ink-runtime/src/world-layer.js b/dist/packages/ink-runtime/src/world-layer.js
+--- a/dist/packages/ink-runtime/src/world-layer.js
++++ b/dist/packages/ink-runtime/src/world-layer.js
+@@ -25,7 +25,7 @@ export function planInkWorldLayerBounds(options) {
+         throw new Error("Ink world layer requires a positive finite camera scale");
+     }
+     const visible = visibleBoardRect(camera, viewport);
+-    const bufferPixels = Math.max(320, Math.min(900, Math.max(viewport.width, viewport.height) * .5));
++    const bufferPixels = Math.max(320, Math.min(520, Math.max(viewport.width, viewport.height) * .35));
+     const buffer = bufferPixels / camera.scale;
+     const guard = Math.min(buffer * .35, 240 / camera.scale);
+     if (current && contains(current, visible, guard))
 diff --git a/dist/packages/web-runtime/src/board-view.js b/dist/packages/web-runtime/src/board-view.js
 --- a/dist/packages/web-runtime/src/board-view.js
 +++ b/dist/packages/web-runtime/src/board-view.js
@@ -234,9 +261,3 @@ diff --git a/dist/packages/web-runtime/src/board-view.js b/dist/packages/web-run
              || boardInputTargetsInteractiveUi(event.composedPath()))
              return;
          event.preventDefault();
-diff --git a/packages/ink-runtime/styles.css b/packages/ink-runtime/styles.css
---- a/packages/ink-runtime/styles.css
-+++ b/packages/ink-runtime/styles.css
-@@ -28,1 +28,2 @@
- .oll-ink-layer .imageEditorRenderArea { background: transparent; }
-+.oll-ink-layer .imageEditorRenderArea canvas { background: transparent; }

--- a/patches/octos-lesson-language@0.1.0-rc.1.patch
+++ b/patches/octos-lesson-language@0.1.0-rc.1.patch
@@ -169,17 +169,26 @@ index 9ecf2c58f2e93f6af42b4054475f4bf5decc2486..25c2c6bb8676b17be44c724f1835f4f9
 diff --git a/dist/packages/ink-runtime/src/runtime.js b/dist/packages/ink-runtime/src/runtime.js
 --- a/dist/packages/ink-runtime/src/runtime.js
 +++ b/dist/packages/ink-runtime/src/runtime.js
-@@ -22,6 +22,9 @@ export class InkRuntime {
+@@ -22,6 +22,10 @@ export class InkRuntime {
      changeRevision = 0;
      savedChangeRevision = 0;
      saveTimer;
 +    pixelRatioTimer;
 +    pendingCamera;
 +    appliedPixelRatio;
++    compactedScale;
      saveQueue = Promise.resolve(null);
      destroyPromise;
      restoreFailure;
-@@ -161,8 +164,36 @@ export class InkRuntime {
+@@ -38,6 +42,7 @@ export class InkRuntime {
+         this.options = options;
+         this.host = host;
+         this.layerBounds = layerBounds;
++        this.compactedScale = options.board.getCameraState().scale;
+         this.editor = this.createEditor();
+         this.prepareEditor();
+         this.unmountWorldLayer = unmountWorldLayer;
+@@ -161,8 +166,40 @@ export class InkRuntime {
          }
          const hostWindow = this.options.viewport.ownerDocument.defaultView;
          if (hostWindow) {
@@ -197,14 +206,18 @@ diff --git a/dist/packages/ink-runtime/src/runtime.js b/dist/packages/ink-runtim
 +                    width: this.options.viewport.clientWidth,
 +                    height: this.options.viewport.clientHeight,
 +                };
-+                const settledBounds = planInkWorldLayerBounds({ camera: settledCamera, viewport });
-+                if (settledBounds.left !== this.layerBounds.left
-+                    || settledBounds.top !== this.layerBounds.top
-+                    || settledBounds.width !== this.layerBounds.width
-+                    || settledBounds.height !== this.layerBounds.height) {
-+                    this.layerBounds = settledBounds;
-+                    InkRuntime.applyWorldLayerBounds(this.host, settledBounds);
-+                    this.resetEditorViewport();
++                let settledBounds = this.layerBounds;
++                if (settledCamera.scale !== this.compactedScale) {
++                    settledBounds = planInkWorldLayerBounds({ camera: settledCamera, viewport });
++                    if (settledBounds.left !== this.layerBounds.left
++                        || settledBounds.top !== this.layerBounds.top
++                        || settledBounds.width !== this.layerBounds.width
++                        || settledBounds.height !== this.layerBounds.height) {
++                        this.layerBounds = settledBounds;
++                        InkRuntime.applyWorldLayerBounds(this.host, settledBounds);
++                        this.resetEditorViewport();
++                    }
++                    this.compactedScale = settledCamera.scale;
 +                }
 +                const requestedPixelRatio = hostWindow.devicePixelRatio * settledCamera.scale;
 +                const edgeLimitedPixelRatio = Math.min(8192 / settledBounds.width, 8192 / settledBounds.height);
@@ -218,7 +231,7 @@ diff --git a/dist/packages/ink-runtime/src/runtime.js b/dist/packages/ink-runtim
          }
      }
      prepareBoardInput() {
-@@ -514,6 +545,8 @@ export class InkRuntime {
+@@ -514,6 +551,8 @@ export class InkRuntime {
              return this.destroyPromise;
          if (this.saveTimer)
              clearTimeout(this.saveTimer);

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5,7 +5,7 @@ settings:
   excludeLinksFromLockfile: false
 
 patchedDependencies:
-  octos-lesson-language@0.1.0-rc.1: 282490105bf3849a2e922ac7cb3e7488c8698449b7e8996ac3bb27f9edda486d
+  octos-lesson-language@0.1.0-rc.1: 7f3702e68418da745b9354d8dba052caaa43c14cb523ada7cca102d9353e1e41
 
 importers:
 
@@ -52,7 +52,7 @@ importers:
         version: 11.15.0
       octos-lesson-language:
         specifier: git+https://github.com/alan0x/octos-lesson-language.git#714ad6ec38f0fd42a7d7722a70fd2e5f85d78718
-        version: https://codeload.github.com/alan0x/octos-lesson-language/tar.gz/714ad6ec38f0fd42a7d7722a70fd2e5f85d78718(patch_hash=282490105bf3849a2e922ac7cb3e7488c8698449b7e8996ac3bb27f9edda486d)
+        version: https://codeload.github.com/alan0x/octos-lesson-language/tar.gz/714ad6ec38f0fd42a7d7722a70fd2e5f85d78718(patch_hash=7f3702e68418da745b9354d8dba052caaa43c14cb523ada7cca102d9353e1e41)
       onnxruntime-web:
         specifier: ^1.26.0
         version: 1.26.0
@@ -7492,7 +7492,7 @@ snapshots:
 
   nwsapi@2.2.23: {}
 
-  octos-lesson-language@https://codeload.github.com/alan0x/octos-lesson-language/tar.gz/714ad6ec38f0fd42a7d7722a70fd2e5f85d78718(patch_hash=282490105bf3849a2e922ac7cb3e7488c8698449b7e8996ac3bb27f9edda486d):
+  octos-lesson-language@https://codeload.github.com/alan0x/octos-lesson-language/tar.gz/714ad6ec38f0fd42a7d7722a70fd2e5f85d78718(patch_hash=7f3702e68418da745b9354d8dba052caaa43c14cb523ada7cca102d9353e1e41):
     dependencies:
       ajv: 8.20.0
       js-draw: 1.33.0

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4,6 +4,9 @@ settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
 
+patchedDependencies:
+  octos-lesson-language@0.1.0-rc.1: c0910000c0cbd0a404372a80f2a9021dab254fa31c6e35ab4e399b93c6362137
+
 importers:
 
   .:
@@ -49,7 +52,7 @@ importers:
         version: 11.15.0
       octos-lesson-language:
         specifier: git+https://github.com/alan0x/octos-lesson-language.git#714ad6ec38f0fd42a7d7722a70fd2e5f85d78718
-        version: https://codeload.github.com/alan0x/octos-lesson-language/tar.gz/714ad6ec38f0fd42a7d7722a70fd2e5f85d78718
+        version: https://codeload.github.com/alan0x/octos-lesson-language/tar.gz/714ad6ec38f0fd42a7d7722a70fd2e5f85d78718(patch_hash=c0910000c0cbd0a404372a80f2a9021dab254fa31c6e35ab4e399b93c6362137)
       onnxruntime-web:
         specifier: ^1.26.0
         version: 1.26.0
@@ -7489,7 +7492,7 @@ snapshots:
 
   nwsapi@2.2.23: {}
 
-  octos-lesson-language@https://codeload.github.com/alan0x/octos-lesson-language/tar.gz/714ad6ec38f0fd42a7d7722a70fd2e5f85d78718:
+  octos-lesson-language@https://codeload.github.com/alan0x/octos-lesson-language/tar.gz/714ad6ec38f0fd42a7d7722a70fd2e5f85d78718(patch_hash=c0910000c0cbd0a404372a80f2a9021dab254fa31c6e35ab4e399b93c6362137):
     dependencies:
       ajv: 8.20.0
       js-draw: 1.33.0

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5,7 +5,7 @@ settings:
   excludeLinksFromLockfile: false
 
 patchedDependencies:
-  octos-lesson-language@0.1.0-rc.1: 23d9c10a20bfddc9ad527f274a668671a5d457781b0dc56713d30cc5d30816f7
+  octos-lesson-language@0.1.0-rc.1: 9cb6e84e9adf9339cddc59ed247b3625a71002bad2146896e1d9afe0e795dd5d
 
 importers:
 
@@ -52,7 +52,7 @@ importers:
         version: 11.15.0
       octos-lesson-language:
         specifier: git+https://github.com/alan0x/octos-lesson-language.git#714ad6ec38f0fd42a7d7722a70fd2e5f85d78718
-        version: https://codeload.github.com/alan0x/octos-lesson-language/tar.gz/714ad6ec38f0fd42a7d7722a70fd2e5f85d78718(patch_hash=23d9c10a20bfddc9ad527f274a668671a5d457781b0dc56713d30cc5d30816f7)
+        version: https://codeload.github.com/alan0x/octos-lesson-language/tar.gz/714ad6ec38f0fd42a7d7722a70fd2e5f85d78718(patch_hash=9cb6e84e9adf9339cddc59ed247b3625a71002bad2146896e1d9afe0e795dd5d)
       onnxruntime-web:
         specifier: ^1.26.0
         version: 1.26.0
@@ -7492,7 +7492,7 @@ snapshots:
 
   nwsapi@2.2.23: {}
 
-  octos-lesson-language@https://codeload.github.com/alan0x/octos-lesson-language/tar.gz/714ad6ec38f0fd42a7d7722a70fd2e5f85d78718(patch_hash=23d9c10a20bfddc9ad527f274a668671a5d457781b0dc56713d30cc5d30816f7):
+  octos-lesson-language@https://codeload.github.com/alan0x/octos-lesson-language/tar.gz/714ad6ec38f0fd42a7d7722a70fd2e5f85d78718(patch_hash=9cb6e84e9adf9339cddc59ed247b3625a71002bad2146896e1d9afe0e795dd5d):
     dependencies:
       ajv: 8.20.0
       js-draw: 1.33.0

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5,7 +5,7 @@ settings:
   excludeLinksFromLockfile: false
 
 patchedDependencies:
-  octos-lesson-language@0.1.0-rc.1: 7f3702e68418da745b9354d8dba052caaa43c14cb523ada7cca102d9353e1e41
+  octos-lesson-language@0.1.0-rc.1: 23d9c10a20bfddc9ad527f274a668671a5d457781b0dc56713d30cc5d30816f7
 
 importers:
 
@@ -52,7 +52,7 @@ importers:
         version: 11.15.0
       octos-lesson-language:
         specifier: git+https://github.com/alan0x/octos-lesson-language.git#714ad6ec38f0fd42a7d7722a70fd2e5f85d78718
-        version: https://codeload.github.com/alan0x/octos-lesson-language/tar.gz/714ad6ec38f0fd42a7d7722a70fd2e5f85d78718(patch_hash=7f3702e68418da745b9354d8dba052caaa43c14cb523ada7cca102d9353e1e41)
+        version: https://codeload.github.com/alan0x/octos-lesson-language/tar.gz/714ad6ec38f0fd42a7d7722a70fd2e5f85d78718(patch_hash=23d9c10a20bfddc9ad527f274a668671a5d457781b0dc56713d30cc5d30816f7)
       onnxruntime-web:
         specifier: ^1.26.0
         version: 1.26.0
@@ -7492,7 +7492,7 @@ snapshots:
 
   nwsapi@2.2.23: {}
 
-  octos-lesson-language@https://codeload.github.com/alan0x/octos-lesson-language/tar.gz/714ad6ec38f0fd42a7d7722a70fd2e5f85d78718(patch_hash=7f3702e68418da745b9354d8dba052caaa43c14cb523ada7cca102d9353e1e41):
+  octos-lesson-language@https://codeload.github.com/alan0x/octos-lesson-language/tar.gz/714ad6ec38f0fd42a7d7722a70fd2e5f85d78718(patch_hash=23d9c10a20bfddc9ad527f274a668671a5d457781b0dc56713d30cc5d30816f7):
     dependencies:
       ajv: 8.20.0
       js-draw: 1.33.0

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5,7 +5,7 @@ settings:
   excludeLinksFromLockfile: false
 
 patchedDependencies:
-  octos-lesson-language@0.1.0-rc.1: c0910000c0cbd0a404372a80f2a9021dab254fa31c6e35ab4e399b93c6362137
+  octos-lesson-language@0.1.0-rc.1: 282490105bf3849a2e922ac7cb3e7488c8698449b7e8996ac3bb27f9edda486d
 
 importers:
 
@@ -52,7 +52,7 @@ importers:
         version: 11.15.0
       octos-lesson-language:
         specifier: git+https://github.com/alan0x/octos-lesson-language.git#714ad6ec38f0fd42a7d7722a70fd2e5f85d78718
-        version: https://codeload.github.com/alan0x/octos-lesson-language/tar.gz/714ad6ec38f0fd42a7d7722a70fd2e5f85d78718(patch_hash=c0910000c0cbd0a404372a80f2a9021dab254fa31c6e35ab4e399b93c6362137)
+        version: https://codeload.github.com/alan0x/octos-lesson-language/tar.gz/714ad6ec38f0fd42a7d7722a70fd2e5f85d78718(patch_hash=282490105bf3849a2e922ac7cb3e7488c8698449b7e8996ac3bb27f9edda486d)
       onnxruntime-web:
         specifier: ^1.26.0
         version: 1.26.0
@@ -7492,7 +7492,7 @@ snapshots:
 
   nwsapi@2.2.23: {}
 
-  octos-lesson-language@https://codeload.github.com/alan0x/octos-lesson-language/tar.gz/714ad6ec38f0fd42a7d7722a70fd2e5f85d78718(patch_hash=c0910000c0cbd0a404372a80f2a9021dab254fa31c6e35ab4e399b93c6362137):
+  octos-lesson-language@https://codeload.github.com/alan0x/octos-lesson-language/tar.gz/714ad6ec38f0fd42a7d7722a70fd2e5f85d78718(patch_hash=282490105bf3849a2e922ac7cb3e7488c8698449b7e8996ac3bb27f9edda486d):
     dependencies:
       ajv: 8.20.0
       js-draw: 1.33.0

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -2,3 +2,5 @@ allowBuilds:
   esbuild: true
   octos-lesson-language: true
   protobufjs: true
+patchedDependencies:
+  octos-lesson-language@0.1.0-rc.1: patches/octos-lesson-language@0.1.0-rc.1.patch

--- a/src/learning/oll/course-reading-layout.test.ts
+++ b/src/learning/oll/course-reading-layout.test.ts
@@ -1,0 +1,200 @@
+import { describe, expect, it } from "vitest";
+import { computeBoardLayout } from "octos-lesson-language/web-runtime";
+
+type BoardState = Parameters<typeof computeBoardLayout>[0];
+
+function boardWithNodes(nodes: Record<string, unknown>): BoardState {
+  return {
+    board_id: "saved-board",
+    revision: 8,
+    nodes,
+    groups: {},
+    connections: {},
+    variables: {},
+    focus: [],
+  } as unknown as BoardState;
+}
+
+describe("course reading layout", () => {
+  it("reflows an existing visual and derivation chain into two stable lanes", () => {
+    const board = boardWithNodes({
+      circle: {
+        id: "circle",
+        kind: "geometry",
+        region_id: "course-one",
+        content: { title: "完整圆周" },
+        placement: { relation: "new_region" },
+      },
+      arcFormula: {
+        id: "arcFormula",
+        kind: "math",
+        region_id: "course-one",
+        content: { latex: "l_1=2\\pi r/360=\\pi r/180" },
+        placement: { relation: "new_region" },
+      },
+      circumference: {
+        id: "circumference",
+        kind: "math",
+        region_id: "course-one",
+        content: { latex: "C=2\\pi r" },
+        placement: {
+          relation: "below",
+          anchor: "circle",
+          align: "center",
+        },
+      },
+      result: {
+        id: "result",
+        kind: "math",
+        region_id: "course-one",
+        content: { latex: "l=n\\pi r/180" },
+        placement: {
+          relation: "below",
+          anchor: "circumference",
+          align: "center",
+        },
+      },
+    });
+    const layout = computeBoardLayout(board, {
+      circle: { width: 380, height: 300 },
+      arcFormula: { width: 620, height: 96 },
+      circumference: { width: 360, height: 96 },
+      result: { width: 440, height: 96 },
+    }, {
+      regions: {
+        "course-one": {
+          x: 394,
+          y: 90,
+          reservedWidth: 886,
+          flow: "reading",
+        },
+      },
+    });
+
+    expect(layout.nodes.circle).toEqual({
+      x: 394,
+      y: 120,
+      width: 380,
+      height: 300,
+    });
+    expect([
+      layout.nodes.arcFormula?.x,
+      layout.nodes.circumference?.x,
+      layout.nodes.result?.x,
+    ]).toEqual([828, 828, 828]);
+    expect([
+      layout.nodes.arcFormula?.y,
+      layout.nodes.circumference?.y,
+      layout.nodes.result?.y,
+    ]).toEqual([120, 244, 368]);
+    expect(layout.nodes.arcFormula?.width).toBe(452);
+    expect(
+      Math.max(...Object.values(layout.nodes).map((node) => node.x + node.width)),
+    ).toBeLessThanOrEqual(394 + 886);
+  });
+
+  it("keeps independently persisted course regions separated after reflow", () => {
+    const board = boardWithNodes({
+      oldVisual: {
+        id: "oldVisual",
+        kind: "scene3d",
+        region_id: "old-course",
+        content: {},
+        placement: { relation: "new_region" },
+      },
+      oldExplanation: {
+        id: "oldExplanation",
+        kind: "math",
+        region_id: "old-course",
+        content: { latex: "x" },
+        placement: { relation: "below", anchor: "oldVisual" },
+      },
+      nextVisual: {
+        id: "nextVisual",
+        kind: "geometry",
+        region_id: "next-course",
+        content: {},
+        placement: { relation: "new_region" },
+      },
+      nextExplanation: {
+        id: "nextExplanation",
+        kind: "text",
+        region_id: "next-course",
+        content: { text: "下一节课" },
+        placement: { relation: "right_of", anchor: "nextVisual" },
+      },
+    });
+    const layout = computeBoardLayout(board, {
+      oldVisual: { width: 460, height: 360 },
+      oldExplanation: { width: 680, height: 136 },
+      nextVisual: { width: 380, height: 300 },
+      nextExplanation: { width: 440, height: 106 },
+    }, {
+      regions: {
+        "old-course": {
+          x: 394,
+          y: 90,
+          reservedWidth: 886,
+          flow: "reading",
+        },
+        "next-course": {
+          x: 1_754,
+          y: 90,
+          reservedWidth: 886,
+          flow: "reading",
+        },
+      },
+    });
+
+    const oldRight = Math.max(
+      layout.nodes.oldVisual!.x + layout.nodes.oldVisual!.width,
+      layout.nodes.oldExplanation!.x + layout.nodes.oldExplanation!.width,
+    );
+    const nextLeft = Math.min(
+      layout.nodes.nextVisual!.x,
+      layout.nodes.nextExplanation!.x,
+    );
+    expect(oldRight).toBeLessThanOrEqual(394 + 886);
+    expect(nextLeft).toBe(1_754);
+    expect(oldRight).toBeLessThan(nextLeft);
+  });
+
+  it("preserves intentional overlays inside an interactive visual", () => {
+    const board = boardWithNodes({
+      visual: {
+        id: "visual",
+        kind: "geometry",
+        region_id: "course",
+        content: {},
+        placement: { relation: "new_region" },
+      },
+      annotation: {
+        id: "annotation",
+        kind: "note",
+        region_id: "course",
+        content: { text: "圆心" },
+        placement: { relation: "overlay", anchor: "visual" },
+      },
+    });
+    const layout = computeBoardLayout(board, {
+      visual: { width: 380, height: 300 },
+      annotation: { width: 120, height: 72 },
+    }, {
+      regions: {
+        course: {
+          x: 394,
+          y: 90,
+          reservedWidth: 886,
+          flow: "reading",
+        },
+      },
+    });
+
+    expect(layout.nodes.annotation).toEqual({
+      x: 418,
+      y: 144,
+      width: 120,
+      height: 72,
+    });
+  });
+});

--- a/src/learning/oll/ink-world-layer-regression.test.ts
+++ b/src/learning/oll/ink-world-layer-regression.test.ts
@@ -4,12 +4,15 @@ import type { CameraState } from "octos-lesson-language/web-runtime";
 
 type RuntimeHarness = {
   options: { viewport: HTMLElement };
-  host: HTMLElement;
-  editor: { display: { setDevicePixelRatio: ReturnType<typeof vi.fn> } };
-  layerBounds: { left: number; top: number; width: number; height: number };
-  compactedScale: number;
-  pixelRatioTimer?: ReturnType<typeof setTimeout>;
+  editor: {
+    getRootElement: () => HTMLElement;
+    display: { setDevicePixelRatio: ReturnType<typeof vi.fn> };
+    queueRerender: ReturnType<typeof vi.fn>;
+  };
+  renderedCamera: CameraState;
   pendingCamera?: CameraState;
+  cameraRenderTimer?: ReturnType<typeof setTimeout>;
+  cameraRenderRevision: number;
   appliedPixelRatio?: number;
   resetEditorViewport: ReturnType<typeof vi.fn>;
 };
@@ -20,18 +23,21 @@ const updateWorldLayer = (
   }
 ).updateWorldLayer;
 
-function createHarness(): RuntimeHarness {
+function createHarness(renderedCamera: CameraState): RuntimeHarness & {
+  editorRoot: HTMLElement;
+} {
   const viewport = document.createElement("div");
-  Object.defineProperties(viewport, {
-    clientWidth: { value: 1200 },
-    clientHeight: { value: 800 },
-  });
+  const editorRoot = document.createElement("div");
   return {
     options: { viewport },
-    host: document.createElement("div"),
-    editor: { display: { setDevicePixelRatio: vi.fn() } },
-    layerBounds: { left: -420, top: -420, width: 2040, height: 1640 },
-    compactedScale: 1,
+    editorRoot,
+    editor: {
+      getRootElement: () => editorRoot,
+      display: { setDevicePixelRatio: vi.fn() },
+      queueRerender: vi.fn(async () => undefined),
+    },
+    renderedCamera,
+    cameraRenderRevision: 0,
     resetEditorViewport: vi.fn(),
   };
 }
@@ -40,35 +46,36 @@ afterEach(() => {
   vi.useRealTimers();
 });
 
-describe("ink world-layer camera settlement", () => {
-  it("keeps the existing world layer when the learner only pans the board", () => {
+describe("ink camera synchronization", () => {
+  it("uses the same translation as the board while panning, then redraws in place", async () => {
     vi.useFakeTimers();
-    const runtime = createHarness();
-    const originalBounds = runtime.layerBounds;
+    const runtime = createHarness({ panX: 80, panY: 60, scale: 1 });
 
     updateWorldLayer.call(runtime, { panX: -100, panY: -60, scale: 1 });
-    vi.advanceTimersByTime(120);
 
-    expect(runtime.layerBounds).toBe(originalBounds);
+    expect(runtime.editorRoot.style.transform).toBe("matrix(1, 0, 0, 1, -180, -120)");
     expect(runtime.resetEditorViewport).not.toHaveBeenCalled();
-    expect(runtime.compactedScale).toBe(1);
+
+    await vi.advanceTimersByTimeAsync(120);
+
+    expect(runtime.renderedCamera).toEqual({ panX: -100, panY: -60, scale: 1 });
+    expect(runtime.resetEditorViewport).toHaveBeenCalledOnce();
+    expect(runtime.editor.queueRerender).toHaveBeenCalledOnce();
+    expect(runtime.editorRoot.style.transform).toBe("");
   });
 
-  it("compacts and redraws the world layer after a zoom settles", () => {
+  it("keeps the ink aligned to the zoom anchor and redraws at screen DPR", async () => {
     vi.useFakeTimers();
-    const runtime = createHarness();
+    const runtime = createHarness({ panX: 80, panY: 60, scale: 1 });
 
-    updateWorldLayer.call(runtime, { panX: 0, panY: 0, scale: 1.2 });
-    vi.advanceTimersByTime(120);
+    updateWorldLayer.call(runtime, { panX: 20, panY: 10, scale: 1.25 });
 
-    expect(runtime.layerBounds).toEqual({
-      left: -350,
-      top: -350,
-      width: 1700,
-      height: 1367,
-    });
-    expect(runtime.resetEditorViewport).toHaveBeenCalledOnce();
-    expect(runtime.compactedScale).toBe(1.2);
-    expect(runtime.editor.display.setDevicePixelRatio).toHaveBeenCalledOnce();
+    expect(runtime.editorRoot.style.transform).toBe("matrix(1.25, 0, 0, 1.25, -80, -65)");
+
+    await vi.advanceTimersByTimeAsync(120);
+
+    expect(runtime.renderedCamera).toEqual({ panX: 20, panY: 10, scale: 1.25 });
+    expect(runtime.editor.display.setDevicePixelRatio).toHaveBeenCalledWith(window.devicePixelRatio);
+    expect(runtime.editorRoot.style.transform).toBe("");
   });
 });

--- a/src/learning/oll/ink-world-layer-regression.test.ts
+++ b/src/learning/oll/ink-world-layer-regression.test.ts
@@ -1,0 +1,74 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { InkRuntime } from "octos-lesson-language/ink-runtime";
+import type { CameraState } from "octos-lesson-language/web-runtime";
+
+type RuntimeHarness = {
+  options: { viewport: HTMLElement };
+  host: HTMLElement;
+  editor: { display: { setDevicePixelRatio: ReturnType<typeof vi.fn> } };
+  layerBounds: { left: number; top: number; width: number; height: number };
+  compactedScale: number;
+  pixelRatioTimer?: ReturnType<typeof setTimeout>;
+  pendingCamera?: CameraState;
+  appliedPixelRatio?: number;
+  resetEditorViewport: ReturnType<typeof vi.fn>;
+};
+
+const updateWorldLayer = (
+  InkRuntime.prototype as unknown as {
+    updateWorldLayer: (this: RuntimeHarness, camera: CameraState) => void;
+  }
+).updateWorldLayer;
+
+function createHarness(): RuntimeHarness {
+  const viewport = document.createElement("div");
+  Object.defineProperties(viewport, {
+    clientWidth: { value: 1200 },
+    clientHeight: { value: 800 },
+  });
+  return {
+    options: { viewport },
+    host: document.createElement("div"),
+    editor: { display: { setDevicePixelRatio: vi.fn() } },
+    layerBounds: { left: -420, top: -420, width: 2040, height: 1640 },
+    compactedScale: 1,
+    resetEditorViewport: vi.fn(),
+  };
+}
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+describe("ink world-layer camera settlement", () => {
+  it("keeps the existing world layer when the learner only pans the board", () => {
+    vi.useFakeTimers();
+    const runtime = createHarness();
+    const originalBounds = runtime.layerBounds;
+
+    updateWorldLayer.call(runtime, { panX: -100, panY: -60, scale: 1 });
+    vi.advanceTimersByTime(120);
+
+    expect(runtime.layerBounds).toBe(originalBounds);
+    expect(runtime.resetEditorViewport).not.toHaveBeenCalled();
+    expect(runtime.compactedScale).toBe(1);
+  });
+
+  it("compacts and redraws the world layer after a zoom settles", () => {
+    vi.useFakeTimers();
+    const runtime = createHarness();
+
+    updateWorldLayer.call(runtime, { panX: 0, panY: 0, scale: 1.2 });
+    vi.advanceTimersByTime(120);
+
+    expect(runtime.layerBounds).toEqual({
+      left: -350,
+      top: -350,
+      width: 1700,
+      height: 1367,
+    });
+    expect(runtime.resetEditorViewport).toHaveBeenCalledOnce();
+    expect(runtime.compactedScale).toBe(1.2);
+    expect(runtime.editor.display.setDevicePixelRatio).toHaveBeenCalledOnce();
+  });
+});

--- a/src/learning/oll/oll-lesson-runtime.test.tsx
+++ b/src/learning/oll/oll-lesson-runtime.test.tsx
@@ -135,12 +135,14 @@ function QuestionPlacementProbe({
   pending = false,
   showLoading = pending,
   withCourseRegion = false,
+  withTallNarrative = false,
 }: {
   onPlaceQuestion: (questionId: string, position: { x: number; y: number }) => void;
   inkSessionId?: string;
   pending?: boolean;
   showLoading?: boolean;
   withCourseRegion?: boolean;
+  withTallNarrative?: boolean;
 }) {
   const runtime = useOllLessonRuntime({
     source: unitCircleSineLessonSource,
@@ -148,11 +150,30 @@ function QuestionPlacementProbe({
     startAtEnd: true,
   });
   if (!runtime) return null;
+  const board = withTallNarrative && runtime.board ? {
+    ...runtime.board,
+    nodes: {
+      ...runtime.board.nodes,
+      ...Object.fromEntries(Array.from({ length: 10 }, (_, index) => [
+        `late-narrative-${index}`,
+        {
+          id: `late-narrative-${index}`,
+          kind: "note",
+          content: {
+            title: `补充讲解 ${index + 1}`,
+            text: "右侧讲解继续增长，但不应推动左侧图形下方的滑块。",
+          },
+          placement: { relation: "new_region" },
+        },
+      ])),
+    },
+  } : runtime.board;
   return (
     <div style={{ width: 1200, height: 800 }}>
       <OllLessonBoard
         runtime={{
           ...runtime,
+          board,
           outline: runtime.outline.map((topic) => ({
             ...topic,
             questionId: "lesson-unit-circle-sine-001",
@@ -911,6 +932,7 @@ describe("OLL lesson Runtime integration", () => {
       <QuestionPlacementProbe
         onPlaceQuestion={onPlaceQuestion}
         withCourseRegion
+        withTallNarrative
       />,
     );
 
@@ -927,11 +949,54 @@ describe("OLL lesson Runtime integration", () => {
     expect(onPlaceQuestion).not.toHaveBeenCalled();
     const controls = await screen.findByTestId("oll-variable-controls");
     const controlTop = Number.parseFloat(controls.style.top);
+    const visualBottom = Math.max(...Array.from(
+      document.querySelectorAll<HTMLElement>(
+        ".board-node:is([data-kind='geometry'], [data-kind='scene3d'], [data-kind='plot'], [data-kind='image'], [data-kind='diagram'])",
+      ),
+    ).map((node) => Number.parseFloat(node.style.top)
+      + Number.parseFloat(node.style.height)));
     const lessonBottom = Math.max(...Array.from(
       document.querySelectorAll<HTMLElement>(".board-node"),
     ).map((node) => Number.parseFloat(node.style.top)
       + Number.parseFloat(node.style.height)));
-    expect(controlTop).toBeGreaterThanOrEqual(lessonBottom + 42);
+    expect(controlTop).toBeGreaterThanOrEqual(visualBottom + 42);
+    expect(controlTop).toBeLessThan(lessonBottom + 42);
+  });
+
+  it("keeps wheel zoom available while ink selection owns pointer input", async () => {
+    const state: InkRuntimeState = {
+      mode: "select",
+      component_count: 1,
+      selected_count: 0,
+      selection_revision: 0,
+      document_version: 1,
+      saved: true,
+    };
+    mountInkRuntimeMock.mockImplementation((options) => ({
+      ready: Promise.resolve(),
+      subscribe: vi.fn((listener: (next: InkRuntimeState) => void) => {
+        listener(state);
+        return () => undefined;
+      }),
+      setMode: vi.fn((mode: InkMode) => {
+        options.board.setInputOwner(mode === "navigate" ? "runtime" : "ink");
+      }),
+      destroy: vi.fn(() => Promise.resolve()),
+    }));
+    render(<InkRuntimeProbe />);
+
+    await waitFor(() => expect(mountInkRuntimeMock).toHaveBeenCalledOnce());
+    fireEvent.click(screen.getByRole("button", { name: "框选多个笔迹" }));
+    const board = screen.getByTestId("oll-lesson-board");
+    const world = board.querySelector<HTMLElement>(
+      "[data-oll-board-runtime-world]",
+    );
+    const transformBefore = world?.style.transform;
+
+    fireEvent.wheel(board, { deltaY: -120, clientX: 400, clientY: 300 });
+
+    expect(world?.style.transform).not.toBe(transformBefore);
+    expect(board.classList.contains("manual-navigation")).toBe(true);
   });
 
   it("reserves a new course area before its loading state renders", async () => {

--- a/src/learning/oll/oll-lesson-runtime.test.tsx
+++ b/src/learning/oll/oll-lesson-runtime.test.tsx
@@ -919,6 +919,7 @@ describe("OLL lesson Runtime integration", () => {
         __legacy__: {
           x: 2_694,
           y: 160,
+          flow: "reading",
           reservedWidth: 886,
         },
       });

--- a/src/learning/oll/oll-lesson-runtime.tsx
+++ b/src/learning/oll/oll-lesson-runtime.tsx
@@ -197,6 +197,13 @@ const selectionContentKindLabels: Record<SelectionContentKind, string> = {
 };
 
 const boardOcclusionSelector = "[data-learning-board-occlusion]";
+const courseVisualNodeKinds = new Set([
+  "diagram",
+  "geometry",
+  "image",
+  "plot",
+  "scene3d",
+]);
 const PENDING_QUESTION_FOOTPRINT_WIDTH = COURSE_PENDING_FOOTPRINT_WIDTH;
 const PENDING_QUESTION_FOOTPRINT_HEIGHT = COURSE_PENDING_FOOTPRINT_HEIGHT;
 
@@ -249,6 +256,35 @@ function renderedWorldRect(element: HTMLElement): WhiteboardRect | null {
   return Number.isFinite(x) && Number.isFinite(y) && width > 0 && height > 0
     ? { x, y, width, height }
     : null;
+}
+
+function measureVisualRegionBounds(
+  board: OllLessonRuntimeController["board"],
+  nodeLayer: HTMLElement,
+): Record<string, WhiteboardRect> {
+  if (!board) return {};
+  const rectsByRegion = new Map<string, WhiteboardRect[]>();
+  for (const element of nodeLayer.querySelectorAll<HTMLElement>(
+    ".board-node[data-id]",
+  )) {
+    const nodeId = element.dataset.id;
+    const node = nodeId ? board.nodes[nodeId] : undefined;
+    if (!node || !courseVisualNodeKinds.has(String(node.kind ?? "text"))) {
+      continue;
+    }
+    const bounds = renderedWorldRect(element);
+    if (!bounds) continue;
+    const regionId = typeof node.region_id === "string" && node.region_id
+      ? node.region_id
+      : "__legacy__";
+    const rects = rectsByRegion.get(regionId) ?? [];
+    rects.push(bounds);
+    rectsByRegion.set(regionId, rects);
+  }
+  return Object.fromEntries([...rectsByRegion].flatMap(([regionId, rects]) => {
+    const bounds = unionWhiteboardRects(rects);
+    return bounds ? [[regionId, bounds]] : [];
+  }));
 }
 
 const emptyInkState: LearningInkState = {
@@ -488,6 +524,9 @@ export function LearningWhiteboard({
   const [runtimeRegionBounds, setRuntimeRegionBounds] = useState<
     Record<string, WhiteboardRect>
   >({});
+  const [runtimeVisualRegionBounds, setRuntimeVisualRegionBounds] = useState<
+    Record<string, WhiteboardRect>
+  >({});
   const [selectionQuestionOpen, setSelectionQuestionOpen] = useState(false);
   const [selectionQuestion, setSelectionQuestion] = useState("");
   const [selectionContentKind, setSelectionContentKind] =
@@ -637,15 +676,22 @@ export function LearningWhiteboard({
       width: 760,
       height: 300,
     };
-    const top = base.y + base.height + 42;
+    const visualBounds = runtimeVisualRegionBounds[
+      runtimeRegionIdForTopic(topic.id)
+    ] ?? (presentationTopics.length === 1
+      ? runtimeVisualRegionBounds.__legacy__
+      : undefined);
+    const controlsBase = visualBounds ?? base;
+    const controlsTop = controlsBase.y + controlsBase.height + 42;
+    const tasksTop = base.y + base.height + 42;
     return [{
       topic,
       controls,
       tasks,
-      controlsPosition: { x: base.x, y: top },
+      controlsPosition: { x: controlsBase.x, y: controlsTop },
       tasksPosition: {
         x: base.x + (controls.length > 0 ? 388 : 0),
-        y: top,
+        y: tasksTop,
       },
     }];
   });
@@ -1452,14 +1498,23 @@ export function LearningWhiteboard({
   }, [inkSessionId]);
 
   useEffect(() => {
-    const view = mountedRef.current?.view;
-    if (!view) return;
+    const mounted = mountedRef.current;
+    if (!mounted) return;
+    const { view } = mounted;
     view.setRegionLayouts(regionLayoutConstraints);
     const nextRegionBounds = view.getRegionBoundsMap();
     setRuntimeRegionBounds((current) =>
       JSON.stringify(current) === JSON.stringify(nextRegionBounds)
         ? current
         : nextRegionBounds);
+    const nextVisualBounds = measureVisualRegionBounds(
+      runtimeRef.current?.board ?? null,
+      mounted.elements.nodes,
+    );
+    setRuntimeVisualRegionBounds((current) =>
+      JSON.stringify(current) === JSON.stringify(nextVisualBounds)
+        ? current
+        : nextVisualBounds);
   }, [enhancementLayer, regionLayoutConstraints]);
 
   useEffect(() => {
@@ -1520,7 +1575,8 @@ export function LearningWhiteboard({
   useEffect(() => {
     const activeRuntime = runtimeRef.current;
     if (!activeRuntime) return;
-    const view = mountedRef.current?.view;
+    const mounted = mountedRef.current;
+    const view = mounted?.view;
     const attentionTargets = activeRuntime.attentionTargets;
     const attentionKey = attentionTargets.length > 0
       ? `${activeRuntime.currentOperation?.operation_id ?? activeRuntime.cursor}\u0000${attentionTargets.join("\u0000")}`
@@ -1553,6 +1609,13 @@ export function LearningWhiteboard({
       JSON.stringify(current) === JSON.stringify(nextRegionBounds)
         ? current
         : nextRegionBounds);
+    const nextVisualBounds = mounted
+      ? measureVisualRegionBounds(activeRuntime.board, mounted.elements.nodes)
+      : {};
+    setRuntimeVisualRegionBounds((current) =>
+      JSON.stringify(current) === JSON.stringify(nextVisualBounds)
+        ? current
+        : nextVisualBounds);
     const viewport = viewportRef.current;
     if (viewport) ensureScene3dInteractionHints(viewport);
     if (attentionTargets.length > 0 && attentionChanged) {

--- a/src/learning/oll/oll-lesson-runtime.tsx
+++ b/src/learning/oll/oll-lesson-runtime.tsx
@@ -574,6 +574,7 @@ export function LearningWhiteboard({
       return [[runtimeRegionIdForTopic(topic.id), {
         x: region.origin.x + COURSE_RUNTIME_OFFSET_X,
         y: region.origin.y,
+        flow: "reading",
         reservedWidth: Math.max(
           0,
           region.reservedWidth - COURSE_RUNTIME_OFFSET_X,


### PR DESCRIPTION
## Summary

- arrange lesson cards in a stable two-lane reading layout while preserving logical course regions on the infinite board
- keep interactive variable controls anchored below their related visual content instead of pushing them below growing narrative content
- allow wheel zoom while the ink selection tool owns board input and reduce unnecessary camera work during manual navigation
- synchronize student ink with the exact board camera transform during pan and zoom, then redraw at screen DPR after the camera settles
- keep the ink canvas viewport-sized to avoid oversized canvas allocation, blurry zoomed ink, rendering stalls, and white-background failures

## Compatibility

- applies the updated layout at render time, including existing semantic lessons
- preserves independent placement for multiple courses through their logical region constraints
- keeps saved student ink in board coordinates

## Testing

- `pnpm test:unit` — 145 test files, 1001 tests passed
- `pnpm exec tsc --noEmit`
- `pnpm run build`
- focused ESLint and Learn runtime regression tests
